### PR TITLE
Governance/context sensitive project context policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Portable Runtime is the first Orchestra release that normalizes the repository a
 - Wired `tests/runtime` into CI, enforced portable runtime coverage with `pytest-cov --cov-fail-under=90`, switched `validate.yml` to `python tests/behavior/run_tests.py`, and added runtime tests for alias loading, default-command fallback, and unresolved command-to-skill handling.
 
 ### Added
+- Added a context-sensitive `PROJECT_CONTEXT.md` enforcement policy defining advisory, recommended, and strict-governed validation modes based on project type and risk level.
 - Added a Steward-led `PROJECT_CONTEXT.md` decision prompt for choosing advisory or governed project context workflows before introducing hard enforcement.
 - Added scaffold adapter graduation criteria defining promotion levels, validation requirements, documentation requirements, and recommended graduation order for scaffold-only adapters.
 - Added `scripts/check_for_updates.py` for notification-only release checks against the latest GitHub release using local manifest and adapter metadata.

--- a/docs/governance/PROJECT_CONTEXT_DECISION_PROMPT.md
+++ b/docs/governance/PROJECT_CONTEXT_DECISION_PROMPT.md
@@ -6,7 +6,7 @@ This document defines a Steward-led prompt workflow for deciding whether a repos
 
 `PROJECT_CONTEXT.md` exists to preserve project-specific context, boundaries, assumptions, constraints, and operating rules so governance review does not rely on guesswork.
 
-This phase is decision support only. It does not make `PROJECT_CONTEXT.md` mandatory, and it does not modify CI enforcement.
+This phase is decision support only. It does not make `PROJECT_CONTEXT.md` mandatory, and it does not modify CI enforcement. For context-sensitive enforcement modes after classification, see `docs/governance/PROJECT_CONTEXT_ENFORCEMENT_POLICY.md`.
 
 ## When to Use This Prompt
 

