### PR TITLE
Add JetBrains packaging scaffold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This changelog tracks the repository history using git tags, merge history, and 
 ## Unreleased
 
 ### Added
+- Added scaffold-only JetBrains packaging files and metadata that point to the existing `JetBrainsAdapter` runtime contract without introducing marketplace publication.
 - Added scaffold-only packaging folders and package manifests for Cursor, Windsurf, and VS Code that point to the shared runtime adapters without introducing marketplace publication.
 - Added contract-ready runtime adapters for Cursor, Windsurf, VS Code, JetBrains, Zed, and Neovim without introducing marketplace packaging.
 - Added `orchestra_runtime/` runtime core models, services, factories, repositories, and thin Codex, Antigravity, and Claude Code adapters.

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Orchestra can be used across different AI-assisted development environments, but
 | Cursor                    | Scaffold-only packaging plus repo instructions | Uses a scaffold package manifest and workspace instructions that point at the shared runtime adapter | Use `adapters/cursor` scaffolding, not marketplace publication |
 | Windsurf                  | Scaffold-only packaging plus repo instructions | Uses a scaffold package manifest and workspace instructions that point at the shared runtime adapter | Use `adapters/windsurf` scaffolding, not marketplace publication |
 | VS Code                   | Scaffold-only packaging plus repo instructions | Uses a scaffold package manifest and extension or workspace instructions that point at the shared runtime adapter | Use `adapters/vscode` scaffolding, not full skill folders |
-| IntelliJ / JetBrains IDEs | Per plugin or per project instructions | Depends on JetBrains AI Assistant, Copilot, Junie, or similar plugins | Use instruction files or project docs               |
+| IntelliJ / JetBrains IDEs | Scaffold-only packaging plus project instructions | Uses a scaffold plugin surface and project instructions that point at the shared runtime adapter | Use `adapters/jetbrains` scaffolding, not marketplace publication |
 | Other AI coding tools     |                          Tool-specific | Usually reads repo instructions, rules, or prompt files               | Adapt Orchestra as project instructions             |
 
 ---
@@ -398,6 +398,8 @@ Recommended setup:
 * If the guidance should be shared with contributors, document it in the repo.
 * If it is only for local use, keep it outside Git tracking.
 
+The repository now includes scaffold-only JetBrains packaging metadata in `adapters/jetbrains/`. It binds the JetBrains packaging surface to the shared `JetBrainsAdapter` runtime contract but does not publish a JetBrains Marketplace plugin yet.
+
 Optional shared project file:
 
 ```text
@@ -414,6 +416,13 @@ Preserve existing project structure.
 Validate before summarizing.
 Report changed files, validation results, remaining risks, and next recommended step.
 ```
+
+JetBrains-specific scaffold files in this phase:
+
+- `adapters/jetbrains/plugin.xml`
+- `adapters/jetbrains/package.json`
+- `adapters/jetbrains/install-guide.md`
+- `adapters/jetbrains/workspace-instructions.template.md`
 
 ---
 

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -4,6 +4,7 @@ Adapters bridge the Markdown skills into tool-specific instruction formats. They
 
 - [Codex](codex/README.md)
 - [Cursor packaging scaffold](cursor/README.md)
+- [JetBrains packaging scaffold](jetbrains/README.md)
 - [Windsurf packaging scaffold](windsurf/README.md)
 - [VS Code AI workflows](vscode/README.md)
 - [Antigravity](antigravity/README.md)

--- a/adapters/jetbrains/README.md
+++ b/adapters/jetbrains/README.md
@@ -1,0 +1,5 @@
+# JetBrains Packaging Scaffold
+
+This folder contains scaffold-only JetBrains packaging files for Orchestra. It points JetBrains-specific packaging metadata at the shared `JetBrainsAdapter` runtime contract in `orchestra_runtime`.
+
+See [install-guide.md](install-guide.md), [workspace-instructions.template.md](workspace-instructions.template.md), [plugin.xml](plugin.xml), and [package.json](package.json).

