### PR TITLE
Use existing Amalgam Conductor icon as plugin icon

### DIFF
--- a/PLUGIN_READINESS.md
+++ b/PLUGIN_READINESS.md
@@ -18,8 +18,11 @@ This document tracks the readiness of the Amalgamatic Orchestra framework for it
   - GitHub repo has been renamed to `Baelfyre/amalgam-conductor`.
 - **Plugin install validation status:** Completed
   - `agy plugin install https://github.com/Baelfyre/amalgam-conductor` successfully processed 9 skills and 9 commands.
+- **Plugin icon status:** Completed
+  - The existing Amalgam Conductor icon is used as the plugin icon: `assets/icons/amalgam-conductor.png`.
+  - The broader framework logo remains available at `assets/logo/orchestra-of-amalgamation.png`.
 - **Remaining step:** Pending
-  - Add or refine the final plugin logo/icon if needed.
+  - Validate whether the target plugin loader displays the manifest-level icon path.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Amalgam Conductor is an installable AI workflow plugin built on the Amalgamatic 
 
 The framework remains Markdown-first so the core instructions can stay reusable across tools. The plugin layer provides clean commands and skill discovery for supported plugin environments while the underlying Markdown files remain portable.
 
+The plugin uses the existing Amalgam Conductor icon at `assets/icons/amalgam-conductor.png`. The broader framework logo remains `assets/logo/orchestra-of-amalgamation.png`.
+
 ## What this repository is
 
 ## Codex compatibility

--- a/plugin.json
+++ b/plugin.json
@@ -5,6 +5,8 @@
     "version": "1.0.0",
     "license": "MIT",
     "repository": "https://github.com/Baelfyre/amalgam-conductor",
+    "icon_path": "assets/icons/amalgam-conductor.png",
+    "logo_path": "assets/logo/orchestra-of-amalgamation.png",
     "safety_note": "The hidden-dagger skill and resilience-check command execute destructive, negative, fuzz, adversarial QA, and failure-mode testing. They require explicit user approval, non-production scope, and a safety gate before execution.",
     "commands": [
         "amalgam-conductor",


### PR DESCRIPTION
## Summary

Uses the existing Amalgam Conductor icon as the plugin icon instead of adding or replacing image assets.

## Changes

- Adds root manifest icon metadata:
  - `icon_path`: `assets/icons/amalgam-conductor.png`
  - `logo_path`: `assets/logo/orchestra-of-amalgamation.png`
- Documents the selected plugin icon in `README.md`.
- Updates `PLUGIN_READINESS.md` to mark plugin icon selection as completed.

## Asset safety

No image files were deleted, replaced, or modified. This PR only updates text/manifest metadata.

## Validation note

The existing plugin install already processed 9 skills and 9 commands successfully. This PR only adds icon metadata/documentation.