### PR TITLE
docs(testing): link CI artifact index

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,7 @@ Output from Conductor and its specialists automatically adapts to your intent:
 | Installation | [Installation Guide](docs/setup/INSTALLATION.md) | Set up the plugin in Antigravity, Codex, VS Code, or JetBrains IDEs |
 | Changelog | [Changelog](CHANGELOG.md) | Track release history and documented repo milestones |
 | Validation | [Validation Guide](docs/setup/VALIDATION.md) | Run structure and manifest checks |
+| CI Artifacts | [CI Artifact Index](docs/testing/CI_ARTIFACT_INDEX.md) | Browse governance reports and validation CI artifacts |
 | Maturity | [Maturity](docs/MATURITY.md) | Current project stability and roadmap |
 | Contributing | [Contributing Guide](docs/CONTRIBUTING.md) | Guidelines for contributing and safety policies |
 | Disclaimer | [Disclaimer](docs/meta/DISCLAIMER.md) | Understand legal and operational limitations |

--- a/docs/performance/PROMPT_LOAD_METRICS.md
+++ b/docs/performance/PROMPT_LOAD_METRICS.md
@@ -42,6 +42,8 @@ This metric script directly proves the benchmarks defined in `ROUTER_VALIDATION_
 ## CI Integration
 Prompt load metrics are measured automatically in the `governance-check.yml` CI workflow. The script output is captured and published as part of the `governance-validation-report` CI artifact (`artifacts/prompt_load_metrics.txt`). CI also executes the threshold checker (`artifacts/prompt_load_threshold_report.txt`), publishing both raw prompt load metrics and threshold status. Currently, these metrics are for observability only and do not trigger hard CI failures based on prompt size thresholds.
 
+For a complete guide to accessing and interpreting all governance artifacts, see the [CI Artifact Index](../testing/CI_ARTIFACT_INDEX.md).
+
 ## Threshold Policy
 For details on the acceptable growth limits of prompt payload sizes and the actions required when these limits are exceeded, see [PROMPT_LOAD_THRESHOLD_POLICY.md](PROMPT_LOAD_THRESHOLD_POLICY.md).
 

--- a/docs/performance/PROMPT_LOAD_THRESHOLD_CHECKER.md
+++ b/docs/performance/PROMPT_LOAD_THRESHOLD_CHECKER.md
@@ -34,7 +34,7 @@ python scripts/check_prompt_load_thresholds.py
 The script prints the current metrics compared to the limits, followed by a clear status report for Group A, Grand Total, and the Conductor skill.
 
 ## CI Usage
-This script is executed automatically during the GitHub Actions governance workflow (`governance-check.yml`). Its report is saved and published as part of the `governance-validation-report` CI artifact, providing visibility into prompt load degradation over time.
+This script is executed automatically during the GitHub Actions governance workflow (`governance-check.yml`). Its report is saved and published as part of the `governance-validation-report` CI artifact, providing visibility into prompt load degradation over time. For details on accessing and interpreting this artifact, see the [CI Artifact Index](../testing/CI_ARTIFACT_INDEX.md).
 
 ## Failure Behavior
 Because this is a dry-run checker, it will **not** block pull requests or fail CI runs upon threshold breaches.

--- a/docs/performance/PROMPT_LOAD_THRESHOLD_POLICY.md
+++ b/docs/performance/PROMPT_LOAD_THRESHOLD_POLICY.md
@@ -55,7 +55,7 @@ If a soft threshold is exceeded, maintainers should:
 To validate current payloads against these thresholds, you can use the dry-run checker. For details on how to run it and interpret its statuses, see [PROMPT_LOAD_THRESHOLD_CHECKER.md](PROMPT_LOAD_THRESHOLD_CHECKER.md).
 
 ## CI Artifact Usage
-The `measure_prompt_load.py` script runs automatically in the `governance-check.yml` CI workflow. Its output is published as `prompt_load_metrics.txt` in the `governance-validation-report` artifact. This ensures continuous observability of prompt load metrics.
+The `measure_prompt_load.py` script runs automatically in the `governance-check.yml` CI workflow. Its output is published as `prompt_load_metrics.txt` in the `governance-validation-report` artifact. This ensures continuous observability of prompt load metrics. For details on all governance artifacts, see the [CI Artifact Index](../testing/CI_ARTIFACT_INDEX.md).
 
 ## Non-Goals
 This policy does not govern user prompt sizes, session history limits, or downstream specialist output tokens. It only governs the static context injected into the Conductor's routing prompt.

--- a/docs/testing/ROUTER_BENCHMARK_RUNNER.md
+++ b/docs/testing/ROUTER_BENCHMARK_RUNNER.md
@@ -20,7 +20,7 @@ Execute the following from the repository root:
 ```bash
 python scripts/router_benchmark_runner.py
 ```
-*(Note: This runner is automatically executed as part of the CI validation workflow in `.github/workflows/governance-check.yml`.)*
+*(Note: This runner is automatically executed as part of the CI validation workflow in `.github/workflows/governance-check.yml`. For details on the generated `router_benchmark_report.txt` artifact, see the [CI Artifact Index](CI_ARTIFACT_INDEX.md).)*
 
 ## Expected Output
 A structured text report detailing:


### PR DESCRIPTION
- link CI artifact index from README
- cross-reference artifact index from testing and performance docs
- improve discoverability of governance validation artifacts
- preserve CI behavior and governance gates
- update changelog if required by strict governance freshness

## Summary

Improves discoverability of the CI artifact index from the README and related validation documentation.

## Changes

- Adds a README Documentation Map link to `docs/testing/CI_ARTIFACT_INDEX.md`.
- Cross-references the artifact index from router benchmark documentation.
- Cross-references the artifact index from prompt load metrics documentation.
- Cross-references the artifact index from prompt load threshold checker documentation.
- Cross-references the artifact index from prompt load threshold policy documentation.

## Notes

This is documentation-only. No CI behavior, runtime behavior, tests, plugin metadata, or skill frontmatter were changed.

## Validation

- `python scripts/check_prompt_load_thresholds.py` passed.
- `python scripts/measure_prompt_load.py` passed.
- `python scripts/router_benchmark_runner.py` passed.
- `python tests/behavior/evaluate_governance.py` passed.
- `python tests/behavior/run_tests.py` passed.
- `python scripts/validate_manifest.py` passed.
- `python scripts/governance_check.py --strict` passed.
- `git diff --check` passed.