### PR TITLE
test(routing): add priority 1 benchmark fixture cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,4 +169,5 @@ Changes after `v1.0.1` currently tracked in this checkout:
  -   r e c o r d e d   n e g a t i v e   f i x t u r e   t e s t   a r t i f a c t s   i n   C I   a r t i f a c t   i n d e x  
  -   a d d e d   r o u t e r   b e n c h m a r k   m a i n t e n a n c e   g u i d e   w i t h   r e v i e w   c h e c k l i s t s   a n d   v a l i d a t i o n   p r o c e d u r e s  
  -   d r a f t e d   r o u t e r   b e n c h m a r k   c o v e r a g e   e x p a n s i o n   p l a n   f o r   f u t u r e   r o u t i n g   s c e n a r i o s  
+ -   a d d e d   p r i o r i t y   1   r o u t e r   b e n c h m a r k   c a s e s   B M - 1 3   t h r o u g h   B M - 1 6  
  

--- a/docs/testing/ROUTER_BENCHMARK_COVERAGE_EXPANSION_PLAN.md
+++ b/docs/testing/ROUTER_BENCHMARK_COVERAGE_EXPANSION_PLAN.md
@@ -34,7 +34,7 @@ While foundational modes and statuses are covered, the following complex scenari
 ## Candidate Benchmark Categories
 Future expansion will target the following categories to close the identified gaps:
 
-### Priority 1 Cases (BM-13 through BM-16)
+### Priority 1 Cases (BM-13 through BM-16) [IMPLEMENTED]
 - **Multi-Skill Handoff**: Explicitly routing to an initial specialist with a designated follow-up (e.g., `weaver` -> `scribe`).
 - **Ambiguity Resolution**: Forcing the router to ask a clarifying question rather than guessing a path.
 - **Contextual Escalation**: Starting as a standard task but escalating due to implicit database or security context.

--- a/docs/testing/ROUTER_BENCHMARK_FIXTURE_SCHEMA.md
+++ b/docs/testing/ROUTER_BENCHMARK_FIXTURE_SCHEMA.md
@@ -53,7 +53,7 @@ The following fields must be strictly typed as JSON Arrays (lists):
 ## Validation Rules
 The benchmark fixture is validated by `scripts/router_benchmark_runner.py`, which enforces:
 - The root object is a dictionary containing `schema_version` equal to "1.0".
-- The `benchmarks` array exists and contains exactly 12 benchmark cases.
+- The `benchmarks` array exists and contains exactly 16 benchmark cases.
 - All `case_id` values are unique.
 - All required fields are present in every case.
 - Arrays and strings are of the correct types and non-empty where applicable.

--- a/docs/testing/ROUTER_BENCHMARK_RUNNER.md
+++ b/docs/testing/ROUTER_BENCHMARK_RUNNER.md
@@ -17,6 +17,7 @@ This runner script is scoped exclusively to parsing, validating, and summarizing
 ## What It Validates
 - Ensures every benchmark case has all required keys: `case_id`, `request_type`, `expected_mode`, `expected_skill_route`, `required_context`, `excluded_context`, `governance_status`, and `pass_criteria`.
 - Validates the overall completeness of the defined scenarios.
+- Ensures the fixture contains exactly 16 benchmark cases.
 - Verifies that destructive-operation coverage exists.
 
 ## What It Does Not Validate

--- a/docs/testing/ROUTER_VALIDATION_BENCHMARKS.md
+++ b/docs/testing/ROUTER_VALIDATION_BENCHMARKS.md
@@ -52,6 +52,10 @@ A transition from "Very High" to "Low" prompt load for standard tasks, while ach
 | BM-10 | release-readiness task | AUDIT | `overseer` / `steward` | Release slice, Governance | Destructive context | REQUIRED | Formal audit report generated |
 | BM-11 | destructive-operation task | DESTRUCTIVE | `dagger` | Target environment, Guardrails | Standard context | BLOCKED_PENDING_AUTHORIZATION | Pauses for authorization |
 | BM-12 | ambiguous multi-skill task | STANDARD | `conductor` (workflow gen) | `ROUTING_MAP.md` | Specific implementations | CONDITIONAL | Loads ROUTING_MAP.md to resolve |
