### PR TITLE
docs(orchestration): align semantic output contracts

### DIFF
--- a/adapters/codex/skills/amalgam-conductor/OUTPUT_FORMATS.md
+++ b/adapters/codex/skills/amalgam-conductor/OUTPUT_FORMATS.md
@@ -1,8 +1,9 @@
-# Output Formats
+﻿# Output Formats
 
-## Full mode
+## Routing Plan
 
-Use this structure. Keep it compact for simple tasks.
+### Full Orchestration
+Use this structure for comprehensive planning. Keep it compact for simple tasks.
 
 ```markdown
 # Amalgam Conductor Routing Plan
@@ -47,13 +48,13 @@ Use this structure. Keep it compact for simple tasks.
 - Git status:
 - Approval required:
 
-## Commands or Prompts to Run
-Provide copy-paste-ready Codex prompts. Do not include commit, push, PR, install, or destructive commands unless explicitly approved.
-
 ## Final Recommendation
 State the shortest effective workflow.
 ```
 
-## Compact mode
-
+### Compact Routing
 For a simple route, use `# Conductor Quick Route` followed by project signal, selected skill, reason, exclusions, approval boundary, and one copy-paste prompt.
+
+## Prompts
+
+Provide copy-paste-ready Codex prompts to execute the defined Routing Plan. Do not include commit, push, PR, install, or destructive commands unless explicitly approved.

--- a/scripts/validate-manifest.ps1
+++ b/scripts/validate-manifest.ps1
@@ -21,9 +21,6 @@ $skillFolders = Get-ChildItem -LiteralPath $skillsDir -Directory
 $skillIndexLines = Get-Content -LiteralPath (Join-Path $Root "SKILL_INDEX.md")
 
 $exceptions = @{
-    'amalgam-conductor' = 'Semantic routing formats pending dedicated alignment pass'
-    'the-steward'       = 'Governance Review is a semantic format covering compact and expanded templates'
-    'the-governor'      = 'Governance Review is a semantic format covering compact and expanded templates'
 }
 
 $errors = 0

--- a/skills/amalgam-conductor/OUTPUT_FORMATS.md
+++ b/skills/amalgam-conductor/OUTPUT_FORMATS.md
@@ -1,8 +1,9 @@
-# Output Formats
+﻿# Output Formats
 
-## Full mode
+## Routing Plan
 
-Use this structure. Keep it compact for simple tasks.
+### Full Orchestration
+Use this structure for comprehensive planning. Keep it compact for simple tasks.
 
 ```markdown
 # Amalgam Conductor Routing Plan
@@ -47,13 +48,13 @@ Use this structure. Keep it compact for simple tasks.
 - Git status:
 - Approval required:
 
-## Commands or Prompts to Run
-Provide copy-paste-ready Codex prompts. Do not include commit, push, PR, install, or destructive commands unless explicitly approved.
-
 ## Final Recommendation
 State the shortest effective workflow.
 ```
 
-## Compact mode
-
+### Compact Routing
 For a simple route, use `# Conductor Quick Route` followed by project signal, selected skill, reason, exclusions, approval boundary, and one copy-paste prompt.
+
+## Prompts
+
+Provide copy-paste-ready Codex prompts to execute the defined Routing Plan. Do not include commit, push, PR, install, or destructive commands unless explicitly approved.

--- a/skills/the-governor/OUTPUT_FORMATS.md
+++ b/skills/the-governor/OUTPUT_FORMATS.md
@@ -1,8 +1,11 @@
-# The Governor Output Format
+# Output Formats
 
-## Compact (Default)
+## Governance Review
 
-```
+### Compact
+Use this default compact format for general governance reviews.
+
+```text
 REVIEWER: the-governor
 PROJECT_CONTEXT: [project type] | [risk level]
 DECISION: [APPROVED | ADVISORY_ONLY | REVISION_REQUIRED | BLOCKED | NOT_APPLICABLE]
@@ -12,9 +15,10 @@ RISKS: [identified risks or "none"]
 REQUIRED_ACTIONS: [actions needed or "none"]
 ```
 
-## Expanded (When Findings Exist)
+### Expanded
+Use this expanded format when significant findings or risks exist.
 
-```
+```text
 REVIEWER: the-governor
 PROJECT_CONTEXT: [project type] | [risk level]
 DECISION: [APPROVED | ADVISORY_ONLY | REVISION_REQUIRED | BLOCKED | NOT_APPLICABLE]

--- a/skills/the-steward/OUTPUT_FORMATS.md
+++ b/skills/the-steward/OUTPUT_FORMATS.md
@@ -1,8 +1,11 @@
-# The Steward Output Format
+# Output Formats
 
-## Compact (Default)
+## Governance Review
 
-```
+### Compact
+Use this default compact format for general governance reviews.
+
+```text
 REVIEWER: the-steward
 PROJECT_CONTEXT: [project type] | [risk level]
 DECISION: [APPROVED | ADVISORY_ONLY | REVISION_REQUIRED | BLOCKED | NOT_APPLICABLE]
@@ -11,9 +14,10 @@ RISKS: [identified risks or "none"]
 REQUIRED_ACTIONS: [actions needed or "none"]
 ```
 
-## Expanded (When Findings Exist)
+### Expanded
+Use this expanded format when significant findings or risks exist.
 
-```
+```text
 REVIEWER: the-steward
 PROJECT_CONTEXT: [project type] | [risk level]
 DECISION: [APPROVED | ADVISORY_ONLY | REVISION_REQUIRED | BLOCKED | NOT_APPLICABLE]


### PR DESCRIPTION
## Summary

This PR aligns the final semantic output-contract exceptions for Amalgam Conductor, The Steward, and The Governor.

## Changes

- Updated `skills/amalgam-conductor/OUTPUT_FORMATS.md` so its H2 headings match declared output formats:
  - `Routing Plan`
  - `Prompts`
- Updated `skills/the-steward/OUTPUT_FORMATS.md` so `Governance Review` is the primary output heading.
- Updated `skills/the-governor/OUTPUT_FORMATS.md` so `Governance Review` is the primary output heading.
- Preserved compact and expanded guidance as nested subsections.
- Removed the remaining output-contract exceptions from `validate-manifest.ps1`.
- Regenerated the Codex adapter output format for Amalgam Conductor.

## Validation

Passed:

```powershell
powershell -ExecutionPolicy Bypass -File .\scripts\validate-manifest.ps1
powershell -ExecutionPolicy Bypass -File .\scripts\validate-structure.ps1
powershell -ExecutionPolicy Bypass -File .\adapters\codex\validate-codex-export.ps1