### PR TITLE
test(routing): add priority 2 router benchmark cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,4 +170,5 @@ Changes after `v1.0.1` currently tracked in this checkout:
  -   a d d e d   r o u t e r   b e n c h m a r k   m a i n t e n a n c e   g u i d e   w i t h   r e v i e w   c h e c k l i s t s   a n d   v a l i d a t i o n   p r o c e d u r e s  
  -   d r a f t e d   r o u t e r   b e n c h m a r k   c o v e r a g e   e x p a n s i o n   p l a n   f o r   f u t u r e   r o u t i n g   s c e n a r i o s  
  -   a d d e d   p r i o r i t y   1   r o u t e r   b e n c h m a r k   c a s e s   B M - 1 3   t h r o u g h   B M - 1 6  
+ -   a d d e d   p r i o r i t y   2   r o u t e r   b e n c h m a r k   c a s e s   B M - 1 7   t h r o u g h   B M - 2 0  
  

--- a/docs/testing/ROUTER_BENCHMARK_COVERAGE_EXPANSION_PLAN.md
+++ b/docs/testing/ROUTER_BENCHMARK_COVERAGE_EXPANSION_PLAN.md
@@ -40,7 +40,7 @@ Future expansion will target the following categories to close the identified ga
 - **Contextual Escalation**: Starting as a standard task but escalating due to implicit database or security context.
 - **Audit Compliance**: Enforcing read-only behavior for comprehensive review tasks.
 
-### Priority 2 Cases (BM-17 through BM-20)
+### Priority 2 Cases (BM-17 through BM-20) [IMPLEMENTED]
 - **Frontend Guardrails**: Requiring architecture (`Clockwork`), security (`Cipher`), or data (`Chronicler`) review before executing frontend changes (`Ponytail`).
 - **Documentation Efficiency**: Stripping all code files from context for pure documentation updates.
 - **Database Sensitivity**: Aggressive `GOVERNANCE_LAYER.md` loading for schema changes.

--- a/docs/testing/ROUTER_BENCHMARK_FIXTURE_SCHEMA.md
+++ b/docs/testing/ROUTER_BENCHMARK_FIXTURE_SCHEMA.md
@@ -53,7 +53,7 @@ The following fields must be strictly typed as JSON Arrays (lists):
 ## Validation Rules
 The benchmark fixture is validated by `scripts/router_benchmark_runner.py`, which enforces:
 - The root object is a dictionary containing `schema_version` equal to "1.0".
-- The `benchmarks` array exists and contains exactly 16 benchmark cases.
+- The `benchmarks` array exists and contains exactly 20 benchmark cases.
 - All `case_id` values are unique.
 - All required fields are present in every case.
 - Arrays and strings are of the correct types and non-empty where applicable.

--- a/docs/testing/ROUTER_BENCHMARK_RUNNER.md
+++ b/docs/testing/ROUTER_BENCHMARK_RUNNER.md
@@ -17,7 +17,7 @@ This runner script is scoped exclusively to parsing, validating, and summarizing
 ## What It Validates
 - Ensures every benchmark case has all required keys: `case_id`, `request_type`, `expected_mode`, `expected_skill_route`, `required_context`, `excluded_context`, `governance_status`, and `pass_criteria`.
 - Validates the overall completeness of the defined scenarios.
-- Ensures the fixture contains exactly 16 benchmark cases.
+- Ensures the fixture contains exactly 20 benchmark cases.
 - Verifies that destructive-operation coverage exists.
 
 ## What It Does Not Validate

--- a/docs/testing/ROUTER_VALIDATION_BENCHMARKS.md
+++ b/docs/testing/ROUTER_VALIDATION_BENCHMARKS.md
@@ -56,6 +56,10 @@ A transition from "Very High" to "Low" prompt load for standard tasks, while ach
 | BM-14 | ambiguous request requiring clarification or reroute | STANDARD | `conductor` | routing, skill index | destructive-operation context, database/security context unless clarified | CONDITIONAL | Ambiguity detection and no premature specialist execution |
 | BM-15 | STANDARD to GOVERNED escalation | GOVERNED | `conductor` -> `the-steward` -> `the-governor` | governance, routing, execution modes | implementation-only context until governance clears | REQUIRED | Escalation when security, database, CI/CD, compliance, or credential-sensitive scope appears |
 | BM-16 | audit-only no-edit task | AUDIT | `conductor` -> `arbiter` | audit, governance, relevant routing context | implementation, destructive-operation context | CONDITIONAL | Read-only findings and no file edits unless explicitly approved |