--- a/adapters/jetbrains/install-guide.md
+++ b/adapters/jetbrains/install-guide.md
@@ -1,0 +1,6 @@
+# JetBrains Installation Guide
+
+1. Use the scaffold metadata in `package.json` and `plugin.xml` for packaging structure only.
+2. Keep routing, governance, execution, manifest parsing, and audit behavior in the shared runtime core.
+3. Apply [workspace-instructions.template.md](workspace-instructions.template.md) through JetBrains project or AI assistant instructions where supported.
+4. Treat this folder as packaging scaffolding, not a published JetBrains Marketplace plugin.

--- a/adapters/jetbrains/package.json
+++ b/adapters/jetbrains/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "orchestra-jetbrains-scaffold",
+  "displayName": "Orchestra JetBrains Scaffold",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Scaffold-only JetBrains packaging manifest for Orchestra runtime adapter integration.",
+  "orchestra": {
+    "host": "jetbrains",
+    "runtime_adapter": "jetbrains",
+    "runtime_package": "orchestra_runtime",
+    "scaffold_only": true,
+    "install_guide": "install-guide.md",
+    "entry_templates": [
+      "workspace-instructions.template.md"
+    ],
+    "deferred_items": [
+      "marketplace-publication",
+      "signed-plugin-distribution",
+      "intellij-platform-build"
+    ]
+  }
+}

--- a/adapters/jetbrains/plugin.xml
+++ b/adapters/jetbrains/plugin.xml
@@ -1,0 +1,10 @@
+<idea-plugin>
+  <id>com.baelfyre.orchestra.scaffold</id>
+  <name>Orchestra JetBrains Scaffold</name>
+  <vendor>Baelfyre</vendor>
+  <version>0.0.0</version>
+  <description>Scaffold-only JetBrains packaging metadata for Orchestra runtime adapter integration.</description>
+  <depends>com.intellij.modules.platform</depends>
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+</idea-plugin>

--- a/adapters/jetbrains/workspace-instructions.template.md
+++ b/adapters/jetbrains/workspace-instructions.template.md
@@ -1,0 +1,8 @@
+# JetBrains Workspace Instructions
+
+Use Orchestra through the shared runtime adapter contract for `jetbrains`.
+
+- Start from the Conductor entrypoint when routing is unclear.
+- Keep routing, governance, execution, manifest parsing, and audit behavior in the shared runtime core.
+- Load the smallest relevant specialist context first.
+- Validate changes before summarizing results.

--- a/docs/project/OOP_RUNTIME_ARCHITECTURE.md
+++ b/docs/project/OOP_RUNTIME_ARCHITECTURE.md
@@ -43,7 +43,9 @@ The repository already had adapter-specific validation and export logic spread a
 ## Current packaging boundary
 
 - Cursor, Windsurf, and VS Code now have scaffold-only packaging folders under `adapters/`.
+- JetBrains now has a scaffold-only packaging folder under `adapters/jetbrains/`.
 - Their package manifests point back to the shared runtime adapter classes.
+- JetBrains uses `plugin.xml` plus scaffold metadata that still points back to the shared runtime adapter.
 - Packaging validation checks required files, JSON manifests, and runtime-adapter references.
 - Packaging does not own routing, governance, execution, manifest parsing, or audit behavior.
 
@@ -53,4 +55,5 @@ The repository already had adapter-specific validation and export logic spread a
 - PowerShell installers and Markdown host guides remain in place and unchanged unless they need runtime data.
 - Runtime execution still returns orchestration decisions, not full host-native execution side effects.
 - Marketplace publication remains deferred for Cursor, Windsurf, and VS Code.
-- JetBrains, Zed, and Neovim packaging remain out of scope for this branch.
+- JetBrains marketplace publication remains deferred.
+- Zed and Neovim packaging remain out of scope for this branch.

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -3,7 +3,7 @@
 - [ ] Package for a future supported skill marketplace.
 - [ ] Expand the runtime core beyond validation and adapter contracts into more host-native execution paths.
 - [ ] Promote Cursor, Windsurf, and VS Code packaging scaffolds into publishable marketplace or extension distributions.
