### PR TITLE
ci(routing): run router benchmark validation

### DIFF
--- a/.github/workflows/governance-check.yml
+++ b/.github/workflows/governance-check.yml
@@ -33,6 +33,11 @@ jobs:
       - name: Create Artifacts Directory
         run: mkdir -p artifacts
 
+      - name: Run Router Benchmark Validation
+        run: |
+          python scripts/router_benchmark_runner.py > artifacts/router_benchmark_report.txt
+          cat artifacts/router_benchmark_report.txt
+
       - name: Run Stage 1 Strict Governance Check
         run: |
           python scripts/governance_check.py --strict > artifacts/governance_report.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog tracks the repository history using git tags, merge history, and 
 
 ## Unreleased
 
+- Wired router benchmark validation (`scripts/router_benchmark_runner.py`) into the `governance-check.yml` CI workflow to automatically verify benchmark definitions on pull requests.
+
 - Added structured automated router benchmark runner (`scripts/router_benchmark_runner.py`) to validate test case definitions without triggering live LLM behavior.
 
 - Reduced `skills/conductor/SKILL.md` prompt payload by consolidating duplicate execution mode rules into canonical pointers, while preserving strict behavior conformance.

--- a/docs/testing/ROUTER_BENCHMARK_RUNNER.md
+++ b/docs/testing/ROUTER_BENCHMARK_RUNNER.md
@@ -20,6 +20,7 @@ Execute the following from the repository root:
 ```bash
 python scripts/router_benchmark_runner.py
 ```
+*(Note: This runner is automatically executed as part of the CI validation workflow in `.github/workflows/governance-check.yml`.)*
 
 ## Expected Output
 A structured text report detailing:


### PR DESCRIPTION
- add router benchmark runner to CI validation

- keep existing governance and behavior checks intact

- document CI coverage for router benchmark definitions

- preserve runtime behavior and governance gates

- update changelog if required by strict governance freshness