### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text storage of sensitive information

### DIFF
--- a/tests/behavior/run_tests.py
+++ b/tests/behavior/run_tests.py
@@ -46,7 +46,7 @@ def main():
     os.makedirs(temp_dir, exist_ok=True)
     try:
         violation_file = os.path.join(temp_dir, "mock_secrets.txt")
-        mock_secret = "AKIA" + "1234567890ABCDEF"
+        mock_secret = "REDACT_ME_TEST_TOKEN"
         with open(violation_file, "w", encoding="utf-8") as f:
             f.write(f"AWS_SECRET = {mock_secret}")
         


### PR DESCRIPTION
Potential fix for [https://github.com/Baelfyre/Orchestra/security/code-scanning/2](https://github.com/Baelfyre/Orchestra/security/code-scanning/2)

General fix: avoid writing sensitive data (or realistic secret values) in plaintext to storage. For tests, use a clearly non-sensitive sentinel string that exercises detection logic without representing an actual secret.

Best fix here (without changing behavior): in `tests/behavior/run_tests.py`, replace the hardcoded secret-like value with a non-sensitive placeholder token and keep the rest of the regression flow intact (including leak-check assertion against that placeholder). This preserves the test’s purpose (guardrail finds/redacts suspicious content) while removing clear-text storage of a secret.

Changes needed:
- In the regression test block around lines 49–51, change `mock_secret` assignment from `AKIA...` to a benign placeholder (for example `REDACT_ME_TEST_TOKEN`).
- Keep line 51 writing `AWS_SECRET = {mock_secret}` so the guardrail still sees a suspicious key context.
- No new imports, methods, or dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
