### PR TITLE
docs(hidden-dagger): align caveman output contract

### DIFF
--- a/adapters/codex/skills/hidden-dagger/OUTPUT_FORMATS.md
+++ b/adapters/codex/skills/hidden-dagger/OUTPUT_FORMATS.md
@@ -1,6 +1,23 @@
 # Output Formats
 
-## Output
+## Caveman
+
+You must output using this strict Caveman format. Keep it concise, focused, and free of unnecessary essays.
+
+```text
+TASK TYPE:
+RISK LEVEL:
+TARGET BOUNDARY:
+FAILURE SCENARIO:
+CONTROLLED TEST INPUT / FAILURE TRIGGER:
+EXPECTED FAILURE OR BEHAVIOR:
+SAFETY GATE:
+ACME HANDOFF:
+CIPHER HANDOFF:
+PONYTAIL HANDOFF:
+```
+
+### Review and Planning Guidance
 
 For planning, report safety status, target, highest-risk areas, proposed tests, approval required, and next action.
 
@@ -16,8 +33,9 @@ For a full review, report:
 
 Use Critical, Major, Minor, or Cleanup severity. Never mark a test passed unless it ran and evidence is available.
 
-## Scoring
+### Risk Scoring Guidance
 
 Use 0 to 100: 90-100 strong with minor gaps; 75-89 generally strong with targeted fixes; 60-74 moderate with meaningful risk; 40-59 weak with major gaps; 0-39 high risk and failure-prone.
 
 Weight critical workflow impact, safety, data integrity, security and privacy, likelihood, severity, and recovery difficulty. Mark scores provisional when evidence is incomplete.
+

--- a/scripts/validate-manifest.ps1
+++ b/scripts/validate-manifest.ps1
@@ -24,7 +24,6 @@ $exceptions = @{
     'amalgam-conductor' = 'Semantic routing formats pending dedicated alignment pass'
     'the-steward'       = 'Governance Review is a semantic format covering compact and expanded templates'
     'the-governor'      = 'Governance Review is a semantic format covering compact and expanded templates'
-    'hidden-dagger'     = 'Legacy output headings pending dedicated alignment pass'
     'meister-weaver'    = 'Diagram syntax labels pending dedicated alignment pass'
 }
 

--- a/skills/hidden-dagger/OUTPUT_FORMATS.md
+++ b/skills/hidden-dagger/OUTPUT_FORMATS.md
@@ -1,6 +1,23 @@
 # Output Formats
 
-## Output
+## Caveman
+
+You must output using this strict Caveman format. Keep it concise, focused, and free of unnecessary essays.
+
+```text
+TASK TYPE:
+RISK LEVEL:
+TARGET BOUNDARY:
+FAILURE SCENARIO:
+CONTROLLED TEST INPUT / FAILURE TRIGGER:
+EXPECTED FAILURE OR BEHAVIOR:
+SAFETY GATE:
+ACME HANDOFF:
+CIPHER HANDOFF:
+PONYTAIL HANDOFF:
+```
+
+### Review and Planning Guidance
 
 For planning, report safety status, target, highest-risk areas, proposed tests, approval required, and next action.
 
@@ -16,8 +33,9 @@ For a full review, report:
 
 Use Critical, Major, Minor, or Cleanup severity. Never mark a test passed unless it ran and evidence is available.
 
-## Scoring
+### Risk Scoring Guidance
 
 Use 0 to 100: 90-100 strong with minor gaps; 75-89 generally strong with targeted fixes; 60-74 moderate with meaningful risk; 40-59 weak with major gaps; 0-39 high risk and failure-prone.
 
 Weight critical workflow impact, safety, data integrity, security and privacy, likelihood, severity, and recovery difficulty. Mark scores provisional when evidence is incomplete.
+


### PR DESCRIPTION
## Summary

This PR aligns Hidden Dagger’s output contract with its declared `Caveman` output format and removes its validator exception.

## Changes

- Updated `skills/hidden-dagger/OUTPUT_FORMATS.md` so the primary output heading is `## Caveman`.
- Converted previous `Output` and `Scoring` sections into supporting H3 guidance under the Caveman format.
- Preserved Hidden Dagger’s approval-gated, scenario-planning-only safety posture.
- Removed `hidden-dagger` from the output-contract exception map in `validate-manifest.ps1`.
- Regenerated the Codex adapter output format file through `export-codex-skills.ps1`.

## Validation

Passed:

```powershell
powershell -ExecutionPolicy Bypass -File .\adapters\codex\export-codex-skills.ps1
powershell -ExecutionPolicy Bypass -File .\scripts\validate-manifest.ps1
powershell -ExecutionPolicy Bypass -File .\scripts\validate-structure.ps1
powershell -ExecutionPolicy Bypass -File .\adapters\codex\validate-codex-export.ps1