### PR TITLE
Feature/conductor final routing alignment

### DIFF
--- a/ROUTING_MAP.md
+++ b/ROUTING_MAP.md
@@ -30,15 +30,16 @@ If Arbiter returns `HOLD` or `BLOCKED`, the Conductor pauses continuation, merge
 |-----------|--------------|-----------|
 | Business alignment, scope, requirements review | `the-steward` | Validating project direction or SDLC |
 | Legal, compliance, privacy, IP, licensing review | `the-governor` | Validating compliance or legal risk |
-| Continuity, handoff, merge readiness, branch divergence, source-of-truth review | `arbiter` | Transition, validation, or continuation safety is uncertain |
-| UI/UX review, accessibility, frontend layout | `cloak` | Reviewing user-facing visible layers |
-| README, documentation, final submission | `scribe` | Source evidence is available to verify claims. **Fallback**: if source evidence is unavailable, Scribe must stop, report the missing evidence, and return control to the Conductor. It must not generate speculative documentation. |
-| SQL, schemas, database testing, migrations | `chronicler` | Analyzing data layers or database relationships |
-| QA, release readiness, test cases, defects | `overseer` | Normal quality assurance |
-| Security, privacy, RBAC, defensive review | `cipher` | Evaluating defensive posture |
-| UML, ERD visuals, architecture workflows | `weaver` | Creating or reviewing system models |
+| Continuity, handoff, merge readiness, branch drift, source-of-truth checks | `arbiter` | Transition, validation, or continuation safety is uncertain |
+| Implementation, code editing, minimal safe edits | `ponytail` | Design/architecture is clear and ready for code |
 | OOP, SOLID, code structure, architecture, refactoring | `clockwork` | Reviewing architecture, layering, or object-oriented design |
-| Gated resilience or negative testing | `dagger` | Requires explicit approval and safe environment |
+| SQL, schemas, persistence, ORM, migrations, normalization | `chronicler` | Analyzing data layers or database relationships |
+| Security, privacy, RBAC, auth, API hardening | `cipher` | Evaluating defensive posture |
+| UI/UX review, accessibility, frontend layout, secure UX | `cloak` | Reviewing user-facing visible layers |
+| QA, release readiness, test cases, defects, validation gates | `overseer` | Normal quality assurance |
+| Controlled stress, failure scenarios, chaos, negative testing | `dagger` | Requires explicit approval and safe environment |
+| README, documentation, source-backed prose | `scribe` | Source evidence is available to verify claims. |
+| UML, ERD visuals, architecture workflows, Mermaid/PlantUML | `weaver` | Creating or reviewing system models |
 | Broad, unclear, or multi-skill tasks | `conductor` | When ownership overlaps or dependencies exist |
 
 ## Conductor Authority

--- a/adapters/codex/skills/conductor/ROUTING_MAP.md
+++ b/adapters/codex/skills/conductor/ROUTING_MAP.md
@@ -30,15 +30,16 @@ If Arbiter returns `HOLD` or `BLOCKED`, the Conductor pauses continuation, merge
 |-----------|--------------|-----------|
 | Business alignment, scope, requirements review | `the-steward` | Validating project direction or SDLC |
 | Legal, compliance, privacy, IP, licensing review | `the-governor` | Validating compliance or legal risk |
-| Continuity, handoff, merge readiness, branch divergence, source-of-truth review | `arbiter` | Transition, validation, or continuation safety is uncertain |
-| UI/UX review, accessibility, frontend layout | `cloak` | Reviewing user-facing visible layers |
-| README, documentation, final submission | `scribe` | Source evidence is available to verify claims. **Fallback**: if source evidence is unavailable, Scribe must stop, report the missing evidence, and return control to the Conductor. It must not generate speculative documentation. |
-| SQL, schemas, database testing, migrations | `chronicler` | Analyzing data layers or database relationships |
-| QA, release readiness, test cases, defects | `overseer` | Normal quality assurance |
-| Security, privacy, RBAC, defensive review | `cipher` | Evaluating defensive posture |
-| UML, ERD visuals, architecture workflows | `weaver` | Creating or reviewing system models |
+| Continuity, handoff, merge readiness, branch drift, source-of-truth checks | `arbiter` | Transition, validation, or continuation safety is uncertain |
+| Implementation, code editing, minimal safe edits | `ponytail` | Design/architecture is clear and ready for code |
 | OOP, SOLID, code structure, architecture, refactoring | `clockwork` | Reviewing architecture, layering, or object-oriented design |
