### PR TITLE
docs: finalize CI visibility and guardrail documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@
     <a href="SKILL_INDEX.md">Skills</a> •
     <a href="docs/setup/VALIDATION.md">Validation</a>
   </p>
+  <p>
+    <a href="https://github.com/Baelfyre/Orchestra/actions/workflows/validate.yml">
+      <img src="https://github.com/Baelfyre/Orchestra/actions/workflows/validate.yml/badge.svg" alt="validate" />
+    </a>
+  </p>
 </div>
 
 ---
@@ -237,18 +242,23 @@ Output from Conductor and its specialists automatically adapts to your intent:
 | Contributing | [Contributing Guide](docs/CONTRIBUTING.md) | Guidelines for contributing and safety policies |
 | Disclaimer | [Disclaimer](docs/meta/DISCLAIMER.md) | Understand legal and operational limitations |
 
-## Validation
+## Validation & Enforceable Governance
 
-Before releasing or pushing changes, verify the plugin structural integrity and manifest alignment:
+Before releasing, staging, or pushing changes, run the centralized behavior validation suite:
 
 ```powershell
-# Verify files, directories, and icon overrides
-powershell -ExecutionPolicy Bypass -File .\scripts\validate-structure.ps1
-
-# Verify manifest properties against skill frontmatter
-powershell -ExecutionPolicy Bypass -File .\scripts\validate-manifest.ps1
+# Run all validation checks (structure, manifest, stale references, and locking tests)
+powershell -NoProfile -ExecutionPolicy Bypass -File .\tests\behavior\run-tests.ps1
 ```
-For more information, see the [Validation Guide](docs/setup/VALIDATION.md).
+
+### Governance Verification Workflow
+- **Centralized Test Runner (`run-tests.ps1`)**: Verifies project directory structure, manifest definitions against skill frontmatter, stale reference checks, Codex skill adapter alignment, and lock/guardrail regression cases.
+- **Opt-In Runtime Guardrails**: Scans staged or modified files for security risks (secrets, copyleft licenses, PII leaks, destructive commands, or stale naming conventions).
+  - *Warning-Only Mode (Default)*: Scans are advisory and exit with code `0`.
+  - *Strict Enforcement*: Set `$env:ORCHESTRA_ENFORCE_GUARDRAILS = "true"` to fail the build (exit code `1`) upon safety violations.
+- **Workspace State Locking**: Manages a `.amalgam/lock.json` file during workflow executions to prevent concurrent agent collisions, automatically detecting and cleaning stale locks based on process ID (PID) liveness.
+
+For full configuration and usage instructions, see the [Validation & Enforceable Governance Guide](docs/setup/VALIDATION.md).
 
 ---
 
