### PR TITLE
ci(performance): publish prompt load metrics artifact

### DIFF
--- a/.github/workflows/governance-check.yml
+++ b/.github/workflows/governance-check.yml
@@ -38,6 +38,11 @@ jobs:
           python scripts/router_benchmark_runner.py > artifacts/router_benchmark_report.txt
           cat artifacts/router_benchmark_report.txt
 
+      - name: Measure Prompt Load
+        run: |
+          python scripts/measure_prompt_load.py > artifacts/prompt_load_metrics.txt
+          cat artifacts/prompt_load_metrics.txt
+
       - name: Run Stage 1 Strict Governance Check
         run: |
           python scripts/governance_check.py --strict > artifacts/governance_report.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog tracks the repository history using git tags, merge history, and 
 
 ## Unreleased
 
+- Configured `governance-check.yml` CI workflow to run and publish `measure_prompt_load.py` output as a downloadable artifact for observability, without introducing hard prompt-size failure thresholds yet.
+
 - Wired router benchmark validation (`scripts/router_benchmark_runner.py`) into the `governance-check.yml` CI workflow to automatically verify benchmark definitions on pull requests.
 
 - Added structured automated router benchmark runner (`scripts/router_benchmark_runner.py`) to validate test case definitions without triggering live LLM behavior.

--- a/docs/performance/PROMPT_LOAD_METRICS.md
+++ b/docs/performance/PROMPT_LOAD_METRICS.md
@@ -39,6 +39,9 @@ The script prints per-file metrics, per-group totals, and a grand total, highlig
 ## Baseline Comparison Use
 This metric script directly proves the benchmarks defined in `ROUTER_VALIDATION_BENCHMARKS.md`, verifying the reduction from "Very High" to "Low" prompt load.
 
+## CI Integration
+Prompt load metrics are measured automatically in the `governance-check.yml` CI workflow. The script output is captured and published as part of the `governance-validation-report` CI artifact (`artifacts/prompt_load_metrics.txt`). Currently, these metrics are for observability only and do not trigger hard CI failures based on prompt size thresholds.
+
 ## Non-Goals
 This method does not measure user prompt sizes, session history sizes, or downstream specialist output token generation costs.
 


### PR DESCRIPTION
- run prompt load metrics during governance CI

- publish prompt load metrics as a CI artifact

- keep router benchmark artifact output intact

- avoid hard prompt-load thresholds for now

- preserve runtime behavior and governance gates

- update changelog if required by strict governance freshness