### PR TITLE
docs(routing): harden router-first documentation cross-links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog tracks the repository history using git tags, merge history, and 
 
 ## Unreleased
 
+- Added router-first documentation cross-links for Phase 8 hardening.
+
 - Added Phase 8A router-first integration hardening audit documentation.
 
 - Documented the `tests/fixtures/router_benchmarks.json` schema in `ROUTER_BENCHMARK_FIXTURE_SCHEMA.md` and updated the benchmark validation runner to enforce the root shape and `schema_version`.

--- a/README.md
+++ b/README.md
@@ -512,7 +512,11 @@ Output from Conductor and its specialists automatically adapts to your intent:
 | Installation | [Installation Guide](docs/setup/INSTALLATION.md) | Set up the plugin in Antigravity, Codex, VS Code, or JetBrains IDEs |
 | Changelog | [Changelog](CHANGELOG.md) | Track release history and documented repo milestones |
 | Validation | [Validation Guide](docs/setup/VALIDATION.md) | Run structure and manifest checks |
+| Routing | [Router Architecture](docs/routing/ROUTER_FIRST_ARCHITECTURE.md) | Understand the router-first model and context retrieval |
+| Performance | [Prompt Load Metrics](docs/performance/PROMPT_LOAD_METRICS.md) | Track prompt load and threshold policies |
+| Benchmarks | [Benchmark Validation](docs/testing/ROUTER_VALIDATION_BENCHMARKS.md) | Review the router validation testing suite |
 | CI Artifacts | [CI Artifact Index](docs/testing/CI_ARTIFACT_INDEX.md) | Browse governance reports and validation CI artifacts |
+| Audits | [Phase 8A Audit](docs/routing/ROUTER_FIRST_INTEGRATION_HARDENING_AUDIT.md) | Review the router-first integration hardening audit |
 | Maturity | [Maturity](docs/MATURITY.md) | Current project stability and roadmap |
 | Contributing | [Contributing Guide](docs/CONTRIBUTING.md) | Guidelines for contributing and safety policies |
 | Disclaimer | [Disclaimer](docs/meta/DISCLAIMER.md) | Understand legal and operational limitations |

--- a/docs/performance/PROMPT_LOAD_METRICS.md
+++ b/docs/performance/PROMPT_LOAD_METRICS.md
@@ -52,3 +52,9 @@ This method does not measure user prompt sizes, session history sizes, or downst
 
 ## Metrics Result
 PROMPT_LOAD_METRICS_DEFINED
+
+## Related Documents
+- [Prompt Load Threshold Policy](PROMPT_LOAD_THRESHOLD_POLICY.md)
+- [Prompt Load Threshold Checker](PROMPT_LOAD_THRESHOLD_CHECKER.md)
+- [CI Artifact Index](../testing/CI_ARTIFACT_INDEX.md)
+- [Phase 8A Audit](../routing/ROUTER_FIRST_INTEGRATION_HARDENING_AUDIT.md)

--- a/docs/performance/PROMPT_LOAD_THRESHOLD_CHECKER.md
+++ b/docs/performance/PROMPT_LOAD_THRESHOLD_CHECKER.md
@@ -47,3 +47,7 @@ This checker does not evaluate downstream specialist prompt loads, session histo
 
 ## Checker Result
 PROMPT_LOAD_THRESHOLD_CHECKER_DEFINED
+
+## Related Documents
+- [Prompt Load Threshold Policy](PROMPT_LOAD_THRESHOLD_POLICY.md)
+- [CI Artifact Index](../testing/CI_ARTIFACT_INDEX.md)

--- a/docs/performance/PROMPT_LOAD_THRESHOLD_POLICY.md
+++ b/docs/performance/PROMPT_LOAD_THRESHOLD_POLICY.md
@@ -62,3 +62,8 @@ This policy does not govern user prompt sizes, session history limits, or downst
 
 ## Policy Result
 PROMPT_LOAD_THRESHOLD_POLICY_DEFINED
+
+## Related Documents
+- [Prompt Load Metrics](PROMPT_LOAD_METRICS.md)
+- [Prompt Load Threshold Checker](PROMPT_LOAD_THRESHOLD_CHECKER.md)
+- [CI Artifact Index](../testing/CI_ARTIFACT_INDEX.md)

--- a/docs/routing/CONTEXT_RETRIEVAL_RULES.md
+++ b/docs/routing/CONTEXT_RETRIEVAL_RULES.md
@@ -88,9 +88,11 @@ By default, the minimal package consists of the Conductor intent classifier and 
 - Altering the strictness of existing safety and governance gates.
 
 ## Canonical References
-- [Governance Layer](docs/governance/GOVERNANCE_LAYER.md)
-- [Routing Map](ROUTING_MAP.md)
-- [Skill Index](SKILL_INDEX.md)
+- [Governance Layer](../governance/GOVERNANCE_LAYER.md)
+- [Routing Map](../../ROUTING_MAP.md)
+- [Skill Index](../../SKILL_INDEX.md)
+- [Prompt Load Metrics](../performance/PROMPT_LOAD_METRICS.md)
+- [Prompt Load Threshold Policy](../performance/PROMPT_LOAD_THRESHOLD_POLICY.md)
 
 ## Retrieval Result
 CONTEXT_RETRIEVAL_RULES_DEFINED

