### PR TITLE
test(routing): document router benchmark fixture schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog tracks the repository history using git tags, merge history, and 
 
 ## Unreleased
 
+- Documented the `tests/fixtures/router_benchmarks.json` schema in `ROUTER_BENCHMARK_FIXTURE_SCHEMA.md` and updated the benchmark validation runner to enforce the root shape and `schema_version`.
+
 - Refactored `scripts/router_benchmark_runner.py` to extract hardcoded definitions into a machine-readable fixture at `tests/fixtures/router_benchmarks.json`, preserving existing validation capabilities.
 
 - Documented CI artifact outputs in `CI_ARTIFACT_INDEX.md` to explain the reports generated during governance validation.

--- a/docs/testing/ROUTER_BENCHMARK_FIXTURE_SCHEMA.md
+++ b/docs/testing/ROUTER_BENCHMARK_FIXTURE_SCHEMA.md
@@ -1,0 +1,86 @@
+# Router Benchmark Fixture Schema
+
+## Purpose
+This document defines the schema for `tests/fixtures/router_benchmarks.json`, which acts as the machine-readable source of truth for all router validation benchmarks.
+
+## Scope
+This schema dictates the required shape and values for the router benchmark JSON fixture.
+
+## Fixture Location
+`tests/fixtures/router_benchmarks.json`
+
+## Root Object Schema
+The root of the fixture must be a JSON object containing:
+- `schema_version`: String, must be "1.0"
+- `benchmarks`: Array of benchmark case objects
+
+## Benchmark Case Schema
+Each benchmark object within the `benchmarks` array must adhere to the rules below.
+
+## Required Fields
+Every benchmark case must include the following keys:
+- `case_id`: String (unique identifier)
+- `request_type`: String (description of the request)
+- `expected_mode`: String (must be an allowed mode)
+- `expected_skill_route`: String (expected routing path)
+- `required_context`: Array of strings (context that must be present)
+- `excluded_context`: Array of strings (context that must not be present)
+- `governance_status`: String (must be an allowed status)
+- `pass_criteria`: String (must be non-empty description)
+
+## Allowed Execution Modes
+The `expected_mode` field must be one of:
+- `FAST`
+- `STANDARD`
+- `GOVERNED`
+- `AUDIT`
+- `DESTRUCTIVE`
+
+## Allowed Governance Statuses
+The `governance_status` field must be one of:
+- `NOT_REQUIRED`
+- `CONDITIONAL`
+- `REQUIRED`
+- `BLOCKED_PENDING_AUTHORIZATION`
+
+## List Fields
+The following fields must be strictly typed as JSON Arrays (lists):
+- `required_context`
+- `excluded_context`
+
+## Validation Rules
+The benchmark fixture is validated by `scripts/router_benchmark_runner.py`, which enforces:
+- The root object is a dictionary containing `schema_version` equal to "1.0".
+- The `benchmarks` array exists and contains exactly 12 benchmark cases.
+- All `case_id` values are unique.
+- All required fields are present in every case.
+- Arrays and strings are of the correct types and non-empty where applicable.
+- Enums (`expected_mode`, `governance_status`) match the allowed values exactly.
+
+## Example Fixture Entry
+```json
+{
+  "case_id": "BM-01",
+  "request_type": "simple Q&A",
+  "expected_mode": "FAST",
+  "expected_skill_route": "conductor (direct answer)",
+  "required_context": [
+    "SKILL.md"
+  ],
+  "excluded_context": [
+    "Full index",
+    "Governance"
+  ],
+  "governance_status": "NOT_REQUIRED",
+  "pass_criteria": "Answers directly without full context"
+}
+```
+
+## Runner Integration
+The runner script `scripts/router_benchmark_runner.py` automatically parses the JSON fixture and performs strict structural validation against this schema before summarizing mode and governance coverage.
+
+## Non-Goals
+This schema validation does not execute the actual live routing tests or prompt the LLM. It solely ensures the test definitions are well-formed.
+
+## Schema Result
+ROUTER_BENCHMARK_FIXTURE_SCHEMA_DEFINED

--- a/docs/testing/ROUTER_BENCHMARK_RUNNER.md
+++ b/docs/testing/ROUTER_BENCHMARK_RUNNER.md
@@ -8,6 +8,7 @@ This runner script is scoped exclusively to parsing, validating, and summarizing
 
 ## Source of Truth
 - **Machine-Readable Fixture**: Benchmark definitions live in `tests/fixtures/router_benchmarks.json`. The runner loads and validates this fixture.
+- **Fixture Schema**: The exact schema contract is defined in [ROUTER_BENCHMARK_FIXTURE_SCHEMA.md](ROUTER_BENCHMARK_FIXTURE_SCHEMA.md).
 - **Human-Readable Guide**: `docs/testing/ROUTER_VALIDATION_BENCHMARKS.md` remains the primary human-readable benchmark guide.
 
 ## What It Validates

--- a/scripts/router_benchmark_runner.py
+++ b/scripts/router_benchmark_runner.py
@@ -31,15 +31,27 @@ def main():
     try:
         with open(fixture_path, "r", encoding="utf-8") as f:
             fixture_data = json.load(f)
-            
+
+        if not isinstance(fixture_data, dict):
+            print(f"[ERROR] Fixture {fixture_path} root must be a dictionary")
+            sys.exit(1)
+
         if "schema_version" not in fixture_data:
             print(f"[ERROR] Fixture {fixture_path} is missing schema_version")
             sys.exit(1)
-            
+
+        if fixture_data["schema_version"] != "1.0":
+            print(f"[ERROR] Fixture {fixture_path} schema_version must be '1.0'")
+            sys.exit(1)
+
         if "benchmarks" not in fixture_data:
             print(f"[ERROR] Fixture {fixture_path} is missing benchmarks list")
             sys.exit(1)
-            
+
+        if not isinstance(fixture_data["benchmarks"], list):
+            print(f"[ERROR] Fixture {fixture_path} 'benchmarks' must be a list")
+            sys.exit(1)
+
         BENCHMARK_CASES = fixture_data["benchmarks"]
     except Exception as e:
         print(f"[ERROR] Failed to load {fixture_path}: {e}")


### PR DESCRIPTION
- document router benchmark fixture schema

- enforce schema version and fixture shape in runner

- preserve all benchmark coverage and validation behavior

- link benchmark runner docs to schema contract

- preserve runtime behavior and governance gates

- update changelog if required by strict governance freshness

## Summary

Adds an explicit schema contract for the router benchmark fixture and strengthens runner validation.

## Changes

- Adds `docs/testing/ROUTER_BENCHMARK_FIXTURE_SCHEMA.md`.
- Updates `tests/fixtures/router_benchmarks.json` to use a versioned root object.
- Updates `scripts/router_benchmark_runner.py` to validate fixture root shape, schema version, and benchmarks array.
- Updates `docs/testing/ROUTER_BENCHMARK_RUNNER.md` to link to the schema contract.
- Updates `CHANGELOG.md` for governance freshness compliance.

## Validation

- `python scripts/router_benchmark_runner.py` passed.
- Benchmark count remains exactly 12.
- `python scripts/check_prompt_load_thresholds.py` passed.
- `python scripts/measure_prompt_load.py` passed.
- `python tests/behavior/evaluate_governance.py` passed.
- `python tests/behavior/run_tests.py` passed.
- `python scripts/validate_manifest.py` passed.
- `python scripts/governance_check.py --strict` passed.
- `git diff --check` passed.

## Notes

This is validation tooling and documentation only. No runtime behavior, plugin metadata, skill frontmatter, or behavior tests were changed.