### PR TITLE
Add Cursor Windsurf VS Code packaging scaffolds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This changelog tracks the repository history using git tags, merge history, and 
 ## Unreleased
 
 ### Added
+- Added scaffold-only packaging folders and package manifests for Cursor, Windsurf, and VS Code that point to the shared runtime adapters without introducing marketplace publication.
 - Added contract-ready runtime adapters for Cursor, Windsurf, VS Code, JetBrains, Zed, and Neovim without introducing marketplace packaging.
 - Added `orchestra_runtime/` runtime core models, services, factories, repositories, and thin Codex, Antigravity, and Claude Code adapters.
 - Added runtime-core pytest coverage for skill loading, adapter contracts, and governance blocking for destructive and high-risk routes.
@@ -13,6 +14,7 @@ This changelog tracks the repository history using git tags, merge history, and 
 - Added validation script for Claude Code plugin: `scripts/validate_claude_plugin.py`
 
 ### Fixed
+- Added IDE packaging validation so scaffold manifests, required files, and runtime adapter references are checked centrally.
 - Refactored manifest, skill, and adapter validation scripts to use the shared runtime repositories and registry instead of duplicating core loading logic.
 - Fixed Claude Code marketplace source path from "." to "./" and bumped Claude plugin metadata to 1.0.1 so Claude Code can detect and refresh the plugin correctly.
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,9 @@ Orchestra can be used across different AI-assisted development environments, but
 | Antigravity / `agy`       |                                 Global | Installed as an Antigravity plugin                                    | Use `agy plugin install` once                       |
 | Claude Code | Marketplace / global plugin | Installed from `.claude-plugin/marketplace.json`; skills load under the `orchestra:` namespace | Use `/plugin marketplace add Baelfyre/Orchestra`, then `/plugin install orchestra@orchestra` |
 | Codex                     |       Marketplace / global plugin first | Installed from Codex Plugins, with repo-local skills as fallback      | Install through Marketplace, then use `@Orchestra`  |
-| VS Code                   | Per extension or per repo instructions | Depends on the AI extension, such as Copilot or Continue              | Use instruction files, not full skill folders       |
+| Cursor                    | Scaffold-only packaging plus repo instructions | Uses a scaffold package manifest and workspace instructions that point at the shared runtime adapter | Use `adapters/cursor` scaffolding, not marketplace publication |
+| Windsurf                  | Scaffold-only packaging plus repo instructions | Uses a scaffold package manifest and workspace instructions that point at the shared runtime adapter | Use `adapters/windsurf` scaffolding, not marketplace publication |
+| VS Code                   | Scaffold-only packaging plus repo instructions | Uses a scaffold package manifest and extension or workspace instructions that point at the shared runtime adapter | Use `adapters/vscode` scaffolding, not full skill folders |
 | IntelliJ / JetBrains IDEs | Per plugin or per project instructions | Depends on JetBrains AI Assistant, Copilot, Junie, or similar plugins | Use instruction files or project docs               |
 | Other AI coding tools     |                          Tool-specific | Usually reads repo instructions, rules, or prompt files               | Adapt Orchestra as project instructions             |
 
@@ -331,6 +333,8 @@ Prioritize:
 
 Commit this file only if the repository should permanently share these AI instructions.
 
+The repository now includes scaffold-only packaging metadata in `adapters/vscode/package.json`. It exists to bind the VS Code packaging surface to the shared `VSCodeAdapter` runtime contract. It is not a published marketplace package yet.
+
 #### Optional: Agentic Skill Installer Extension
 
 VS Code users may optionally use the **Agentic Skill Installer** extension to browse, install, and update Orchestra skills, prompts, and agents from GitHub repositories directly inside VS Code.