-| Gated resilience or negative testing | `dagger` | Requires explicit approval and safe environment |
+| SQL, schemas, persistence, ORM, migrations, normalization | `chronicler` | Analyzing data layers or database relationships |
+| Security, privacy, RBAC, auth, API hardening | `cipher` | Evaluating defensive posture |
+| UI/UX review, accessibility, frontend layout, secure UX | `cloak` | Reviewing user-facing visible layers |
+| QA, release readiness, test cases, defects, validation gates | `overseer` | Normal quality assurance |
+| Controlled stress, failure scenarios, chaos, negative testing | `dagger` | Requires explicit approval and safe environment |
+| README, documentation, source-backed prose | `scribe` | Source evidence is available to verify claims. |
+| UML, ERD visuals, architecture workflows, Mermaid/PlantUML | `weaver` | Creating or reviewing system models |
 | Broad, unclear, or multi-skill tasks | `conductor` | When ownership overlaps or dependencies exist |
 
 ## Conductor Authority

--- a/adapters/codex/skills/conductor/SKILL.md
+++ b/adapters/codex/skills/conductor/SKILL.md
@@ -131,42 +131,54 @@ Before routing any request to execution skills, the Conductor **must** perform *
 
 ## Task Type Detection & Routing Matrix
 
-Classify the user's request into one of the following Task Types and route it exactly as specified:
+1. **Architecture & Refactoring**
+   â†’ `clockwork` (for OOP, SOLID, layering, boundary identification) â†’ `ponytail` (for implementation)
 
-1. **Bug Fix**
-   â†’ `ponytail`
+2. **Database & Persistence**
+   â†’ `chronicler` (for SQL, schema, ORM, migrations, normalization) â†’ `ponytail`
 
-2. **Architecture Design**
-   â†’ `clockwork`
+3. **Security & Privacy**
+   â†’ `cipher` (for RBAC, auth, secrets, API hardening) â†’ `ponytail`
 
-3. **Backend Development (Feature)**
-   â†’ `clockwork` (only if new architecture/boundaries are needed) â†’ `ponytail`
+4. **UI/UX & Frontend**
+   â†’ `cloak` (for accessibility, responsive layout, secure UX) â†’ `ponytail`
 
-4. **Feature Development (General)**
-   â†’ `clockwork` (if boundary needed) â†’ `ponytail`
+5. **QA, Testing & Validation**
+   â†’ `overseer` (for test strategy, validation gates, release readiness)
 
-5. **Refactoring**
-   â†’ `clockwork` (for boundary identification) â†’ `ponytail` (for implementation)
+6. **Controlled Stress & Resilience**
+   â†’ `dagger` (for chaos, negative testing, failure scenarios - only when authorized)
 
-6. **Security Review**
-   â†’ `cipher` â†’ `ponytail`
+7. **Documentation & Knowledge**
+   â†’ `scribe` (for source-backed documentation and prose)
 
-7. **Database & Record Accuracy Work**
-   â†’ `chronicler` (must confirm UI/domain mapping, source links, and asset availability) â†’ `ponytail`
+8. **Diagrams & Visual Modeling**
+   â†’ `weaver` (for Mermaid/PlantUML, UML, ERD)
 
-**Ponytail Handoff Restriction:**
-Ponytail must not implement factual or curated records until Chronicler confirms source-of-truth fields, domain/interface fields, UI-rendered fields, fallback behavior, source link structure, and asset availability.
+9. **Continuity & Transition Review**
+   â†’ `arbiter` (for branch drift, validation gaps, merge readiness, source-of-truth uncertainty)
 
