### PR TITLE
docs(testing): add router benchmark maintenance guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,4 +167,5 @@ Changes after `v1.0.1` currently tracked in this checkout:
  -   a l l o w   r u n n e r   t o   a c c e p t   e x p l i c i t   f i x t u r e   p a t h   a r g u m e n t  
  -   a d d e d   n e g a t i v e   r o u t e r   b e n c h m a r k   f i x t u r e   v a l i d a t i o n   t o   C I   p i p e l i n e  
  -   r e c o r d e d   n e g a t i v e   f i x t u r e   t e s t   a r t i f a c t s   i n   C I   a r t i f a c t   i n d e x  
+ -   a d d e d   r o u t e r   b e n c h m a r k   m a i n t e n a n c e   g u i d e   w i t h   r e v i e w   c h e c k l i s t s   a n d   v a l i d a t i o n   p r o c e d u r e s  
  

--- a/docs/testing/ROUTER_BENCHMARK_FIXTURE_SCHEMA.md
+++ b/docs/testing/ROUTER_BENCHMARK_FIXTURE_SCHEMA.md
@@ -1,7 +1,9 @@
 # Router Benchmark Fixture Schema
 
 ## Purpose
-This document defines the schema for `tests/fixtures/router_benchmarks.json`, which acts as the machine-readable source of truth for all router validation benchmarks.
+This document defines the exact schema contract for the router benchmark JSON fixture (`tests/fixtures/router_benchmarks.json`). It is strictly enforced by the `scripts/router_benchmark_runner.py` runner to prevent malformed validation coverage.
+
+If you need to add or edit benchmarks, first read the [ROUTER_BENCHMARK_MAINTENANCE_GUIDE.md](ROUTER_BENCHMARK_MAINTENANCE_GUIDE.md).
 
 ## Scope
 This schema dictates the required shape and values for the router benchmark JSON fixture.

--- a/docs/testing/ROUTER_BENCHMARK_MAINTENANCE_GUIDE.md
+++ b/docs/testing/ROUTER_BENCHMARK_MAINTENANCE_GUIDE.md
@@ -1,0 +1,103 @@
+# Router Benchmark Maintenance Guide
+
+## Purpose
+This document provides explicit instructions for maintaining the router benchmark definitions. It acts as a procedural guide to safely add, edit, and review routing tests while preserving continuous integration validation coverage.
+
+## Scope
+This guide covers only the definition, adjustment, and schema-compliance of the benchmark cases used by `scripts/router_benchmark_runner.py`.
+
+## Source of Truth
+The canonical machine-readable source of truth for benchmark evaluation is:
+`tests/fixtures/router_benchmarks.json`
+
+The human-readable explanation of these benchmarks is maintained in:
+`docs/testing/ROUTER_VALIDATION_BENCHMARKS.md`
+
+## When to Add a Benchmark Case
+You should add a benchmark case if you are:
+- Introducing a fundamentally new routing mode.
+- Adding a new governance check that implies a new required routing behavior.
+- Documenting an adversarial edge case that was previously undefined.
+
+## When to Edit an Existing Case
+You should edit an existing case if:
+- A routing rule changes intentionally (e.g. relaxing or tightening required context).
+- The underlying schema introduces new required fields.
+- Note: Do NOT edit cases simply to cover up a regression.
+
+## Required Fixture Fields
+Every benchmark case must comply with the `ROUTER_BENCHMARK_FIXTURE_SCHEMA.md`.
+Required fields for every case:
+- `case_id`
+- `request_type`
+- `expected_mode`
+- `expected_skill_route`
+- `required_context`
+- `excluded_context`
+- `governance_status`
+- `pass_criteria`
+
+## Case ID Rules
+- `case_id` must follow the format `BM-XX`, where `XX` is an incrementing numeric identifier.
+- No duplicate `case_id`s are permitted in the fixture array.
+
+## Execution Mode Selection
+`expected_mode` must be one of:
+- `FAST`
+- `STANDARD`
+- `GOVERNED`
+- `AUDIT`
+- `DESTRUCTIVE`
+
+## Governance Status Selection
+`governance_status` must be one of:
+- `NOT_REQUIRED`
+- `CONDITIONAL`
+- `REQUIRED`
+- `BLOCKED_PENDING_AUTHORIZATION`
+
+## Context Selection Rules
+`required_context` and `excluded_context` must be JSON arrays (lists of strings). They must never be scalar strings or null. If no context is required or excluded, use an empty array `[]`.
+
+## Pass Criteria Rules
+`pass_criteria` must be a clear, non-empty descriptive string explaining what runtime behavior constitutes a pass.
+
+## Review Checklist
+Before submitting a PR that edits the benchmark fixture:
+- [ ] I verified the `schema_version` is exactly `"1.0"`.
+- [ ] I preserved existing `case_id` values unless intentionally replacing a scenario.
+- [ ] I did NOT weaken governance expectations for any existing case.
+- [ ] I did NOT remove `DESTRUCTIVE` coverage.
+- [ ] I did NOT reduce coverage across existing execution modes without explicit justification.
+- [ ] I updated `docs/testing/ROUTER_VALIDATION_BENCHMARKS.md` to reflect any new or modified scenarios.
+
+## Validation Commands
+Run the following checks to prove your changes are schema-compliant and safe:
+
+```bash
+python scripts/router_benchmark_runner.py
+python tests/behavior/test_router_benchmark_fixture_validation.py
+python scripts/check_prompt_load_thresholds.py
+python scripts/measure_prompt_load.py
+python tests/behavior/evaluate_governance.py
+python tests/behavior/run_tests.py
+python scripts/validate_manifest.py
+python scripts/governance_check.py --strict
+git diff --check
+```
+
+## CI Reports to Review
+Always verify the uploaded `governance-validation-report` artifact in your Pull Request to confirm:
+1. `router_benchmark_report.txt` exits 0 cleanly.
+2. `router_benchmark_negative_fixture_report.txt` exits 0 cleanly.
+
+## Common Mistakes
+- **Typos in Mode names**: e.g. using `DESTRUCT` instead of `DESTRUCTIVE`. The runner explicitly validates exact string matches.
+- **Incorrect Type for Context**: Providing `"context_a"` instead of `["context_a"]` for `required_context`. The runner strictly requires lists.
+- **Missing DESTRUCTIVE coverage**: The runner explicitly requires at least one destructive case to prove guardrails are active. Deleting it will fail the build.
+
+## Non-Goals
+This document does not specify how to write LLM behavior evaluation tests (those reside in `tests/behavior/`). It strictly concerns the maintenance of the JSON benchmark schema definitions.
+
+## Guide Result
+ROUTER_BENCHMARK_MAINTENANCE_GUIDE_DEFINED