+| BM-13 | multi-skill routing chain | GOVERNED | `conductor` -> `clockwork` -> `cipher` -> `chronicler` -> `ponytail` | routing, architecture, security, persistence, frontend | destructive-operation context | REQUIRED | Preserves ordered specialist routing before implementation |
+| BM-14 | ambiguous request requiring clarification or reroute | STANDARD | `conductor` | routing, skill index | destructive-operation context, database/security context unless clarified | CONDITIONAL | Ambiguity detection and no premature specialist execution |
+| BM-15 | STANDARD to GOVERNED escalation | GOVERNED | `conductor` -> `the-steward` -> `the-governor` | governance, routing, execution modes | implementation-only context until governance clears | REQUIRED | Escalation when security, database, CI/CD, compliance, or credential-sensitive scope appears |
+| BM-16 | audit-only no-edit task | AUDIT | `conductor` -> `arbiter` | audit, governance, relevant routing context | implementation, destructive-operation context | CONDITIONAL | Read-only findings and no file edits unless explicitly approved |
 
 ## Context Exclusion Checks
 1. Assert `GOVERNANCE_LAYER.md` is strictly absent during FAST mode syntax fixes.
@@ -80,7 +84,7 @@ A transition from "Very High" to "Low" prompt load for standard tasks, while ach
 4. CI/CD strict governance script failures.
 
 ## Validation Checklist
-- [ ] Run dry-run prompt captures for BM-01 through BM-12.
+- [ ] Run dry-run prompt captures for BM-01 through BM-16.
 - [ ] Evaluate context inclusion/exclusion mathematically or via manual log inspection.
 - [ ] Run `python tests/behavior/evaluate_governance.py` to confirm behavioral bounds.
 - [ ] Run `python scripts/governance_check.py --strict` to verify policy adherence.

--- a/scripts/router_benchmark_runner.py
+++ b/scripts/router_benchmark_runner.py
@@ -134,8 +134,8 @@ def main():
         print("[ERROR] No destructive-operation benchmarks found! Failing.")
         sys.exit(1)
 
-    if total_cases != 12:
-        print(f"[ERROR] Expected exactly 12 benchmark cases, found {total_cases}.")
+    if total_cases != 16:
+        print(f"[ERROR] Expected exactly 16 benchmark cases, found {total_cases}.")
         sys.exit(1)
 
     print("[SUCCESS] Benchmark definitions are structurally valid.")

--- a/tests/behavior/test_router_benchmark_fixture_validation.py
+++ b/tests/behavior/test_router_benchmark_fixture_validation.py
@@ -31,10 +31,10 @@ def test_negative_cases():
         "pass_criteria": "pass"
     }
     
-    # helper to generate 12 cases
-    def generate_12_cases(override_case=None):
+    # helper to generate 16 cases
+    def generate_16_cases(override_case=None):
         cases = []
-        for i in range(12):
+        for i in range(16):
             case = base_case.copy()
             case["case_id"] = f"BM-{i}"
             if i == 0 and override_case:
@@ -49,22 +49,22 @@ def test_negative_cases():
     assert run_runner(valid_fixture_path) == 0, "Valid fixture failed"
 
     negative_cases = [
-        ("missing schema_version", {"benchmarks": generate_12_cases()}),
-        ("wrong schema_version", {"schema_version": "2.0", "benchmarks": generate_12_cases()}),
+        ("missing schema_version", {"benchmarks": generate_16_cases()}),
+        ("wrong schema_version", {"schema_version": "2.0", "benchmarks": generate_16_cases()}),
         ("missing benchmarks key", {"schema_version": "1.0"}),
         ("benchmarks is not a list", {"schema_version": "1.0", "benchmarks": {}}),
-        ("duplicate case_id", {"schema_version": "1.0", "benchmarks": generate_12_cases({"case_id": "BM-1"})}),
-        ("missing required field", {"schema_version": "1.0", "benchmarks": generate_12_cases()}),
-        ("invalid expected_mode", {"schema_version": "1.0", "benchmarks": generate_12_cases({"expected_mode": "INVALID"})}),
-        ("invalid governance_status", {"schema_version": "1.0", "benchmarks": generate_12_cases({"governance_status": "INVALID"})}),
-        ("required_context is not a list", {"schema_version": "1.0", "benchmarks": generate_12_cases({"required_context": "string"})}),
-        ("excluded_context is not a list", {"schema_version": "1.0", "benchmarks": generate_12_cases({"excluded_context": "string"})}),
-        ("empty pass_criteria", {"schema_version": "1.0", "benchmarks": generate_12_cases({"pass_criteria": "   "})}),
-        ("benchmark count not equal to 12", {"schema_version": "1.0", "benchmarks": generate_12_cases()[:-1]}),
+        ("duplicate case_id", {"schema_version": "1.0", "benchmarks": generate_16_cases({"case_id": "BM-1"})}),
+        ("missing required field", {"schema_version": "1.0", "benchmarks": generate_16_cases()}),
+        ("invalid expected_mode", {"schema_version": "1.0", "benchmarks": generate_16_cases({"expected_mode": "INVALID"})}),
+        ("invalid governance_status", {"schema_version": "1.0", "benchmarks": generate_16_cases({"governance_status": "INVALID"})}),
+        ("required_context is not a list", {"schema_version": "1.0", "benchmarks": generate_16_cases({"required_context": "string"})}),
+        ("excluded_context is not a list", {"schema_version": "1.0", "benchmarks": generate_16_cases({"excluded_context": "string"})}),
+        ("empty pass_criteria", {"schema_version": "1.0", "benchmarks": generate_16_cases({"pass_criteria": "   "})}),
+        ("benchmark count not equal to 16", {"schema_version": "1.0", "benchmarks": generate_16_cases()[:-1]}),
     ]
     
     # Fix the missing required field test