-- [ ] Keep JetBrains packaging separate from generic editor packaging because IntelliJ Platform distribution is a different ecosystem.
+- [ ] Promote the JetBrains scaffold into an IntelliJ Platform build and distribution flow separately from the generic editor packaging branch.
 - [ ] Keep Zed and Neovim packaging deferred until after the first editor-packaging branch is stable.
 - [ ] Add an optional cross-platform CLI validator.
 - [ ] Add an optional local-model retrieval index.

--- a/scripts/validate_ide_packaging.py
+++ b/scripts/validate_ide_packaging.py
@@ -17,6 +17,13 @@ PACKAGING_SCAFFOLDS = {
         "workspace-instructions.template.md",
         "package.json",
     ),
+    "jetbrains": (
+        "README.md",
+        "install-guide.md",
+        "workspace-instructions.template.md",
+        "plugin.xml",
+        "package.json",
+    ),
     "windsurf": (
         "README.md",
         "install-guide.md",
@@ -99,6 +106,23 @@ def validate_packaging_scaffold(repo_root: Path | str) -> list[str]:
             AdapterFactory.create(adapter_name, root)
         except ValueError as exc:
             errors.append(f"AdapterFactory cannot build '{adapter_name}': {exc}")
+
+        if adapter_name == "jetbrains":
+            plugin_path = adapter_dir / "plugin.xml"
+            if plugin_path.is_file():
+                plugin_text = plugin_path.read_text(encoding="utf-8")
+                if "<idea-plugin>" not in plugin_text or "<id>com.baelfyre.orchestra.scaffold</id>" not in plugin_text:
+                    errors.append("Invalid basic JetBrains plugin scaffold structure in adapters/jetbrains/plugin.xml")
+                forbidden_hits = [
+                    marker
+                    for marker in ("routing", "governance", "execution", "manifest parsing", "audit")
+                    if marker in plugin_text.lower()
+                ]
+                if forbidden_hits:
+                    errors.append(
+                        "JetBrains plugin scaffold mentions core-owned responsibilities in plugin.xml: "
+                        + ", ".join(forbidden_hits)
+                    )
 
     return errors
 

--- a/scripts/validate_structure.py
+++ b/scripts/validate_structure.py
@@ -32,7 +32,7 @@ def main():
         'assets/logo/orchestra.ico'
     ]
     
-    adapters = ['codex','cursor','windsurf','vscode','antigravity','claude-code','local-ai']
+    adapters = ['codex','cursor','jetbrains','windsurf','vscode','antigravity','claude-code','local-ai']
     
     templates = [
         'generic-skill-template.md','review-output-template.md','audit-output-template.md',

--- a/tests/runtime/test_ide_packaging.py
+++ b/tests/runtime/test_ide_packaging.py
@@ -6,3 +6,14 @@ from scripts.validate_ide_packaging import validate_packaging_scaffold
 def test_ide_packaging_scaffolds_validate():
     repo_root = Path(__file__).resolve().parents[2]
     assert validate_packaging_scaffold(repo_root) == []
+
+
+def test_jetbrains_packaging_files_exist():
+    repo_root = Path(__file__).resolve().parents[2]
+    jetbrains_dir = repo_root / "adapters" / "jetbrains"
+
+    assert (jetbrains_dir / "README.md").is_file()
+    assert (jetbrains_dir / "install-guide.md").is_file()
+    assert (jetbrains_dir / "workspace-instructions.template.md").is_file()
+    assert (jetbrains_dir / "plugin.xml").is_file()
+    assert (jetbrains_dir / "package.json").is_file()


### PR DESCRIPTION
## Summary

Adds scaffold-only JetBrains packaging for Orchestra while keeping runtime core responsibilities centralized.

## Validation

Passed:

```bash
python scripts/validate_manifest.py
python scripts/governance_check.py --strict
python -m pytest -q tests/runtime
python -m pytest