### PR TITLE
docs(conductor): wire execution modes policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This changelog tracks the repository history using git tags, merge history, and 
 
 ## Unreleased
 
+- Wired Execution Modes Policy (`docs/routing/EXECUTION_MODES_POLICY.md`) into Conductor.
+- Replaced legacy Ideation/Prototype/Release modes with formal FAST, STANDARD, GOVERNED, AUDIT, and DESTRUCTIVE modes.
+
 - Created `EXECUTION_MODES_POLICY.md` to formalize FAST, STANDARD, GOVERNED, AUDIT, and DESTRUCTIVE modes.
 - Defined mode escalation paths, exclusions, and matrix.
 

--- a/skills/conductor/SKILL.md
+++ b/skills/conductor/SKILL.md
@@ -19,19 +19,25 @@ Conductor operates on a router-first execution model to optimize prompt load. **
 
 ## Default Execution Flow
 1. **Intake & Intent**: Receive user request. Conductor must classify task intent first.
-2. **Mode Selection**: Conductor must select the execution mode (Ideation, Prototype, Implementation, Audit, Release).
-3. **Context Selection**: Conductor must consult `docs/routing/CONTEXT_RETRIEVAL_RULES.md` before loading context.
-4. **Governance Escalation**: Conductor must consult `docs/governance/GOVERNANCE_LAYER.md` only when governance triggers are present.
-5. **Skill Selection**: Conductor must consult `SKILL_INDEX.md` for skill lookup. Conductor must consult `ROUTING_MAP.md` only when routing is ambiguous, multi-step, or cross-specialist.
+2. **Mode Selection**: Conductor must select the execution mode using `docs/routing/EXECUTION_MODES_POLICY.md`.
+3. **Context Selection**: Conductor must apply context retrieval using `docs/routing/CONTEXT_RETRIEVAL_RULES.md`.
+4. **Skill Selection**: Conductor must consult `SKILL_INDEX.md` for skill lookup. Conductor must consult `ROUTING_MAP.md` only when routing is ambiguous, multi-step, or cross-specialist.
+5. **Governance Escalation**: Conductor must consult `docs/governance/GOVERNANCE_LAYER.md` only when governance triggers are present.
 6. **Execution Routing**: Conductor must assemble specialist handoff prompts using `docs/routing/MINIMAL_PROMPT_FORMAT.md`.
 
 ## Execution Modes
-Select the active Operating Mode to dictate how strictly rules are applied:
-1. **Ideation**: Brainstorming, no code edits.
-2. **Prototype**: Experimental local code.
-3. **Implementation**: Standard development, fast-path governance.
-4. **Audit**: Read-only formal reviews, full governance.
-5. **Release**: Deployment or public artifacts, strict compliance gates.
+Select the active mode based on `docs/routing/EXECUTION_MODES_POLICY.md`:
+- **FAST**: Use for low-risk Q&A, typo, formatting, and simple local explanation tasks.
+- **STANDARD**: Use for normal implementation, documentation, and refactoring tasks.
+- **GOVERNED**: Use for security, database, CI/CD, compliance, credential, or policy-sensitive tasks.
+- **AUDIT**: Use for read-only review, inspection, governance review, or release-readiness assessment.
+- **DESTRUCTIVE**: Use only for authorized destructive, chaos, resilience, or production-impacting test requests.
+
+### Escalation Behavior
+- FAST escalates to STANDARD when file changes, multi-step work, or implementation is required.
+- STANDARD escalates to GOVERNED when security, database, CI/CD, compliance, credential, or governance triggers appear.
+- GOVERNED escalates to AUDIT when formal review or release readiness is requested.
+- Any mode escalates to DESTRUCTIVE blocked state when destructive operations are requested.
 
 ## Context Loading Rules
 Conditionally load supporting context to prevent token exhaustion per `docs/routing/CONTEXT_RETRIEVAL_RULES.md`. Check lightweight memory (`SESSION_HANDOFF.md`, `PROJECT_STATE.md`, or `.amalgam/state.json`) to confirm active repo, allowed files, and latest validated state.


### PR DESCRIPTION
- reference execution modes policy from Conductor

- align Conductor mode selection with router-first execution

- preserve context retrieval and minimal prompt handoff rules

- preserve required governance behavior contracts

- preserve destructive-operation safety gates

- update changelog if required by strict governance freshness