### PR TITLE
docs(routing): add Issue 56 closeout note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog tracks the repository history using git tags, merge history, and 
 
 ## Unreleased
 
+- Added Issue #56 router-first closeout note.
+
 - Added final router-first readiness review for Issue #56 closeout.
 
 - Added Phase 8 router-first hardening completion review.

--- a/README.md
+++ b/README.md
@@ -518,6 +518,7 @@ Output from Conductor and its specialists automatically adapts to your intent:
 - [Prompt load threshold policy](docs/performance/PROMPT_LOAD_THRESHOLD_POLICY.md): Policies and soft limits for prompt load size.
 - [Prompt load threshold checker](docs/performance/PROMPT_LOAD_THRESHOLD_CHECKER.md): Dry-run validation script for tracking prompt load limits.
 - [CI artifact index](docs/testing/CI_ARTIFACT_INDEX.md): Directory of generated CI validation and governance reports.
+- [Issue #56 closeout note](docs/routing/ISSUE_56_CLOSEOUT_NOTE.md): Final closeout note and GitHub closing comment for Issue #56.
 - [Final router-first readiness review](docs/routing/ROUTER_FIRST_FINAL_READINESS_REVIEW.md): Readiness review for closing Issue #56.
 - [Phase 8 router-first hardening completion review](docs/routing/ROUTER_FIRST_HARDENING_COMPLETION_REVIEW.md): Final completion review and deferred items for Phase 8.
 - [Phase 8A integration hardening audit](docs/routing/ROUTER_FIRST_INTEGRATION_HARDENING_AUDIT.md): Gap analysis and recommended hardening actions.

--- a/docs/routing/ISSUE_56_CLOSEOUT_NOTE.md
+++ b/docs/routing/ISSUE_56_CLOSEOUT_NOTE.md
@@ -1,0 +1,62 @@
+# Issue #56 Closeout Note
+
+## Purpose
+This document provides the final administrative record for the closure of GitHub Issue #56 ('Implement Router-First Architecture for Conductor'). It summarizes the work completed, confirms validation, documents deferred items, and provides the official closing comment.
+
+## Issue Summary
+Issue #56 tracked the transition of the Conductor from a full-context initialization model to a selective, router-first architecture. The goal was to drastically reduce the initial prompt payload by loading deep governance and specialist context only when explicitly required by the routing decision.
+
+## Completed Work
+The following objectives have been fully satisfied:
+- Router-first architecture implemented and documented.
+- Selective context loading documented and formalized.
+- Execution modes (FAST, STANDARD, GOVERNED, AUDIT, DESTRUCTIVE) formalized.
+- Benchmark fixture and runner established.
+- Negative fixture validation established.
+- 24 canonical benchmark cases, BM-01 through BM-24, defined and validated.
+- Prompt-load metrics and threshold checker established.
+- Threshold checker explicitly remains observability-only and report-only.
+- No hard CI prompt-load failure threshold introduced yet.
+- CI artifact index established for clear observability.
+- Phase 8 documentation hardening and cross-linking completed.
+- Final readiness review completed.
+- Governance gates and destructive operational blocks preserved.
+
+## Validation Summary
+All router-first architectural validations pass cleanly. The benchmark runner successfully validates all 24 schema definitions. The prompt load checker confirms that Group A (Conductor's minimal context) remains well below the target thresholds. Strict behavioral governance checks pass without modification to runtime behavior.
+
+## Closeout Decision
+Based on the completion of the implementation, validation, observability, and hardening phases, Issue #56 is approved for closure.
+
+**Decision**: ISSUE_56_READY_TO_CLOSE
+
+## Deferred Items
+To maintain scope discipline, the following items are deferred to future issues or phases:
+- Future hard CI prompt-load enforcement (transitioning from report-only to block-on-failure).
+- Future benchmark expansion (only if new routing categories are added).
+- Future release-readiness review.
+- Future runtime loader automation, if desired.
+
+## Suggested GitHub Closing Comment
+
+\\markdown
+The router-first architecture for the Conductor has been successfully implemented, validated, and hardened across Phases 1 through 9.
+
+**Key achievements:**
+- Decoupled Conductor initialization from deep specialist and governance context.
+- Established 24 canonical machine-readable benchmark cases (BM-01 through BM-24).
+- Formalized FAST, STANDARD, GOVERNED, AUDIT, and DESTRUCTIVE execution modes.
+- Implemented prompt-load metrics and observability threshold checking.
+- Hardened all documentation cross-links and README maintainer entry points.
+- Preserved all static behavioral governance gates.
+
+**Deferred to future issues:**
+- Hard CI enforcement for prompt-load thresholds.
+- Benchmark expansion (if new routing modes are added).
+- Final release-readiness reviews.
+- Automated runtime loader scripts.
+
+All validation checks pass cleanly. 
+
+Closeout result: ISSUE_56_READY_TO_CLOSE
+\

--- a/docs/routing/ROUTER_FIRST_FINAL_READINESS_REVIEW.md
+++ b/docs/routing/ROUTER_FIRST_FINAL_READINESS_REVIEW.md
@@ -76,3 +76,7 @@ The following items are explicitly deferred to future phases and will not block 
 
 ## Final Readiness Result
 ROUTER_FIRST_FINAL_READINESS_READY_FOR_ISSUE_56_CLOSEOUT
+
+## Next Steps
+
+For the final GitHub closing comment, see the [Issue #56 Closeout Note](ISSUE_56_CLOSEOUT_NOTE.md).


### PR DESCRIPTION
## Summary

Adds the final Issue #56 closeout note for the router-first architecture implementation.

## Changes

- Adds `docs/routing/ISSUE_56_CLOSEOUT_NOTE.md`.
- Records the final closeout decision: `ISSUE_56_READY_TO_CLOSE`.
- Summarizes completed router-first architecture, selective context loading, execution mode, benchmark validation, prompt-load observability, CI artifact, Phase 8 hardening, and governance preservation work.
- Includes a ready-to-paste GitHub closing comment for Issue #56.
- Records deferred items for future work.
- Adds a README link to the closeout note.
- Adds a forward link from the final router-first readiness review.
- Updates `CHANGELOG.md` for governance freshness compliance.

## Validation

- `python scripts/router_benchmark_runner.py` passed.
- Benchmark count remains exactly 24.
- `python tests/behavior/test_router_benchmark_fixture_validation.py` passed.
- `python scripts/check_prompt_load_thresholds.py` passed.
- `python scripts/measure_prompt_load.py` passed.
- `python tests/behavior/evaluate_governance.py` passed.
- `python tests/behavior/run_tests.py` passed.
- `python scripts/validate_manifest.py` passed.
- `python scripts/governance_check.py --strict` passed.
- `git diff --check` passed.

## Notes

This is documentation-only. No runtime behavior, CI workflow files, benchmark fixtures, plugin metadata, skill frontmatter, or behavior tests were changed.