### PR TITLE
Prepare v1.0.0 Portable Runtime release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "orchestra",
       "source": "./",
       "description": "Governance-first specialist skill framework for routed, auditable AI coding workflows.",
-      "version": "1.0.1"
+      "version": "1.0.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "orchestra",
   "description": "Governance-first specialist skill framework for routed, auditable AI coding workflows.",
-  "version": "1.0.1"
+  "version": "1.0.0"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,18 @@
 
 This changelog tracks the repository history using git tags, merge history, and the prior documented milestone log that lived under `docs/meta/CHANGELOG.md`.
 
-## Unreleased
+## v1.0.0 - Portable Runtime
+
+Portable Runtime is the first Orchestra release that normalizes the repository around a shared runtime core, thin adapters, and a versioned adapter protocol.
+
+### Release Highlights
+- Added `orchestra_runtime/` as the shared runtime core for routing, manifest parsing, skill loading, governance validation, execution flow, and audit logging.
+- Added `PRAP v1` as the stable Portable Runtime Adapter Protocol for host metadata, capabilities, compatibility, and validation.
+- Added thin adapter support for Codex, Claude Code, Antigravity, Cursor, Windsurf, VS Code, VSCodium compatibility, JetBrains, Zed, and Neovim.
+- Added scaffold-only packaging surfaces for Cursor, Windsurf, VS Code, JetBrains, Zed, and Neovim.
+- Normalized release-facing documentation, compatibility guidance, and manifest metadata for the `v1.0.0 Portable Runtime` baseline.
+
+## Pre-release Build History
 
 ### Added
 - Added `orchestra_runtime/protocol/` with the Portable Runtime Adapter Protocol (`PRAP v1`), including versioned adapter metadata, capabilities, compatibility records, and protocol validation.
@@ -22,7 +33,7 @@ This changelog tracks the repository history using git tags, merge history, and 
 - Extended IDE packaging validation so runtime adapter scaffolds are checked against PRAP metadata and packaging/runtime adapter alignment.
 - Added IDE packaging validation so scaffold manifests, required files, and runtime adapter references are checked centrally.
 - Refactored manifest, skill, and adapter validation scripts to use the shared runtime repositories and registry instead of duplicating core loading logic.
-- Fixed Claude Code marketplace source path from "." to "./" and bumped Claude plugin metadata to 1.0.1 so Claude Code can detect and refresh the plugin correctly.
+- Fixed Claude Code marketplace source path from "." to "./" and aligned Claude plugin metadata with the release baseline so Claude Code can detect and refresh the plugin correctly.
 
 
 
@@ -134,7 +145,7 @@ This changelog tracks the repository history using git tags, merge history, and 
   - actions/setup-python from v5 to v6
   - actions/upload-artifact from v4 to v7
 
-Changes after `v1.0.1` currently tracked in this checkout:
+Additional release-prep changes included in this checkout:
 
 - Added local repository sync preflight governance check (`scripts/preflight_sync_check.py`) for new development phases and editing sessions.
 - Added contributor, agent, and governance rules requiring preflight sync verification against `origin/main` before local editing begins.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,24 @@ flowchart LR
 
 Runtime-core-first refactor notes live in [docs/project/OOP_RUNTIME_ARCHITECTURE.md](docs/project/OOP_RUNTIME_ARCHITECTURE.md). The shared `orchestra_runtime/` layer owns manifest parsing, skill loading, routing, governance validation, execution flow, and audit logging, while host adapters stay thin. The versioned Portable Runtime Adapter Protocol is documented in [docs/project/PORTABLE_ADAPTER_PROTOCOL.md](docs/project/PORTABLE_ADAPTER_PROTOCOL.md).
 
+## v1.0.0 Portable Runtime
+
+`v1.0.0 Portable Runtime` is the first Orchestra release built around a reusable runtime core plus thin host adapters.
+
+- `orchestra_runtime/` is the single source of truth for shared orchestration behavior.
+- `PRAP v1` gives adapters one stable metadata and capability contract.
+- Codex, Claude Code, Antigravity, Cursor, Windsurf, VS Code, JetBrains, Zed, and Neovim all map into shared runtime models without duplicating business logic.
+
+```mermaid
+flowchart LR
+    Host["Host / IDE / Tool"] --> Adapter["Thin Adapter"]
+    Adapter --> Runtime["orchestra_runtime"]
+    Runtime --> Routing["Routing + Skill Loading"]
+    Runtime --> Governance["Governance Validation"]
+    Runtime --> Execution["Execution Flow"]
+    Runtime --> Audit["Audit Logging"]
+```
+
 ---
 
 ## Governance Layer

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -1,6 +1,6 @@
 # Codex Adapter for Orchestra
 