-8. **UI/UX Work**
-   â†’ `cloak` â†’ `ponytail`
+10. **General Implementation & Bug Fixes**
+    â†’ `ponytail` (for safe code navigation and minimal safe edits - no architecture/design decisions)
 
-9. **Documentation**
-   â†’ `scribe`
+### Bounded Routing Rules
 
-*Note: For testing/QA, route to `overseer`.*
+- **Bounded Task Packets:** Conductor must create small, discrete task packets.
+- **Decision First, Implementation Second:** Conductor should route the decision-making specialist first, then `ponytail` only for implementation.
+- **No Monolithic Handoffs:** Conductor must not collapse all work into `ponytail`. Ponytail is the implementation destination, not a general governance or design authority.
+- **Arbiter Safety:** Conductor must not bypass `arbiter` when transition, merge, or validation risk exists.
+- **Secure UX Routing:** Conductor must not route security-sensitive UI concerns only to `cloak`; use `cipher` first, then `cloak`.
+- **Database Safety:** Conductor must not route database-backed implementation directly to `ponytail` without `chronicler` when schema/persistence rules are unclear.
+- **Architecture Safety:** Conductor must not route architecture refactors directly to `ponytail` without `clockwork` when boundaries are unclear.
 
-10. **Continuity / Transition Review**
-   â†’ `arbiter`
+### Routing Examples
+
+- **"Implement feature with new DB table"** â†’ `chronicler`, `clockwork` if layering is affected, `ponytail`, `overseer`
+- **"Fix UI form layout and validation messages"** â†’ `cloak`, `cipher` if security-sensitive, `ponytail`, `overseer`
+- **"Review API for abuse and overload protection"** â†’ `cipher`, `dagger` if controlled scenario expansion is approved, `overseer`
+- **"Refactor service/repository logic"** â†’ `clockwork`, `ponytail`, `overseer`
+- **"Prepare project documentation"** â†’ `scribe`, with specialist source-of-truth owner first when technical facts are involved
+- **"After interrupted branch work"** â†’ `arbiter` before continuing
 
 ## Central Naming Resolution
 Use `aliases.json` in the project root to map old multi-word names (e.g. `cloak-meister`) to their clean clean one-word counterparts (e.g. `cloak`) dynamically. If user prompts or environment states use older names, resolve them to the clean slugs before routing.

--- a/adapters/codex/skills/conductor/SKILL.md
+++ b/adapters/codex/skills/conductor/SKILL.md
@@ -55,7 +55,7 @@ The following gates must be enforced across all orchestration, to prevent contex
 - No implementation handoff.
 - No generated report file unless user explicitly approves writing an artifact.
 - Final output must be findings and fix plan only.
-- Acme must verify `git status` did not change after audit-only tasks.
+- Conductor must verify `git status` did not change after audit-only tasks.
 
 ### 4. Conductor Scalability (Bounded Task Packets)
 **Trigger:** Routing to any specialist execution skill.
@@ -113,10 +113,10 @@ Before routing any request to execution skills, the Conductor **must** perform *
 5. **Release Mode**: For production deployment, public releases, or client delivery. Enforces strict compliance gates; requires complete context and halts on any unresolved flags.
 
 **Gate Rules (for Prototype, Implementation, Audit, and Release modes):**
-- If Steward or Governor returns `BLOCKED` â†’ Conductor **stops**. Returns findings to requester.
-- If Steward or Governor returns `REVISION_REQUIRED` (and mode requires it) â†’ Conductor **pauses**. Returns findings for revision.
-- If Governor sets `human_review_required: true` â†’ Conductor **pauses** until human review completes.
-- If both return `APPROVED`, `ADVISORY_ONLY`, or `NOT_APPLICABLE` â†’ Conductor proceeds to routing.
+- If Steward or Governor returns `BLOCKED` -> Conductor **stops**. Returns findings to requester.
+- If Steward or Governor returns `REVISION_REQUIRED` (and mode requires it) -> Conductor **pauses**. Returns findings for revision.
+- If Governor sets `human_review_required: true` -> Conductor **pauses** until human review completes.
+- If both return `APPROVED`, `ADVISORY_ONLY`, or `NOT_APPLICABLE` -> Conductor proceeds to routing.
 
 **Fast Path:** For trivial requests, typo fixes, formatting-only edits, simple explanations, or low-risk local changes, the Conductor proceeds immediately under a fast path.
 