--- a/docs/testing/ROUTER_BENCHMARK_RUNNER.md
+++ b/docs/testing/ROUTER_BENCHMARK_RUNNER.md
@@ -9,7 +9,10 @@ This runner script is scoped exclusively to parsing, validating, and summarizing
 ## Source of Truth
 - **Machine-Readable Fixture**: Benchmark definitions live in `tests/fixtures/router_benchmarks.json`. The runner loads and validates this fixture.
 - **Fixture Schema**: The exact schema contract is defined in [ROUTER_BENCHMARK_FIXTURE_SCHEMA.md](ROUTER_BENCHMARK_FIXTURE_SCHEMA.md).
+- **Maintenance Guide**: Refer to [ROUTER_BENCHMARK_MAINTENANCE_GUIDE.md](ROUTER_BENCHMARK_MAINTENANCE_GUIDE.md) before making edits to the fixture.
 - **Human-Readable Guide**: `docs/testing/ROUTER_VALIDATION_BENCHMARKS.md` remains the primary human-readable benchmark guide.
+
+## Validation Scope
 
 ## What It Validates
 - Ensures every benchmark case has all required keys: `case_id`, `request_type`, `expected_mode`, `expected_skill_route`, `required_context`, `excluded_context`, `governance_status`, and `pass_criteria`.

--- a/docs/testing/ROUTER_VALIDATION_BENCHMARKS.md
+++ b/docs/testing/ROUTER_VALIDATION_BENCHMARKS.md
@@ -3,6 +3,8 @@
 ## Purpose
 This document defines the validation benchmarks used to evaluate the efficiency, accuracy, and safety of the Conductor's router-first execution model against the legacy monolithic context approach.
 
+If you need to add or edit benchmarks, please read the [ROUTER_BENCHMARK_MAINTENANCE_GUIDE.md](ROUTER_BENCHMARK_MAINTENANCE_GUIDE.md).
+
 ## Scope
 These benchmarks apply exclusively to the Conductor's intent classification, mode selection, context retrieval filtering, governance escalation, and skill routing precision. They do not test the actual execution quality of the downstream specialist skills.
 


### PR DESCRIPTION
## Summary

Adds a maintainer guide for safely adding, editing, reviewing, and validating router benchmark fixture cases.

## Changes

- Adds `docs/testing/ROUTER_BENCHMARK_MAINTENANCE_GUIDE.md`.
- Links the maintenance guide from:
  - `docs/testing/ROUTER_BENCHMARK_FIXTURE_SCHEMA.md`
  - `docs/testing/ROUTER_BENCHMARK_RUNNER.md`
  - `docs/testing/ROUTER_VALIDATION_BENCHMARKS.md`
- Updates `CHANGELOG.md` for governance freshness compliance.

## Validation

- `python scripts/router_benchmark_runner.py` passed.
- `python tests/behavior/test_router_benchmark_fixture_validation.py` passed.
- `python scripts/check_prompt_load_thresholds.py` passed.
- `python scripts/measure_prompt_load.py` passed.
- `python tests/behavior/evaluate_governance.py` passed.
- `python tests/behavior/run_tests.py` passed.
- `python scripts/validate_manifest.py` passed.
- `python scripts/governance_check.py --strict` passed.
- `git diff --check` passed.
- `git status --short` passed.

## Notes

This is documentation-only. Runtime behavior, CI behavior, plugin metadata, skill frontmatter, and behavior tests were not changed.