### PR TITLE
test(routing): add priority 3 router benchmark cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,4 +171,5 @@ Changes after `v1.0.1` currently tracked in this checkout:
  -   d r a f t e d   r o u t e r   b e n c h m a r k   c o v e r a g e   e x p a n s i o n   p l a n   f o r   f u t u r e   r o u t i n g   s c e n a r i o s  
  -   a d d e d   p r i o r i t y   1   r o u t e r   b e n c h m a r k   c a s e s   B M - 1 3   t h r o u g h   B M - 1 6  
  -   a d d e d   p r i o r i t y   2   r o u t e r   b e n c h m a r k   c a s e s   B M - 1 7   t h r o u g h   B M - 2 0  
+ -   a d d e d   p r i o r i t y   3   r o u t e r   b e n c h m a r k   c a s e s   B M - 2 1   t h r o u g h   B M - 2 4  
  

--- a/docs/testing/ROUTER_BENCHMARK_COVERAGE_EXPANSION_PLAN.md
+++ b/docs/testing/ROUTER_BENCHMARK_COVERAGE_EXPANSION_PLAN.md
@@ -46,7 +46,7 @@ Future expansion will target the following categories to close the identified ga
 - **Database Sensitivity**: Aggressive `GOVERNANCE_LAYER.md` loading for schema changes.
 - **Security Scrutiny**: Unconditional escalation for authentication/authorization changes.
 
-### Priority 3 Cases (BM-21 through BM-24)
+### Priority 3 Cases (BM-21 through BM-24) [IMPLEMENTED]
 - **CI/CD Impact**: Mode escalation for modifying workflow files.
 - **Release Readiness**: Triggering formal audit generation for release preparations.
 - **Prompt Load Extremes**: Cases designed specifically to measure the limits of minimal vs. full context loading.

--- a/docs/testing/ROUTER_BENCHMARK_FIXTURE_SCHEMA.md
+++ b/docs/testing/ROUTER_BENCHMARK_FIXTURE_SCHEMA.md
@@ -53,7 +53,7 @@ The following fields must be strictly typed as JSON Arrays (lists):
 ## Validation Rules
 The benchmark fixture is validated by `scripts/router_benchmark_runner.py`, which enforces:
 - The root object is a dictionary containing `schema_version` equal to "1.0".
-- The `benchmarks` array exists and contains exactly 20 benchmark cases.
+- The `benchmarks` array exists and contains exactly 24 benchmark cases.
 - All `case_id` values are unique.
 - All required fields are present in every case.
 - Arrays and strings are of the correct types and non-empty where applicable.

--- a/docs/testing/ROUTER_BENCHMARK_RUNNER.md
+++ b/docs/testing/ROUTER_BENCHMARK_RUNNER.md
@@ -17,7 +17,7 @@ This runner script is scoped exclusively to parsing, validating, and summarizing
 ## What It Validates
 - Ensures every benchmark case has all required keys: `case_id`, `request_type`, `expected_mode`, `expected_skill_route`, `required_context`, `excluded_context`, `governance_status`, and `pass_criteria`.
 - Validates the overall completeness of the defined scenarios.
-- Ensures the fixture contains exactly 20 benchmark cases.
+- Ensures the fixture contains exactly 24 benchmark cases.
 - Verifies that destructive-operation coverage exists.
 
 ## What It Does Not Validate

--- a/docs/testing/ROUTER_VALIDATION_BENCHMARKS.md
+++ b/docs/testing/ROUTER_VALIDATION_BENCHMARKS.md
@@ -60,6 +60,10 @@ A transition from "Very High" to "Low" prompt load for standard tasks, while ach
 | BM-18 | frontend requiring Cipher before Ponytail | GOVERNED | `conductor` -> `cipher` -> `ponytail` | routing, security, frontend, governance | destructive-operation context unless destructive scope appears | REQUIRED | Cipher review before Ponytail when frontend work affects authorization, privacy, destructive actions, secrets, security-sensitive workflows, payments, or compliance-sensitive journeys |
 | BM-19 | frontend requiring Chronicler before Ponytail | GOVERNED | `conductor` -> `chronicler` -> `ponytail` | routing, persistence, database, frontend, governance | destructive-operation context | REQUIRED | Chronicler review before Ponytail when frontend work affects persistence, schema, migrations, reporting data, ORM behavior, or stored records |
 | BM-20 | docs-only lightweight routing | FAST | `conductor` -> `scribe` | documentation, skill index | governance, destructive-operation, database, security, CI/CD, implementation-heavy context | NOT_REQUIRED | Lightweight docs routing with no unnecessary governance hydration |