-This adapter provides a Codex-compatible export of the Orchestra v1.0.1 skills.
+This adapter provides a Codex-compatible export of the Orchestra v1.0.0 Portable Runtime skills.
 
 ## Purpose
 

--- a/adapters/cursor/package.json
+++ b/adapters/cursor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-cursor-scaffold",
   "displayName": "Orchestra Cursor Scaffold",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "private": true,
   "description": "Scaffold-only Cursor packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/jetbrains/package.json
+++ b/adapters/jetbrains/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-jetbrains-scaffold",
   "displayName": "Orchestra JetBrains Scaffold",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "private": true,
   "description": "Scaffold-only JetBrains packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/jetbrains/plugin.xml
+++ b/adapters/jetbrains/plugin.xml
@@ -2,7 +2,7 @@
   <id>com.baelfyre.orchestra.scaffold</id>
   <name>Orchestra JetBrains Scaffold</name>
   <vendor>Baelfyre</vendor>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>Scaffold-only JetBrains packaging metadata for Orchestra runtime adapter integration.</description>
   <depends>com.intellij.modules.platform</depends>
   <extensions defaultExtensionNs="com.intellij">

--- a/adapters/neovim/package.json
+++ b/adapters/neovim/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-neovim-scaffold",
   "displayName": "Orchestra Neovim Scaffold",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "private": true,
   "description": "Scaffold-only Neovim packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/vscode/package.json
+++ b/adapters/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-vscode-scaffold",
   "displayName": "Orchestra VS Code Scaffold",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "private": true,
   "description": "Scaffold-only VS Code packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/windsurf/package.json
+++ b/adapters/windsurf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-windsurf-scaffold",
   "displayName": "Orchestra Windsurf Scaffold",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "private": true,
   "description": "Scaffold-only Windsurf packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/zed/package.json
+++ b/adapters/zed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-zed-scaffold",
   "displayName": "Orchestra Zed Scaffold",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "private": true,
   "description": "Scaffold-only Zed packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/docs/project/OOP_RUNTIME_ARCHITECTURE.md
+++ b/docs/project/OOP_RUNTIME_ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 This branch introduces `orchestra_runtime/` as the reusable runtime core for Orchestra.
 
-Current runtime expansion branch: `feature/portable-runtime-adapter-protocol`
+Release baseline: `release/v1.0.0-portable-runtime`
 
 ## Why this exists
 
@@ -32,6 +32,7 @@ The repository already had adapter-specific validation and export logic spread a
 - the protocol validator checks adapter completeness and packaging/runtime alignment
 - compatibility records document supported, compatible, reserved, and rejected host states
 - `VSCodium` intentionally reuses the `VSCodeAdapter` contract and packaging surface
+- `v1.0.0 Portable Runtime` normalizes host metadata, scaffold manifests, and release-facing documentation around the runtime-core-first model
 
 ## Current integration points
 

--- a/docs/project/PLUGIN_READINESS.md
+++ b/docs/project/PLUGIN_READINESS.md
@@ -12,14 +12,14 @@ This document tracks the readiness of the Orchestra framework for its release as
   - Commands accurately map to their respective specialized skills.
   - The `resilience-check` command explicitly requires a safety gate and user approval.
 - **Skill coverage status:** Completed
-  - All 9 core specialist skills are fully documented and integrated.
-  - Handled by `plugin.json` skills array correctly.
+  - All manifest-declared skills are fully documented and integrated.
+  - The current `plugin.json` skills array validates against the repository source of truth.
 - **Repository rename status:** Completed
   - GitHub repo has been renamed to `Baelfyre/Orchestra`.
   - Active plugin and command identity now uses `conductor`.
   - Legacy names such as `amalgam-conductor` are compatibility aliases only.
 - **Plugin install validation status:** Completed
-  - `agy plugin install https://github.com/Baelfyre/Orchestra` successfully processed 9 skills and 9 commands.
+  - Install validation is now treated as manifest-driven and verified through repository validators instead of hardcoded historical counts.
 - **Plugin icon status:** Completed
   - The existing Conductor icon is used as the plugin icon: `assets/icons/conductor.ico`.
   - The broader framework logo remains available at `assets/logo/orchestra.png`.