+| BM-17 | frontend requiring Clockwork before Ponytail | GOVERNED | `conductor` -> `clockwork` -> `ponytail` | routing, architecture, frontend, execution modes | destructive-operation context | REQUIRED | Clockwork review before Ponytail when frontend work affects API shape, data flow, service boundaries, backend validation, auth boundary placement, or architectural layering |
+| BM-18 | frontend requiring Cipher before Ponytail | GOVERNED | `conductor` -> `cipher` -> `ponytail` | routing, security, frontend, governance | destructive-operation context unless destructive scope appears | REQUIRED | Cipher review before Ponytail when frontend work affects authorization, privacy, destructive actions, secrets, security-sensitive workflows, payments, or compliance-sensitive journeys |
+| BM-19 | frontend requiring Chronicler before Ponytail | GOVERNED | `conductor` -> `chronicler` -> `ponytail` | routing, persistence, database, frontend, governance | destructive-operation context | REQUIRED | Chronicler review before Ponytail when frontend work affects persistence, schema, migrations, reporting data, ORM behavior, or stored records |
+| BM-20 | docs-only lightweight routing | FAST | `conductor` -> `scribe` | documentation, skill index | governance, destructive-operation, database, security, CI/CD, implementation-heavy context | NOT_REQUIRED | Lightweight docs routing with no unnecessary governance hydration |
 
 ## Context Exclusion Checks
 1. Assert `GOVERNANCE_LAYER.md` is strictly absent during FAST mode syntax fixes.
@@ -84,7 +88,7 @@ A transition from "Very High" to "Low" prompt load for standard tasks, while ach
 4. CI/CD strict governance script failures.
 
 ## Validation Checklist
-- [ ] Run dry-run prompt captures for BM-01 through BM-16.
+- [ ] Run dry-run prompt captures for BM-01 through BM-20.
 - [ ] Evaluate context inclusion/exclusion mathematically or via manual log inspection.
 - [ ] Run `python tests/behavior/evaluate_governance.py` to confirm behavioral bounds.
 - [ ] Run `python scripts/governance_check.py --strict` to verify policy adherence.

--- a/scripts/router_benchmark_runner.py
+++ b/scripts/router_benchmark_runner.py
@@ -55,6 +55,7 @@ def main():
             print(f"[ERROR] Fixture {fixture_path} 'benchmarks' must be a list")
             sys.exit(1)
 
+        EXPECTED_BENCHMARK_COUNT = 20
         BENCHMARK_CASES = fixture_data["benchmarks"]
     except Exception as e:
         print(f"[ERROR] Failed to load {fixture_path}: {e}")
@@ -134,8 +135,8 @@ def main():
         print("[ERROR] No destructive-operation benchmarks found! Failing.")
         sys.exit(1)
 
-    if total_cases != 16:
-        print(f"[ERROR] Expected exactly 16 benchmark cases, found {total_cases}.")
+    if total_cases != 20:
+        print(f"[ERROR] Expected exactly 20 benchmark cases, found {total_cases}.")
         sys.exit(1)
 
     print("[SUCCESS] Benchmark definitions are structurally valid.")

--- a/tests/behavior/test_router_benchmark_fixture_validation.py
+++ b/tests/behavior/test_router_benchmark_fixture_validation.py
@@ -31,10 +31,10 @@ def test_negative_cases():
         "pass_criteria": "pass"
     }
     
-    # helper to generate 16 cases
-    def generate_16_cases(override_case=None):
+    # helper to generate 20 cases
+    def generate_20_cases(override_case=None):
         cases = []