--- a/docs/governance/PROJECT_CONTEXT_ENFORCEMENT_POLICY.md
+++ b/docs/governance/PROJECT_CONTEXT_ENFORCEMENT_POLICY.md
@@ -1,0 +1,214 @@
+# PROJECT_CONTEXT Enforcement Policy
+
+## Purpose
+
+This document defines a context-sensitive policy for when `PROJECT_CONTEXT.md` should remain advisory, when it should be strongly recommended, and when it should become a blocking governance requirement.
+
+The goal is not to make `PROJECT_CONTEXT.md` universally mandatory. The goal is to scale governance according to project type, coordination needs, and real-world risk.
+
+## Enforcement Principle
+
+`PROJECT_CONTEXT.md` enforcement should depend on project classification and risk level.
+
+- low-risk, exploratory, educational, and sandbox work should stay advisory by default
+- moderate coordination work should receive stronger recommendations without default blocking
+- real-world, real-data, compliance-sensitive, destructive, or release-critical work should require `PROJECT_CONTEXT.md` as a gated validation item
+
+The Steward owns classification and context sufficiency. The Governor should only participate in blocking enforcement after the project is classified as strict-governed, a maintainer explicitly requests strict enforcement, or release governance requires it.
+
+## Project Classification Levels
+
+### Advisory
+
+Use for:
+
+- school projects
+- learning repos
+- experiments
+- prototypes
+- throwaway demos
+- personal sandbox projects
+
+Behavior:
+
+- missing `PROJECT_CONTEXT.md` should produce a warning or recommendation only
+- validation should not block CI by default
+- incomplete context should not become a hard failure unless a higher-risk mode is explicitly requested
+
+### Recommended
+
+Use for:
+
+- active internal tools
+- portfolio projects intended for reuse
+- multi-agent development repos
+- projects with moderate coordination needs
+
+Behavior:
+
+- missing `PROJECT_CONTEXT.md` should produce a stronger warning
+- validation may report advisory failure or visible warning status
+- CI should not block unless maintainers explicitly configure stricter behavior
+
+### Strict-Governed
+
+Use for:
+
+- real-world projects
+- production projects
+- client-facing projects
+- projects with real-world user data
+- projects with sensitive business data
+- projects with security, legal, financial, medical, or privacy implications
+- destructive automation workflows
+- release-critical repos
+
+Behavior:
+
+- missing `PROJECT_CONTEXT.md` should be a blocking validation failure
+- incomplete `PROJECT_CONTEXT.md` should be a blocking validation failure when required sections are missing
+- governance enforcement should be treated as part of release and operational safety, not as optional documentation polish
+
+## Risk Signals
+
+The following signals push a project toward `Strict-Governed` classification:
+
+- real user data
+- client data
+- production deployment
+- legal or compliance exposure
+- financial or billing data
+- authentication or authorization logic
+- destructive actions
+- secrets or credential handling
+- medical, legal, HR, or education records
+- public release or marketplace publication
+- multi-agent automation with write permissions
+
+A single signal does not always force strict governance by itself, but multiple signals or any clearly high-risk signal should trigger a Steward recommendation toward `Strict-Governed`.
+
+## Enforcement Modes
+
+### Advisory Mode
+
+- `PROJECT_CONTEXT.md` is recommended, not required
+- warnings should explain why more context would help
+- validation output should preserve exploration and low-friction workflows
+
+### Recommended Mode
+
+- `PROJECT_CONTEXT.md` is strongly encouraged
+- missing or thin context should be visible in governance output
+- blocking should remain opt-in unless maintainers explicitly promote the repository to stricter enforcement
+
+### Strict-Governed Mode
+
+- `PROJECT_CONTEXT.md` is required
+- required sections must be present and materially complete
+- blocking validation is appropriate because project context is part of safety, scope control, and release discipline
+
+## Required Strict-Governed PROJECT_CONTEXT Sections
+
+Strict-governed projects should include at least:
+
+- Project Name
+- Project Purpose
+- Project Type
+- Data Sensitivity
+- Primary Users
+- Runtime or Deployment Context
+- Governance Level
+- Safety Boundaries
+- Validation Requirements
+- Known Non-Goals
+- Maintainer Approval Rules
+
+## Recommended Advisory and Recommended Sections
+
+Advisory and recommended projects should include, at minimum:
+
+- Project Name
+- Project Purpose
+- Project Type
+- Current Stage
+- User Preferences
+- Known Constraints
+- Validation Notes
+
+## Steward Decision Workflow
+
+The Steward workflow should be:
+
+1. gather initial context
+2. classify project type
+3. identify risk signals
+4. recommend `Advisory`, `Recommended`, or `Strict-Governed`
+5. ask for or accept user direction
+6. produce one of the following:
+   - `PROJECT_CONTEXT.md`
+   - decision summary
+   - implementation plan
+
+The Steward owns:
+
+- context classification
+- context sufficiency judgment
+- initial recommendation of enforcement mode
+- the distinction between advisory context and future blocking context
+
+## Governor Escalation Workflow
+
+The Governor should only enforce blocking behavior when one of these is true:
+
+- the project is classified `Strict-Governed`
+- the maintainer explicitly requests strict enforcement
+- release governance requires it
+
+The Governor should not be used to turn `PROJECT_CONTEXT.md` into a universal requirement for all repositories.
+
+## Validation Behavior
+
+Current-phase policy direction:
+
+- advisory projects should warn, not block
+- recommended projects should warn strongly, not block by default
+- strict-governed projects should block on missing or materially incomplete `PROJECT_CONTEXT.md`
+
+This document defines policy first. It does not require immediate implementation in `scripts/validate_project_context.py`.
+
+## Examples
+
+### Advisory Example
+
+A school capstone prototype with no real user data and no public deployment path should remain advisory. Missing `PROJECT_CONTEXT.md` should not block CI.
+
+### Recommended Example
+
+A reusable internal automation repo used by multiple agents or contributors should be classified as recommended. Missing `PROJECT_CONTEXT.md` should surface clearly, but remain non-blocking until maintainers opt into stricter governance.
+
+### Strict-Governed Example
+
+A client-facing automation system that handles credentials, user data, destructive operations, or release-critical workflows should be classified as strict-governed. Missing or incomplete `PROJECT_CONTEXT.md` should block validation.
+
+## Non-goals
+
+This policy does not:
+
+- make `PROJECT_CONTEXT.md` universally mandatory
+- hard-fail school, trial, prototype, or sandbox repos by default
+- modify CI in this phase
+- rewrite `scripts/validate_project_context.py` in this phase
+- replace the Steward-led decision prompt
+- bypass maintainer approval for future enforcement changes
+
+## Future Implementation Checklist
+
+Future work for `scripts/validate_project_context.py` should consider:
+
+- detect `PROJECT_CONTEXT.md` presence
+- detect governance level
+- validate required sections by governance level
+- warn for advisory projects
+- warn strongly for recommended projects
+- block for strict-governed projects
+- allow explicit override only with documented maintainer approval