@@ -132,34 +132,34 @@ Before routing any request to execution skills, the Conductor **must** perform *
 ## Task Type Detection & Routing Matrix
 
 1. **Architecture & Refactoring**
-   â†’ `clockwork` (for OOP, SOLID, layering, boundary identification) â†’ `ponytail` (for implementation)
+   -> `clockwork` (for OOP, SOLID, layering, boundary identification) -> `ponytail` (for implementation)
 
 2. **Database & Persistence**
-   â†’ `chronicler` (for SQL, schema, ORM, migrations, normalization) â†’ `ponytail`
+   -> `chronicler` (for SQL, schema, ORM, migrations, normalization) -> `ponytail`
 
 3. **Security & Privacy**
-   â†’ `cipher` (for RBAC, auth, secrets, API hardening) â†’ `ponytail`
+   -> `cipher` (for RBAC, auth, secrets, API hardening) -> `ponytail`
 
 4. **UI/UX & Frontend**
-   â†’ `cloak` (for accessibility, responsive layout, secure UX) â†’ `ponytail`
+   -> `cloak` (for accessibility, responsive layout, secure UX) -> `ponytail`
 
 5. **QA, Testing & Validation**
-   â†’ `overseer` (for test strategy, validation gates, release readiness)
+   -> `overseer` (for test strategy, validation gates, release readiness)
 
 6. **Controlled Stress & Resilience**
-   â†’ `dagger` (for chaos, negative testing, failure scenarios - only when authorized)
+   -> `dagger` (for chaos, negative testing, failure scenarios - only when authorized)
 
 7. **Documentation & Knowledge**
-   â†’ `scribe` (for source-backed documentation and prose)
+   -> `scribe` (for source-backed documentation and prose)
 
 8. **Diagrams & Visual Modeling**
-   â†’ `weaver` (for Mermaid/PlantUML, UML, ERD)
+   -> `weaver` (for Mermaid/PlantUML, UML, ERD)
 
 9. **Continuity & Transition Review**
-   â†’ `arbiter` (for branch drift, validation gaps, merge readiness, source-of-truth uncertainty)
+   -> `arbiter` (for branch drift, validation gaps, merge readiness, source-of-truth uncertainty)
 
 10. **General Implementation & Bug Fixes**
-    â†’ `ponytail` (for safe code navigation and minimal safe edits - no architecture/design decisions)
+    -> `ponytail` (for safe code navigation and minimal safe edits - no architecture/design decisions)
 
 ### Bounded Routing Rules
 
@@ -173,12 +173,12 @@ Before routing any request to execution skills, the Conductor **must** perform *
 
 ### Routing Examples
 
-- **"Implement feature with new DB table"** â†’ `chronicler`, `clockwork` if layering is affected, `ponytail`, `overseer`
-- **"Fix UI form layout and validation messages"** â†’ `cloak`, `cipher` if security-sensitive, `ponytail`, `overseer`
-- **"Review API for abuse and overload protection"** â†’ `cipher`, `dagger` if controlled scenario expansion is approved, `overseer`
-- **"Refactor service/repository logic"** â†’ `clockwork`, `ponytail`, `overseer`
-- **"Prepare project documentation"** â†’ `scribe`, with specialist source-of-truth owner first when technical facts are involved
-- **"After interrupted branch work"** â†’ `arbiter` before continuing
+- **"Implement feature with new DB table"** -> `chronicler`, `clockwork` if layering is affected, `ponytail`, `overseer`
+- **"Fix UI form layout and validation messages"** -> `cloak`, `cipher` if security-sensitive, `ponytail`, `overseer`
+- **"Review API for abuse and overload protection"** -> `cipher`, `dagger` if controlled scenario expansion is approved, `overseer`
+- **"Refactor service/repository logic"** -> `clockwork`, `ponytail`, `overseer`
+- **"Prepare project documentation"** -> `scribe`, with specialist source-of-truth owner first when technical facts are involved
+- **"After interrupted branch work"** -> `arbiter` before continuing
 
 ## Central Naming Resolution
 Use `aliases.json` in the project root to map old multi-word names (e.g. `cloak-meister`) to their clean clean one-word counterparts (e.g. `cloak`) dynamically. If user prompts or environment states use older names, resolve them to the clean slugs before routing.

