### PR TITLE
Add staged runtime export pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Portable Runtime is the first Orchestra release that normalizes the repository a
 - Added `scripts/check_for_updates.py` for notification-only release checks against the latest GitHub release using local manifest and adapter metadata.
 - Added update-check metadata defaults to the root manifest, Claude plugin manifest, and scaffold adapter package metadata.
 - Added runtime tests covering current-version, newer-release, invalid-version, unavailable-GitHub, and disabled-update-check behavior.
+- Added a temp-staged Codex runtime refresh pipeline that exports to a temporary directory, validates staged output, installs into repo-local and global Codex runtime locations, verifies file-list and SHA-256 parity, and deletes staged output by default.
+- Added reusable PowerShell directory parity helpers for recursive file-list and SHA-256 comparison across staged and installed runtime surfaces.
 
 ### Added
 - Added `orchestra_runtime/protocol/` with the Portable Runtime Adapter Protocol (`PRAP v1`), including versioned adapter metadata, capabilities, compatibility records, and protocol validation.
@@ -41,6 +43,7 @@ Portable Runtime is the first Orchestra release that normalizes the repository a
 - Added IDE packaging validation so scaffold manifests, required files, and runtime adapter references are checked centrally.
 - Refactored manifest, skill, and adapter validation scripts to use the shared runtime repositories and registry instead of duplicating core loading logic.
 - Fixed Claude Code marketplace source path from "." to "./" and aligned Claude plugin metadata with the release baseline so Claude Code can detect and refresh the plugin correctly.
+- Fixed Codex refresh so normal installs no longer dirty tracked export folders during runtime refreshes.
 
 
 

--- a/README.md
+++ b/README.md
@@ -315,6 +315,8 @@ cd C:\conductor
 powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\refresh-installed-integrations.ps1 -Target Codex -CodexRepoPath "C:\path\to\your\project" -Force
 ```
 
+The refresh pipeline keeps repository source, generated export output, and installed runtime locations separate. By default it exports Codex skills into a temporary staging directory, validates that staged export, installs from the staged copy, verifies file-list and SHA-256 parity against both repo-local and global Codex runtime locations, and then deletes the temporary staging directory.
+
 Important:
 
 * Marketplace installation is the default Codex setup.
@@ -338,6 +340,8 @@ Recommended local-only entries:
 This keeps the files available locally without adding them to the shared repository.
 
 Use `.gitignore` only if the whole project intentionally wants to share those AI configuration files with all contributors.
+
+Use `-KeepTempExport` only when you need to inspect the staged export during debugging.
 
 ---
 

--- a/adapters/codex/install-to-repo.ps1
+++ b/adapters/codex/install-to-repo.ps1
@@ -1,12 +1,13 @@
 param(
     [Parameter(Mandatory=$true)]
     [string]$TargetRepo,
+
+    [string]$SourceSkillsDir = (Join-Path $PSScriptRoot "skills"),
     
     [switch]$Force
 )
 
 $targetAgentsDir = Join-Path $TargetRepo ".agents\skills"
-$sourceSkillsDir = Join-Path $PSScriptRoot "skills"
 
 if (-not (Test-Path $sourceSkillsDir)) {
     Write-Error "Source skills directory not found: $sourceSkillsDir. Please run export-codex-skills.ps1 first."

--- a/adapters/codex/validate_codex_export.py
+++ b/adapters/codex/validate_codex_export.py
@@ -1,4 +1,5 @@
 import json
+import argparse
 import re
 import sys
 from pathlib import Path
@@ -170,10 +171,28 @@ def validate_tracked_export_parity(root):
 
     return errors
 
-def main():
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description="Validate Codex export output.")
+    parser.add_argument(
+        "--export-root",
+        type=Path,
+        default=None,
+        help="Root directory containing the exported Codex skills folder.",
+    )
+    parser.add_argument(
+        "--skip-tracked-export-parity",
+        action="store_true",
+        help="Skip tracked export parity checks.",
+    )
+    return parser.parse_args(argv)
+
+def main(argv=None):
+    args = parse_args(argv)
     script_dir = Path(__file__).resolve().parent
-    codex_skills_dir = script_dir / "skills"
     root = script_dir.parent.parent
+    export_root = args.export_root.resolve() if args.export_root else script_dir
+    codex_skills_dir = export_root / "skills"
     
     manifest_path = root / "plugin.json"
     if not manifest_path.is_file():
@@ -230,7 +249,8 @@ def main():
             print_error(f"Exported conductor references missing skill: {required_skill}")
             errors += 1
 
-    errors += validate_tracked_export_parity(root)
+    if not args.skip_tracked_export_parity and export_root == script_dir.resolve():
+        errors += validate_tracked_export_parity(root)
                 
     if errors > 0:
         print_error(f"Codex export validation failed with {errors} errors.")

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -1,6 +1,7 @@
 # Roadmap
 
 - [ ] Add host-specific update commands after the shared notification-only update check stabilizes.
+- [ ] Add host-specific update commands on top of the reproducible temp-staged runtime refresh pipeline.
 - [ ] Publish an Adapter SDK with base classes, helper utilities, templates, and a reference implementation.
 - [ ] Publish a contributor guide covering adapter construction, testing requirements, packaging conventions, and governance expectations.
 - [ ] Add a `PRAP v1 Compatible` certification path with a validation checklist and compliance requirements.

--- a/docs/setup/INSTALLATION.md
+++ b/docs/setup/INSTALLATION.md
@@ -67,6 +67,8 @@ powershell -ExecutionPolicy Bypass -File .\scripts\refresh-installed-integration
 
 Do not commit `.agents/` unless the repo intentionally shares those Codex skill files. For local-only setup, add `.agents/` to `.git/info/exclude`.
 
+The Codex refresh path now uses a temporary staging export by default. It reads tracked repository source, exports into a temp directory outside the repo, validates the staged export, installs from that staged copy, verifies parity, and then removes the temp directory. Generated runtime output is not written into tracked export folders during a normal refresh.
+
 ## 3. Claude Code Plugin Setup
 
 For Claude Code, you can install the Orchestra plugin directly using its marketplace.
@@ -123,6 +125,21 @@ powershell -ExecutionPolicy Bypass -File .\scripts\refresh-installed-integration
 powershell -ExecutionPolicy Bypass -File .\scripts\refresh-installed-integrations.ps1 -Target Codex -CodexRepoPath "C:\path\to\your\project"
 ```
 *(Marketplace installation is the default Codex setup.)*