+| BM-21 | CI/CD-sensitive request | GOVERNED | `conductor` -> `the-steward` -> `the-governor` -> `overseer` | routing, governance, CI/CD, validation, release/readiness | destructive-operation context unless destructive commands appear | REQUIRED | Requires governance review before CI/CD workflow changes and preserve existing validation gates |
+| BM-22 | release-readiness request | AUDIT | `conductor` -> `arbiter` -> `overseer` | audit, release/readiness, governance, validation, changelog | implementation-heavy, destructive-operation context | CONDITIONAL | Requires read-only release readiness findings and no implementation unless explicitly approved |
+| BM-23 | prompt-load/context-selection scenario | STANDARD | `conductor` | prompt-load metrics, threshold policy, routing, context retrieval rules | destructive-operation, implementation-heavy, database, security context unless triggered | CONDITIONAL | Requires loading only minimal relevant context and avoiding broad hydration |
+| BM-24 | complex destructive-operation request | DESTRUCTIVE | `conductor` -> `dagger` | destructive-operation, governance, safety, authorization | implementation execution context until authorization clears | BLOCKED_PENDING_AUTHORIZATION | Requires blocking execution pending explicit authorization and safety gate evidence |
 
 ## Context Exclusion Checks
 1. Assert `GOVERNANCE_LAYER.md` is strictly absent during FAST mode syntax fixes.
@@ -88,7 +92,7 @@ A transition from "Very High" to "Low" prompt load for standard tasks, while ach
 4. CI/CD strict governance script failures.
 
 ## Validation Checklist
-- [ ] Run dry-run prompt captures for BM-01 through BM-20.
+- [ ] Run dry-run prompt captures for BM-01 through BM-24.
 - [ ] Evaluate context inclusion/exclusion mathematically or via manual log inspection.
 - [ ] Run `python tests/behavior/evaluate_governance.py` to confirm behavioral bounds.
 - [ ] Run `python scripts/governance_check.py --strict` to verify policy adherence.

--- a/scripts/router_benchmark_runner.py
+++ b/scripts/router_benchmark_runner.py
@@ -55,7 +55,7 @@ def main():
             print(f"[ERROR] Fixture {fixture_path} 'benchmarks' must be a list")
             sys.exit(1)
 
-        EXPECTED_BENCHMARK_COUNT = 20
+        EXPECTED_BENCHMARK_COUNT = 24
         BENCHMARK_CASES = fixture_data["benchmarks"]
     except Exception as e:
         print(f"[ERROR] Failed to load {fixture_path}: {e}")
@@ -135,8 +135,8 @@ def main():
         print("[ERROR] No destructive-operation benchmarks found! Failing.")
         sys.exit(1)
 
-    if total_cases != 20:
-        print(f"[ERROR] Expected exactly 20 benchmark cases, found {total_cases}.")
+    if total_cases != 24:
+        print(f"[ERROR] Expected exactly 24 benchmark cases, found {total_cases}.")
         sys.exit(1)
 
     print("[SUCCESS] Benchmark definitions are structurally valid.")

--- a/tests/behavior/test_router_benchmark_fixture_validation.py
+++ b/tests/behavior/test_router_benchmark_fixture_validation.py
@@ -31,10 +31,10 @@ def test_negative_cases():
         "pass_criteria": "pass"
     }
     
-    # helper to generate 20 cases
-    def generate_20_cases(override_case=None):
+    # helper to generate 24 cases
+    def generate_24_cases(override_case=None):
         cases = []
