### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/scripts/helpers.py
+++ b/scripts/helpers.py
@@ -25,6 +25,22 @@ def test_file_not_empty(path):
     except OSError:
         return False
 
+def _sanitize_log_message(message):
+    import re
+    text = str(message)
+    redaction_patterns = [
+        re.compile(r'\bAKIA[0-9A-Z]{16}\b'),
+        re.compile(r'https://hooks\.slack\.com/services/T[A-Z0-9]+/B[A-Z0-9]+/[A-Za-z0-9]+'),
+        re.compile(r'(api[_-]?key\s*[:=]\s*["\'])[A-Za-z0-9_\-+=]{16,}(["\'])', re.IGNORECASE),
+        re.compile(r'-----BEGIN[ A-Z]+PRIVATE KEY-----')
+    ]
+    for pattern in redaction_patterns:
+        if pattern.pattern.startswith('(api'):
+            text = pattern.sub(r'\1[REDACTED]\2', text)
+        else:
+            text = pattern.sub('[REDACTED]', text)
+    return text
+
 def write_color_host(msg_type, message):
     colors = {
         'SUCCESS': '\033[92m', # Green
@@ -34,7 +50,8 @@ def write_color_host(msg_type, message):
     }
     reset = '\033[0m'
     color = colors.get(msg_type, '\033[96m')
-    print(f"{color}[{msg_type}] {message}{reset}")
+    safe_message = _sanitize_log_message(message)
+    print(f"{color}[{msg_type}] {safe_message}{reset}")
 
 def get_json_manifest(path=""):
     root = get_project_root()


### PR DESCRIPTION
Potential fix for [https://github.com/Baelfyre/Orchestra/security/code-scanning/1](https://github.com/Baelfyre/Orchestra/security/code-scanning/1)

General fix approach: avoid logging raw content that may contain secrets, and redact sensitive portions before emitting messages. The best minimal-change fix is to sanitize message text centrally in `helpers.write_color_host`, so all current/future callers benefit without changing behavior elsewhere.

Best single fix here:
- In `scripts/helpers.py`, add a helper that redacts high-risk patterns (AWS keys, Slack webhook URLs, generic API key assignments, private key headers).
- Update `write_color_host` to sanitize `message` before printing.
- Keep colorized output and message structure unchanged, only replacing sensitive substrings with `[REDACTED]`.

This preserves functionality (users still see violation type, file, and line number) while preventing clear-text exposure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
