### PR TITLE
docs(routing): clean router-first documentation consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog tracks the repository history using git tags, merge history, and 
 
 ## Unreleased
 
+- Cleaned router-first documentation terminology and consistency.
+
 - Added router-first documentation cross-links for Phase 8 hardening.
 
 - Added Phase 8A router-first integration hardening audit documentation.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Conductor uses 5 distinct operating modes to scale governance dynamically, ensur
 1. **Ideation Mode**: Brainstorming, exploration, planning, concept development, prompt refinement. Returns `ADVISORY_ONLY` or `NOT_APPLICABLE`.
 2. **Prototype Mode**: Local experiments, throwaway proofs-of-concept. Lightweight checks only.
 3. **Implementation Mode**: Making file, code, documentation, or architecture changes. Uses fast path by default. Escalate to expanded review only if risk triggers are met.
-4. **Audit Mode**: Explicit request for a review, compliance check, or risk assessment. Context-heavy.
+4. **AUDIT mode**: Explicit request for a review, compliance check, or risk assessment. Context-heavy.
 5. **Release Mode**: Production deployment, public release, client delivery, or open-source distribution. Strictest path. Escalate uncertain issues for human review.
 
 ### Interpret the Decision

--- a/docs/performance/PROMPT_LOAD_METRICS.md
+++ b/docs/performance/PROMPT_LOAD_METRICS.md
@@ -40,7 +40,7 @@ The script prints per-file metrics, per-group totals, and a grand total, highlig
 This metric script directly proves the benchmarks defined in `ROUTER_VALIDATION_BENCHMARKS.md`, verifying the reduction from "Very High" to "Low" prompt load.
 
 ## CI Integration
-Prompt load metrics are measured automatically in the `governance-check.yml` CI workflow. The script output is captured and published as part of the `governance-validation-report` CI artifact (`artifacts/prompt_load_metrics.txt`). CI also executes the threshold checker (`artifacts/prompt_load_threshold_report.txt`), publishing both raw prompt load metrics and threshold status. Currently, these metrics are for observability only and do not trigger hard CI failures based on prompt size thresholds.
+Prompt load metrics are measured automatically in the `governance-check.yml` CI workflow. The script output is captured and published as part of the `governance-validation-report` CI artifact (`artifacts/prompt_load_metrics.txt`). CI also executes the threshold checker (`artifacts/prompt_load_threshold_report.txt`), publishing both raw prompt load metrics and threshold status. Currently, these metrics are for observability-only and do not trigger hard CI failures based on prompt size thresholds.
 
 For a complete guide to accessing and interpreting all governance artifacts, see the [CI Artifact Index](../testing/CI_ARTIFACT_INDEX.md).
 