-        for i in range(20):
+        for i in range(24):
             case = base_case.copy()
             case["case_id"] = f"BM-{i}"
             if i == 0 and override_case:
@@ -49,22 +49,22 @@ def test_negative_cases():
     assert run_runner(valid_fixture_path) == 0, "Valid fixture failed"
 
     negative_cases = [
-        ("missing schema_version", {"benchmarks": generate_20_cases()}),
-        ("wrong schema_version", {"schema_version": "2.0", "benchmarks": generate_20_cases()}),
+        ("missing schema_version", {"benchmarks": generate_24_cases()}),
+        ("wrong schema_version", {"schema_version": "2.0", "benchmarks": generate_24_cases()}),
         ("missing benchmarks key", {"schema_version": "1.0"}),
         ("benchmarks is not a list", {"schema_version": "1.0", "benchmarks": {}}),
-        ("duplicate case_id", {"schema_version": "1.0", "benchmarks": generate_20_cases({"case_id": "BM-1"})}),
-        ("missing required field", {"schema_version": "1.0", "benchmarks": generate_20_cases()}),
-        ("invalid expected_mode", {"schema_version": "1.0", "benchmarks": generate_20_cases({"expected_mode": "INVALID"})}),
-        ("invalid governance_status", {"schema_version": "1.0", "benchmarks": generate_20_cases({"governance_status": "INVALID"})}),
-        ("required_context is not a list", {"schema_version": "1.0", "benchmarks": generate_20_cases({"required_context": "string"})}),
-        ("excluded_context is not a list", {"schema_version": "1.0", "benchmarks": generate_20_cases({"excluded_context": "string"})}),
-        ("empty pass_criteria", {"schema_version": "1.0", "benchmarks": generate_20_cases({"pass_criteria": "   "})}),
-        ("benchmark count not equal to 20", {"schema_version": "1.0", "benchmarks": generate_20_cases()[:-1]}),
+        ("duplicate case_id", {"schema_version": "1.0", "benchmarks": generate_24_cases({"case_id": "BM-1"})}),
+        ("missing required field", {"schema_version": "1.0", "benchmarks": generate_24_cases()}),
+        ("invalid expected_mode", {"schema_version": "1.0", "benchmarks": generate_24_cases({"expected_mode": "INVALID"})}),
+        ("invalid governance_status", {"schema_version": "1.0", "benchmarks": generate_24_cases({"governance_status": "INVALID"})}),
+        ("required_context is not a list", {"schema_version": "1.0", "benchmarks": generate_24_cases({"required_context": "string"})}),
+        ("excluded_context is not a list", {"schema_version": "1.0", "benchmarks": generate_24_cases({"excluded_context": "string"})}),
+        ("empty pass_criteria", {"schema_version": "1.0", "benchmarks": generate_24_cases({"pass_criteria": "   "})}),
+        ("benchmark count not equal to 24", {"schema_version": "1.0", "benchmarks": generate_24_cases()[:-1]}),
     ]
     
     # Fix the missing required field test
-    cases_missing_field = generate_20_cases()
+    cases_missing_field = generate_24_cases()
     del cases_missing_field[0]["request_type"]
     negative_cases[5] = ("missing required field", {"schema_version": "1.0", "benchmarks": cases_missing_field})
 

--- a/tests/fixtures/router_benchmarks.json
+++ b/tests/fixtures/router_benchmarks.json
@@ -324,6 +324,80 @@
       ],
       "governance_status": "NOT_REQUIRED",
       "pass_criteria": "Lightweight docs routing with no unnecessary governance hydration"
