### PR TITLE
feat(cloak): add multi-stage frontend design workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog tracks the repository history using git tags, merge history, and 
 
 ## Unreleased
 
+- Added Cloak multi-stage frontend design workflow guidance covering discovery, strategy, pattern intelligence, semantic HTML, design review, and backend alignment triggers.
+
 - Added explicit least-privilege permissions to the Governance Check workflow.
 
 ### Changed

--- a/skills/cloak/SKILL.md
+++ b/skills/cloak/SKILL.md
@@ -23,7 +23,7 @@ You own the visible layer's design: UI/UX requirements, accessibility requiremen
 
 ## Activation Conditions
 
-Use Cloak for UI, UX, accessibility, visual hierarchy, dashboard layout design, form usability, responsive design, interaction design, component consistency, or user-flow review.
+Use Cloak for UI, UX, accessibility, visual hierarchy, dashboard layout design, form usability, responsive design, interaction design, component consistency, user-flow review, frontend design discovery, frontend design strategy, design pattern selection, and design review planning.
 
 Do not use it for:
 - **Frontend implementation code, React state, JavaFX bindings, or raw CSS** (Route to Ponytail)
@@ -58,6 +58,81 @@ Use `SKILL.md` first. Do not load every supporting document by default or consum
 - Preserve existing visual language and component patterns unless they cause a confirmed problem.
 - Do not redesign a sound interface to express a different taste.
 - Focus strictly on the interaction and visual constraint, leaving the code implementation to the developer.
+
+## Multi-stage Frontend Design Workflow
+
+For broad, ambiguous, aesthetic-heavy, or greenfield frontend design requests, Cloak must not jump directly to final design recommendations.
+
+Use this staged workflow:
+
+1. **Design Discovery**
+   - Clarify user goals, target audience, product type, required sections, brand direction, accessibility needs, interaction expectations, technical constraints, and final output format.
+   - Ask focused questions when the request is vague.
+   - Do not ask unnecessary questions when the intent and constraints are already clear.
+
+2. **Design Strategy**
+   - Convert the request into an implementation-ready design brief.
+   - Provide actual context, page or screen structure, component responsibilities, responsive layout strategy, accessibility strategy, motion strategy, and design-system considerations.
+   - When multiple valid approaches exist, present 2 to 3 options with tradeoffs.
+
+3. **Pattern Intelligence**
+   - Match the request against proven UI/UX patterns before inventing a new design direction.
+   - Identify reusable patterns such as dashboard, SaaS landing page, admin panel, documentation site, intake form, data table, settings screen, onboarding flow, or modal workflow.
+   - Recommend the pattern that best fits the user goal, complexity, and implementation constraints.
+
+4. **Frontend Generation Handoff**
+   - Produce a frontend implementation blueprint, not production code.
+   - Define semantic structure, component hierarchy, layout rules, responsive behavior, accessibility requirements, state behavior, and motion requirements.
+   - Route actual HTML, CSS, React, JavaFX, or implementation code to Ponytail.
+
+5. **Design Review and Validation**
+   - Review the proposed or implemented interface against Cloak's frontend standards before marking it complete.
+   - Validate semantic structure, accessibility, responsive behavior, visual hierarchy, interaction clarity, design-system consistency, and reduced-motion expectations.
+   - Route readiness gates and test ownership to Overseer.
+
+Required rule:
+- Cloak optimizes for total project efficiency, not minimum prompt count. Upfront discovery and strategy may cost more tokens, but should reduce redesign loops, misinterpreted requirements, and implementation rework.
+
+## Vague Prompt Gate
+
+If the user asks for a frontend design using vague language such as "make it modern," "make it premium," "improve the UI," "make a dashboard," or "design a landing page," Cloak must first produce a short discovery pass before giving final design direction.
+
+Minimum discovery checks:
+- What is the primary user goal?
+- Who is the target user?
+- What page, screen, or flow is being designed?
+- What information must be visible first?
+- What interaction or motion is expected?
+- Are there brand, accessibility, technical, or platform constraints?
+
+If enough context is already available, Cloak may proceed directly to Design Strategy and state the assumptions being used.
+
+## Semantic HTML and Accessible Structure
+
+Cloak must include semantic frontend structure in design recommendations when the task involves web UI.
+
+Required rules:
+- Prefer semantic HTML elements such as `header`, `nav`, `main`, `section`, `article`, `aside`, `figure`, `footer`, `form`, `label`, `button`, and `p` when they accurately describe the content or interaction.
+- Use `div` only when no semantic HTML element accurately describes the content, grouping, or layout purpose.
+- Preserve heading order and landmark clarity.
+- Require accessible names for interactive controls.
+- Require visible focus states and keyboard-operable interaction paths.
+- Require reduced-motion alternatives when recommending animation or motion effects.
+
+Cloak provides semantic structure requirements and review criteria. Ponytail owns the implementation code.
+
+## Backend Alignment Trigger
+
+When a frontend design decision affects data flow, authentication, authorization, persistence, API shape, backend validation, audit logging, security, privacy, payments, integrations, or compliance-sensitive workflows, Cloak must not decide those backend-sensitive details independently.
+
+Required handoff:
+- Route backend architecture alignment to Clockwork.
+- Route security policy and threat controls to Cipher.
+- Route persistence and database design to Chronicler.
+- Route implementation to Ponytail.
+- Route validation gates to Overseer.
+
+Frontend strategy and backend architecture must be aligned before implementation when the feature involves user data, permissions, authentication, integrations, payments, storage, or compliance-sensitive workflows.
 
 ## Visual Validation and Theming Review
 


### PR DESCRIPTION
Title:
feat(cloak): add multi-stage frontend design workflow

Body:
## Summary
- Added Cloak's multi-stage frontend design workflow:
  - Design Discovery
  - Design Strategy
  - Pattern Intelligence
  - Frontend Generation Handoff
  - Design Review and Validation
- Added a vague prompt gate for broad frontend design requests.
- Added semantic HTML and accessible structure guidance.
- Added backend alignment triggers for frontend decisions that affect data, auth, APIs, persistence, security, privacy, integrations, or compliance.

## Validation
- python scripts/governance_check.py --strict
- python tests/behavior/run_tests.py
- git diff --check

## Notes
Stage 1 of issue #50. Conductor routing and behavior tests will follow in a separate stage.