### PR TITLE
chore(ci): update governance workflow actions

### DIFF
--- a/.github/workflows/governance-check.yml
+++ b/.github/workflows/governance-check.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -60,7 +60,7 @@ jobs:
 
       - name: Upload Governance Artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: governance-validation-report
           path: artifacts/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This changelog tracks the repository history using git tags, merge history, and 
 
 ## Unreleased
 
+### Changed
+- Updated GitHub Actions dependencies for the governance workflow:
+  - actions/checkout from v4 to v7
+  - actions/setup-python from v5 to v6
+  - actions/upload-artifact from v4 to v7
+
 Changes after `v1.0.1` currently tracked in this checkout:
 
 - Added local repository sync preflight governance check (`scripts/preflight_sync_check.py`) for new development phases and editing sessions.


### PR DESCRIPTION
## Summary
- Updated governance workflow GitHub Actions dependencies:
  - actions/checkout from v4 to v7
  - actions/setup-python from v5 to v6
  - actions/upload-artifact from v4 to v7
- Added/confirmed the CHANGELOG.md entry for the workflow dependency update.

## Validation
- python scripts/governance_check.py --strict
- python scripts/test_dagger_guardrail.py
- python tests/behavior/evaluate_governance.py
- python tests/behavior/run_tests.py
- python -m json.tool plugin.json | Out-Null
- git diff --check

## Notes
This rollup supersedes the individual Dependabot PRs for checkout, setup-python, and upload-artifact.