@@ -265,17 +275,17 @@ GitHub displays repository files above the README by default. This README keeps 
 
 ```
 skills/
-├── acme-overseer/
-├── amalgam-conductor/
-├── cipher-meister/
-├── cloak-meister/
-├── clockwork-meister/
-├── hidden-dagger/
-├── meister-chronicler/
-├── meister-weaver/
-├── scribe-meister/
+├── chronicler/
+├── cipher/
+├── cloak/
+├── clockwork/
+├── conductor/
+├── dagger/
+├── overseer/
+├── scribe/
 ├── the-governor/
-└── the-steward/
+├── the-steward/
+└── weaver/
 
 docs/
 ├── CONTRIBUTING.md

--- a/docs/setup/VALIDATION.md
+++ b/docs/setup/VALIDATION.md
@@ -1,29 +1,80 @@
-# Validation
+# Validation & Enforceable Governance Guide
 
-1. Run `scripts/validate-structure.ps1` or `scripts/validate-structure.sh`.
-2. Run `scripts/check-stale-references.ps1` or `scripts/check-stale-references.sh`.
-3. Confirm every skill folder contains `SKILL.md` and required support files.
-4. Validate local Markdown links and balanced code fences.
-5. Scan for private names, local paths, emails, secrets, unsupported compliance claims, and project-specific examples.
-6. Confirm Conductor routes UI, documentation, diagrams, databases, QA, security/privacy, and gated resilience correctly.
-7. Confirm Overseer owns normal QA and Cipher owns normal security/privacy review.
-8. Confirm Dagger is not automatic, requires a safety gate, excludes production and real user data, and provides defensive guidance only.
-9. Confirm external tools are not bundled and adapter guides avoid unsupported native-compatibility claims.
+Orchestra uses a multi-layered verification system to programmatically enforce project structure, manifest properties, safety guardrails, and concurrent execution safeguards.
 
-Run the official skill validator supplied by your Codex installation against each `skills/*` folder when available.
+---
 
-## Expected output
+## 1. Centralized Test Runner (`run-tests.ps1`)
 
-Successful structure validation:
+The framework provides a unified test runner, [tests/behavior/run-tests.ps1](file:///c:/conductor/tests/behavior/run-tests.ps1), which executes all structural, consistency, and regression checks.
 
-```text
-Structure valid: 11 skills, 9 commands, 5 adapters, 7 templates, 3 tests.
+### How to Run Tests Locally
+Open a PowerShell session and execute:
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\tests\behavior\run-tests.ps1
 ```
 
-Successful stale-reference validation:
+### What is Validated
+The validation suite runs the following checks sequentially:
+1. **Structure Validation (`validate-structure.ps1`)**: Verifies that all expected repository directories, specialist skill files, adapter configurations, command entry points, and templates exist and match schema definitions.
+2. **Manifest Verification (`validate-manifest.ps1`)**: Cross-checks skill manifests in `plugin.json` against the frontmatter definitions in `skills/**/SKILL.md` to ensure active slugs and properties are aligned.
+3. **Stale References Scan (`check-stale-references.ps1`)**: Scans code files for hardcoded obsolete naming references or invalid system identifiers.
+4. **Codex Skill Export Alignment (`validate-codex-export.ps1`)**: Verifies that generated/exported Codex skill definitions match the source rules.
+5. **Guardrail and Locking Regression Tests**: Runs isolated simulations in temporary workspace folders to assert that security, PII, destructive command blocks, and lock acquisition behaviors function correctly.
 
-```text
-No stale or disallowed references found.
+---
+
+## 2. Programmatic Runtime Guardrails
+
+Runtime guardrails scan repository files and staged changes for safety and naming violations before git commits or execution.
+
+### Active Safety Scans
+- **Secrets Scanning**: Matches patterns for AWS keys, Slack webhooks, private keys, and generic credential variables.
+- **Copyleft License Detection**: Warns if GPL, AGPL, or LGPL licenses are added to dependencies.
+- **PII Leak Protection**: Detects SSNs or credit card patterns and requires a corresponding `PRIVACY_POLICY.md` file.
+- **Destructive Operations Block**: Catches raw volume formatting or unsafe recursive force deletions (`rm -rf`, `Remove-Item -Force`).
+- **Unsafe Command Execution**: Prevents dangerous expressions like `Invoke-Expression` or `iex`.
+- **Forbidden Target Mutations**: Blocks edits to folders designated in `forbidden_repos` inside `.amalgam/state.json`.
+
+### How to Enable Guardrail Enforcement
+By default, guardrail scans are **warning-only and non-blocking** (they output warning logs but exit with code `0` to keep early prototyping fast). 
+
+To turn on strict enforcement (where any violation throws an error and exits with code `1`), set the environment variable:
+```powershell
+# In PowerShell (Windows)
+$env:ORCHESTRA_ENFORCE_GUARDRAILS = "true"
+
+# In Bash (Linux / CI)
+export ORCHESTRA_ENFORCE_GUARDRAILS="true"
+```
+You can also trigger scans manually with parameters:
+```powershell
+# Run manual scan recursively over the workspace
+powershell -File .\scripts\runtime-guardrail.ps1 -Enabled
+
+# Run manual scan with strict enforcement enabled
+powershell -File .\scripts\runtime-guardrail.ps1 -Enabled -Enforce
 ```
 