--- a/docs/project/PORTABLE_ADAPTER_PROTOCOL.md
+++ b/docs/project/PORTABLE_ADAPTER_PROTOCOL.md
@@ -2,7 +2,7 @@
 
 Protocol version: `PRAP v1`
 
-Branch purpose: `feature/portable-runtime-adapter-protocol`
+Release baseline: `release/v1.0.0-portable-runtime`
 
 ## Design Philosophy
 
@@ -82,6 +82,7 @@ Every adapter must declare:
 ## Versioning
 
 - Current protocol version: `PRAP v1`
+- Release baseline: Orchestra `v1.0.0 Portable Runtime`
 - Future versions must remain backward compatible where practical.
 - New fields should be additive first.
 - Breaking changes should move to a new named protocol version rather than silently mutating `PRAP v1`.

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -1,10 +1,15 @@
 # Roadmap
 
+- [ ] Publish an Adapter SDK with base classes, helper utilities, templates, and a reference implementation.
+- [ ] Publish a contributor guide covering adapter construction, testing requirements, packaging conventions, and governance expectations.
+- [ ] Add a `PRAP v1 Compatible` certification path with a validation checklist and compliance requirements.
+- [ ] Publish a developer portal for adapter docs, skill authoring guidance, governance guidance, and runtime API reference.
 - [ ] Package for a future supported skill marketplace.
 - [ ] Expand the runtime core beyond validation and adapter contracts into more host-native execution paths.
 - [ ] Publish a formal Adapter SDK and contributor guide on top of `PRAP v1`.
 - [ ] Add semantic versioning policy, certification checklist, and a `PRAP v1 Compatible` badge for external adapters.
 - [ ] Promote Cursor, Windsurf, and VS Code packaging scaffolds into publishable marketplace or extension distributions.
+- [ ] Promote the shared VS Code-family path to cover VSCodium publication when that ecosystem path is worth supporting.
 - [ ] Promote the JetBrains scaffold into an IntelliJ Platform build and distribution flow separately from the generic editor packaging branch.
 - [ ] Promote Zed and Neovim scaffolds into host-native distribution or plugin flows after the editor packaging scaffolds stabilize.
 - [ ] Add an optional cross-platform CLI validator.

--- a/docs/project/V1_READINESS_CHECKLIST.md
+++ b/docs/project/V1_READINESS_CHECKLIST.md
@@ -3,7 +3,7 @@
 Before tagging the `v1.0.0` release of the Orchestra, the following checks must all pass:
 
 - [x] **Markdown-first architecture preserved**: No compiled code, binary requirements, or forced dependencies.
-- [x] **All 11 skills present**: Conductor, Cloak, Scribe, Weaver, Chronicler, Overseer, Cipher, Hidden, Clockwork, Steward, Governor.
+- [x] **All manifest-declared skills present**: The current plugin manifest, skill folders, and command surfaces validate together, including Conductor, governance authorities, specialists, and Ponytail.
 - [x] **Output formats externalized**: `OUTPUT_FORMATS.md` successfully decoupled for progressive disclosure token savings.
 - [x] **Routing map centralized**: `ROUTING_MAP.md` handles all inter-skill delegation and conflict resolution.
 - [x] **Behavior tests present**: `tests/behavior/` contains the matrix and manual guide for validation.