--- a/docs/performance/PROMPT_LOAD_THRESHOLD_CHECKER.md
+++ b/docs/performance/PROMPT_LOAD_THRESHOLD_CHECKER.md
@@ -7,7 +7,7 @@ This document describes the Prompt Load Threshold Checker (`scripts/check_prompt
 The checker targets the exact same files and grouping logic defined in `measure_prompt_load.py`, isolating Core Router-First Context (Group A) from secondary governance and documentation groups.
 
 ## Dry-Run Mode
-Currently, the checker operates exclusively in **dry-run/report-only mode**. It will always exit with a successful `0` status code, even if multiple thresholds are exceeded. This ensures that CI is not arbitrarily broken while the team calibrates baseline stability.
+Currently, the checker operates exclusively in **observability-only and report-only mode**. There is no hard CI prompt-load failure threshold yet. It will always exit with a successful `0` status code, even if multiple thresholds are exceeded. This ensures that CI is not arbitrarily broken while the team calibrates baseline stability.
 
 ## What It Checks
 - **Group A (Core Context)**: Total token approximation against a soft limit.

--- a/docs/performance/PROMPT_LOAD_THRESHOLD_POLICY.md
+++ b/docs/performance/PROMPT_LOAD_THRESHOLD_POLICY.md
@@ -23,7 +23,7 @@ As of the initial measurement, the baseline metrics are:
 - Grand Total: ~17080 estimated tokens
 
 ## Soft Thresholds
-Soft thresholds act as observability triggers.
+Soft thresholds act as observability-only and report-only triggers. There is no hard CI prompt-load failure threshold yet.
 - **Group A (Core Context)**: Should remain under 8,000 estimated tokens.
 - **Group B (Broader Context)**: Should remain under 6,000 estimated tokens.
 - **Group C (Governance Context)**: Allowed to grow as compliance rules evolve, but should remain under 4,000 estimated tokens.
@@ -55,7 +55,7 @@ If a soft threshold is exceeded, maintainers should:
 To validate current payloads against these thresholds, you can use the dry-run checker. For details on how to run it and interpret its statuses, see [PROMPT_LOAD_THRESHOLD_CHECKER.md](PROMPT_LOAD_THRESHOLD_CHECKER.md).
 
 ## CI Artifact Usage
-The `measure_prompt_load.py` script runs automatically in the `governance-check.yml` CI workflow. Its output is published as `prompt_load_metrics.txt` in the `governance-validation-report` artifact. This ensures continuous observability of prompt load metrics. For details on all governance artifacts, see the [CI Artifact Index](../testing/CI_ARTIFACT_INDEX.md).
+The `measure_prompt_load.py` script runs automatically in the `governance-check.yml` CI workflow. Its output is published as `prompt_load_metrics.txt` in the `governance-validation-report` artifact. This ensures continuous observability-only tracking of prompt load metrics. For details on all governance artifacts, see the [CI Artifact Index](../testing/CI_ARTIFACT_INDEX.md).
 
 ## Non-Goals
 This policy does not govern user prompt sizes, session history limits, or downstream specialist output tokens. It only governs the static context injected into the Conductor's routing prompt.

--- a/docs/routing/CONTEXT_RETRIEVAL_RULES.md
+++ b/docs/routing/CONTEXT_RETRIEVAL_RULES.md
@@ -11,7 +11,7 @@ This policy governs how Conductor and other executing specialists retrieve archi
 
 ## Context Priority Levels
 - **Required**: Must be loaded for every task in this category.
-- **Conditional**: Loaded only if specific risk triggers or cross-domain dependencies are met.
+- **CONDITIONAL**: Loaded only if specific risk triggers or cross-domain dependencies are met.
 - **Optional**: Loaded only upon explicit user request.
 - **Avoid unless triggered**: Strictly blocked from loading unless a high-risk or specific operational gate is crossed.
 
@@ -32,7 +32,7 @@ This policy governs how Conductor and other executing specialists retrieve archi
 
 ## Task-to-Context Lookup
 
-| Task Type | Required Context | Conditional Context | Avoid Loading By Default |
+| Task Type | Required Context | CONDITIONAL Context | Avoid Loading By Default |
 |---|---|---|---|
 | Simple Q&A | Core manifest context | Skill index context | All other contexts |
 | Documentation updates | Documentation context | Governance context | Database, Security, Frontend |
@@ -57,7 +57,7 @@ This policy governs how Conductor and other executing specialists retrieve archi
 - Release readiness: Require release/readiness and full governance context.
 - Destructive operations: Require destructive-operation context and safety guardrails.
 
-## Conditional Context Rules
+## CONDITIONAL Context Rules
 - If a Code Implementation task touches authentication or database layers, conditionally load Security or Database contexts.
 - If a Documentation task involves public release, conditionally load Governance context.
 - If a CI/CD change affects deployment targets, conditionally load Security context.

--- a/docs/routing/EXECUTION_MODES_POLICY.md
+++ b/docs/routing/EXECUTION_MODES_POLICY.md
@@ -11,7 +11,7 @@ The Conductor must select the execution mode that provides the lowest safe frict
 
 ## Execution Modes
 
-## FAST Mode
+## FAST mode
 - **Purpose**: Rapid execution of simple, low-risk, well-defined tasks.
 - **Allowed Task Types**: Syntax formatting, typo fixes, simple UI tweaks, and unambiguous singular code changes.
 - **Required Context**: Only the immediate file being edited and the required specialist `SKILL.md` file.
@@ -21,7 +21,7 @@ The Conductor must select the execution mode that provides the lowest safe frict
 - **Escalation Triggers**: If the task requires architectural changes or touches multiple files, escalate to STANDARD mode.
 - **Expected Result Status**: Task completed directly.
 
-## STANDARD Mode
+## STANDARD mode
 - **Purpose**: Normal multi-step or multi-file development and feature implementation.
 - **Allowed Task Types**: Feature additions, backend logic, standard UI/UX flows, and refactoring within existing architectural boundaries.
 - **Required Context**: Immediate files, relevant specialist files, and architectural dependencies.
@@ -31,7 +31,7 @@ The Conductor must select the execution mode that provides the lowest safe frict
 - **Escalation Triggers**: If the task touches security, privacy, database migrations, or compliance domains, escalate to GOVERNED mode.
 - **Expected Result Status**: Feature implemented and locally validated.
 
-## GOVERNED Mode
+## GOVERNED mode
 - **Purpose**: Execution of tasks that require structural, security, or compliance oversight.
 - **Allowed Task Types**: Database migrations, authentication/authorization updates, secret handling, cross-service APIs, and privacy-impacting features.
 - **Required Context**: Affected files, `docs/governance/GOVERNANCE_LAYER.md` (only when governance triggers are present), and required domain specialist skills.
@@ -41,7 +41,7 @@ The Conductor must select the execution mode that provides the lowest safe frict
 - **Escalation Triggers**: If the task requires formal read-only review or is considered too risky for immediate implementation, escalate to AUDIT mode.
 - **Expected Result Status**: Implementation verified against governance constraints.
 
-## AUDIT Mode
+## AUDIT mode
 - **Purpose**: Formal read-only review, compliance auditing, and risk assessment.
 - **Allowed Task Types**: Security reviews, architecture reviews, compliance audits, and resilience planning.
 - **Required Context**: Entire feature slice, `GOVERNANCE_LAYER.md`, and relevant audit specialist skills (e.g., Arbiter, Cipher, Clockwork).
@@ -51,7 +51,7 @@ The Conductor must select the execution mode that provides the lowest safe frict
 - **Escalation Triggers**: Escalates to DESTRUCTIVE mode if resilience testing requires negative live execution.
 - **Expected Result Status**: Audit report delivered. (AUDIT mode is read-only unless the user explicitly approves remediation work.)
 
-## DESTRUCTIVE Mode
+## DESTRUCTIVE mode
 - **Purpose**: Execution of high-risk tasks that modify production data, perform destructive negative testing, or bypass normal safety constraints.
 - **Allowed Task Types**: Chaos testing, negative path simulation, and authorized live data modification.
 - **Required Context**: Target environment context, guardrail scripts, and Dagger skill.
@@ -78,7 +78,7 @@ The Conductor must select the execution mode that provides the lowest safe frict
 - **any mode to DESTRUCTIVE**: Any task requiring destructive testing, production modification, or guardrail bypass is immediately placed in a DESTRUCTIVE blocked state.
 
 ## Governance Status Mapping
-- **NOT_REQUIRED**: Fast mode tasks without compliance impact.
+- **NOT_REQUIRED**: FAST mode tasks without compliance impact.
 - **CONDITIONAL**: Standard tasks where governance is loaded only if triggers appear.
 - **REQUIRED**: Governed and Audit tasks requiring explicit policy adherence.
 - **BLOCKED_PENDING_AUTHORIZATION**: Destructive tasks.

--- a/docs/routing/MINIMAL_PROMPT_FORMAT.md
+++ b/docs/routing/MINIMAL_PROMPT_FORMAT.md
@@ -18,7 +18,7 @@ Every assembled prompt must include the following metadata block:
 - **Execution Mode**: FAST, STANDARD, GOVERNED, AUDIT, or DESTRUCTIVE.
 - **Risk Level**: Low, Medium, High, or Extreme.
 - **Required Context**: Absolute paths to minimal context documents.
-- **Conditional Context**: Conditionally included paths based on domain overlap.
+- **CONDITIONAL Context**: Conditionally included paths based on domain overlap.
 - **Constraints**: Task boundaries, do-nots, and style locks.
 - **Governance Status**: Current standing of the request.
 - **Expected Output**: The desired artifact or standard response format.
@@ -28,27 +28,27 @@ Every assembled prompt must include the following metadata block:
 ## Execution Mode Formats
 The layout of the prompt package adapts to the execution mode selected during intake.
 
-## FAST Mode Format
+## FAST mode Format
 **Use**: Ideation, prototype, simple Q&A.
 **Include**: Task, Intent, Selected Skill, Result Status.
 **Exclude**: Deep governance context, detailed validation rules.
 
-## STANDARD Mode Format
+## STANDARD mode Format
 **Use**: Routine feature development, documentation, general backend/frontend implementation.
 **Include**: All standard package fields. Minimal required context (e.g., standard testing context).
 **Exclude**: Formal governance audit steps unless explicitly triggered.
 
-## GOVERNED Mode Format
+## GOVERNED mode Format
 **Use**: Security-sensitive logic, database persistence, access control.
 **Include**: All standard package fields, Governance Status, explicit conditional contexts (Security, Database).
 **Exclude**: Broad UI/UX context (unless UI touches security/auth).
 
-## AUDIT Mode Format
+## AUDIT mode Format
 **Use**: Formal compliance, release reviews, read-only inspections.
 **Include**: Task, Intent, `docs/governance/GOVERNANCE_LAYER.md`, Risk Level, Constraints, Expected Output.
 **Exclude**: Implementation commands, destructive operation context.
 
-## DESTRUCTIVE Mode Format
+## DESTRUCTIVE mode Format
 **Use**: Chaos, negative path, resilience testing (e.g., `dagger`).
 **Include**: Task, Intent, Destructive-operation context, Explicit Authorization checks, Validation Requirements.
 **Rule**: Destructive-operation prompts must never proceed without explicit user authorization and required guardrail validation (`scripts/dagger_guardrail.py`).

--- a/docs/routing/ROUTER_FIRST_INTEGRATION_HARDENING_AUDIT.md
+++ b/docs/routing/ROUTER_FIRST_INTEGRATION_HARDENING_AUDIT.md
@@ -44,7 +44,7 @@ The JSON fixture correctly holds 24 benchmark cases aligned exactly to the `ROUT
 `measure_prompt_load.py` consistently calculates tokens and context length for reporting.
 
 ### Threshold Checker Integration
-`check_prompt_load_thresholds.py` compares metrics against the soft targets in `PROMPT_LOAD_THRESHOLD_POLICY.md`. However, it currently operates as a report-only check, lacking a hard CI failure switch.
+`check_prompt_load_thresholds.py` compares metrics against the soft targets in `PROMPT_LOAD_THRESHOLD_POLICY.md`. However, it currently operates as an observability-only and report-only check. There is no hard CI prompt-load failure threshold yet.
 
 ### CI Artifact Integration
 `governance-check.yml` correctly generates and bundles 8 distinct artifact reports (including benchmark, prompt-load, and negative fixture results) as documented in `CI_ARTIFACT_INDEX.md`.

--- a/docs/testing/CI_ARTIFACT_INDEX.md
+++ b/docs/testing/CI_ARTIFACT_INDEX.md
@@ -30,7 +30,7 @@ This report captures raw prompt load measurements (line count, word count, chara
 
 ## Prompt Load Threshold Report
 **File**: `artifacts/prompt_load_threshold_report.txt`
-This report compares the raw token approximations against established soft thresholds to detect context bloat. It currently operates in report-only (dry-run) mode and does not cause hard CI failures. See [PROMPT_LOAD_THRESHOLD_CHECKER.md](../performance/PROMPT_LOAD_THRESHOLD_CHECKER.md) and [PROMPT_LOAD_THRESHOLD_POLICY.md](../performance/PROMPT_LOAD_THRESHOLD_POLICY.md) for limits.
+This report compares the raw token approximations against established soft thresholds to detect context bloat. It currently operates in observability-only and report-only mode. There is no hard CI prompt-load failure threshold yet. See [PROMPT_LOAD_THRESHOLD_CHECKER.md](../performance/PROMPT_LOAD_THRESHOLD_CHECKER.md) and [PROMPT_LOAD_THRESHOLD_POLICY.md](../performance/PROMPT_LOAD_THRESHOLD_POLICY.md) for limits.
 
 ## Governance Reports
 The remaining artifacts capture standard repository behavior and governance rule conformance:

--- a/docs/testing/ROUTER_BENCHMARK_COVERAGE_EXPANSION_PLAN.md
+++ b/docs/testing/ROUTER_BENCHMARK_COVERAGE_EXPANSION_PLAN.md
@@ -7,7 +7,7 @@ This document outlines the strategic plan for expanding the validation coverage 
 This plan applies to the definition and structured expansion of the machine-readable benchmark cases stored in `tests/fixtures/router_benchmarks.json` and evaluated by `scripts/router_benchmark_runner.py`. It is a planning document and does not actively modify the runtime test suite.
 
 ## Current Coverage Baseline
-As of the initial router-first validation release, the coverage baseline is exactly **12 benchmark cases**:
+As of the initial router-first validation release, the coverage baseline is exactly **24 benchmark cases**:
 - **Execution Modes**: Full coverage established (`FAST`, `STANDARD`, `GOVERNED`, `AUDIT`, `DESTRUCTIVE`).
 - **Governance Statuses**: Full coverage established (`NOT_REQUIRED`, `CONDITIONAL`, `REQUIRED`, `BLOCKED_PENDING_AUTHORIZATION`).
 - **Destructive Operations**: Coverage exists to prove active blocks.


### PR DESCRIPTION
- standardize router-first terminology across routing, performance, and testing docs

- confirm benchmark references align to BM-01 through BM-24

- clarify observability-only prompt-load threshold status

- preserve runtime behavior and governance gates

- update changelog if required by strict governance freshness
## Summary

Standardizes router-first documentation terminology and consistency across routing, performance, testing, and CI artifact documentation.

## Changes

- Standardizes execution mode wording: FAST, STANDARD, GOVERNED, AUDIT, DESTRUCTIVE.
- Standardizes governance status wording: NOT_REQUIRED and CONDITIONAL where applicable.
- Confirms benchmark references align to BM-01 through BM-24.
- Clarifies that the benchmark runner validates benchmark definitions only and does not test live LLM behavior.
- Clarifies prompt-load threshold status as observability-only and report-only.
- Confirms there is no hard CI prompt-load failure threshold yet.
- Updates `CHANGELOG.md` for governance freshness compliance.

## Validation

- `python scripts/router_benchmark_runner.py` passed.
- Benchmark count remains exactly 24.
- `python tests/behavior/test_router_benchmark_fixture_validation.py` passed.
- `python scripts/check_prompt_load_thresholds.py` passed.
- `python scripts/measure_prompt_load.py` passed.
- `python tests/behavior/evaluate_governance.py` passed.
- `python tests/behavior/run_tests.py` passed.
- `python scripts/validate_manifest.py` passed.
- `python scripts/governance_check.py --strict` passed.
- `git diff --check` passed.

## Notes

This is documentation-only. No runtime behavior, CI workflow files, benchmark fixtures, plugin metadata, skill frontmatter, or behavior tests were changed.