### PR TITLE
test(conductor): validate frontend backend routing contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog tracks the repository history using git tags, merge history, and 
 
 ## Unreleased
 
+- Added behavior fixtures validating Conductor routing for Cloak multi-stage workflow preservation and frontend/backend alignment with Clockwork, Cipher, and Chronicler.
+
 - Added Conductor routing rules for Cloak and backend alignment, requiring Clockwork, Cipher, and/or Chronicler before implementation when frontend work affects data, auth, APIs, persistence, security, privacy, integrations, payments, or compliance-sensitive workflows.
 
 - Added Cloak multi-stage frontend design workflow guidance covering discovery, strategy, pattern intelligence, semantic HTML, design review, and backend alignment triggers.

--- a/tests/behavior/governance-conformance-fixtures.json
+++ b/tests/behavior/governance-conformance-fixtures.json
@@ -1,98 +1,123 @@
 [
-    {
-        "scenario": "Conductor halts on Steward BLOCKED",
-        "skill": "conductor",
-        "pattern": "Steward.*BLOCKED.*stops|Steward.*BLOCKED.*halts",
-        "type": "Routing Gate"
-    },
-    {
-        "scenario": "Conductor halts on Governor BLOCKED",
-        "skill": "conductor",
-        "pattern": "Governor.*BLOCKED.*stops|Governor.*BLOCKED.*halts",
-        "type": "Routing Gate"
-    },
-    {
-        "scenario": "Conductor pauses on human_review_required: true",
-        "skill": "conductor",
-        "pattern": "human_review_required.*true.*pauses",
-        "type": "Routing Gate"
-    },
-    {
-        "scenario": "Conductor proceeds on APPROVED",
-        "skill": "conductor",
-        "pattern": "APPROVED.*proceeds",
-        "type": "Routing Gate"
-    },
-    {
-        "scenario": "Conductor does not treat NOT_APPLICABLE as full clearance",
-        "skill": "conductor",
-        "pattern": "NOT_APPLICABLE.*proceeds",
-        "type": "Routing Gate"
-    },
-    {
-        "scenario": "Arbiter returns HOLD when validation evidence is missing",
-        "skill": "arbiter",
-        "pattern": "HOLD.*missing.*proof|HOLD.*when.*missing|missing.*validation.*HOLD",
-        "type": "Continuity Gate"
-    },
-    {
-        "scenario": "Arbiter returns BLOCKED when source-of-truth conflict is unresolved",
-        "skill": "arbiter",
-        "pattern": "BLOCKED",
-        "type": "Continuity Gate"
-    },
-    {
-        "scenario": "Arbiter defines governance severity buckets",
-        "skill": "arbiter",
-        "pattern": "Critical findings.*Major findings.*Minor findings.*Cleanup findings",
-        "type": "Governance Calibration"
-    },
-    {
-        "scenario": "Arbiter uses READY_WITH_REQUIRED_FIXES for advisory governance gaps",
-        "skill": "arbiter",
-        "pattern": "READY_WITH_REQUIRED_FIXES",
-        "type": "Governance Calibration"
-    },
-    {
-        "scenario": "Arbiter keeps CI advisory and Dagger simulation-only during calibration",
-        "skill": "arbiter",
-        "pattern": "keep CI advisory|Dagger remains simulation-only and unpromoted",
-        "type": "Governance Calibration"
-    },
-    {
-        "scenario": "Routing template enforces specialist reroute",
-        "file": "templates/routing-output-template.md",
-        "pattern": "SPECIALIST_REROUTE_REQUIRED.*(do not execute|must not execute)|(do not execute|must not execute).*SPECIALIST_REROUTE_REQUIRED",
-        "type": "Routing Gate"
-    },
-    {
-        "scenario": "Conductor output formats defines specialist reroute",
-        "file": "skills/conductor/OUTPUT_FORMATS.md",
-        "pattern": "SPECIALIST_REROUTE_REQUIRED.*route the task to the correct specialist",
-        "type": "Routing Gate"
-    },
-    {
-        "scenario": "Conductor SKILL enforces scope routing",
-        "skill": "conductor",
-        "pattern": "classify.*SPECIALIST_REROUTE_REQUIRED.*must not allow a specialist to execute outside",
-        "type": "Routing Gate"
-    },
-    {
-        "scenario": "Specialist self-boundary reroute contract",
-        "skill": "ponytail",
-        "pattern": "SPECIALIST_REROUTE_REQUIRED.*do not execute|do not execute.*SPECIALIST_REROUTE_REQUIRED",
-        "type": "Routing Gate"
-    },
-    {
-        "scenario": "Arbiter severity handles specialist scope misuse",
-        "skill": "arbiter",
-        "pattern": "specialist-scope misuse without reroute",
-        "type": "Governance Calibration"
-    },
-    {
-        "scenario": "Command files contain mismatch preamble",
-        "file": "commands/dagger.md",
-        "pattern": "SPECIALIST_REROUTE_REQUIRED.*do not execute|do not execute.*SPECIALIST_REROUTE_REQUIRED",
-        "type": "Routing Gate"
-    }
+  {
+    "scenario": "Conductor halts on Steward BLOCKED",
+    "skill": "conductor",
+    "pattern": "Steward.*BLOCKED.*stops|Steward.*BLOCKED.*halts",
+    "type": "Routing Gate"
+  },
+  {
+    "scenario": "Conductor halts on Governor BLOCKED",
+    "skill": "conductor",
+    "pattern": "Governor.*BLOCKED.*stops|Governor.*BLOCKED.*halts",
+    "type": "Routing Gate"
+  },
+  {
+    "scenario": "Conductor pauses on human_review_required: true",
+    "skill": "conductor",
+    "pattern": "human_review_required.*true.*pauses",
+    "type": "Routing Gate"
+  },
+  {
+    "scenario": "Conductor proceeds on APPROVED",
+    "skill": "conductor",
+    "pattern": "APPROVED.*proceeds",
+    "type": "Routing Gate"
+  },
+  {
+    "scenario": "Conductor does not treat NOT_APPLICABLE as full clearance",
+    "skill": "conductor",
+    "pattern": "NOT_APPLICABLE.*proceeds",
+    "type": "Routing Gate"
+  },
+  {
+    "scenario": "Arbiter returns HOLD when validation evidence is missing",
+    "skill": "arbiter",
+    "pattern": "HOLD.*missing.*proof|HOLD.*when.*missing|missing.*validation.*HOLD",
+    "type": "Continuity Gate"
+  },
+  {
+    "scenario": "Arbiter returns BLOCKED when source-of-truth conflict is unresolved",
+    "skill": "arbiter",
+    "pattern": "BLOCKED",
+    "type": "Continuity Gate"
+  },
+  {
+    "scenario": "Arbiter defines governance severity buckets",
+    "skill": "arbiter",
+    "pattern": "Critical findings.*Major findings.*Minor findings.*Cleanup findings",
+    "type": "Governance Calibration"
+  },
+  {
+    "scenario": "Arbiter uses READY_WITH_REQUIRED_FIXES for advisory governance gaps",
+    "skill": "arbiter",
+    "pattern": "READY_WITH_REQUIRED_FIXES",
+    "type": "Governance Calibration"
+  },
+  {
+    "scenario": "Arbiter keeps CI advisory and Dagger simulation-only during calibration",
+    "skill": "arbiter",
+    "pattern": "keep CI advisory|Dagger remains simulation-only and unpromoted",
+    "type": "Governance Calibration"
+  },
+  {
+    "scenario": "Routing template enforces specialist reroute",
+    "file": "templates/routing-output-template.md",
+    "pattern": "SPECIALIST_REROUTE_REQUIRED.*(do not execute|must not execute)|(do not execute|must not execute).*SPECIALIST_REROUTE_REQUIRED",
+    "type": "Routing Gate"
+  },
+  {
+    "scenario": "Conductor output formats defines specialist reroute",
+    "file": "skills/conductor/OUTPUT_FORMATS.md",
+    "pattern": "SPECIALIST_REROUTE_REQUIRED.*route the task to the correct specialist",
+    "type": "Routing Gate"
+  },
+  {
+    "scenario": "Conductor SKILL enforces scope routing",
+    "skill": "conductor",
+    "pattern": "classify.*SPECIALIST_REROUTE_REQUIRED.*must not allow a specialist to execute outside",
+    "type": "Routing Gate"
+  },
+  {
+    "scenario": "Specialist self-boundary reroute contract",
+    "skill": "ponytail",
+    "pattern": "SPECIALIST_REROUTE_REQUIRED.*do not execute|do not execute.*SPECIALIST_REROUTE_REQUIRED",
+    "type": "Routing Gate"
+  },
+  {
+    "scenario": "Arbiter severity handles specialist scope misuse",
+    "skill": "arbiter",
+    "pattern": "specialist-scope misuse without reroute",
+    "type": "Governance Calibration"
+  },
+  {
+    "scenario": "Command files contain mismatch preamble",
+    "file": "commands/dagger.md",
+    "pattern": "SPECIALIST_REROUTE_REQUIRED.*do not execute|do not execute.*SPECIALIST_REROUTE_REQUIRED",
+    "type": "Routing Gate"
+  },
+  {
+    "skill": "conductor",
+    "scenario": "Conductor preserves Cloak multi-stage workflow",
+    "pattern": "Cloak Workflow Preservation.*multi-stage design workflow"
+  },
+  {
+    "skill": "conductor",
+    "scenario": "Conductor blocks direct Cloak to Ponytail for backend-sensitive frontend work",
+    "pattern": "must not route data-aware, auth-aware, API-backed, payment, integration, storage, or compliance-sensitive frontend work directly from `cloak` to `ponytail`"
+  },
+  {
+    "skill": "conductor",
+    "scenario": "Conductor requires Clockwork for frontend backend boundary alignment",
+    "pattern": "Route to `clockwork` before implementation when the frontend design affects API shape, data flow, service boundaries, backend validation, auth boundary placement, or architectural layering"
+  },
+  {
+    "skill": "conductor",
+    "scenario": "Conductor requires Cipher for security-sensitive frontend work",
+    "pattern": "Route to `cipher` before implementation when the frontend design affects authorization, privacy, destructive actions, secrets, security-sensitive workflows, payments, or compliance-sensitive user journeys"
+  },
+  {
+    "skill": "conductor",
+    "scenario": "Conductor requires Chronicler for persistence-aware frontend work",
+    "pattern": "Route to `chronicler` before implementation when the frontend design affects persistence, schema, migrations, reporting data, ORM behavior, or stored records"
+  }
 ]


### PR DESCRIPTION
## Summary
- Added behavior fixtures for Conductor's frontend/backend routing contract.
- Validates Cloak multi-stage workflow preservation.
- Validates that backend-sensitive frontend work is not routed directly from Cloak to Ponytail.
- Validates required routing through Clockwork, Cipher, and Chronicler when frontend decisions affect backend, security, or persistence boundaries.

## Validation
- python tests/behavior/evaluate_governance.py
- python scripts/governance_check.py --strict
- python tests/behavior/run_tests.py
- python -m json.tool tests/behavior/governance-conformance-fixtures.json | Out-Null
- git diff --check

## Notes
Stage 3 of issue #50.