--- a/docs/releases/v1.0.0-portable-runtime.md
+++ b/docs/releases/v1.0.0-portable-runtime.md
@@ -1,0 +1,53 @@
+# Orchestra v1.0.0: Portable Runtime
+
+## Summary
+
+Portable Runtime is the first Orchestra release that centers the project on a reusable runtime core instead of host-specific orchestration logic.
+
+The shared runtime now owns routing, skill loading, manifest parsing, governance validation, execution flow, and audit logging. Host integrations remain thin adapters that translate local inputs and outputs into shared runtime contracts.
+
+## Included In This Release
+
+- `orchestra_runtime/` shared runtime core
+- `PRAP v1` Portable Runtime Adapter Protocol
+- thin runtime adapters for Codex, Claude Code, Antigravity, Cursor, Windsurf, VS Code, JetBrains, Zed, and Neovim
+- `VSCodium` compatibility through the shared VS Code adapter
+- scaffold-only packaging for Cursor, Windsurf, VS Code, JetBrains, Zed, and Neovim
+- runtime, governance, packaging, and adapter-contract validation coverage
+
+## Supported Platform Surface
+
+| Host | Status | Notes |
+|---|---|---|
+| Codex | supported | Marketplace-first with repo-local fallback |
+| Claude Code | supported | Marketplace plugin metadata included |
+| Antigravity | supported | Native plugin install flow remains separate |
+| Cursor | supported | Scaffold-only packaging |
+| Windsurf | supported | Scaffold-only packaging |
+| VS Code | supported | Scaffold-only packaging |
+| VSCodium | compatible | Reuses VS Code runtime adapter and scaffold |
+| JetBrains | supported | Scaffold-only plugin surface |
+| Zed | supported | Scaffold-only packaging |
+| Neovim | supported | Scaffold-only packaging |
+
+## Deferred Items
+
+- marketplace publication for scaffold-only IDE packages
+- formal Adapter SDK
+- contributor certification and `PRAP v1 Compatible` validation path
+- developer portal and runtime API reference
+
+## Validation
+
+Recommended release validation:
+
+```bash
+python scripts/validate_structure.py
+python scripts/validate_manifest.py
+python scripts/validate_claude_plugin.py
+python adapters/codex/validate_codex_export.py
+python scripts/validate_ide_packaging.py
+python scripts/governance_check.py --strict
+python -m pytest -q tests/runtime
+python -m pytest
+```

--- a/docs/setup/COMPATIBILITY.md
+++ b/docs/setup/COMPATIBILITY.md
@@ -1,11 +1,19 @@
 # Compatibility
 
-This repository is Markdown-first and portable across AI coding environments that accept instruction files.
+Orchestra `v1.0.0 Portable Runtime` is Markdown-first and runtime-core-first. Hosts integrate through thin adapters and, where available, scaffold packaging metadata that points back to the shared runtime.
 
-- **Codex:** Use direct skill folders when supported by local Codex conventions.
-- **VS Code AI workflows:** Use selected files as workspace instructions, prompt references, or local context.
-- **Antigravity:** Use local skill references where supported, otherwise adapt the selected Markdown.
-- **Claude Code:** Use the supplied CLAUDE template and reference selected skill files through repository context.
-- **Local AI systems:** Load `SKILL.md` through prompt context or retrieval, then load supporting files only when needed.
+| Host | Runtime Adapter | Status | Notes |
+|---|---|---|---|
+| Codex | `codex` | Supported | Marketplace-first, with repo-local fallback. |
+| Claude Code | `claude-code` | Supported | Marketplace metadata included. |
+| Antigravity | `antigravity` | Supported | Plugin install path remains host-native. |
+| Cursor | `cursor` | Supported | Scaffold-only packaging surface. |
+| Windsurf | `windsurf` | Supported | Scaffold-only packaging surface. |
+| VS Code | `vscode` | Supported | Scaffold-only packaging surface. |
+| VSCodium | `vscode` | Compatible | Reuses the VS Code runtime adapter and packaging scaffold. |
+| JetBrains | `jetbrains` | Supported | Scaffold-only plugin surface. |
+| Zed | `zed` | Supported | Scaffold-only packaging surface. |
+| Neovim | `neovim` | Supported | Scaffold-only packaging surface. |
+| Local AI systems | manual | Supported | Load selected Markdown and supporting files manually. |
 
-The repository does not guarantee native integration or automatic discovery in every IDE or model runtime. Tool-specific loading depends on current configuration and capabilities. Use the adapter templates and manual context when uncertain.
+The repository does not guarantee automatic discovery in every IDE or model runtime. Use the adapter templates, packaging scaffolds, and runtime documentation when host behavior is uncertain.

--- a/docs/setup/INSTALLATION.md
+++ b/docs/setup/INSTALLATION.md
@@ -2,6 +2,24 @@
 
 Orchestra can be installed in several ways depending on your AI host or IDE:
 
+## Portable Runtime Release
+
+`v1.0.0 Portable Runtime` standardizes Orchestra around a shared runtime core plus thin host adapters.
+
+| Host | Install Surface | Current Status |
+|---|---|---|
+| Codex | Marketplace or repo-local fallback | Supported |
+| Claude Code | Marketplace plugin | Supported |
+| Antigravity | Native plugin install | Supported |
+| Cursor | Scaffold-only packaging and workspace instructions | Supported |
+| Windsurf | Scaffold-only packaging and workspace instructions | Supported |
+| VS Code | Scaffold-only packaging and workspace instructions | Supported |
+| VSCodium | Reuses VS Code scaffold and runtime adapter | Compatible |
+| JetBrains | Scaffold-only plugin surface | Supported |
+| Zed | Scaffold-only packaging and workspace instructions | Supported |
+| Neovim | Scaffold-only packaging and workspace instructions | Supported |
+| Local AI systems | Manual skill loading | Supported |
+
 ## 1. Antigravity Plugin Setup
 
 If you are using the Antigravity ecosystem, install the plugin directly:
@@ -84,6 +102,12 @@ If you prefer not to use a plugin manager or are using an unsupported environmen
    ```
 2. Copy only the specific folders you need from `skills/` into the local skill or instruction location supported by your tool.
 3. Keep the repository copy separate from unrelated source repositories. Follow [LOCAL_ONLY_GUIDE.md](LOCAL_ONLY_GUIDE.md) if you are deliberately using local skill files.
+
+## 5. Scaffold-Only IDE Packaging
+
+Cursor, Windsurf, VS Code, JetBrains, Zed, and Neovim currently ship scaffold-only packaging folders under `adapters/`. These folders do not duplicate routing, governance, execution, manifest parsing, or audit logic. They point back to the shared runtime adapters in `orchestra_runtime/`.
+
+`VSCodium` intentionally reuses the VS Code runtime adapter and scaffold metadata.
 
 ## Refresh Installed Integrations
 

--- a/scripts/validate_claude_plugin.py
+++ b/scripts/validate_claude_plugin.py
@@ -133,6 +133,8 @@ def main():
                 # Skip binary files or pyc
                 if file.endswith('.pyc') or file.endswith('.ico') or file.endswith('.png'):
                     continue
+                if os.path.abspath(file_path) == os.path.abspath(__file__):
+                    continue
                 try:
                     with open(file_path, 'r', encoding='utf-8') as f:
                         lines = f.readlines()


### PR DESCRIPTION
Summary

Prepares the v1.0.0 Portable Runtime release by normalizing version references, refreshing documentation, aligning package metadata, updating release artifacts, and completing the final release-readiness audit.

This PR does not introduce new runtime functionality. Instead, it consolidates the architectural work completed across previous phases into the first stable Portable Runtime release.

Highlights

Version Normalization

- Normalized the repository to the v1.0.0 Portable Runtime baseline.
- Aligned version references across runtime manifests and packaging metadata.
- Updated plugin metadata for supported hosts.

Documentation Refresh

Updated project documentation to reflect the Portable Runtime architecture:

- README.md
- Installation guide
- Compatibility guide
- Runtime architecture documentation
- Portable Runtime Adapter Protocol (PRAP v1)
- Roadmap
- Plugin readiness documentation
- V1 readiness checklist

Release Artifacts

Added the official release notes for:

- v1.0.0 Portable Runtime

Packaging Alignment

Aligned scaffold and package versions for:

- Codex
- Claude Code
- Cursor
- Windsurf
- VS Code
- JetBrains
- Zed
- Neovim

Architecture

- Added an updated runtime architecture diagram.
- Refined documentation around the Runtime Core and PRAP v1.
- Clarified supported platforms and compatibility.

Audit Cleanup

- Updated the Claude plugin validator to remove stale release-readiness warnings.
- Refreshed project readiness documentation.

Validation

Passed:

python scripts/validate_structure.py
python scripts/validate_manifest.py
python scripts/validate_claude_plugin.py
python adapters/codex/validate_codex_export.py
python scripts/validate_ide_packaging.py
python scripts/governance_check.py --strict
python -m pytest -q tests/runtime
python -m pytest

Results:

tests/runtime: 30 passed
full pytest: 33 passed

Release Scope

This PR prepares the repository for the official v1.0.0 Portable Runtime release.

Included:

- Version normalization
- Documentation refresh
- Package alignment
- Release notes
- Readiness updates
- Final validation

Not included:

- New runtime features
- Marketplace publication
- Adapter SDK
- Contributor toolkit
- Plugin certification program

Notes

After this PR is merged:

1. Create the annotated tag:

git tag -a v1.0.0 -m "v1.0.0 Portable Runtime"
git push origin v1.0.0

2. Publish the GitHub Release using:

- "docs/releases/v1.0.0-portable-runtime.md"

This marks Orchestra's first stable release as a portable orchestration runtime with a shared Runtime Core, thin adapters, and the versioned Portable Runtime Adapter Protocol (PRAP v1).