-    cases_missing_field = generate_12_cases()
+    cases_missing_field = generate_16_cases()
     del cases_missing_field[0]["request_type"]
     negative_cases[5] = ("missing required field", {"schema_version": "1.0", "benchmarks": cases_missing_field})
 

--- a/tests/fixtures/router_benchmarks.json
+++ b/tests/fixtures/router_benchmarks.json
@@ -185,6 +185,73 @@
       ],
       "governance_status": "CONDITIONAL",
       "pass_criteria": "Loads ROUTING_MAP.md to resolve"
+    },
+    {
+      "case_id": "BM-13",
+      "request_type": "multi-skill routing chain",
+      "expected_mode": "GOVERNED",
+      "expected_skill_route": "conductor -> clockwork -> cipher -> chronicler -> ponytail",
+      "required_context": [
+        "routing",
+        "architecture",
+        "security",
+        "persistence",
+        "frontend"
+      ],
+      "excluded_context": [
+        "destructive-operation context"
+      ],
+      "governance_status": "REQUIRED",
+      "pass_criteria": "Preserves ordered specialist routing before implementation"
+    },
+    {
+      "case_id": "BM-14",
+      "request_type": "ambiguous request requiring clarification or reroute",
+      "expected_mode": "STANDARD",
+      "expected_skill_route": "conductor",
+      "required_context": [
+        "routing",
+        "skill index"
+      ],
+      "excluded_context": [
+        "destructive-operation context",
+        "database/security context unless clarified"
+      ],
+      "governance_status": "CONDITIONAL",
+      "pass_criteria": "Ambiguity detection and no premature specialist execution"
+    },
+    {
+      "case_id": "BM-15",
+      "request_type": "STANDARD to GOVERNED escalation",
+      "expected_mode": "GOVERNED",
+      "expected_skill_route": "conductor -> the-steward -> the-governor",
+      "required_context": [
+        "governance",
+        "routing",
+        "execution modes"
+      ],
+      "excluded_context": [
+        "implementation-only context until governance clears"
+      ],
+      "governance_status": "REQUIRED",
+      "pass_criteria": "Escalation when security, database, CI/CD, compliance, or credential-sensitive scope appears"
+    },
+    {
+      "case_id": "BM-16",
+      "request_type": "audit-only no-edit task",
+      "expected_mode": "AUDIT",
+      "expected_skill_route": "conductor -> arbiter",
+      "required_context": [
+        "audit",
+        "governance",
+        "relevant routing context"
+      ],
+      "excluded_context": [
+        "implementation",
+        "destructive-operation context"
+      ],
+      "governance_status": "CONDITIONAL",
+      "pass_criteria": "Read-only findings and no file edits unless explicitly approved"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Implements Priority 1 router benchmark coverage expansion by adding BM-13 through BM-16.

## Changes

- Adds BM-13 through BM-16 to `tests/fixtures/router_benchmarks.json`.
- Expands benchmark count from 12 to 16.
- Updates `scripts/router_benchmark_runner.py`.
- Updates `tests/behavior/test_router_benchmark_fixture_validation.py`.
- Updates benchmark documentation and fixture schema documentation.
- Marks Priority 1 coverage as implemented in `docs/testing/ROUTER_BENCHMARK_COVERAGE_EXPANSION_PLAN.md`.
- Updates `CHANGELOG.md` for governance freshness compliance.

## New Benchmark Cases

- BM-13: Multi-skill routing chain.
- BM-14: Ambiguous request requiring clarification or reroute.
- BM-15: STANDARD to GOVERNED escalation.
- BM-16: Audit-only no-edit task.

## Validation

- `python scripts/router_benchmark_runner.py` passed.
- Benchmark count is exactly 16.
- `python tests/behavior/test_router_benchmark_fixture_validation.py` passed.
- `python scripts/check_prompt_load_thresholds.py` passed.
- `python scripts/measure_prompt_load.py` passed.
- `python tests/behavior/evaluate_governance.py` passed.
- `python tests/behavior/run_tests.py` passed.
- `python scripts/validate_manifest.py` passed.
- `python scripts/governance_check.py --strict` passed.
- `git diff --check` passed.

## Notes

This is benchmark fixture and validation tooling only. Runtime behavior, CI workflow files, plugin metadata, skill frontmatter, and existing benchmark coverage were not weakened.