### PR TITLE
Add expanded IDE runtime adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This changelog tracks the repository history using git tags, merge history, and 
 ## Unreleased
 
 ### Added
+- Added contract-ready runtime adapters for Cursor, Windsurf, VS Code, JetBrains, Zed, and Neovim without introducing marketplace packaging.
 - Added `orchestra_runtime/` runtime core models, services, factories, repositories, and thin Codex, Antigravity, and Claude Code adapters.
 - Added runtime-core pytest coverage for skill loading, adapter contracts, and governance blocking for destructive and high-risk routes.
 - Added `docs/project/OOP_RUNTIME_ARCHITECTURE.md` to document the runtime-core-first branch architecture and current integration points.

--- a/docs/project/OOP_RUNTIME_ARCHITECTURE.md
+++ b/docs/project/OOP_RUNTIME_ARCHITECTURE.md
@@ -22,7 +22,7 @@ The repository already had adapter-specific validation and export logic spread a
 
 ## Adapter ownership
 
-`CodexAdapter`, `AntigravityAdapter`, and `ClaudeCodeAdapter` now translate host-specific prompts into shared runtime commands and context packages. They do not own routing or governance logic.
+`CodexAdapter`, `AntigravityAdapter`, `ClaudeCodeAdapter`, `CursorAdapter`, `WindsurfAdapter`, `VSCodeAdapter`, `JetBrainsAdapter`, `ZedAdapter`, and `NeovimAdapter` translate host-specific prompts into shared runtime commands and context packages. They do not own routing or governance logic.
 
 ## Current integration points
 
@@ -45,3 +45,4 @@ The repository already had adapter-specific validation and export logic spread a
 - The runtime currently centralizes Python validation and adapter-contract behavior first.
 - PowerShell installers and Markdown host guides remain in place and unchanged unless they need runtime data.
 - Runtime execution still returns orchestration decisions, not full host-native execution side effects.
+- Marketplace and installer packaging for Cursor, Windsurf, VS Code, JetBrains, Zed, and Neovim remain out of scope for this phase.

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -2,6 +2,8 @@
 
 - [ ] Package for a future supported skill marketplace.
 - [ ] Expand the runtime core beyond validation and adapter contracts into more host-native execution paths.
+- [ ] Package Cursor, Windsurf, and VS Code adapters after the contract-ready adapter phase lands.
+- [ ] Keep JetBrains packaging separate from generic editor packaging because IntelliJ Platform distribution is a different ecosystem.
 - [ ] Add an optional cross-platform CLI validator.
 - [ ] Add an optional local-model retrieval index.
 - [ ] Improve adapters as tool capabilities change.

