### PR TITLE
Define scaffold adapter graduation criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Portable Runtime is the first Orchestra release that normalizes the repository a
 - Wired `tests/runtime` into CI, enforced portable runtime coverage with `pytest-cov --cov-fail-under=90`, switched `validate.yml` to `python tests/behavior/run_tests.py`, and added runtime tests for alias loading, default-command fallback, and unresolved command-to-skill handling.
 
 ### Added
+- Added scaffold adapter graduation criteria defining promotion levels, validation requirements, documentation requirements, and recommended graduation order for scaffold-only adapters.
 - Added `scripts/check_for_updates.py` for notification-only release checks against the latest GitHub release using local manifest and adapter metadata.
 - Added update-check metadata defaults to the root manifest, Claude plugin manifest, and scaffold adapter package metadata.
 - Added runtime tests covering current-version, newer-release, invalid-version, unavailable-GitHub, and disabled-update-check behavior.

--- a/docs/project/PLUGIN_READINESS.md
+++ b/docs/project/PLUGIN_READINESS.md
@@ -23,6 +23,8 @@ This document tracks the readiness of the Orchestra framework for its release as
 - **Plugin icon status:** Completed
   - The existing Conductor icon is used as the plugin icon: `assets/icons/conductor.ico`.
   - The broader framework logo remains available at `assets/logo/orchestra.png`.
+- **Scaffold adapter promotion policy:** Defined
+  - Scaffold-only host promotion now follows `docs/project/SCAFFOLD_ADAPTER_GRADUATION_CRITERIA.md` before support or marketplace claims are raised.
 - **Remaining step:** Pending
   - Validate whether the target plugin loader displays the manifest-level icon path.
 

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -14,6 +14,7 @@
 - [ ] Promote the shared VS Code-family path to cover VSCodium publication when that ecosystem path is worth supporting.
 - [ ] Promote the JetBrains scaffold into an IntelliJ Platform build and distribution flow separately from the generic editor packaging branch.
 - [ ] Promote Zed and Neovim scaffolds into host-native distribution or plugin flows after the editor packaging scaffolds stabilize.
+- [ ] Apply `docs/project/SCAFFOLD_ADAPTER_GRADUATION_CRITERIA.md` before promoting any scaffold-only adapter support level.
 - [ ] Add an optional cross-platform CLI validator.
 - [ ] Add an optional local-model retrieval index.
 - [ ] Improve adapters as tool capabilities change.

