### PR TITLE
Add notify-only update check

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,10 @@
 {
   "name": "orchestra",
   "description": "Governance-first specialist skill framework for routed, auditable AI coding workflows.",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "update_check": {
+    "update_check_enabled": true,
+    "update_check_channel": "stable",
+    "update_check_frequency": "manual"
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ Portable Runtime is the first Orchestra release that normalizes the repository a
 
 ## Pre-release Build History
 
+## Unreleased
+
+### Added
+- Added `scripts/check_for_updates.py` for notification-only release checks against the latest GitHub release using local manifest and adapter metadata.
+- Added update-check metadata defaults to the root manifest, Claude plugin manifest, and scaffold adapter package metadata.
+- Added runtime tests covering current-version, newer-release, invalid-version, unavailable-GitHub, and disabled-update-check behavior.
+
 ### Added
 - Added `orchestra_runtime/protocol/` with the Portable Runtime Adapter Protocol (`PRAP v1`), including versioned adapter metadata, capabilities, compatibility records, and protocol validation.
 - Added runtime protocol tests covering metadata completeness, capability validation, compatibility matrix coverage, VSCodium compatibility, and unknown adapter rejection.

--- a/README.md
+++ b/README.md
@@ -730,6 +730,33 @@ For full configuration and usage instructions, see the [Validation & Enforceable
 
 ---
 
+## Update Notifications
+
+Orchestra does not auto-update installed files. Update checks are notify-only.
+
+Run the shared update checker manually:
+
+```powershell
+python .\scripts\check_for_updates.py
+```
+
+The checker reads local version metadata from `plugin.json`, `.claude-plugin/plugin.json`, and adapter `package.json` files where applicable, compares that version to the latest GitHub release, and prints:
+
+- current version
+- latest version
+- release URL
+- a host-specific refresh or reinstall reminder
+
+Optional manifest metadata supports:
+
+- `update_check_enabled`
+- `update_check_channel`
+- `update_check_frequency`
+
+Current defaults are `true`, `stable`, and `manual`.
+
+---
+
 ## Limitations
 
 - **Instruction-Level Framework:** Orchestra primarily operates through structured instructions, skills, and documentation.

--- a/adapters/cursor/package.json
+++ b/adapters/cursor/package.json
@@ -8,6 +8,11 @@
     "host": "cursor",
     "runtime_adapter": "cursor",
     "runtime_package": "orchestra_runtime",
+    "update_check": {
+      "update_check_enabled": true,
+      "update_check_channel": "stable",
+      "update_check_frequency": "manual"
+    },
     "scaffold_only": true,
     "install_guide": "install-guide.md",
     "entry_templates": [

--- a/adapters/jetbrains/package.json
+++ b/adapters/jetbrains/package.json
@@ -8,6 +8,11 @@
     "host": "jetbrains",
     "runtime_adapter": "jetbrains",
     "runtime_package": "orchestra_runtime",
+    "update_check": {
+      "update_check_enabled": true,
+      "update_check_channel": "stable",
+      "update_check_frequency": "manual"
+    },
     "scaffold_only": true,
     "install_guide": "install-guide.md",
     "entry_templates": [

--- a/adapters/neovim/package.json
+++ b/adapters/neovim/package.json
@@ -8,6 +8,11 @@
     "host": "neovim",
     "runtime_adapter": "neovim",
     "runtime_package": "orchestra_runtime",
+    "update_check": {
+      "update_check_enabled": true,
+      "update_check_channel": "stable",
+      "update_check_frequency": "manual"
+    },
     "scaffold_only": true,
     "install_guide": "install-guide.md",
     "entry_templates": [

--- a/adapters/vscode/package.json
+++ b/adapters/vscode/package.json
@@ -8,6 +8,11 @@
     "host": "vscode",
     "runtime_adapter": "vscode",
     "runtime_package": "orchestra_runtime",
+    "update_check": {
+      "update_check_enabled": true,
+      "update_check_channel": "stable",
+      "update_check_frequency": "manual"
+    },
     "scaffold_only": true,
     "install_guide": "install-guide.md",
     "entry_templates": [

--- a/adapters/windsurf/package.json
+++ b/adapters/windsurf/package.json
@@ -8,6 +8,11 @@
     "host": "windsurf",
     "runtime_adapter": "windsurf",
     "runtime_package": "orchestra_runtime",
+    "update_check": {
+      "update_check_enabled": true,
+      "update_check_channel": "stable",
+      "update_check_frequency": "manual"
+    },
     "scaffold_only": true,
     "install_guide": "install-guide.md",
     "entry_templates": [

--- a/adapters/zed/package.json
+++ b/adapters/zed/package.json
@@ -8,6 +8,11 @@
     "host": "zed",
     "runtime_adapter": "zed",
     "runtime_package": "orchestra_runtime",
+    "update_check": {
+      "update_check_enabled": true,
+      "update_check_channel": "stable",
+      "update_check_frequency": "manual"
+    },
     "scaffold_only": true,
     "install_guide": "install-guide.md",
     "entry_templates": [

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -1,5 +1,6 @@
 # Roadmap
 
+- [ ] Add host-specific update commands after the shared notification-only update check stabilizes.
 - [ ] Publish an Adapter SDK with base classes, helper utilities, templates, and a reference implementation.
 - [ ] Publish a contributor guide covering adapter construction, testing requirements, packaging conventions, and governance expectations.
 - [ ] Add a `PRAP v1 Compatible` certification path with a validation checklist and compliance requirements.

--- a/docs/setup/INSTALLATION.md
+++ b/docs/setup/INSTALLATION.md
@@ -124,6 +124,20 @@ powershell -ExecutionPolicy Bypass -File .\scripts\refresh-installed-integration
 ```
 *(Marketplace installation is the default Codex setup.)*
 
+## Check for Updates
+
+Orchestra update checks are notify-only. They do not silently modify installed plugin files.
+
+Run:
+
+```sh
+python .\scripts\check_for_updates.py
+```
+
+The script reads local version metadata from the root manifest, Claude plugin manifest, and adapter package manifests where applicable, then compares it to the latest GitHub release.
+
+If a newer release exists, use your host-specific refresh or reinstall flow to update.
+
 ## Verify
 
 Run the structure validator (`.\scripts\validate-structure.ps1`) and confirm that normal QA routes to Overseer, normal security/privacy review routes to Cipher, and Dagger remains gated.

--- a/plugin.json
+++ b/plugin.json
@@ -7,6 +7,11 @@
     "repository": "https://github.com/Baelfyre/Orchestra",
     "icon_path": "assets/icons/conductor.ico",
     "logo_path": "assets/logo/orchestra.ico",
+    "update_check": {
+        "update_check_enabled": true,
+        "update_check_channel": "stable",
+        "update_check_frequency": "manual"
+    },
     "safety_note": "The dagger skill and resilience-check command execute destructive, negative, fuzz, adversarial QA, and failure-mode testing. They require explicit user approval, non-production scope, and a passing scripts/dagger_guardrail.py validation before execution. WARNING: Phase 2 allows simulation only and blocks live destructive execution. Do not proceed in a production environment.",
     "commands": [
         "conductor",

--- a/scripts/check_for_updates.py
+++ b/scripts/check_for_updates.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LATEST_RELEASE_URL = "https://api.github.com/repos/Baelfyre/Orchestra/releases/latest"
+DEFAULT_UPDATE_CONFIG = {
+    "update_check_enabled": True,
+    "update_check_channel": "stable",
+    "update_check_frequency": "manual",
+}
+VALID_FREQUENCIES = {"manual", "daily", "startup"}
+VALID_CHANNELS = {"stable"}
+
+
+@dataclass(frozen=True)
+class VersionSurface:
+    surface: str
+    path: Path
+    version: str
+    update_config: dict[str, object]
+
+
+@dataclass(frozen=True)
+class ReleaseInfo:
+    version: str
+    url: str
+
+
+@dataclass(frozen=True)
+class UpdateStatus:
+    current_version: str
+    latest_version: str | None
+    release_url: str | None
+    update_available: bool
+    disabled: bool
+    message: str
+    instruction: str | None = None
+
+
+class UpdateCheckError(ValueError):
+    pass
+
+
+def read_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def parse_version(value: str) -> tuple[int, int, int]:
+    normalized = value.strip()
+    if normalized.startswith("v"):
+        normalized = normalized[1:]
+    parts = normalized.split(".")
+    if len(parts) != 3 or any(not part.isdigit() for part in parts):
+        raise UpdateCheckError(f"Invalid version: {value}")
+    return tuple(int(part) for part in parts)
+
+
+def read_update_config(payload: dict, container_key: str | None = None) -> dict[str, object]:
+    container = payload if container_key is None else payload.get(container_key, {})
+    if container_key is not None and not isinstance(container, dict):
+        container = {}
+    config = dict(DEFAULT_UPDATE_CONFIG)
+    config.update(container.get("update_check", {}))
+    return config
+
+
+def validate_update_config(config: dict[str, object]) -> None:
+    frequency = str(config.get("update_check_frequency", "")).lower()
+    channel = str(config.get("update_check_channel", "")).lower()
+    enabled = config.get("update_check_enabled")
+
+    if not isinstance(enabled, bool):
+        raise UpdateCheckError("update_check_enabled must be true or false.")
+    if frequency not in VALID_FREQUENCIES:
+        raise UpdateCheckError(f"Invalid update check frequency: {frequency}")
+    if channel not in VALID_CHANNELS:
+        raise UpdateCheckError(f"Invalid update check channel: {channel}")
+
+
+def load_version_surfaces(repo_root: Path) -> tuple[VersionSurface, ...]:
+    surfaces: list[VersionSurface] = []
+
+    plugin_payload = read_json(repo_root / "plugin.json")
+    surfaces.append(
+        VersionSurface(
+            surface="plugin",
+            path=repo_root / "plugin.json",
+            version=str(plugin_payload.get("version", "")),
+            update_config=read_update_config(plugin_payload),
+        )
+    )
+
+    claude_payload = read_json(repo_root / ".claude-plugin" / "plugin.json")
+    surfaces.append(
+        VersionSurface(
+            surface="claude-code",
+            path=repo_root / ".claude-plugin" / "plugin.json",
+            version=str(claude_payload.get("version", "")),
+            update_config=read_update_config(claude_payload),
+        )
+    )
+
+    for package_path in sorted((repo_root / "adapters").glob("*/package.json")):
+        payload = read_json(package_path)
+        adapter_name = package_path.parent.name
+        surfaces.append(
+            VersionSurface(
+                surface=adapter_name,
+                path=package_path,
+                version=str(payload.get("version", "")),
+                update_config=read_update_config(payload, "orchestra"),
+            )
+        )
+
+    return tuple(surfaces)
+
+
+def check_surface_consistency(surfaces: tuple[VersionSurface, ...]) -> str:
+    versions = {surface.surface: surface.version for surface in surfaces}
+    for version in versions.values():
+        parse_version(version)
+
+    unique_versions = sorted(set(versions.values()))
+    if len(unique_versions) != 1:
+        raise UpdateCheckError(
+            "Version mismatch across local manifests: "
+            + ", ".join(f"{name}={version}" for name, version in sorted(versions.items()))
+        )
+    return unique_versions[0]
+
+
+def is_update_check_enabled(surfaces: tuple[VersionSurface, ...]) -> bool:
+    return all(bool(surface.update_config.get("update_check_enabled", True)) for surface in surfaces)
+
+
+def fetch_latest_release(fetcher: Callable[[str], dict] | None = None) -> ReleaseInfo:
+    payload_fetcher = fetcher or _fetch_latest_release_payload
+    payload = payload_fetcher(LATEST_RELEASE_URL)
+    tag_name = str(payload.get("tag_name", ""))
+    html_url = str(payload.get("html_url", ""))
+    if not tag_name or not html_url:
+        raise UpdateCheckError("Latest release payload is missing tag_name or html_url.")
+    parse_version(tag_name)
+    return ReleaseInfo(version=tag_name.removeprefix("v"), url=html_url)
+
+
+def _fetch_latest_release_payload(url: str) -> dict:
+    request = Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "orchestra-update-checker/1.0.0",
+        },
+    )
+    try:
+        with urlopen(request, timeout=10) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except HTTPError as exc:
+        raise UpdateCheckError(f"GitHub release check failed: HTTP {exc.code}") from exc
+    except URLError as exc:
+        raise UpdateCheckError(f"GitHub release check failed: {exc.reason}") from exc
+
+
+def build_update_status(
+    repo_root: Path,
+    fetcher: Callable[[str], dict] | None = None,
+) -> UpdateStatus:
+    surfaces = load_version_surfaces(repo_root)
+    for surface in surfaces:
+        validate_update_config(surface.update_config)
+    current_version = check_surface_consistency(surfaces)
+
+    if not is_update_check_enabled(surfaces):
+        return UpdateStatus(
+            current_version=current_version,
+            latest_version=None,
+            release_url=None,
+            update_available=False,
+            disabled=True,
+            message="Orchestra update check is disabled.",
+        )
+
+    latest = fetch_latest_release(fetcher)
+    update_available = parse_version(latest.version) > parse_version(current_version)
+    if update_available:
+        return UpdateStatus(
+            current_version=current_version,
+            latest_version=latest.version,
+            release_url=latest.url,
+            update_available=True,
+            disabled=False,
+            message=(
+                "Orchestra update available.\n\n"
+                f"Current version: {current_version}\n"
+                f"Latest version: {latest.version}\n\n"
+                f"Release:\n{latest.url}\n\n"
+                "Run your host-specific refresh or reinstall command to update."
+            ),
+            instruction="Run your host-specific refresh or reinstall command to update.",
+        )
+
+    return UpdateStatus(
+        current_version=current_version,
+        latest_version=latest.version,
+        release_url=latest.url,
+        update_available=False,
+        disabled=False,
+        message=(
+            "Orchestra is up to date.\n\n"
+            f"Current version: {current_version}\n"
+            f"Latest version: {latest.version}\n\n"
+            f"Release:\n{latest.url}"
+        ),
+    )
+
+
+def main() -> int:
+    try:
+        status = build_update_status(REPO_ROOT)
+    except UpdateCheckError as exc:
+        print(f"ERROR: {exc}")
+        return 1
+
+    print(status.message)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/runtime/test_update_check.py
+++ b/tests/runtime/test_update_check.py
@@ -1,0 +1,118 @@
+from pathlib import Path
+
+import pytest
+
+from scripts.check_for_updates import (
+    DEFAULT_UPDATE_CONFIG,
+    UpdateCheckError,
+    build_update_status,
+    parse_version,
+)
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(__import__("json").dumps(payload, indent=2), encoding="utf-8")
+
+
+def create_repo(tmp_path: Path, version: str = "1.0.0", enabled: bool = True) -> Path:
+    repo_root = tmp_path / "repo"
+    update_check = {
+        **DEFAULT_UPDATE_CONFIG,
+        "update_check_enabled": enabled,
+    }
+    write_json(
+        repo_root / "plugin.json",
+        {
+            "name": "conductor",
+            "display_name": "Orchestra",
+            "version": version,
+            "commands": [],
+            "skills": [],
+            "update_check": update_check,
+        },
+    )
+    write_json(
+        repo_root / ".claude-plugin" / "plugin.json",
+        {
+            "name": "orchestra",
+            "description": "test",
+            "version": version,
+            "update_check": update_check,
+        },
+    )
+    write_json(
+        repo_root / "adapters" / "vscode" / "package.json",
+        {
+            "name": "orchestra-vscode-scaffold",
+            "version": version,
+            "orchestra": {
+                "runtime_adapter": "vscode",
+                "host": "vscode",
+                "update_check": update_check,
+            },
+        },
+    )
+    return repo_root
+
+
+def test_current_version_is_latest(tmp_path: Path):
+    repo_root = create_repo(tmp_path)
+
+    status = build_update_status(
+        repo_root,
+        fetcher=lambda _: {"tag_name": "v1.0.0", "html_url": "https://example.test/v1.0.0"},
+    )
+
+    assert status.update_available is False
+    assert status.current_version == "1.0.0"
+    assert status.latest_version == "1.0.0"
+    assert "up to date" in status.message.lower()
+
+
+def test_newer_version_exists(tmp_path: Path):
+    repo_root = create_repo(tmp_path)
+
+    status = build_update_status(
+        repo_root,
+        fetcher=lambda _: {"tag_name": "v1.0.1", "html_url": "https://example.test/v1.0.1"},
+    )
+
+    assert status.update_available is True
+    assert status.latest_version == "1.0.1"
+    assert status.release_url == "https://example.test/v1.0.1"
+    assert "Run your host-specific refresh or reinstall command to update." in status.message
+
+
+def test_invalid_version_fails(tmp_path: Path):
+    repo_root = create_repo(tmp_path, version="one.two.three")
+
+    with pytest.raises(UpdateCheckError, match="Invalid version"):
+        build_update_status(
+            repo_root,
+            fetcher=lambda _: {"tag_name": "v1.0.1", "html_url": "https://example.test/v1.0.1"},
+        )
+
+
+def test_github_unavailable_fails(tmp_path: Path):
+    repo_root = create_repo(tmp_path)
+
+    with pytest.raises(UpdateCheckError, match="unavailable"):
+        build_update_status(repo_root, fetcher=lambda _: (_ for _ in ()).throw(UpdateCheckError("GitHub unavailable")))
+
+
+def test_update_check_disabled(tmp_path: Path):
+    repo_root = create_repo(tmp_path, enabled=False)
+
+    status = build_update_status(
+        repo_root,
+        fetcher=lambda _: {"tag_name": "v1.0.1", "html_url": "https://example.test/v1.0.1"},
+    )
+
+    assert status.disabled is True
+    assert status.update_available is False
+    assert status.latest_version is None
+
+
+def test_parse_version_accepts_v_prefix():
+    assert parse_version("v1.0.1") == (1, 0, 1)


### PR DESCRIPTION
## Summary

Adds a notify-only update checker for Orchestra installations.

The checker reads local plugin and adapter versions, checks the latest stable GitHub Release, compares semantic versions, and reports whether a newer release is available. It does not mutate files, reinstall plugins, or perform silent updates.

## What Changed

- Added `scripts/check_for_updates.py`.
- Added update-check defaults to plugin metadata.
- Added focused update-check tests.
- Updated installation and roadmap documentation.
- Updated adapter package metadata.
- Kept update behavior notification-only.

## Validation

Passed:

```bash
python -m pytest -q tests/runtime/test_update_check.py
python scripts/validate_manifest.py
python scripts/validate_claude_plugin.py
python scripts/validate_ide_packaging.py
python scripts/validate_structure.py
python scripts/governance_check.py --strict
python -m pytest -q tests/runtime
python -m pytest
python scripts/check_for_updates.py