--- a/docs/routing/EXECUTION_MODES_POLICY.md
+++ b/docs/routing/EXECUTION_MODES_POLICY.md
@@ -99,6 +99,7 @@ This policy does not dictate how the underlying LLM functions, but rather strict
 - [Router-First Architecture](ROUTER_FIRST_ARCHITECTURE.md)
 - [Context Retrieval Rules](CONTEXT_RETRIEVAL_RULES.md)
 - [Governance Layer](../governance/GOVERNANCE_LAYER.md)
+- [Router Validation Benchmarks](../testing/ROUTER_VALIDATION_BENCHMARKS.md)
 
 ## Policy Result
 EXECUTION_MODES_POLICY_DEFINED

--- a/docs/routing/ROUTER_FIRST_ARCHITECTURE.md
+++ b/docs/routing/ROUTER_FIRST_ARCHITECTURE.md
@@ -67,3 +67,9 @@ The new `skills/conductor/SKILL.md` will be refactored to focus solely on the in
 
 ## Architecture Result
 ROUTER_ARCHITECTURE_DEFINED
+
+## Related Documents
+- [Context Retrieval Rules](CONTEXT_RETRIEVAL_RULES.md)
+- [Minimal Prompt Format](MINIMAL_PROMPT_FORMAT.md)
+- [Execution Modes Policy](EXECUTION_MODES_POLICY.md)
+- [Phase 8A Audit](ROUTER_FIRST_INTEGRATION_HARDENING_AUDIT.md)

--- a/docs/routing/ROUTER_FIRST_INTEGRATION_HARDENING_AUDIT.md
+++ b/docs/routing/ROUTER_FIRST_INTEGRATION_HARDENING_AUDIT.md
@@ -77,3 +77,9 @@ To close these gaps in Phase 8B, the following actions are recommended:
 
 ## Audit Result
 ROUTER_FIRST_INTEGRATION_HARDENING_AUDIT_DEFINED
+
+## Related Documents
+- [Router-First Architecture](ROUTER_FIRST_ARCHITECTURE.md)
+- [Context Retrieval Rules](CONTEXT_RETRIEVAL_RULES.md)
+- [Prompt Load Metrics](../performance/PROMPT_LOAD_METRICS.md)
+- [CI Artifact Index](../testing/CI_ARTIFACT_INDEX.md)

--- a/docs/testing/CI_ARTIFACT_INDEX.md
+++ b/docs/testing/CI_ARTIFACT_INDEX.md
@@ -61,3 +61,8 @@ This index does not document application build artifacts (e.g., compiled binarie
 
 ## Index Result
 CI_ARTIFACT_INDEX_DEFINED
+
+## Related Documents
+- [Prompt Load Metrics](../performance/PROMPT_LOAD_METRICS.md)
+- [Prompt Load Threshold Checker](../performance/PROMPT_LOAD_THRESHOLD_CHECKER.md)
+- [Router Benchmark Runner](ROUTER_BENCHMARK_RUNNER.md)

--- a/docs/testing/ROUTER_BENCHMARK_COVERAGE_COMPLETION_REVIEW.md
+++ b/docs/testing/ROUTER_BENCHMARK_COVERAGE_COMPLETION_REVIEW.md
@@ -69,3 +69,6 @@ Refer to [ROUTER_BENCHMARK_MAINTENANCE_GUIDE.md](file:///c:/conductor/docs/testi
 
 ## Completion Result
 ROUTER_BENCHMARK_COVERAGE_COMPLETION_REVIEW_DEFINED
+
+## Related Documents
+- [Phase 8A Audit](../routing/ROUTER_FIRST_INTEGRATION_HARDENING_AUDIT.md)

--- a/docs/testing/ROUTER_BENCHMARK_RUNNER.md
+++ b/docs/testing/ROUTER_BENCHMARK_RUNNER.md
@@ -58,3 +58,7 @@ The runner script itself is validated against malformed data inputs by `tests/be
 
 ## Runner Result
 ROUTER_BENCHMARK_RUNNER_DEFINED
+
+## Related Documents
+- [Phase 8A Audit](../routing/ROUTER_FIRST_INTEGRATION_HARDENING_AUDIT.md)
+- [CI Artifact Index](CI_ARTIFACT_INDEX.md)


### PR DESCRIPTION
- add reciprocal links across routing, performance, testing, and CI artifact docs

- improve README discoverability for router-first validation materials

- link Phase 8A audit to related canonical documents

- preserve runtime behavior and governance gates

- update changelog if required by strict governance freshness
## Summary

Improves router-first documentation discoverability and cross-linking across routing, performance, testing, and CI artifact documentation.

## Changes

- Updates README documentation map with router-first validation references.
- Adds reciprocal links across router-first architecture, context retrieval, execution mode, benchmark, prompt-load, threshold, and CI artifact docs.
- Links Phase 8A integration audit to related canonical documents.
- Updates `CHANGELOG.md` for governance freshness compliance.

## Validation

- `python scripts/router_benchmark_runner.py` passed.
- Benchmark count remains exactly 24.
- `python tests/behavior/test_router_benchmark_fixture_validation.py` passed.
- `python scripts/check_prompt_load_thresholds.py` passed.
- `python scripts/measure_prompt_load.py` passed.
- `python tests/behavior/evaluate_governance.py` passed.
- `python tests/behavior/run_tests.py` passed.
- `python scripts/validate_manifest.py` passed.
- `python scripts/governance_check.py --strict` passed.
- `git diff --check` passed.

## Notes

This is documentation-only. No runtime behavior, CI workflow files, benchmark fixtures, plugin metadata, skill frontmatter, or test suites were modified.