--- a/skills/conductor/SKILL.md
+++ b/skills/conductor/SKILL.md
@@ -62,7 +62,7 @@ The following gates must be enforced across all orchestration, to prevent contex
 - No implementation handoff.
 - No generated report file unless user explicitly approves writing an artifact.
 - Final output must be findings and fix plan only.
-- Acme must verify `git status` did not change after audit-only tasks.
+- Conductor must verify `git status` did not change after audit-only tasks.
 
 ### 4. Conductor Scalability (Bounded Task Packets)
 **Trigger:** Routing to any specialist execution skill.
@@ -120,10 +120,10 @@ Before routing any request to execution skills, the Conductor **must** perform *
 5. **Release Mode**: For production deployment, public releases, or client delivery. Enforces strict compliance gates; requires complete context and halts on any unresolved flags.
 
 **Gate Rules (for Prototype, Implementation, Audit, and Release modes):**
-- If Steward or Governor returns `BLOCKED` → Conductor **stops**. Returns findings to requester.
-- If Steward or Governor returns `REVISION_REQUIRED` (and mode requires it) → Conductor **pauses**. Returns findings for revision.
-- If Governor sets `human_review_required: true` → Conductor **pauses** until human review completes.
-- If both return `APPROVED`, `ADVISORY_ONLY`, or `NOT_APPLICABLE` → Conductor proceeds to routing.
+- If Steward or Governor returns `BLOCKED` -> Conductor **stops**. Returns findings to requester.
+- If Steward or Governor returns `REVISION_REQUIRED` (and mode requires it) -> Conductor **pauses**. Returns findings for revision.
+- If Governor sets `human_review_required: true` -> Conductor **pauses** until human review completes.
+- If both return `APPROVED`, `ADVISORY_ONLY`, or `NOT_APPLICABLE` -> Conductor proceeds to routing.
 
 **Fast Path:** For trivial requests, typo fixes, formatting-only edits, simple explanations, or low-risk local changes, the Conductor proceeds immediately under a fast path.
 
@@ -139,34 +139,34 @@ Before routing any request to execution skills, the Conductor **must** perform *
 ## Task Type Detection & Routing Matrix
 
 1. **Architecture & Refactoring**
-   → `clockwork` (for OOP, SOLID, layering, boundary identification) → `ponytail` (for implementation)
+   -> `clockwork` (for OOP, SOLID, layering, boundary identification) -> `ponytail` (for implementation)
 
 2. **Database & Persistence**
-   → `chronicler` (for SQL, schema, ORM, migrations, normalization) → `ponytail`
+   -> `chronicler` (for SQL, schema, ORM, migrations, normalization) -> `ponytail`
 
 3. **Security & Privacy**
-   → `cipher` (for RBAC, auth, secrets, API hardening) → `ponytail`
+   -> `cipher` (for RBAC, auth, secrets, API hardening) -> `ponytail`
 
 4. **UI/UX & Frontend**
-   → `cloak` (for accessibility, responsive layout, secure UX) → `ponytail`
+   -> `cloak` (for accessibility, responsive layout, secure UX) -> `ponytail`
 
 5. **QA, Testing & Validation**
-   → `overseer` (for test strategy, validation gates, release readiness)
+   -> `overseer` (for test strategy, validation gates, release readiness)
 
 6. **Controlled Stress & Resilience**
-   → `dagger` (for chaos, negative testing, failure scenarios - only when authorized)
+   -> `dagger` (for chaos, negative testing, failure scenarios - only when authorized)
 
 7. **Documentation & Knowledge**
