### PR TITLE
chore(ci): restrict governance workflow permissions

### DIFF
--- a/.github/workflows/governance-check.yml
+++ b/.github/workflows/governance-check.yml
@@ -9,6 +9,10 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+  artifact-metadata: write
+
 jobs:
   governance-check:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog tracks the repository history using git tags, merge history, and 
 
 ## Unreleased
 
+- Added explicit least-privilege permissions to the Governance Check workflow.
+
 ### Changed
 - Updated GitHub Actions dependencies for the governance workflow:
   - actions/checkout from v4 to v7


### PR DESCRIPTION
## Summary
- Added explicit least-privilege permissions to the Governance Check workflow.
- Keeps repository contents access read-only.
- Allows artifact metadata writes for governance validation artifact upload.

## Validation
- python scripts/governance_check.py --strict
- python scripts/test_dagger_guardrail.py
- python tests/behavior/evaluate_governance.py
- python tests/behavior/run_tests.py
- python -m json.tool plugin.json | Out-Null
- git diff --check

## Notes
This addresses the open workflow permissions security finding by declaring workflow-level permissions instead of relying on implicit defaults.