+    },
+    {
+      "case_id": "BM-21",
+      "request_type": "CI/CD-sensitive request requiring GOVERNED routing",
+      "expected_mode": "GOVERNED",
+      "expected_skill_route": "conductor -> the-steward -> the-governor -> overseer",
+      "required_context": [
+        "routing",
+        "governance",
+        "CI/CD",
+        "validation",
+        "release/readiness"
+      ],
+      "excluded_context": [
+        "destructive-operation context unless destructive commands appear"
+      ],
+      "governance_status": "REQUIRED",
+      "pass_criteria": "Requires governance review before CI/CD workflow changes and preserve existing validation gates"
+    },
+    {
+      "case_id": "BM-22",
+      "request_type": "release-readiness request requiring AUDIT routing",
+      "expected_mode": "AUDIT",
+      "expected_skill_route": "conductor -> arbiter -> overseer",
+      "required_context": [
+        "audit",
+        "release/readiness",
+        "governance",
+        "validation",
+        "changelog"
+      ],
+      "excluded_context": [
+        "implementation-heavy",
+        "destructive-operation context"
+      ],
+      "governance_status": "CONDITIONAL",
+      "pass_criteria": "Requires read-only release readiness findings and no implementation unless explicitly approved"
+    },
+    {
+      "case_id": "BM-23",
+      "request_type": "prompt-load/context-selection scenario requiring minimal context control",
+      "expected_mode": "STANDARD",
+      "expected_skill_route": "conductor",
+      "required_context": [
+        "prompt-load metrics",
+        "threshold policy",
+        "routing",
+        "context retrieval rules"
+      ],
+      "excluded_context": [
+        "destructive-operation",
+        "implementation-heavy",
+        "database",
+        "security context unless triggered"
+      ],
+      "governance_status": "CONDITIONAL",
+      "pass_criteria": "Requires loading only minimal relevant context and avoiding broad hydration"
+    },
+    {
+      "case_id": "BM-24",
+      "request_type": "complex destructive-operation request requiring blocked authorization",
+      "expected_mode": "DESTRUCTIVE",
+      "expected_skill_route": "conductor -> dagger",
+      "required_context": [
+        "destructive-operation",
+        "governance",
+        "safety",
+        "authorization"
+      ],
+      "excluded_context": [
+        "implementation execution context until authorization clears"
+      ],
+      "governance_status": "BLOCKED_PENDING_AUTHORIZATION",
+      "pass_criteria": "Requires blocking execution pending explicit authorization and safety gate evidence"
     }
   ]
 }


### PR DESCRIPTION
- add BM-21 through BM-24 priority router benchmark cases

- cover CI/CD, release-readiness, prompt-load, and destructive-operation scenarios

- update benchmark runner and negative validation expected count

- update benchmark documentation and coverage plan

- preserve runtime behavior and governance gates

- update changelog if required by strict governance freshness

## Summary

Implements Priority 3 router benchmark coverage expansion by adding BM-21 through BM-24.

## Changes

- Adds BM-21 through BM-24 to `tests/fixtures/router_benchmarks.json`.
- Expands benchmark count from 20 to 24.
- Updates `scripts/router_benchmark_runner.py`.
- Updates `tests/behavior/test_router_benchmark_fixture_validation.py`.
- Updates benchmark documentation and fixture schema documentation.
- Marks Priority 3 coverage as implemented in `docs/testing/ROUTER_BENCHMARK_COVERAGE_EXPANSION_PLAN.md`.
- Updates `CHANGELOG.md` for governance freshness compliance.

## New Benchmark Cases

- BM-21: CI/CD-sensitive request requiring GOVERNED routing.
- BM-22: Release-readiness request requiring AUDIT routing.
- BM-23: Prompt-load/context-selection scenario requiring minimal context control.
- BM-24: Complex destructive-operation request requiring blocked authorization.

## Validation

- `python scripts/router_benchmark_runner.py` passed.
- Benchmark count is exactly 24.
- `python tests/behavior/test_router_benchmark_fixture_validation.py` passed.
- `python scripts/check_prompt_load_thresholds.py` passed.
- `python scripts/measure_prompt_load.py` passed.
- `python tests/behavior/evaluate_governance.py` passed.
- `python tests/behavior/run_tests.py` passed.
- `python scripts/validate_manifest.py` passed.
- `python scripts/governance_check.py --strict` passed.
- `git diff --check` passed.

## Notes

This is benchmark fixture and validation tooling only. Runtime behavior, CI workflow files, plugin metadata, skill frontmatter, and existing benchmark coverage were not weakened.