### PR TITLE
test(routing): add negative router benchmark fixture tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,3 +163,6 @@ Changes after `v1.0.1` currently tracked in this checkout:
 - Added the eight-skill Orchestra structure.
 - Added IDE adapter guides and templates.
 - Added validation and local-only guidance.
+-   a d d   n e g a t i v e   v a l i d a t i o n   t e s t s   f o r   r o u t e r   b e n c h m a r k   f i x t u r e   s c h e m a   p a r s i n g  
+ -   a l l o w   r u n n e r   t o   a c c e p t   e x p l i c i t   f i x t u r e   p a t h   a r g u m e n t  
+ 

--- a/docs/testing/ROUTER_BENCHMARK_RUNNER.md
+++ b/docs/testing/ROUTER_BENCHMARK_RUNNER.md
@@ -49,5 +49,8 @@ The runner will exit with code `1` (fail) if:
 - It is not a goal to run an LLM evaluation loop in this script. Live behavioral bounds are evaluated separately by `tests/behavior/evaluate_governance.py`.
 - It is not a goal to modify or write any files.
 
+## Negative Validation Testing
+The runner script itself is validated against malformed data inputs by `tests/behavior/test_router_benchmark_fixture_validation.py`. This script automatically constructs temporary malformed JSON fixtures and verifies that the runner fails appropriately for each defined constraint.
+
 ## Runner Result
 ROUTER_BENCHMARK_RUNNER_DEFINED

--- a/scripts/router_benchmark_runner.py
+++ b/scripts/router_benchmark_runner.py
@@ -26,7 +26,10 @@ def main():
     print(" Note: Validates structure, NOT live model routing.")
     print("=" * 60)
 
-    fixture_path = os.path.join(os.path.dirname(__file__), "..", "tests", "fixtures", "router_benchmarks.json")
+    if len(sys.argv) > 1:
+        fixture_path = sys.argv[1]
+    else:
+        fixture_path = os.path.join(os.path.dirname(__file__), "..", "tests", "fixtures", "router_benchmarks.json")
 
     try:
         with open(fixture_path, "r", encoding="utf-8") as f:

--- a/tests/behavior/test_router_benchmark_fixture_validation.py
+++ b/tests/behavior/test_router_benchmark_fixture_validation.py
@@ -1,0 +1,93 @@
+import os
+import json
+import subprocess
+import tempfile
+import sys
+
+def run_runner(fixture_path):
+    runner_script = os.path.join(os.path.dirname(__file__), "..", "..", "scripts", "router_benchmark_runner.py")
+    result = subprocess.run(
+        [sys.executable, runner_script, fixture_path],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+    )
+    return result.returncode
+
+def test_negative_cases():
+    valid_fixture_path = os.path.join(os.path.dirname(__file__), "..", "fixtures", "router_benchmarks.json")
+    
+    with open(valid_fixture_path, "r", encoding="utf-8") as f:
+        valid_data = json.load(f)
+
+    # Base valid single benchmark case to reuse
+    base_case = {
+        "case_id": "BM-TEMP",
+        "request_type": "test",
+        "expected_mode": "STANDARD",
+        "expected_skill_route": "ponytail",
+        "required_context": ["a"],
+        "excluded_context": ["b"],
+        "governance_status": "NOT_REQUIRED",
+        "pass_criteria": "pass"
+    }
+    
+    # helper to generate 12 cases
+    def generate_12_cases(override_case=None):
+        cases = []
+        for i in range(12):
+            case = base_case.copy()
+            case["case_id"] = f"BM-{i}"
+            if i == 0 and override_case:
+                case.update(override_case)
+            cases.append(case)
+        # Ensure at least one DESTRUCTIVE for coverage requirement
+        cases[-1]["expected_mode"] = "DESTRUCTIVE"
+        return cases
+
+    # 1. Valid fixture should exit 0
+    print("[TEST] Valid fixture")
+    assert run_runner(valid_fixture_path) == 0, "Valid fixture failed"
+
+    negative_cases = [
+        ("missing schema_version", {"benchmarks": generate_12_cases()}),
+        ("wrong schema_version", {"schema_version": "2.0", "benchmarks": generate_12_cases()}),
+        ("missing benchmarks key", {"schema_version": "1.0"}),
+        ("benchmarks is not a list", {"schema_version": "1.0", "benchmarks": {}}),
+        ("duplicate case_id", {"schema_version": "1.0", "benchmarks": generate_12_cases({"case_id": "BM-1"})}),
+        ("missing required field", {"schema_version": "1.0", "benchmarks": generate_12_cases()}),
+        ("invalid expected_mode", {"schema_version": "1.0", "benchmarks": generate_12_cases({"expected_mode": "INVALID"})}),
+        ("invalid governance_status", {"schema_version": "1.0", "benchmarks": generate_12_cases({"governance_status": "INVALID"})}),
+        ("required_context is not a list", {"schema_version": "1.0", "benchmarks": generate_12_cases({"required_context": "string"})}),
+        ("excluded_context is not a list", {"schema_version": "1.0", "benchmarks": generate_12_cases({"excluded_context": "string"})}),
+        ("empty pass_criteria", {"schema_version": "1.0", "benchmarks": generate_12_cases({"pass_criteria": "   "})}),
+        ("benchmark count not equal to 12", {"schema_version": "1.0", "benchmarks": generate_12_cases()[:-1]}),
+    ]
+    
+    # Fix the missing required field test
+    cases_missing_field = generate_12_cases()
+    del cases_missing_field[0]["request_type"]
+    negative_cases[5] = ("missing required field", {"schema_version": "1.0", "benchmarks": cases_missing_field})
+
+    failures = 0
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for idx, (desc, data) in enumerate(negative_cases):
+            tmp_path = os.path.join(tmpdir, f"test_{idx}.json")
+            with open(tmp_path, "w", encoding="utf-8") as f:
+                json.dump(data, f)
+            
+            print(f"[TEST] Negative case: {desc}")
+            rc = run_runner(tmp_path)
+            if rc == 0:
+                print(f"  [FAIL] Expected failure for '{desc}', but got exit code 0")
+                failures += 1
+            else:
+                print(f"  [PASS] Failed correctly for '{desc}' (exit {rc})")
+
+    if failures > 0:
+        print(f"\n[SUMMARY] {failures} negative cases failed to trigger an error.")
+        sys.exit(1)
+        
+    print("\n[SUCCESS] All negative validation tests passed.")
+
+if __name__ == "__main__":
+    test_negative_cases()


### PR DESCRIPTION
- allow router benchmark runner to validate an explicit fixture path

- add negative fixture validation tests for malformed schema cases

- confirm valid fixture still passes

- preserve benchmark coverage and governance behavior

- update changelog if required by strict governance freshness

## Summary

Adds negative validation tests for the router benchmark fixture schema.

## Changes

- Updates `scripts/router_benchmark_runner.py` to accept an optional fixture path argument.
- Adds `tests/behavior/test_router_benchmark_fixture_validation.py`.
- Verifies the canonical fixture still passes.
- Adds malformed fixture checks for missing schema keys, invalid schema version, duplicate case IDs, invalid modes, invalid governance statuses, bad list fields, empty pass criteria, and incorrect benchmark count.
- Updates `docs/testing/ROUTER_BENCHMARK_RUNNER.md`.
- Updates `CHANGELOG.md` for governance freshness compliance.

## Validation

- `python scripts/router_benchmark_runner.py` passed.
- `python tests/behavior/test_router_benchmark_fixture_validation.py` passed.
- `python scripts/check_prompt_load_thresholds.py` passed.
- `python scripts/measure_prompt_load.py` passed.
- `python tests/behavior/evaluate_governance.py` passed.
- `python tests/behavior/run_tests.py` passed.
- `python scripts/validate_manifest.py` passed.
- `python scripts/governance_check.py --strict` passed.
- `git diff --check` passed.

## Notes

This is validation testing only. No runtime behavior, plugin metadata, skill frontmatter, or benchmark coverage was weakened.