-   → `scribe` (for source-backed documentation and prose)
+   -> `scribe` (for source-backed documentation and prose)
 
 8. **Diagrams & Visual Modeling**
-   → `weaver` (for Mermaid/PlantUML, UML, ERD)
+   -> `weaver` (for Mermaid/PlantUML, UML, ERD)
 
 9. **Continuity & Transition Review**
-   → `arbiter` (for branch drift, validation gaps, merge readiness, source-of-truth uncertainty)
+   -> `arbiter` (for branch drift, validation gaps, merge readiness, source-of-truth uncertainty)
 
 10. **General Implementation & Bug Fixes**
-    → `ponytail` (for safe code navigation and minimal safe edits - no architecture/design decisions)
+    -> `ponytail` (for safe code navigation and minimal safe edits - no architecture/design decisions)
 
 ### Bounded Routing Rules
 
@@ -180,12 +180,12 @@ Before routing any request to execution skills, the Conductor **must** perform *
 
 ### Routing Examples
 
-- **"Implement feature with new DB table"** → `chronicler`, `clockwork` if layering is affected, `ponytail`, `overseer`
-- **"Fix UI form layout and validation messages"** → `cloak`, `cipher` if security-sensitive, `ponytail`, `overseer`
-- **"Review API for abuse and overload protection"** → `cipher`, `dagger` if controlled scenario expansion is approved, `overseer`
-- **"Refactor service/repository logic"** → `clockwork`, `ponytail`, `overseer`
-- **"Prepare project documentation"** → `scribe`, with specialist source-of-truth owner first when technical facts are involved
-- **"After interrupted branch work"** → `arbiter` before continuing
+- **"Implement feature with new DB table"** -> `chronicler`, `clockwork` if layering is affected, `ponytail`, `overseer`
+- **"Fix UI form layout and validation messages"** -> `cloak`, `cipher` if security-sensitive, `ponytail`, `overseer`
+- **"Review API for abuse and overload protection"** -> `cipher`, `dagger` if controlled scenario expansion is approved, `overseer`
+- **"Refactor service/repository logic"** -> `clockwork`, `ponytail`, `overseer`
+- **"Prepare project documentation"** -> `scribe`, with specialist source-of-truth owner first when technical facts are involved
+- **"After interrupted branch work"** -> `arbiter` before continuing
 
 ## Central Naming Resolution
 Use `aliases.json` in the project root to map old multi-word names (e.g. `cloak-meister`) to their clean clean one-word counterparts (e.g. `cloak`) dynamically. If user prompts or environment states use older names, resolve them to the clean slugs before routing.

--- a/skills/conductor/SKILL.md
+++ b/skills/conductor/SKILL.md
@@ -138,42 +138,54 @@ Before routing any request to execution skills, the Conductor **must** perform *
 
 ## Task Type Detection & Routing Matrix
 
-Classify the user's request into one of the following Task Types and route it exactly as specified:
+1. **Architecture & Refactoring**
+   → `clockwork` (for OOP, SOLID, layering, boundary identification) → `ponytail` (for implementation)
 
-1. **Bug Fix**
-   → `ponytail`
+2. **Database & Persistence**
+   → `chronicler` (for SQL, schema, ORM, migrations, normalization) → `ponytail`
 
-2. **Architecture Design**
-   → `clockwork`
+3. **Security & Privacy**
+   → `cipher` (for RBAC, auth, secrets, API hardening) → `ponytail`
 
-3. **Backend Development (Feature)**
-   → `clockwork` (only if new architecture/boundaries are needed) → `ponytail`
+4. **UI/UX & Frontend**
+   → `cloak` (for accessibility, responsive layout, secure UX) → `ponytail`
 
-4. **Feature Development (General)**
-   → `clockwork` (if boundary needed) → `ponytail`
+5. **QA, Testing & Validation**
+   → `overseer` (for test strategy, validation gates, release readiness)
 