--- a/docs/governance/STRICT_GOVERNANCE_RELEASE_GATE_PLAN.md
+++ b/docs/governance/STRICT_GOVERNANCE_RELEASE_GATE_PLAN.md
@@ -6,7 +6,7 @@ Define the policy and enforcement plan for moving Orchestra from advisory govern
 
 This document began as planning-only. Phase 6 Stage 1 enabled strict deterministic CI failures. Phase 7 now adds a repository-level `main` ruleset requirement for pull requests, review, conversation resolution, and strict required status checks. CI remains non-deployment and non-release, Dagger remains simulation-only and unpromoted, and no release automation was added.
 
-For `PROJECT_CONTEXT.md` specifically, use `docs/governance/PROJECT_CONTEXT_DECISION_PROMPT.md` to decide whether the file should stay advisory or later become a governed enforcement candidate before any hard-gate proposal is considered.
+For `PROJECT_CONTEXT.md` specifically, use `docs/governance/PROJECT_CONTEXT_DECISION_PROMPT.md` to decide whether the file should stay advisory or later become a governed enforcement candidate before any hard-gate proposal is considered. Use `docs/governance/PROJECT_CONTEXT_ENFORCEMENT_POLICY.md` for the context-sensitive classification model that distinguishes advisory, recommended, and strict-governed projects.
 
 ## Phase 6 Stage 1 Status
 

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -15,6 +15,7 @@
 - [ ] Promote the JetBrains scaffold into an IntelliJ Platform build and distribution flow separately from the generic editor packaging branch.
 - [ ] Promote Zed and Neovim scaffolds into host-native distribution or plugin flows after the editor packaging scaffolds stabilize.
 - [ ] Use `docs/governance/PROJECT_CONTEXT_DECISION_PROMPT.md` before proposing any hard enforcement path for `PROJECT_CONTEXT.md`.
+- [ ] Use `docs/governance/PROJECT_CONTEXT_ENFORCEMENT_POLICY.md` before making `PROJECT_CONTEXT.md` blocking for any repository class.
 - [ ] Apply `docs/project/SCAFFOLD_ADAPTER_GRADUATION_CRITERIA.md` before promoting any scaffold-only adapter support level.
 - [ ] Add an optional cross-platform CLI validator.
 - [ ] Add an optional local-model retrieval index.

--- a/skills/the-steward/SKILL.md
+++ b/skills/the-steward/SKILL.md
@@ -75,6 +75,8 @@ Required Documentation:
 
 When the task is to decide whether a repository needs `PROJECT_CONTEXT.md` or how that file should be structured, use `docs/governance/PROJECT_CONTEXT_DECISION_PROMPT.md` as the advisory workflow before proposing any future enforcement.
 