--- a/docs/project/SCAFFOLD_ADAPTER_GRADUATION_CRITERIA.md
+++ b/docs/project/SCAFFOLD_ADAPTER_GRADUATION_CRITERIA.md
@@ -1,0 +1,134 @@
+# Scaffold Adapter Graduation Criteria
+
+## Purpose
+
+This document defines what it means for a scaffold-only adapter to graduate into a higher support tier. It exists to keep Orchestra honest about host support, prevent packaging scaffolds from being described as finished integrations, and provide a repeatable review path before documentation or marketplace surfaces claim broader support.
+
+## Current Scaffold-only Adapters
+
+The following hosts currently have runtime adapter contracts and/or packaging scaffolds, but are not yet documented as fully supported host integrations:
+
+- VS Code
+- VSCodium
+- Cursor
+- Windsurf
+- JetBrains
+- Zed
+- Neovim
+
+## Graduation Status Levels
+
+### `scaffold-only`
+- Runtime adapter and/or packaging surface exists.
+- Host integration is intentionally incomplete.
+- Documentation must not imply finished installation, full host validation, or marketplace readiness.
+
+### `experimental`
+- Core runtime contract works in a narrow, documented path.
+- Installation and execution paths still require manual validation and may change without compatibility guarantees.
+- Marketplace claims remain out of scope.
+
+### `functional`
+- The adapter works end to end in at least one maintained install path.
+- Validation is reproducible and documented.
+- Known limitations are still allowed, but they must be explicit.
+
+### `supported`
+- The adapter has a maintained install path, clear host instructions, documented compatibility expectations, and repeatable validation.
+- Repository documentation may describe the host as supported for the documented path.
+- Support claims must stay scoped to what the validation evidence proves.
+
+### `marketplace-ready`
+- Packaging, metadata, validation, and release handling are complete enough for host-native marketplace or distribution submission.
+- Marketplace documentation, upgrade path, ownership, and release expectations are defined.
+- Marketplace-ready does not bypass the requirements for `supported`; it builds on top of them.
+
+## Minimum Graduation Requirements
+
+A scaffold-only adapter must not graduate past `scaffold-only` until all of the following are true:
+
+1. A runtime adapter contract exists and passes PRAP validation.
+2. Manifest, package, and adapter metadata match the runtime protocol metadata for the host.
+3. Host-specific install and run instructions exist.
+4. At least one smoke test or documented manual validation path exists.
+5. Documentation does not overclaim support, marketplace availability, or automatic host discovery.
+6. The compatibility matrix is updated to reflect the exact support level.
+7. README or setup documentation reflects the same support level as the compatibility matrix.
+
+## Validation Requirements
+
+A graduation review should include, at minimum:
+
+- PRAP validation for the runtime adapter contract.
+- Packaging and metadata validation for the relevant scaffold or plugin surface.
+- One reproducible host validation path.
+  - This may be a smoke test, scripted validation, or a documented manual verification path when automation is not yet practical.
+- Evidence that documented commands, adapter entrypoints, and compatibility notes match actual behavior.
+- Negative confirmation that the repository is not claiming broader support than the validation proves.
+
+## Packaging and Marketplace Readiness Requirements
+
+A host must not be described as `marketplace-ready` unless:
+
+- Host-native packaging files are present and maintained.
+- Package metadata, manifest metadata, and runtime protocol metadata are aligned.
+- Installation, upgrade, and removal paths are documented.
+- Release ownership is clear.
+- Submission constraints for the target host are known and reflected in docs.
+- The repository does not rely on placeholder marketplace language.
+
+## Documentation Requirements
+
+Before a support-level promotion is documented:
+
+- `docs/setup/COMPATIBILITY.md` must reflect the exact support level.
+- Any host-specific setup or install guide must match the validated path.
+- README, setup docs, and project docs must avoid stronger claims than the validated path supports.
+- If limitations remain, they must be documented where the support claim appears.
+
+## Support and Maintenance Requirements
+
+Before a host is described as `supported` or `marketplace-ready`, the project should define:
+
+- Who owns break/fix response for that host.
+- Which validation path is expected to stay green.
+- Which compatibility boundaries are intentionally supported.
+- What changes in host packaging or runtime behavior should block release claims until revalidated.
+
+## Graduation Review Checklist
+
+Use this checklist for each promotion decision:
+
+- [ ] Target host and desired status level are named explicitly.
+- [ ] Runtime adapter contract exists and passes PRAP validation.
+- [ ] Manifest/package metadata matches runtime protocol metadata.
+- [ ] Host-specific install and run instructions exist.
+- [ ] Smoke test or documented manual validation path exists.
+- [ ] Compatibility matrix reflects the target status level.
+- [ ] README or setup docs reflect the same status level.
+- [ ] Marketplace claims are absent unless marketplace readiness is validated.
+- [ ] Known limitations are documented.
+- [ ] Support ownership and maintenance expectations are defined.
+
+## Recommended Graduation Order
+
+Orchestra should graduate scaffold adapters in this order:
+
+1. VS Code / VSCodium
+2. Cursor
+3. Windsurf
+4. JetBrains
+5. Zed
+6. Neovim
+
+This order favors the shared VS Code-family packaging surface first, then nearby editor variants, before moving into more host-specific packaging and validation paths.
+
+## Non-goals
+
+This document does not:
+
+- Change runtime behavior.
+- Upgrade any adapter by itself.
+- Promise marketplace publication dates.
+- Replace PRAP, packaging validation, or compatibility documentation.
+- Treat a packaging scaffold as evidence of real support without validation.

--- a/docs/setup/COMPATIBILITY.md
+++ b/docs/setup/COMPATIBILITY.md
@@ -2,18 +2,20 @@
 
 Orchestra `v1.0.0 Portable Runtime` is Markdown-first and runtime-core-first. Hosts integrate through thin adapters and, where available, scaffold packaging metadata that points back to the shared runtime.
 
+Scaffold-only hosts are not yet full support claims. Promotion requirements and graduation order live in `docs/project/SCAFFOLD_ADAPTER_GRADUATION_CRITERIA.md`.
+
 | Host | Runtime Adapter | Status | Notes |
 |---|---|---|---|
 | Codex | `codex` | Supported | Marketplace-first, with repo-local fallback. |
 | Claude Code | `claude-code` | Supported | Marketplace metadata included. |
 | Antigravity | `antigravity` | Supported | Plugin install path remains host-native. |