-5. **Refactoring**
-   → `clockwork` (for boundary identification) → `ponytail` (for implementation)
+6. **Controlled Stress & Resilience**
+   → `dagger` (for chaos, negative testing, failure scenarios - only when authorized)
 
-6. **Security Review**
-   → `cipher` → `ponytail`
+7. **Documentation & Knowledge**
+   → `scribe` (for source-backed documentation and prose)
 
-7. **Database & Record Accuracy Work**
-   → `chronicler` (must confirm UI/domain mapping, source links, and asset availability) → `ponytail`
+8. **Diagrams & Visual Modeling**
+   → `weaver` (for Mermaid/PlantUML, UML, ERD)
 
-**Ponytail Handoff Restriction:**
-Ponytail must not implement factual or curated records until Chronicler confirms source-of-truth fields, domain/interface fields, UI-rendered fields, fallback behavior, source link structure, and asset availability.
+9. **Continuity & Transition Review**
+   → `arbiter` (for branch drift, validation gaps, merge readiness, source-of-truth uncertainty)
 
-8. **UI/UX Work**
-   → `cloak` → `ponytail`
+10. **General Implementation & Bug Fixes**
+    → `ponytail` (for safe code navigation and minimal safe edits - no architecture/design decisions)
 
-9. **Documentation**
-   → `scribe`
+### Bounded Routing Rules
 
-*Note: For testing/QA, route to `overseer`.*
+- **Bounded Task Packets:** Conductor must create small, discrete task packets.
+- **Decision First, Implementation Second:** Conductor should route the decision-making specialist first, then `ponytail` only for implementation.
+- **No Monolithic Handoffs:** Conductor must not collapse all work into `ponytail`. Ponytail is the implementation destination, not a general governance or design authority.
+- **Arbiter Safety:** Conductor must not bypass `arbiter` when transition, merge, or validation risk exists.
+- **Secure UX Routing:** Conductor must not route security-sensitive UI concerns only to `cloak`; use `cipher` first, then `cloak`.
+- **Database Safety:** Conductor must not route database-backed implementation directly to `ponytail` without `chronicler` when schema/persistence rules are unclear.
+- **Architecture Safety:** Conductor must not route architecture refactors directly to `ponytail` without `clockwork` when boundaries are unclear.
 
-10. **Continuity / Transition Review**
-   → `arbiter`
+### Routing Examples
+
+- **"Implement feature with new DB table"** → `chronicler`, `clockwork` if layering is affected, `ponytail`, `overseer`
+- **"Fix UI form layout and validation messages"** → `cloak`, `cipher` if security-sensitive, `ponytail`, `overseer`
+- **"Review API for abuse and overload protection"** → `cipher`, `dagger` if controlled scenario expansion is approved, `overseer`
+- **"Refactor service/repository logic"** → `clockwork`, `ponytail`, `overseer`
+- **"Prepare project documentation"** → `scribe`, with specialist source-of-truth owner first when technical facts are involved
+- **"After interrupted branch work"** → `arbiter` before continuing
 
 ## Central Naming Resolution
 Use `aliases.json` in the project root to map old multi-word names (e.g. `cloak-meister`) to their clean clean one-word counterparts (e.g. `cloak`) dynamically. If user prompts or environment states use older names, resolve them to the clean slugs before routing.


### PR DESCRIPTION
**Align Conductor routing with specialist foundations**

## Summary
- Aligned Conductor routing with the completed specialist stack.
- Added bounded routing rules for decision-first, implementation-second workflows.
- Clarified Ponytail as the implementation destination, not a design or governance authority.
- Added routing examples for database, UI, API hardening, refactoring, documentation, and interrupted branch work.
- Updated ROUTING_MAP.md for all current specialists.
- Fixed stale Conductor audit-gate wording and normalized routing arrows to ASCII to prevent encoding artifacts.
- Refreshed the Codex export for Conductor.

## Validation
- validate-structure.ps1 passed.
- validate-manifest.ps1 passed.
- check-stale-references.ps1 passed.
- validate-codex-export.ps1 passed.
- git diff --check passed.
- Pre-commit guardrail passed.