--- a/orchestra_runtime/__init__.py
+++ b/orchestra_runtime/__init__.py
@@ -1,4 +1,14 @@
-from .adapters import AntigravityAdapter, ClaudeCodeAdapter, CodexAdapter
+from .adapters import (
+    AntigravityAdapter,
+    ClaudeCodeAdapter,
+    CodexAdapter,
+    CursorAdapter,
+    JetBrainsAdapter,
+    NeovimAdapter,
+    VSCodeAdapter,
+    WindsurfAdapter,
+    ZedAdapter,
+)
 from .factories import AdapterFactory, SkillFactory
 from .interfaces import (
     IAuditSink,
@@ -34,6 +44,7 @@ __all__ = [
     "AuditLogger",
     "ClaudeCodeAdapter",
     "CodexAdapter",
+    "CursorAdapter",
     "Command",
     "ContextAssembler",
     "ContextPackage",
@@ -48,6 +59,7 @@ __all__ = [
     "ISkillRegistry",
     "InMemoryAuditSink",
     "ManifestRepository",
+    "NeovimAdapter",
     "RouteDecision",
     "RouterService",
     "RuntimeExecutor",
@@ -56,4 +68,8 @@ __all__ = [
     "SkillRegistry",
     "SkillSourceRepository",
     "ValidationResult",
+    "VSCodeAdapter",
+    "WindsurfAdapter",
+    "ZedAdapter",
+    "JetBrainsAdapter",
 ]

--- a/orchestra_runtime/adapters.py
+++ b/orchestra_runtime/adapters.py
@@ -91,3 +91,100 @@ class ClaudeCodeAdapter(BaseAdapter):
         ("security check", "security-check"),
         ("resilience check", "resilience-check"),
     )
+
+
+class CursorAdapter(BaseAdapter):
+    adapter_name = "cursor"
+    trigger_map = (
+        ("@orchestra", "conductor"),
+        ("use conductor", "conductor"),
+        ("review architecture", "review-architecture"),
+        ("review ui", "review-ui"),
+        ("review db", "review-db"),
+        ("review docs", "review-docs"),
+        ("diagram check", "diagram-check"),
+        ("qa check", "qa-check"),
+        ("security check", "security-check"),
+        ("resilience check", "resilience-check"),
+    )
+
+
+class WindsurfAdapter(BaseAdapter):
+    adapter_name = "windsurf"
+    trigger_map = (
+        ("@orchestra", "conductor"),
+        ("use conductor", "conductor"),
+        ("/conductor", "conductor"),
+        ("review architecture", "review-architecture"),
+        ("review ui", "review-ui"),
+        ("review db", "review-db"),
+        ("review docs", "review-docs"),
+        ("diagram check", "diagram-check"),
+        ("qa check", "qa-check"),
+        ("security check", "security-check"),
+        ("resilience check", "resilience-check"),
+    )
+
+
+class VSCodeAdapter(BaseAdapter):
+    adapter_name = "vscode"
+    trigger_map = (
+        ("@orchestra", "conductor"),
+        ("orchestra:", "conductor"),
+        ("review architecture", "review-architecture"),
+        ("review ui", "review-ui"),
+        ("review db", "review-db"),
+        ("review docs", "review-docs"),
+        ("diagram check", "diagram-check"),
+        ("qa check", "qa-check"),
+        ("security check", "security-check"),
+        ("resilience check", "resilience-check"),
+    )
+
+
+class JetBrainsAdapter(BaseAdapter):
+    adapter_name = "jetbrains"
+    trigger_map = (
+        ("@orchestra", "conductor"),
+        ("use conductor", "conductor"),
+        ("review architecture", "review-architecture"),
+        ("review ui", "review-ui"),
+        ("review db", "review-db"),
+        ("review docs", "review-docs"),
+        ("diagram check", "diagram-check"),
+        ("qa check", "qa-check"),
+        ("security check", "security-check"),
+        ("resilience check", "resilience-check"),
+    )
+
+
+class ZedAdapter(BaseAdapter):
+    adapter_name = "zed"
+    trigger_map = (
+        ("@orchestra", "conductor"),
+        ("use conductor", "conductor"),
+        ("review architecture", "review-architecture"),
+        ("review ui", "review-ui"),
+        ("review db", "review-db"),
+        ("review docs", "review-docs"),
+        ("diagram check", "diagram-check"),
+        ("qa check", "qa-check"),
+        ("security check", "security-check"),
+        ("resilience check", "resilience-check"),
+    )
+
+
+class NeovimAdapter(BaseAdapter):
+    adapter_name = "neovim"
+    trigger_map = (
+        ("orchestra ", "conductor"),
+        (":orchestra", "conductor"),
+        ("review architecture", "review-architecture"),
+        ("review ui", "review-ui"),
+        ("review db", "review-db"),
+        ("review docs", "review-docs"),
+        ("diagram check", "diagram-check"),
+        ("qa check", "qa-check"),
+        ("security check", "security-check"),
+        ("resilience check", "resilience-check"),
+    )

--- a/orchestra_runtime/factories.py
+++ b/orchestra_runtime/factories.py
@@ -2,7 +2,17 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from .adapters import AntigravityAdapter, ClaudeCodeAdapter, CodexAdapter
+from .adapters import (
+    AntigravityAdapter,
+    ClaudeCodeAdapter,
+    CodexAdapter,
+    CursorAdapter,
+    JetBrainsAdapter,
+    NeovimAdapter,
+    VSCodeAdapter,
+    WindsurfAdapter,
+    ZedAdapter,
+)
 from .models import Skill
 from .repositories import ManifestRepository
 
@@ -50,4 +60,16 @@ class AdapterFactory:
             return AntigravityAdapter(manifest_repository)
         if normalized in {"claude", "claude-code"}:
             return ClaudeCodeAdapter(manifest_repository)
+        if normalized == "cursor":
+            return CursorAdapter(manifest_repository)
+        if normalized == "windsurf":
+            return WindsurfAdapter(manifest_repository)
+        if normalized in {"vscode", "vs-code", "vs_code"}:
+            return VSCodeAdapter(manifest_repository)
+        if normalized in {"jetbrains", "intellij"}:
+            return JetBrainsAdapter(manifest_repository)
+        if normalized == "zed":
+            return ZedAdapter(manifest_repository)
+        if normalized in {"neovim", "nvim"}:
+            return NeovimAdapter(manifest_repository)
         raise ValueError(f"Unsupported adapter: {adapter_name}")

--- a/tests/runtime/test_adapter_contracts.py
+++ b/tests/runtime/test_adapter_contracts.py
@@ -34,6 +34,12 @@ def build_executor(repo_root: Path) -> RuntimeExecutor:
         ("codex", "@Orchestra review-docs"),
         ("antigravity", "/ponytail /conductor review docs"),
         ("claude-code", "Use Conductor for this task"),
+        ("cursor", "@Orchestra review docs"),
+        ("windsurf", "/conductor review docs"),
+        ("vscode", "orchestra: review docs"),
+        ("jetbrains", "Use Conductor to review docs"),
+        ("zed", "@Orchestra review docs"),
+        ("neovim", ":Orchestra review docs"),
     ),
 )
 def test_adapter_contracts(adapter_name: str, prompt: str):
@@ -50,3 +56,24 @@ def test_adapter_contracts(adapter_name: str, prompt: str):
     assert result.adapter_name == adapter_name
     assert result.audit_entry_id
     assert result.output
+
+
+@pytest.mark.parametrize(
+    ("adapter_name", "prompt", "expected_command"),
+    (
+        ("cursor", "@Orchestra review docs", "conductor"),
+        ("windsurf", "/conductor review docs", "conductor"),
+        ("vscode", "orchestra: review docs", "conductor"),
+        ("jetbrains", "Use Conductor to review docs", "conductor"),
+        ("zed", "@Orchestra review docs", "conductor"),
+        ("neovim", ":Orchestra review docs", "conductor"),
+    ),
+)
+def test_new_adapter_command_translation(adapter_name: str, prompt: str, expected_command: str):
+    repo_root = Path(__file__).resolve().parents[2]
+    adapter = AdapterFactory.create(adapter_name, repo_root)
+
+    command = adapter.parse_command(prompt)
+
+    assert command.adapter_name == adapter_name
+    assert command.name == expected_command


### PR DESCRIPTION
## Summary

Adds contract-ready runtime adapters for Cursor, Windsurf, VS Code, JetBrains, Zed, and Neovim.

## What Changed

- Added thin IDE adapter classes.
- Registered new adapters in the runtime factory.
- Exported adapters from the runtime package.
- Expanded adapter contract test coverage.
- Updated architecture documentation, roadmap, and changelog.

## Validation

Passed:

```bash
python -m pytest -q tests\runtime
python scripts\validate_manifest.py
python scripts\governance_check.py --strict
python -m pytest