+
+Default Codex refresh behavior:
+
+- export to a temporary staging directory
+- validate the staged export
+- install staged skills into repo-local `.agents/skills`
+- install staged skills into the global Codex skills directory
+- compare file lists and SHA-256 hashes against the staged export
+- delete the temporary staging directory after a successful refresh
+
+Keep the staged export only when debugging:
+
+```sh
+powershell -ExecutionPolicy Bypass -File .\scripts\refresh-installed-integrations.ps1 -Target Codex -KeepTempExport
+```
 
 ## Check for Updates
 

--- a/scripts/helpers.ps1
+++ b/scripts/helpers.ps1
@@ -118,3 +118,87 @@ function Test-WorkflowLocked {
     catch {}
     return $false
 }
+
+function Get-DirectoryHashIndex {
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$Root
+    )
+
+    if (-not (Test-Path -LiteralPath $Root -PathType Container)) {
+        throw "Directory not found: $Root"
+    }
+
+    $rootItem = Get-Item -LiteralPath $Root -ErrorAction Stop
+    $normalizedRoot = $rootItem.FullName.TrimEnd('\', '/')
+    $index = @{}
+
+    Get-ChildItem -LiteralPath $normalizedRoot -Recurse -File | ForEach-Object {
+        $relativePath = $_.FullName.Substring($normalizedRoot.Length).TrimStart('\', '/').Replace('\', '/')
+        $index[$relativePath] = (Get-FileHash -LiteralPath $_.FullName -Algorithm SHA256).Hash
+    }
+
+    return $index
+}
+
+function Compare-DirectoryParity {
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$SourceRoot,
+
+        [Parameter(Mandatory=$true)]
+        [string]$DestinationRoot
+    )
+
+    $sourceIndex = Get-DirectoryHashIndex -Root $SourceRoot
+    $destinationIndex = Get-DirectoryHashIndex -Root $DestinationRoot
+    $issues = New-Object System.Collections.Generic.List[string]
+
+    foreach ($relativePath in $sourceIndex.Keys) {
+        if (-not $destinationIndex.ContainsKey($relativePath)) {
+            $issues.Add("Missing file in destination: $relativePath")
+            continue
+        }
+
+        if ($sourceIndex[$relativePath] -ne $destinationIndex[$relativePath]) {
+            $issues.Add("Hash mismatch: $relativePath")
+        }
+    }
+
+    foreach ($relativePath in $destinationIndex.Keys) {
+        if (-not $sourceIndex.ContainsKey($relativePath)) {
+            $issues.Add("Unexpected file in destination: $relativePath")
+        }
+    }
+
+    return $issues
+}
+
+function Copy-SkillTree {
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$SourceSkillsDir,
+
+        [Parameter(Mandatory=$true)]
+        [string]$DestinationSkillsDir
+    )
+
+    if (-not (Test-Path -LiteralPath $SourceSkillsDir -PathType Container)) {
+        throw "Source skills directory not found: $SourceSkillsDir"
+    }
+
+    if (-not (Test-Path -LiteralPath $DestinationSkillsDir -PathType Container)) {
+        New-Item -ItemType Directory -Path $DestinationSkillsDir -Force | Out-Null
+    }
+
+    $skills = Get-ChildItem -LiteralPath $SourceSkillsDir -Directory
+    foreach ($skill in $skills) {
+        $dest = Join-Path $DestinationSkillsDir $skill.Name
+        if (Test-Path -LiteralPath $dest) {
+            Remove-Item -LiteralPath $dest -Recurse -Force
+        }
+
+        Copy-Item -LiteralPath $skill.FullName -Destination $dest -Recurse -Force
+        Write-Output "Installed: $($skill.Name)"
+    }
+}