+For context-sensitive classification and future blocking behavior, use `docs/governance/PROJECT_CONTEXT_ENFORCEMENT_POLICY.md` to distinguish advisory, recommended, and strict-governed repositories.
+
 When context is missing (and a review is required based on mode), return:
 ```
 DECISION: REVISION_REQUIRED


### PR DESCRIPTION
Summary

This PR adds a context-sensitive PROJECT_CONTEXT.md enforcement policy.

The policy defines when PROJECT_CONTEXT.md should remain advisory, when it should be strongly recommended, and when it should become a blocking governance requirement based on project type and risk level.

Changes

- Added "docs/governance/PROJECT_CONTEXT_ENFORCEMENT_POLICY.md".
- Defined a context-sensitive enforcement model instead of universal enforcement.
- Added three project classification levels:
  - Advisory
  - Recommended
  - Strict-Governed
- Clarified that low-risk learning, prototype, sandbox, and school projects should remain advisory or non-blocking by default.
- Clarified that moderate-coordination repos should treat PROJECT_CONTEXT.md as strongly recommended.
- Clarified that real-world, production, client-facing, real-data, destructive, compliance-sensitive, or release-critical projects should use blocking validation.
- Added risk signals that push projects toward Strict-Governed classification.
- Defined required PROJECT_CONTEXT.md sections for Strict-Governed projects.
- Added Steward classification and recommendation guidance.
- Added Governor escalation guidance for future blocking enforcement.
- Added a future implementation checklist for "scripts/validate_project_context.py".
- Added minimal cross-links from related governance docs.
- Updated "CHANGELOG.md".

Project Classification Levels

Advisory

Applies to:

- school projects
- learning repos
- experiments
- prototypes
- throwaway demos
- personal sandbox projects

Behavior:

- Missing PROJECT_CONTEXT.md should produce advisory guidance only.
- Validation should not block by default.

Recommended

Applies to:

- active internal tools
- portfolio projects intended for reuse
- multi-agent development repos
- projects with moderate coordination needs

Behavior:

- Missing PROJECT_CONTEXT.md should produce a stronger recommendation.
- Validation should remain non-blocking unless explicitly configured otherwise.

Strict-Governed

Applies to:

- real-world projects
- production projects
- client-facing projects
- projects with real-world user data
- projects with sensitive business data
- projects with security, legal, financial, medical, or privacy implications
- destructive automation workflows
- release-critical repos

Behavior:

- Missing PROJECT_CONTEXT.md should become a blocking validation failure.
- Incomplete PROJECT_CONTEXT.md should become blocking when required sections are missing.

Risk Signals Added

- real user data
- client data
- production deployment
- legal or compliance exposure
- financial or billing data
- authentication or authorization logic
- destructive actions
- secrets or credential handling
- medical, legal, HR, or education records
- public release or marketplace publication
- multi-agent automation with write permissions

Required Strict-Governed PROJECT_CONTEXT.md Sections

- Project Name
- Project Purpose
- Project Type
- Data Sensitivity
- Primary Users
- Runtime or Deployment Context
- Governance Level
- Safety Boundaries
- Validation Requirements
- Known Non-Goals
- Maintainer Approval Rules

Changed Files

- "docs/governance/PROJECT_CONTEXT_ENFORCEMENT_POLICY.md"
- "docs/governance/PROJECT_CONTEXT_DECISION_PROMPT.md"
- "docs/governance/STRICT_GOVERNANCE_RELEASE_GATE_PLAN.md"
- "skills/the-steward/SKILL.md"
- "docs/project/ROADMAP.md"
- "CHANGELOG.md"

Notes

- This PR does not modify CI.
- This PR does not modify "scripts/validate_project_context.py".
- This PR does not modify runtime code.
- This PR does not modify adapter files.
- This PR does not modify plugin manifests.
- This PR does not modify tests.
- This PR does not change version numbers.
- This PR does not create or modify "PROJECT_CONTEXT.md".
- This PR is policy-only.

Validation

- [x] "python scripts/governance_check.py --strict"
  
  - Passed

- [x] "git diff --check origin/main...HEAD"
  
  - Passed in the current local checkout

- [x] "python tests/behavior/run_tests.py"
  
  - Could not be cleanly validated from the current local checkout.
  - Local checkout remained dirty on unrelated branch "fix/runtime-ci-validation-gaps".
  - Local environment reported:
    - "SESSION_HANDOFF.md:2: scripts/missing.py"
    - "ERROR: Lock acquisition failed!"

Validation Caveat

The behavior-suite failure appears tied to the local checkout state and lock handling, not to the remote Phase 4 branch. GitHub Actions should be treated as the clean validation source for this PR.