### PR TITLE
docs(readme): add open source philosophy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@ This changelog tracks the repository history using git tags, merge history, and 
 
 ## Unreleased
 
+### Added
+
+- Added README open-source philosophy section clarifying Orchestra's reuse, attribution, and collaborative development stance.
+
+
 ### Changed
 
 - Removed Docker-specific validation artifacts while preserving native Ubuntu/macOS cross-platform validation.
+- Packaged Conductor router context docs into the Codex export and validated required backtick file references before runtime install.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@
 
 Orchestra uses freedom-first, need-based governance. Users can ideate freely. Governance review is invoked when the task requires alignment review, implementation readiness, audit, risk review, or release validation. The governance layer does not assume what rules apply to every project. Before review, The Steward and The Governor establish the Governance Basis of Review based on the active operating mode and supplied context. If the scope is unclear and review is required, governance returns `REVISION_REQUIRED` instead of assuming.
 
+## Open Source Philosophy
+
+Orchestra is shared as an open-source project because useful ideas grow when people are free to study, adapt, remix, and improve them.
+
+This project is not meant to restrict creative development. It is meant to give developers, students, builders, and AI-assisted teams a structured foundation they can learn from, extend, or reshape for their own workflows.
+
+The only request is simple: respect the license, preserve proper attribution, and build something useful.
+
+Software engineering grows through openness, iteration, collaboration, and responsible reuse. Orchestra exists in that spirit.
+
 ## Architecture
 
 ```mermaid


### PR DESCRIPTION
## Summary

Adds an Open Source Philosophy section to the README.

This clarifies that Orchestra is shared as an open-source project to encourage study, adaptation, remixing, and responsible reuse, while asking users to respect the license and preserve proper attribution.

## Changes

- Added `## Open Source Philosophy` to `README.md`.
- Positioned the section after `Core Concept` and before `Architecture`.
- Updated `CHANGELOG.md`.

## Validation

Validated locally on branch `docs/open-source-philosophy`:

- `python scripts/governance_check.py --strict`
- `python scripts/validate_structure.py`
- `python scripts/validate_manifest.py`
- `python scripts/check_stale_references.py`
- `python tests/behavior/run_tests.py`
- `git diff --check`

Local result: validation passed.

## Scope

This PR is documentation-only. It does not change licensing terms, governance behavior, validation behavior, runtime guardrails, skills, manifests, adapters, or CI workflows.