@@ -347,6 +351,34 @@ Basic setup flow:
 6. Install or use only the skills needed for the active workspace.
 7. Run git status before committing to confirm no local-only skill files were added unintentionally.
 ```
+
+---
+
+### Cursor Setup
+
+Cursor packaging in this phase is scaffold-only.
+
+Use the files under `adapters/cursor/` to keep host-specific instructions and package metadata aligned to the shared `CursorAdapter` runtime contract:
+
+- `adapters/cursor/package.json`
+- `adapters/cursor/install-guide.md`
+- `adapters/cursor/workspace-instructions.template.md`
+
+This branch does not publish a Cursor marketplace package yet. Keep routing, governance, execution, manifest parsing, and audit behavior in the shared runtime core.
+
+---
+
+### Windsurf Setup
+
+Windsurf packaging in this phase is scaffold-only.
+
+Use the files under `adapters/windsurf/` to keep host-specific instructions and package metadata aligned to the shared `WindsurfAdapter` runtime contract:
+
+- `adapters/windsurf/package.json`
+- `adapters/windsurf/install-guide.md`
+- `adapters/windsurf/workspace-instructions.template.md`
+
+This branch does not publish a Windsurf marketplace package yet. Keep routing, governance, execution, manifest parsing, and audit behavior in the shared runtime core.
 
 ---
 

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -3,6 +3,8 @@
 Adapters bridge the Markdown skills into tool-specific instruction formats. They are not guaranteed native plugins and do not imply automatic discovery.
 
 - [Codex](codex/README.md)
+- [Cursor packaging scaffold](cursor/README.md)
+- [Windsurf packaging scaffold](windsurf/README.md)
 - [VS Code AI workflows](vscode/README.md)
 - [Antigravity](antigravity/README.md)
 - [Claude Code](claude-code/README.md)

--- a/adapters/cursor/README.md
+++ b/adapters/cursor/README.md
@@ -1,0 +1,5 @@
+# Cursor Adapter Packaging Scaffold
+
+This folder contains scaffold-only packaging files for Cursor. It points Cursor-specific setup at the shared `CursorAdapter` runtime contract in `orchestra_runtime`.
+
+See [install-guide.md](install-guide.md), [workspace-instructions.template.md](workspace-instructions.template.md), and [package.json](package.json).

--- a/adapters/cursor/install-guide.md
+++ b/adapters/cursor/install-guide.md
@@ -1,0 +1,6 @@
+# Cursor Installation Guide
+
+1. Use the scaffold manifest in `package.json` as host packaging metadata only.
+2. Keep routing, governance, execution, manifest parsing, and audit behavior in the shared runtime core.
+3. Apply [workspace-instructions.template.md](workspace-instructions.template.md) through Cursor workspace or project instructions.
+4. Treat this folder as packaging scaffolding, not a published marketplace package.

--- a/adapters/cursor/package.json
+++ b/adapters/cursor/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "orchestra-cursor-scaffold",
+  "displayName": "Orchestra Cursor Scaffold",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Scaffold-only Cursor packaging manifest for Orchestra runtime adapter integration.",
+  "orchestra": {
+    "host": "cursor",
+    "runtime_adapter": "cursor",
+    "runtime_package": "orchestra_runtime",
+    "scaffold_only": true,
+    "install_guide": "install-guide.md",
+    "entry_templates": [
+      "workspace-instructions.template.md"
+    ],
+    "deferred_items": [
+      "marketplace-publication",
+      "host-distribution",
+      "signed-package-metadata"
+    ]
+  }
+}

--- a/adapters/cursor/workspace-instructions.template.md
+++ b/adapters/cursor/workspace-instructions.template.md
@@ -1,0 +1,8 @@
+# Cursor Workspace Instructions
+
+Use Orchestra through the shared runtime adapter contract for `cursor`.
+
+- Start from `@Orchestra` when routing is unclear.
+- Keep routing, governance, execution, manifest parsing, and audit behavior in the shared runtime core.
+- Load the smallest relevant specialist context first.
+- Validate changes before summarizing results.

--- a/adapters/vscode/README.md
+++ b/adapters/vscode/README.md
@@ -2,4 +2,6 @@
 
 Use selected skill Markdown as workspace instructions, prompt references, or local context documents. Automatic discovery depends on the installed AI extension and its configuration.
 
-See [install-guide.md](install-guide.md) and [workspace-instructions.template.md](workspace-instructions.template.md).
+This folder also includes a scaffold-only `package.json` that points VS Code packaging metadata at the shared `VSCodeAdapter` runtime contract.
+
+See [install-guide.md](install-guide.md), [workspace-instructions.template.md](workspace-instructions.template.md), and [package.json](package.json).

--- a/adapters/vscode/install-guide.md
+++ b/adapters/vscode/install-guide.md
@@ -3,4 +3,5 @@
 1. Keep the full skill folders in a local documentation or tools directory if needed.
 2. Use Conductor to choose the smallest relevant skill text.
 3. Copy or reference that skill in workspace instructions where supported.
-4. Do not assume automatic skill discovery unless the extension is configured for it.
+4. Use the scaffold-only `package.json` only as packaging metadata that points to the shared `VSCodeAdapter`.
+5. Do not assume automatic skill discovery unless the extension is configured for it.

--- a/adapters/vscode/package.json
+++ b/adapters/vscode/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "orchestra-vscode-scaffold",
+  "displayName": "Orchestra VS Code Scaffold",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Scaffold-only VS Code packaging manifest for Orchestra runtime adapter integration.",
+  "orchestra": {
+    "host": "vscode",
+    "runtime_adapter": "vscode",
+    "runtime_package": "orchestra_runtime",
+    "scaffold_only": true,
+    "install_guide": "install-guide.md",
+    "entry_templates": [
+      "workspace-instructions.template.md"
+    ],
+    "deferred_items": [
+      "marketplace-publication",
+      "host-distribution",
+      "signed-package-metadata"
+    ]
+  }
+}

--- a/adapters/vscode/workspace-instructions.template.md
+++ b/adapters/vscode/workspace-instructions.template.md
@@ -1,3 +1,5 @@
 # Workspace AI Instructions
 
 Review named files before editing. Use Conductor only when routing is unclear. Load one relevant specialist first and supporting documents only when needed. Require evidence for findings and validation for changes. Dagger requires explicit selection, authorization, non-production isolation, approval, rollback, cleanup, and stop conditions.
+
+Packaging note: keep routing, governance, execution, manifest parsing, and audit behavior in the shared runtime core.

--- a/adapters/windsurf/README.md
+++ b/adapters/windsurf/README.md
@@ -1,0 +1,5 @@
+# Windsurf Adapter Packaging Scaffold
+
+This folder contains scaffold-only packaging files for Windsurf. It points Windsurf-specific setup at the shared `WindsurfAdapter` runtime contract in `orchestra_runtime`.
+
+See [install-guide.md](install-guide.md), [workspace-instructions.template.md](workspace-instructions.template.md), and [package.json](package.json).

--- a/adapters/windsurf/install-guide.md
+++ b/adapters/windsurf/install-guide.md
@@ -1,0 +1,6 @@
+# Windsurf Installation Guide
+
+1. Use the scaffold manifest in `package.json` as host packaging metadata only.
+2. Keep routing, governance, execution, manifest parsing, and audit behavior in the shared runtime core.
+3. Apply [workspace-instructions.template.md](workspace-instructions.template.md) through Windsurf workspace or project instructions.
+4. Treat this folder as packaging scaffolding, not a published marketplace package.

--- a/adapters/windsurf/package.json
+++ b/adapters/windsurf/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "orchestra-windsurf-scaffold",
+  "displayName": "Orchestra Windsurf Scaffold",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Scaffold-only Windsurf packaging manifest for Orchestra runtime adapter integration.",
+  "orchestra": {
+    "host": "windsurf",
+    "runtime_adapter": "windsurf",
+    "runtime_package": "orchestra_runtime",
+    "scaffold_only": true,
+    "install_guide": "install-guide.md",
+    "entry_templates": [
+      "workspace-instructions.template.md"
+    ],
+    "deferred_items": [
+      "marketplace-publication",
+      "host-distribution",
+      "signed-package-metadata"
+    ]
+  }
+}

--- a/adapters/windsurf/workspace-instructions.template.md
+++ b/adapters/windsurf/workspace-instructions.template.md
@@ -1,0 +1,8 @@
+# Windsurf Workspace Instructions
+
+Use Orchestra through the shared runtime adapter contract for `windsurf`.
+
+- Start from `/conductor` or the host entrypoint when routing is unclear.
+- Keep routing, governance, execution, manifest parsing, and audit behavior in the shared runtime core.
+- Load the smallest relevant specialist context first.
+- Validate changes before summarizing results.

--- a/docs/project/OOP_RUNTIME_ARCHITECTURE.md
+++ b/docs/project/OOP_RUNTIME_ARCHITECTURE.md
@@ -40,9 +40,17 @@ The repository already had adapter-specific validation and export logic spread a
 5. `RuntimeExecutor` returns an `ExecutionResult`.
 6. `AuditLogger` records the execution outcome through an `IAuditSink`.
 
+## Current packaging boundary
+
+- Cursor, Windsurf, and VS Code now have scaffold-only packaging folders under `adapters/`.
+- Their package manifests point back to the shared runtime adapter classes.
+- Packaging validation checks required files, JSON manifests, and runtime-adapter references.
+- Packaging does not own routing, governance, execution, manifest parsing, or audit behavior.
+
 ## Deferred work
 
 - The runtime currently centralizes Python validation and adapter-contract behavior first.
 - PowerShell installers and Markdown host guides remain in place and unchanged unless they need runtime data.
 - Runtime execution still returns orchestration decisions, not full host-native execution side effects.
-- Marketplace and installer packaging for Cursor, Windsurf, VS Code, JetBrains, Zed, and Neovim remain out of scope for this phase.
+- Marketplace publication remains deferred for Cursor, Windsurf, and VS Code.
+- JetBrains, Zed, and Neovim packaging remain out of scope for this branch.

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -2,8 +2,9 @@
 
 - [ ] Package for a future supported skill marketplace.
 - [ ] Expand the runtime core beyond validation and adapter contracts into more host-native execution paths.
-- [ ] Package Cursor, Windsurf, and VS Code adapters after the contract-ready adapter phase lands.
+- [ ] Promote Cursor, Windsurf, and VS Code packaging scaffolds into publishable marketplace or extension distributions.
 - [ ] Keep JetBrains packaging separate from generic editor packaging because IntelliJ Platform distribution is a different ecosystem.
+- [ ] Keep Zed and Neovim packaging deferred until after the first editor-packaging branch is stable.
 - [ ] Add an optional cross-platform CLI validator.
 - [ ] Add an optional local-model retrieval index.
 - [ ] Improve adapters as tool capabilities change.

--- a/scripts/governance_check.py
+++ b/scripts/governance_check.py
@@ -31,6 +31,7 @@ REQUIRED_VALIDATION_SCRIPTS = [
     "scripts/dagger_guardrail.py",
     "scripts/test_dagger_guardrail.py",
     "scripts/preflight_sync_check.py",
+    "scripts/validate_ide_packaging.py",
     "tests/behavior/evaluate_governance.py",
     "tests/behavior/run_tests.py",
 ]
@@ -44,6 +45,7 @@ REPO_MEMORY_FILES = [
 STRICT_VALIDATOR_SCRIPTS = [
     "scripts/validate_structure.py",
     "scripts/validate_manifest.py",
+    "scripts/validate_ide_packaging.py",
 ]
 
 SIGNIFICANT_CHANGE_PATTERNS = [

--- a/scripts/validate_ide_packaging.py
+++ b/scripts/validate_ide_packaging.py
@@ -1,0 +1,118 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from orchestra_runtime.factories import AdapterFactory
+
+
+PACKAGING_SCAFFOLDS = {
+    "cursor": (
+        "README.md",
+        "install-guide.md",
+        "workspace-instructions.template.md",
+        "package.json",
+    ),
+    "windsurf": (
+        "README.md",
+        "install-guide.md",
+        "workspace-instructions.template.md",
+        "package.json",
+    ),
+    "vscode": (
+        "README.md",
+        "install-guide.md",
+        "workspace-instructions.template.md",
+        "package.json",
+    ),
+}
+
+RESTRICTED_ORCHESTRA_KEYS = {
+    "routing",
+    "governance",
+    "execution",
+    "manifest_parsing",
+    "audit_logging",
+}
+
+
+def load_package_manifest(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def validate_packaging_scaffold(repo_root: Path | str) -> list[str]:
+    root = Path(repo_root)
+    errors: list[str] = []
+
+    for adapter_name, required_files in PACKAGING_SCAFFOLDS.items():
+        adapter_dir = root / "adapters" / adapter_name
+        for relative_name in required_files:
+            if not (adapter_dir / relative_name).is_file():
+                errors.append(f"Missing packaging file: adapters/{adapter_name}/{relative_name}")
+
+        package_path = adapter_dir / "package.json"
+        if not package_path.is_file():
+            continue
+
+        try:
+            payload = load_package_manifest(package_path)
+        except json.JSONDecodeError as exc:
+            errors.append(f"Invalid JSON in adapters/{adapter_name}/package.json: {exc}")
+            continue
+
+        orchestra_block = payload.get("orchestra")
+        if not isinstance(orchestra_block, dict):
+            errors.append(f"Missing orchestra metadata block in adapters/{adapter_name}/package.json")
+            continue
+
+        if orchestra_block.get("runtime_adapter") != adapter_name:
+            errors.append(
+                f"Incorrect runtime adapter reference in adapters/{adapter_name}/package.json: "
+                f"{orchestra_block.get('runtime_adapter')}"
+            )
+
+        if orchestra_block.get("scaffold_only") is not True:
+            errors.append(f"Expected scaffold_only=true in adapters/{adapter_name}/package.json")
+
+        restricted_hits = RESTRICTED_ORCHESTRA_KEYS.intersection(orchestra_block.keys())
+        if restricted_hits:
+            errors.append(
+                f"Packaging manifest in adapters/{adapter_name}/package.json claims core-owned responsibilities: "
+                f"{', '.join(sorted(restricted_hits))}"
+            )
+
+        templates = orchestra_block.get("entry_templates", [])
+        if not isinstance(templates, list) or not templates:
+            errors.append(f"Missing entry_templates in adapters/{adapter_name}/package.json")
+        else:
+            for template_name in templates:
+                if not (adapter_dir / template_name).is_file():
+                    errors.append(
+                        f"Missing referenced entry template in adapters/{adapter_name}/package.json: {template_name}"
+                    )
+
+        try:
+            AdapterFactory.create(adapter_name, root)
+        except ValueError as exc:
+            errors.append(f"AdapterFactory cannot build '{adapter_name}': {exc}")
+
+    return errors
+
+
+def main():
+    errors = validate_packaging_scaffold(ROOT)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        sys.exit(1)
+
+    print("SUCCESS: IDE packaging scaffolds validated.")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_structure.py
+++ b/scripts/validate_structure.py
@@ -32,7 +32,7 @@ def main():
         'assets/logo/orchestra.ico'
     ]
     
-    adapters = ['codex','vscode','antigravity','claude-code','local-ai']
+    adapters = ['codex','cursor','windsurf','vscode','antigravity','claude-code','local-ai']
     
     templates = [
         'generic-skill-template.md','review-output-template.md','audit-output-template.md',

--- a/tests/behavior/run_tests.py
+++ b/tests/behavior/run_tests.py
@@ -11,6 +11,7 @@ def main():
     scripts = [
         {"Name": "validate_structure.py", "Path": "scripts/validate_structure.py"},
         {"Name": "validate_manifest.py", "Path": "scripts/validate_manifest.py"},
+        {"Name": "validate_ide_packaging.py", "Path": "scripts/validate_ide_packaging.py"},
         {"Name": "test_governance_check.py", "Path": "scripts/test_governance_check.py"},
         {"Name": "check_stale_references.py", "Path": "scripts/check_stale_references.py"},
         {"Name": "validate_codex_export.py", "Path": "adapters/codex/validate_codex_export.py"},

--- a/tests/runtime/test_ide_packaging.py
+++ b/tests/runtime/test_ide_packaging.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+from scripts.validate_ide_packaging import validate_packaging_scaffold
+
+
+def test_ide_packaging_scaffolds_validate():
+    repo_root = Path(__file__).resolve().parents[2]
+    assert validate_packaging_scaffold(repo_root) == []


### PR DESCRIPTION
## Summary

Adds scaffold-only packaging surfaces for Cursor, Windsurf, and VS Code while keeping the Orchestra runtime core centralized.

## What Changed

- Added packaging scaffolds for Cursor, Windsurf, and VS Code.
- Added package metadata pointing to existing runtime adapters.
- Added IDE packaging validation.
- Added runtime packaging tests.
- Wired packaging validation into governance and structure checks.
- Updated README, adapter docs, roadmap, changelog, and runtime architecture docs.

## Validation

Passed:

```bash
python scripts/validate_manifest.py
python scripts/governance_check.py --strict
python -m pytest -q tests/runtime
python -m pytest