### PR TITLE
ci(performance): publish prompt load threshold report

### DIFF
--- a/.github/workflows/governance-check.yml
+++ b/.github/workflows/governance-check.yml
@@ -43,6 +43,11 @@ jobs:
           python scripts/measure_prompt_load.py > artifacts/prompt_load_metrics.txt
           cat artifacts/prompt_load_metrics.txt
 
+      - name: Check Prompt Load Thresholds
+        run: |
+          python scripts/check_prompt_load_thresholds.py > artifacts/prompt_load_threshold_report.txt
+          cat artifacts/prompt_load_threshold_report.txt
+
       - name: Run Stage 1 Strict Governance Check
         run: |
           python scripts/governance_check.py --strict > artifacts/governance_report.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog tracks the repository history using git tags, merge history, and 
 
 ## Unreleased
 
+- Configured `governance-check.yml` CI workflow to run and publish the dry-run prompt load threshold checker report as a downloadable artifact.
+
 - Added `scripts/check_prompt_load_thresholds.py` as a dry-run prompt load threshold checker to validate current metrics against documented soft limits without breaking CI.
 
 - Defined `PROMPT_LOAD_THRESHOLD_POLICY.md` to establish soft limits and review triggers for context sizes in the router-first architecture, without introducing hard CI enforcement yet.

--- a/docs/performance/PROMPT_LOAD_METRICS.md
+++ b/docs/performance/PROMPT_LOAD_METRICS.md
@@ -40,7 +40,7 @@ The script prints per-file metrics, per-group totals, and a grand total, highlig
 This metric script directly proves the benchmarks defined in `ROUTER_VALIDATION_BENCHMARKS.md`, verifying the reduction from "Very High" to "Low" prompt load.
 
 ## CI Integration
-Prompt load metrics are measured automatically in the `governance-check.yml` CI workflow. The script output is captured and published as part of the `governance-validation-report` CI artifact (`artifacts/prompt_load_metrics.txt`). Currently, these metrics are for observability only and do not trigger hard CI failures based on prompt size thresholds.
+Prompt load metrics are measured automatically in the `governance-check.yml` CI workflow. The script output is captured and published as part of the `governance-validation-report` CI artifact (`artifacts/prompt_load_metrics.txt`). CI also executes the threshold checker (`artifacts/prompt_load_threshold_report.txt`), publishing both raw prompt load metrics and threshold status. Currently, these metrics are for observability only and do not trigger hard CI failures based on prompt size thresholds.
 
 ## Threshold Policy
 For details on the acceptable growth limits of prompt payload sizes and the actions required when these limits are exceeded, see [PROMPT_LOAD_THRESHOLD_POLICY.md](PROMPT_LOAD_THRESHOLD_POLICY.md).

--- a/docs/performance/PROMPT_LOAD_THRESHOLD_CHECKER.md
+++ b/docs/performance/PROMPT_LOAD_THRESHOLD_CHECKER.md
@@ -34,7 +34,7 @@ python scripts/check_prompt_load_thresholds.py
 The script prints the current metrics compared to the limits, followed by a clear status report for Group A, Grand Total, and the Conductor skill.
 
 ## CI Usage
-This script can be executed locally or wired into CI pipelines to generate observability reports. Currently, its primary role is to provide visibility into prompt load degradation over time.
+This script is executed automatically during the GitHub Actions governance workflow (`governance-check.yml`). Its report is saved and published as part of the `governance-validation-report` CI artifact, providing visibility into prompt load degradation over time.
 
 ## Failure Behavior
 Because this is a dry-run checker, it will **not** block pull requests or fail CI runs upon threshold breaches.


### PR DESCRIPTION
- run dry-run prompt load threshold checker during governance CI

- publish threshold report as a CI artifact

- keep threshold checks non-blocking

- preserve existing governance and behavior checks

- document CI artifact coverage

- update changelog if required by strict governance freshness