-| Cursor | `cursor` | Supported | Scaffold-only packaging surface. |
-| Windsurf | `windsurf` | Supported | Scaffold-only packaging surface. |
-| VS Code | `vscode` | Supported | Scaffold-only packaging surface. |
-| VSCodium | `vscode` | Compatible | Reuses the VS Code runtime adapter and packaging scaffold. |
-| JetBrains | `jetbrains` | Supported | Scaffold-only plugin surface. |
-| Zed | `zed` | Supported | Scaffold-only packaging surface. |
-| Neovim | `neovim` | Supported | Scaffold-only packaging surface. |
+| Cursor | `cursor` | Scaffold-only | Runtime adapter exists; packaging surface remains scaffold-only. |
+| Windsurf | `windsurf` | Scaffold-only | Runtime adapter exists; packaging surface remains scaffold-only. |
+| VS Code | `vscode` | Scaffold-only | Shared VS Code-family runtime adapter and packaging scaffold. |
+| VSCodium | `vscode` | Scaffold-only | Reuses the VS Code-family runtime adapter and scaffold packaging path. |
+| JetBrains | `jetbrains` | Scaffold-only | Runtime adapter exists; plugin surface remains scaffold-only. |
+| Zed | `zed` | Scaffold-only | Runtime adapter exists; packaging surface remains scaffold-only. |
+| Neovim | `neovim` | Scaffold-only | Runtime adapter exists; packaging surface remains scaffold-only. |
 | Local AI systems | manual | Supported | Load selected Markdown and supporting files manually. |
 
 The repository does not guarantee automatic discovery in every IDE or model runtime. Use the adapter templates, packaging scaffolds, and runtime documentation when host behavior is uncertain.


### PR DESCRIPTION
## Summary

This PR adds scaffold adapter graduation criteria for Orchestra’s scaffold-only host adapters.

The new policy defines what must be true before a scaffold-only adapter can be promoted to a higher support level, including validation, packaging, documentation, compatibility, and maintenance expectations.

## Changes

- Added `docs/project/SCAFFOLD_ADAPTER_GRADUATION_CRITERIA.md`.
- Defined current scaffold-only hosts:
  - VS Code
  - VSCodium
  - Cursor
  - Windsurf
  - JetBrains
  - Zed
  - Neovim
- Added adapter graduation status levels:
  - `scaffold-only`
  - `experimental`
  - `functional`
  - `supported`
  - `marketplace-ready`
- Defined minimum promotion gates, including:
  - PRAP-valid runtime adapter contract
  - manifest and package metadata parity
  - host-specific install and run documentation
  - smoke test or documented manual validation path
  - compatibility matrix update
  - no overclaiming of support or marketplace availability
- Added validation, packaging, documentation, and maintenance expectations.
- Added a graduation review checklist.
- Added the recommended graduation order:
  1. VS Code / VSCodium
  2. Cursor
  3. Windsurf
  4. JetBrains
  5. Zed
  6. Neovim
- Updated existing docs with minimal cross-links:
  - `docs/project/ROADMAP.md`
  - `docs/project/PLUGIN_READINESS.md`
  - `docs/setup/COMPATIBILITY.md`
- Updated `docs/setup/COMPATIBILITY.md` so scaffold-only hosts are not described as fully supported.
- Added a focused `CHANGELOG.md` entry.

## Changed Files

- `docs/project/SCAFFOLD_ADAPTER_GRADUATION_CRITERIA.md`
- `CHANGELOG.md`
- `docs/project/ROADMAP.md`
- `docs/project/PLUGIN_READINESS.md`
- `docs/setup/COMPATIBILITY.md`

## Validation

- [x] `python scripts/governance_check.py --strict`
  - Passed
- [x] `git diff --check origin/main...HEAD`
  - Passed
- [ ] `python tests/behavior/run_tests.py`
  - Could not be cleanly validated from the current local checkout.
  - Local checkout remained dirty on `fix/runtime-ci-validation-gaps`.
  - Existing local failure reported:
    - `SESSION_HANDOFF.md:2: scripts/missing.py`
    - `ERROR: Lock acquisition failed!`

## Notes

- Work was applied on the remote branch `docs/scaffold-adapter-graduation-criteria`.
- No runtime files were changed.
- No adapter implementation files were changed.
- No workflow files were changed.
- No plugin manifests were changed.
- No test files were changed.
- No version numbers were changed.
