### PR TITLE
ci(routing): run negative benchmark fixture tests

### DIFF
--- a/.github/workflows/governance-check.yml
+++ b/.github/workflows/governance-check.yml
@@ -38,6 +38,11 @@ jobs:
           python scripts/router_benchmark_runner.py > artifacts/router_benchmark_report.txt
           cat artifacts/router_benchmark_report.txt
 
+      - name: Run Negative Router Benchmark Validation
+        run: |
+          python tests/behavior/test_router_benchmark_fixture_validation.py > artifacts/router_benchmark_negative_fixture_report.txt
+          cat artifacts/router_benchmark_negative_fixture_report.txt
+
       - name: Measure Prompt Load
         run: |
           python scripts/measure_prompt_load.py > artifacts/prompt_load_metrics.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,4 +165,6 @@ Changes after `v1.0.1` currently tracked in this checkout:
 - Added validation and local-only guidance.
 -   a d d   n e g a t i v e   v a l i d a t i o n   t e s t s   f o r   r o u t e r   b e n c h m a r k   f i x t u r e   s c h e m a   p a r s i n g  
  -   a l l o w   r u n n e r   t o   a c c e p t   e x p l i c i t   f i x t u r e   p a t h   a r g u m e n t  
+ -   a d d e d   n e g a t i v e   r o u t e r   b e n c h m a r k   f i x t u r e   v a l i d a t i o n   t o   C I   p i p e l i n e  
+ -   r e c o r d e d   n e g a t i v e   f i x t u r e   t e s t   a r t i f a c t s   i n   C I   a r t i f a c t   i n d e x  
  

--- a/docs/testing/CI_ARTIFACT_INDEX.md
+++ b/docs/testing/CI_ARTIFACT_INDEX.md
@@ -12,6 +12,7 @@ The governance CI workflow generates multiple text reports that are zipped into 
 ## Artifact List
 The following files are included in the bundle:
 - `artifacts/router_benchmark_report.txt`
+- `artifacts/router_benchmark_negative_fixture_report.txt`
 - `artifacts/prompt_load_metrics.txt`
 - `artifacts/prompt_load_threshold_report.txt`
 - `artifacts/governance_report.txt`
@@ -19,9 +20,9 @@ The following files are included in the bundle:
 - `artifacts/evaluate_governance_report.txt`
 - `artifacts/run_tests_report.txt`
 
-## Router Benchmark Report
-**File**: `artifacts/router_benchmark_report.txt`
-This report validates the benchmark case definitions against the expected schema, ensuring consistency across all routing test vectors. See [ROUTER_BENCHMARK_RUNNER.md](ROUTER_BENCHMARK_RUNNER.md) for execution details.
+## Router Benchmark Reports
+**Files**: `artifacts/router_benchmark_report.txt`, `artifacts/router_benchmark_negative_fixture_report.txt`
+The primary report validates the benchmark case definitions against the expected schema, ensuring consistency across all routing test vectors. The negative fixture report proves that malformed inputs cause the runner to fail appropriately. See [ROUTER_BENCHMARK_RUNNER.md](ROUTER_BENCHMARK_RUNNER.md) for execution details.
 
 ## Prompt Load Metrics Report
 **File**: `artifacts/prompt_load_metrics.txt`

--- a/docs/testing/ROUTER_BENCHMARK_RUNNER.md
+++ b/docs/testing/ROUTER_BENCHMARK_RUNNER.md
@@ -50,7 +50,7 @@ The runner will exit with code `1` (fail) if:
 - It is not a goal to modify or write any files.
 
 ## Negative Validation Testing
-The runner script itself is validated against malformed data inputs by `tests/behavior/test_router_benchmark_fixture_validation.py`. This script automatically constructs temporary malformed JSON fixtures and verifies that the runner fails appropriately for each defined constraint.
+The runner script itself is validated against malformed data inputs by `tests/behavior/test_router_benchmark_fixture_validation.py`. This script automatically constructs temporary malformed JSON fixtures and verifies that the runner fails appropriately for each defined constraint. This negative validation test runs continuously in CI to ensure the strictness of the benchmark runner is never degraded.
 
 ## Runner Result
 ROUTER_BENCHMARK_RUNNER_DEFINED


### PR DESCRIPTION
- add negative router benchmark fixture tests to CI

- publish negative fixture validation report as CI artifact

- preserve existing benchmark and governance checks

- document artifact coverage

- preserve runtime behavior and governance gates

- update changelog if required by strict governance freshness

## Summary

Adds negative router benchmark fixture validation to the governance CI workflow.

## Changes

- Updates `.github/workflows/governance-check.yml`.
- Adds a CI step to run `python tests/behavior/test_router_benchmark_fixture_validation.py`.
- Publishes `artifacts/router_benchmark_negative_fixture_report.txt`.
- Updates `docs/testing/ROUTER_BENCHMARK_RUNNER.md`.
- Updates `docs/testing/CI_ARTIFACT_INDEX.md`.
- Updates `CHANGELOG.md` for governance freshness compliance.

## Validation

- `python scripts/router_benchmark_runner.py` passed.
- `python tests/behavior/test_router_benchmark_fixture_validation.py` passed.
- `python scripts/check_prompt_load_thresholds.py` passed.
- `python scripts/measure_prompt_load.py` passed.
- `python tests/behavior/evaluate_governance.py` passed.
- `python tests/behavior/run_tests.py` passed.
- `python scripts/validate_manifest.py` passed.
- `python scripts/governance_check.py --strict` passed.
- `git diff --check` passed.

## Notes

This is CI validation wiring only. Runtime behavior, plugin metadata, skill frontmatter, and benchmark coverage were not changed.