--- a/scripts/refresh-installed-integrations.ps1
+++ b/scripts/refresh-installed-integrations.ps1
@@ -3,11 +3,15 @@
 
 param(
     [ValidateSet('Antigravity', 'Codex', 'All')]
-    [string]$Target = 'All',
+    [string]$Target = 'Codex',
 
     [string]$CodexRepoPath,
 
-    [switch]$Force
+    [string]$GlobalCodexSkillsPath = "$HOME\.codex\skills",
+
+    [switch]$Force,
+
+    [switch]$KeepTempExport
 )
 
 $ErrorActionPreference = 'Stop'
@@ -91,12 +95,13 @@ function Refresh-Antigravity {
 }
 
 function Refresh-Codex {
-    if ([string]::IsNullOrWhiteSpace($CodexRepoPath)) {
-        throw "Codex refresh requires -CodexRepoPath."
+    $resolvedCodexRepoPath = $CodexRepoPath
+    if ([string]::IsNullOrWhiteSpace($resolvedCodexRepoPath)) {
+        $resolvedCodexRepoPath = $Root
     }
 
-    if (-not (Test-Path -LiteralPath $CodexRepoPath -PathType Container)) {
-        throw "Codex repo path not found: $CodexRepoPath"
+    if (-not (Test-Path -LiteralPath $resolvedCodexRepoPath -PathType Container)) {
+        throw "Codex repo path not found: $resolvedCodexRepoPath"
     }
 
     if (-not (Test-Path -LiteralPath $codexInstaller -PathType Leaf)) {
@@ -111,22 +116,81 @@ function Refresh-Codex {
         throw "Codex export validator not found: $codexValidator"
     }
 
-    Write-ColorHost 'INFO' "Refreshing Codex skills into: $CodexRepoPath"
-
-    $psExe = (Get-Process -Id $PID).Path
-    Invoke-RequiredCommand -Command $psExe -Arguments @('-ExecutionPolicy', 'Bypass', '-File', $codexExporter)
-
-    $pythonExe = (Get-Command python -ErrorAction Stop).Source
-    Invoke-RequiredCommand -Command $pythonExe -Arguments @($codexValidator)
-
-    $args = @('-ExecutionPolicy', 'Bypass', '-File', $codexInstaller, '-TargetRepo', $CodexRepoPath)
-    if ($Force) {
-        $args += '-Force'
+    if ([string]::IsNullOrWhiteSpace($GlobalCodexSkillsPath)) {
+        throw "Global Codex skills path is required."
     }
 
-    Invoke-RequiredCommand -Command $psExe -Arguments $args
+    if (-not (Test-Path -LiteralPath $GlobalCodexSkillsPath -PathType Container)) {
+        New-Item -ItemType Directory -Path $GlobalCodexSkillsPath -Force | Out-Null
+    }
 
-    Write-ColorHost 'SUCCESS' "Codex refresh complete."
+    Write-ColorHost 'INFO' "Refreshing Codex skills into repo-local and global runtime locations..."
+
+    $psExe = (Get-Process -Id $PID).Path
+    $pythonExe = (Get-Command python -ErrorAction Stop).Source
+    $tempExportRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("orchestra-runtime-export-" + [System.Guid]::NewGuid().ToString("N"))
+    $tempDeleted = $false
+
+    try {
+        New-Item -ItemType Directory -Path $tempExportRoot -Force | Out-Null
+        Write-ColorHost 'INFO' "Temporary export staging: $tempExportRoot"
+
+        Invoke-RequiredCommand -Command $psExe -Arguments @(
+            '-ExecutionPolicy', 'Bypass', '-File', $codexExporter,
+            '-TargetRoot', $tempExportRoot
+        )
+        Invoke-RequiredCommand -Command $pythonExe -Arguments @(
+            $codexValidator, '--export-root', $tempExportRoot
+        )
+
+        $stagedSkillsDir = Join-Path $tempExportRoot 'skills'
+        $localSkillsDir = Join-Path $resolvedCodexRepoPath '.agents\skills'
+
+        Invoke-RequiredCommand -Command $psExe -Arguments @(
+            '-ExecutionPolicy', 'Bypass', '-File', $codexInstaller,
+            '-TargetRepo', $resolvedCodexRepoPath,
+            '-SourceSkillsDir', $stagedSkillsDir,
+            '-Force'
+        )
+
+        Copy-SkillTree -SourceSkillsDir $stagedSkillsDir -DestinationSkillsDir $GlobalCodexSkillsPath | Out-Host
+
+        $localParityIssues = Compare-DirectoryParity -SourceRoot $stagedSkillsDir -DestinationRoot $localSkillsDir
+        if ($localParityIssues.Count -gt 0) {
+            $localParityIssues | ForEach-Object { Write-ColorHost 'ERROR' $_ }
+            throw "Repo-local Codex runtime parity check failed."
+        }
+        Write-ColorHost 'SUCCESS' "Repo-local Codex runtime parity: MATCH"
+
+        $globalStageCompare = Join-Path $tempExportRoot 'global-compare'
+        New-Item -ItemType Directory -Path $globalStageCompare -Force | Out-Null
+        Get-ChildItem -LiteralPath $stagedSkillsDir -Directory | ForEach-Object {
+            Copy-Item -LiteralPath (Join-Path $GlobalCodexSkillsPath $_.Name) -Destination (Join-Path $globalStageCompare $_.Name) -Recurse -Force
+        }
+
+        $globalParityIssues = Compare-DirectoryParity -SourceRoot $stagedSkillsDir -DestinationRoot $globalStageCompare
+        if ($globalParityIssues.Count -gt 0) {
+            $globalParityIssues | ForEach-Object { Write-ColorHost 'ERROR' $_ }
+            throw "Global Codex runtime parity check failed."
+        }
+        Write-ColorHost 'SUCCESS' "Global Codex runtime parity: MATCH"
+
+        if ($KeepTempExport) {
+            Write-ColorHost 'INFO' "Temporary export preserved at: $tempExportRoot"
+        }
+        else {
+            Remove-Item -LiteralPath $tempExportRoot -Recurse -Force
+            $tempDeleted = $true
+            Write-ColorHost 'SUCCESS' "Temporary export deleted."
+        }
+
+        Write-ColorHost 'SUCCESS' "Codex refresh complete."
+    }
+    finally {
+        if (-not $KeepTempExport -and -not $tempDeleted -and (Test-Path -LiteralPath $tempExportRoot -PathType Container)) {
+            Remove-Item -LiteralPath $tempExportRoot -Recurse -Force
+        }
+    }
 }
 
 Invoke-PreRefreshValidation

--- a/tests/runtime/test_codex_export_validator.py
+++ b/tests/runtime/test_codex_export_validator.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import shutil
+
+import pytest
+
+from adapters.codex import validate_codex_export
+
+
+def copy_export_tree(tmp_path: Path) -> Path:
+    repo_root = Path(__file__).resolve().parents[2]
+    export_root = tmp_path / "export"
+    shutil.copytree(repo_root / "adapters" / "codex" / "skills", export_root / "skills")
+    return export_root
+
+
+def test_codex_export_validator_accepts_staged_export(tmp_path: Path):
+    export_root = copy_export_tree(tmp_path)
+
+    with pytest.raises(SystemExit) as exc_info:
+        validate_codex_export.main(["--export-root", str(export_root)])
+
+    assert exc_info.value.code == 0
+
+
+def test_codex_export_validator_rejects_missing_skill_file(tmp_path: Path):
+    export_root = copy_export_tree(tmp_path)
+    (export_root / "skills" / "conductor" / "SKILL.md").unlink()
+
+    with pytest.raises(SystemExit) as exc_info:
+        validate_codex_export.main(["--export-root", str(export_root)])
+
+    assert exc_info.value.code == 1


### PR DESCRIPTION
## Summary

Adds a staged Runtime Export Pipeline so installed Orchestra runtimes can be refreshed without dirtying the repository.

The refresh flow now keeps repository source, generated export output, and installed runtime locations separate. Codex skills are exported to a temporary staging directory, validated, installed into repo-local and global runtime locations, hash-compared for parity, and then cleaned up automatically.

## What Changed

- Updated `scripts/refresh-installed-integrations.ps1` to use a temporary Codex export staging directory by default.
- Added reusable PowerShell helpers for recursive file-list and SHA-256 parity checks.
- Updated `adapters/codex/install-to-repo.ps1` to support `-SourceSkillsDir`.
- Updated `adapters/codex/validate_codex_export.py` to support `--export-root`.
- Added focused runtime tests for staged Codex export validation.
- Updated README, installation docs, roadmap, and changelog.
- Preserved runtime core and PRAP behavior.

## Runtime Export Flow

```text
Repository source
        ↓
Temporary export staging
        ↓
Validation
        ↓
Install to repo-local .agents/skills
        ↓
Install to global Codex skills directory
        ↓
SHA-256 parity check
        ↓
Delete temp staging