-        for i in range(16):
+        for i in range(20):
             case = base_case.copy()
             case["case_id"] = f"BM-{i}"
             if i == 0 and override_case:
@@ -49,22 +49,22 @@ def test_negative_cases():
     assert run_runner(valid_fixture_path) == 0, "Valid fixture failed"
 
     negative_cases = [
-        ("missing schema_version", {"benchmarks": generate_16_cases()}),
-        ("wrong schema_version", {"schema_version": "2.0", "benchmarks": generate_16_cases()}),
+        ("missing schema_version", {"benchmarks": generate_20_cases()}),
+        ("wrong schema_version", {"schema_version": "2.0", "benchmarks": generate_20_cases()}),
         ("missing benchmarks key", {"schema_version": "1.0"}),
         ("benchmarks is not a list", {"schema_version": "1.0", "benchmarks": {}}),
-        ("duplicate case_id", {"schema_version": "1.0", "benchmarks": generate_16_cases({"case_id": "BM-1"})}),
-        ("missing required field", {"schema_version": "1.0", "benchmarks": generate_16_cases()}),
-        ("invalid expected_mode", {"schema_version": "1.0", "benchmarks": generate_16_cases({"expected_mode": "INVALID"})}),
-        ("invalid governance_status", {"schema_version": "1.0", "benchmarks": generate_16_cases({"governance_status": "INVALID"})}),
-        ("required_context is not a list", {"schema_version": "1.0", "benchmarks": generate_16_cases({"required_context": "string"})}),
-        ("excluded_context is not a list", {"schema_version": "1.0", "benchmarks": generate_16_cases({"excluded_context": "string"})}),
-        ("empty pass_criteria", {"schema_version": "1.0", "benchmarks": generate_16_cases({"pass_criteria": "   "})}),
-        ("benchmark count not equal to 16", {"schema_version": "1.0", "benchmarks": generate_16_cases()[:-1]}),
+        ("duplicate case_id", {"schema_version": "1.0", "benchmarks": generate_20_cases({"case_id": "BM-1"})}),
+        ("missing required field", {"schema_version": "1.0", "benchmarks": generate_20_cases()}),
+        ("invalid expected_mode", {"schema_version": "1.0", "benchmarks": generate_20_cases({"expected_mode": "INVALID"})}),
+        ("invalid governance_status", {"schema_version": "1.0", "benchmarks": generate_20_cases({"governance_status": "INVALID"})}),
+        ("required_context is not a list", {"schema_version": "1.0", "benchmarks": generate_20_cases({"required_context": "string"})}),
+        ("excluded_context is not a list", {"schema_version": "1.0", "benchmarks": generate_20_cases({"excluded_context": "string"})}),
+        ("empty pass_criteria", {"schema_version": "1.0", "benchmarks": generate_20_cases({"pass_criteria": "   "})}),
+        ("benchmark count not equal to 20", {"schema_version": "1.0", "benchmarks": generate_20_cases()[:-1]}),
     ]
     
     # Fix the missing required field test
-    cases_missing_field = generate_16_cases()
+    cases_missing_field = generate_20_cases()
     del cases_missing_field[0]["request_type"]
     negative_cases[5] = ("missing required field", {"schema_version": "1.0", "benchmarks": cases_missing_field})
 

--- a/tests/fixtures/router_benchmarks.json
+++ b/tests/fixtures/router_benchmarks.json
@@ -252,6 +252,78 @@
       ],
       "governance_status": "CONDITIONAL",
       "pass_criteria": "Read-only findings and no file edits unless explicitly approved"
