### PR TITLE
test: clarify Steward negative context output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog tracks the repository history using git tags, merge history, and 
 
 ## Unreleased
 
+### Changed
+
+- Clarified Steward context-validator negative test output so expected Release Mode blocking no longer appears as an unqualified CI error.
+
 ### Added
 
 - Added native GitHub Actions cross-platform validation for Ubuntu and macOS.

--- a/tests/behavior/run_tests.py
+++ b/tests/behavior/run_tests.py
@@ -78,17 +78,40 @@ def main():
     os.makedirs(temp_dir2, exist_ok=True)
     try:
         missing_file = os.path.join(temp_dir2, "MISSING.md")
-        warn_exit = subprocess.run([sys.executable, context_script, "--mode", "Implementation Mode", "--context-file", missing_file])
-        err_exit = subprocess.run([sys.executable, context_script, "--mode", "Release Mode", "--context-file", missing_file])
-        
+        warn_exit = subprocess.run(
+            [sys.executable, context_script, "--mode", "Implementation Mode", "--context-file", missing_file],
+            capture_output=True,
+            text=True
+        )
+        err_exit = subprocess.run(
+            [sys.executable, context_script, "--mode", "Release Mode", "--context-file", missing_file],
+            capture_output=True,
+            text=True
+        )
+
+        warn_output = f"{warn_exit.stdout}{warn_exit.stderr}"
+        err_output = f"{err_exit.stdout}{err_exit.stderr}"
+
         if warn_exit.returncode != 0:
-            print(f"\033[91mERROR: Context validator failed in warning mode! (Exit code: {warn_exit.returncode})\033[0m")
+            print(f"[91mERROR: Context validator failed in warning mode! (Exit code: {warn_exit.returncode})[0m")
+            print(warn_output)
+            failed = True
+        elif "This is allowed for Implementation Mode" not in warn_output:
+            print("[91mERROR: Context validator warning output did not confirm Implementation Mode allowance![0m")
+            print(warn_output)
             failed = True
         elif err_exit.returncode != 1:
-            print(f"\033[91mERROR: Context validator did not fail in Release mode! (Exit code: {err_exit.returncode})\033[0m")
+            print(f"[91mERROR: Context validator did not fail in Release mode! (Exit code: {err_exit.returncode})[0m")
+            print(err_output)
+            failed = True
+        elif "Cannot proceed with Release Mode without context" not in err_output:
+            print("[91mERROR: Context validator error output did not confirm Release Mode block![0m")
+            print(err_output)
             failed = True
         else:
-            print("\033[92mSUCCESS: Context validator tests passed.\033[0m")
+            print("[92mSUCCESS: Context validator expected-warning path passed.[0m")
+            print("[92mSUCCESS: Context validator expected Release Mode block passed.[0m")
+            print("[92mSUCCESS: Context validator tests passed.[0m")
     finally:
         if os.path.exists(temp_dir2):
             shutil.rmtree(temp_dir2)


### PR DESCRIPTION
## Summary

Clarifies the Steward project-context negative test output so expected Release Mode blocking no longer appears as an unqualified CI error.

The behavior remains unchanged: missing project context is still allowed as a warning in Implementation Mode and still blocks Release Mode. This PR only improves the test harness output.

## Changes

- Updated `tests/behavior/run_tests.py` to capture expected Steward context-validator output.
- Verifies the Implementation Mode warning path explicitly.
- Verifies the Release Mode blocking path explicitly.
- Replaces raw expected `[ERROR]` output with clearer success messages.
- Updated `CHANGELOG.md`.

## Validation

Validated locally on branch `test/clarify-steward-negative-test-output`:

- `python scripts/governance_check.py --strict`
- `python scripts/validate_structure.py`
- `python scripts/validate_manifest.py`
- `python scripts/check_stale_references.py`
- `python tests/behavior/run_tests.py`
- `git diff --check`

Expected behavior test output now includes:

```text
SUCCESS: Context validator expected-warning path passed.
SUCCESS: Context validator expected Release Mode block passed.
SUCCESS: Context validator tests passed.