-On failure, the structure scripts print `Missing: <path>`. The stale-reference scripts print `<path>:<line>: <matching text>`. All validators exit with status 1 when findings exist.
+---
+
+## 3. Workspace State Locking
+
+State locking prevents concurrent agent executions or developers from accidentally overwriting shared project state files (`PROJECT_STATE.md`, `SESSION_HANDOFF.md`, `DECISION_LOG.md`, `.amalgam/state.json`) during parallel runs.
+
+### How State Locking Works
+1. **Lock File**: When an agent begins a workflow task (e.g. implementation or audit), it checks for the existence of `.amalgam/lock.json`.
+2. **Process Liveness Verification**: If a lock file exists, `manage-state-lock.ps1` parses the PID and verifies if that process is still running on the system.
+   - If the process is dead or the lock is older than 1 hour, the lock is treated as **stale** and automatically ignored.
+   - If the process is alive, it blocks the current run and raises a **lock collision** error.
+3. **Acquisition & Release**: The active session writes its unique Session ID, PID, and timestamp to the lock. Upon task completion or test suite termination, the lock is released.
+
+### Manual Lock Management
+If a lock is abandoned or a crashed process leaves the repository locked, release it manually:
+```powershell
+powershell -File .\scripts\manage-state-lock.ps1 -Action Release
+```
+Check if a lock is currently active:
+```powershell
+powershell -File .\scripts\manage-state-lock.ps1 -Action Check
+```

--- a/scripts/runtime-guardrail.ps1
+++ b/scripts/runtime-guardrail.ps1
@@ -69,6 +69,11 @@ if ($filesToScan.Count -eq 0) {
 
 # 2. Scans
 foreach ($item in $filesToScan) {
+    # Skip self and documentation when scanning for their own documented patterns
+    if ($item.Relative -match 'runtime-guardrail\.ps1|VALIDATION\.md') {
+        continue
+    }
+
     $content = Get-Content -LiteralPath $item.Path -Raw
     $lines = @(Get-Content -LiteralPath $item.Path)
 
@@ -196,12 +201,18 @@ if ($violations.Count -gt 0) {
         foreach ($v in $violations) {
             Write-ColorHost 'ERROR' " - $v"
         }
+        Write-Host "`n[WHAT FAILED] Repository files or changes violated Orchestra's runtime guardrails." -ForegroundColor Red
+        Write-Host "[WHY IT FAILED] Active safety checks blocked the operation due to unsafe patterns (e.g. secrets, copyleft licenses, PII leaks, destructive commands, or stale naming references)." -ForegroundColor Red
+        Write-Host "[HOW TO FIX IT] Review the specific files and line numbers flagged above. Address the violations by removing sensitive strings, cleaning up commands, or replacing legacy names with clean slugs. To run locally without blocking, disable enforcement or omit the -Enforce parameter." -ForegroundColor Yellow
         exit 1
     } else {
         Write-ColorHost 'WARNING' "Guardrail scan found $($violations.Count) potential warnings (Warning-Only Mode):"
         foreach ($v in $violations) {
             Write-ColorHost 'WARNING' " - $v"
         }
+        Write-Host "`n[WHAT FAILED] Potential safety warnings were detected by the guardrail scanner." -ForegroundColor Yellow
+        Write-Host "[WHY IT FAILED] Staged or changed files contain patterns that would block commits under active enforcement." -ForegroundColor Yellow
+        Write-Host "[HOW TO FIX IT] Address the warning details above. To enforce these rules on commits, set the environment variable: `$env:ORCHESTRA_ENFORCE_GUARDRAILS = 'true'` or run with the `-Enforce` parameter." -ForegroundColor Cyan
         exit 0
     }
 }


### PR DESCRIPTION
## Summary

Finalize Phase 6 for Issue #27 by improving CI visibility, validation documentation, and runtime guardrail feedback.

## Changes

- Add CI validation badge to the README.
- Finalize validation, runtime guardrail, and state lock documentation.
- Improve runtime guardrail error messages with actionable sections.
- Exclude validation documentation and the guardrail script itself from false-positive guardrail checks.
- Preserve the completed Phase 6 scope as documentation and operational hardening.

## Validation

- `tests/behavior/run-tests.ps1` passed locally.
- `git diff --check` passed locally.
- `.github/workflows/validate.yml` was reviewed for `pwsh` execution on PR and push validation.

## Issue Linkage

Related to #27

Note: This PR finalizes the operational documentation and CI visibility layer after the enforcement groundwork merged in PR #28. Issue #27 may be closed after this PR is merged if no additional work remains in the current enhancement scope.