+    },
+    {
+      "case_id": "BM-17",
+      "request_type": "frontend requiring Clockwork before Ponytail",
+      "expected_mode": "GOVERNED",
+      "expected_skill_route": "conductor -> clockwork -> ponytail",
+      "required_context": [
+        "routing",
+        "architecture",
+        "frontend",
+        "execution modes"
+      ],
+      "excluded_context": [
+        "destructive-operation context"
+      ],
+      "governance_status": "REQUIRED",
+      "pass_criteria": "Clockwork review before Ponytail when frontend work affects API shape, data flow, service boundaries, backend validation, auth boundary placement, or architectural layering"
+    },
+    {
+      "case_id": "BM-18",
+      "request_type": "frontend requiring Cipher before Ponytail",
+      "expected_mode": "GOVERNED",
+      "expected_skill_route": "conductor -> cipher -> ponytail",
+      "required_context": [
+        "routing",
+        "security",
+        "frontend",
+        "governance"
+      ],
+      "excluded_context": [
+        "destructive-operation context unless destructive scope appears"
+      ],
+      "governance_status": "REQUIRED",
+      "pass_criteria": "Cipher review before Ponytail when frontend work affects authorization, privacy, destructive actions, secrets, security-sensitive workflows, payments, or compliance-sensitive journeys"
+    },
+    {
+      "case_id": "BM-19",
+      "request_type": "frontend requiring Chronicler before Ponytail",
+      "expected_mode": "GOVERNED",
+      "expected_skill_route": "conductor -> chronicler -> ponytail",
+      "required_context": [
+        "routing",
+        "persistence",
+        "database",
+        "frontend",
+        "governance"
+      ],
+      "excluded_context": [
+        "destructive-operation context"
+      ],
+      "governance_status": "REQUIRED",
+      "pass_criteria": "Chronicler review before Ponytail when frontend work affects persistence, schema, migrations, reporting data, ORM behavior, or stored records"
+    },
+    {
+      "case_id": "BM-20",
+      "request_type": "docs-only lightweight routing",
+      "expected_mode": "FAST",
+      "expected_skill_route": "conductor -> scribe",
+      "required_context": [
+        "documentation",
+        "skill index"
+      ],
+      "excluded_context": [
+        "governance",
+        "destructive-operation",
+        "database",
+        "security",
+        "CI/CD",
+        "implementation-heavy context"
+      ],
+      "governance_status": "NOT_REQUIRED",
+      "pass_criteria": "Lightweight docs routing with no unnecessary governance hydration"
     }
   ]
 }


### PR DESCRIPTION
- add BM-17 through BM-20 priority router benchmark cases

- cover frontend Clockwork, Cipher, Chronicler guardrails and lightweight docs routing

- update benchmark runner and negative validation expected count

- update benchmark documentation and coverage plan

- preserve runtime behavior and governance gates

- update changelog if required by strict governance freshness

## Summary

Implements Priority 2 router benchmark coverage expansion by adding BM-17 through BM-20.

## Changes

- Adds BM-17 through BM-20 to `tests/fixtures/router_benchmarks.json`.
- Expands benchmark count from 16 to 20.
- Updates `scripts/router_benchmark_runner.py`.
- Updates `tests/behavior/test_router_benchmark_fixture_validation.py`.
- Updates benchmark documentation and fixture schema documentation.
- Marks Priority 2 coverage as implemented in `docs/testing/ROUTER_BENCHMARK_COVERAGE_EXPANSION_PLAN.md`.
- Updates `CHANGELOG.md` for governance freshness compliance.

## New Benchmark Cases

- BM-17: Frontend work requiring Clockwork before Ponytail.
- BM-18: Frontend work requiring Cipher before Ponytail.
- BM-19: Frontend work requiring Chronicler before Ponytail.
- BM-20: Docs-only lightweight routing that should avoid heavy governance context.

## Validation

- `python scripts/router_benchmark_runner.py` passed.
- Benchmark count is exactly 20.
- `python tests/behavior/test_router_benchmark_fixture_validation.py` passed.
- `python scripts/check_prompt_load_thresholds.py` passed.
- `python scripts/measure_prompt_load.py` passed.
- `python tests/behavior/evaluate_governance.py` passed.
- `python tests/behavior/run_tests.py` passed.
- `python scripts/validate_manifest.py` passed.
- `python scripts/governance_check.py --strict` passed.
- `git diff --check` passed.

## Notes

This is benchmark fixture and validation tooling only. Runtime behavior, CI workflow files, plugin metadata, skill frontmatter, and existing benchmark coverage were not weakened.