### PR TITLE
Fix routing map arrow encoding artifacts

### DIFF
--- a/ROUTING_MAP.md
+++ b/ROUTING_MAP.md
@@ -8,15 +8,15 @@ All requests pass through the following routing sequence:
 
 ```text
 Request
-  ↓
+  ->
 Intent Classification (Determine user objective)
-  ↓
+  ->
 Mode Selection (Select: Ideation, Prototype, Implementation, Audit, Release)
-  ↓
+  ->
 Need-Based Governance (Dynamic checks by The Steward & The Governor when applicable)
-  ↓
+  ->
 Continuity Gate (Arbiter when transition, validation, branch, source-of-truth, or handoff risk exists)
-  â†“
+  ->
 Conductor or Specialist Routing (Route task to destination skill)
 ```
 

--- a/adapters/codex/skills/conductor/ROUTING_MAP.md
+++ b/adapters/codex/skills/conductor/ROUTING_MAP.md
@@ -8,15 +8,15 @@ All requests pass through the following routing sequence:
 
 ```text
 Request
-  ↓
+  ->
 Intent Classification (Determine user objective)
-  ↓
+  ->
 Mode Selection (Select: Ideation, Prototype, Implementation, Audit, Release)
-  ↓
+  ->
 Need-Based Governance (Dynamic checks by The Steward & The Governor when applicable)
-  ↓
+  ->
 Continuity Gate (Arbiter when transition, validation, branch, source-of-truth, or handoff risk exists)
-  â†“
+  ->
 Conductor or Specialist Routing (Route task to destination skill)
 ```
 


### PR DESCRIPTION
## Summary
- Replaced routing map arrow characters with ASCII `->`.
- Removed the remaining mojibake arrow artifact from the source routing map and Codex export routing map.

## Validation
- Confirmed no `â` encoding artifact remains in the routing map files.
- Verified the diff is limited to:
  - ROUTING_MAP.md
  - adapters/codex/skills/conductor/ROUTING_MAP.md