### PR TITLE
Clarify optional project governance rulesets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Portable Runtime is the first Orchestra release that normalizes the repository a
 ## Unreleased
 
 ### Changed
+- Clarified optional project governance rulesets so `PROJECT_CONTEXT.md` enforcement depends on project type, risk level, and declared governance level.
 - Wired `tests/runtime` into CI, enforced portable runtime coverage with `pytest-cov --cov-fail-under=90`, switched `validate.yml` to `python tests/behavior/run_tests.py`, and added runtime tests for alias loading, default-command fallback, and unresolved command-to-skill handling.
 
 ### Added

--- a/docs/MATURITY.md
+++ b/docs/MATURITY.md
@@ -14,7 +14,7 @@ This document classifies the current maturity level of Orchestra's features and 
 ## Beta
 
 * **Governance Instruction Conformance Checks**: Static evaluation of `SKILL.md` instructions against behavioral expectation fixtures (e.g., verifying `BLOCKED`, `HOLD` states are documented).
-* **Project Context Governance Validator**: Validates `PROJECT_CONTEXT.md` presence and required sections against advisory, recommended, and strict-governed governance levels while preserving backward-compatible operating-mode calls.
+* **Project Context Governance Validator**: Validates `PROJECT_CONTEXT.md` presence and required sections against advisory, recommended, and strict-governed governance levels. Advisory and recommended paths remain non-blocking by default; strict-governed remains blocking when declared or explicitly requested.
 * **Codex Export Validation**: Alignment checks for exports specifically intended for the Codex adapter framework.
 
 ## Experimental

--- a/docs/governance/PROJECT_CONTEXT_DECISION_PROMPT.md
+++ b/docs/governance/PROJECT_CONTEXT_DECISION_PROMPT.md
@@ -58,6 +58,8 @@ The Steward must clearly separate:
 
 After intake, The Steward should provide one or two recommendations.
 
+The Steward should recommend, not impose, the governance level unless project risk or release policy clearly requires `Strict-Governed`. Use the optional ruleset in `docs/governance/PROJECT_CONTEXT_ENFORCEMENT_POLICY.md` to frame the default recommendation, then let the user or maintainer confirm or override it.
+
 ### Recommendation 1: Lightweight Advisory PROJECT_CONTEXT.md
 
 Use this when the project is low-to-medium risk, still evolving, single-maintainer, exploratory, or not yet ready for strict governance enforcement.
@@ -178,7 +180,7 @@ The Steward workflow for this phase is:
 2. identify only critical missing context
 3. recommend a lightweight advisory outline by default
 4. recommend a stricter governed outline only when justified by project risk or operating model
-5. let the user accept, refine, or override the recommendation
+5. present governance options and allow user or maintainer direction
 6. produce the requested output without changing CI or declaring `PROJECT_CONTEXT.md` mandatory
 
 ## Non-goal for This Phase

--- a/docs/governance/PROJECT_CONTEXT_ENFORCEMENT_POLICY.md
+++ b/docs/governance/PROJECT_CONTEXT_ENFORCEMENT_POLICY.md
@@ -6,6 +6,8 @@ This document defines a context-sensitive policy for when `PROJECT_CONTEXT.md` s
 
 The goal is not to make `PROJECT_CONTEXT.md` universally mandatory. The goal is to scale governance according to project type, coordination needs, and real-world risk.
 
+`PROJECT_CONTEXT.md` is recommended for governed projects, but not every project should be treated as `Strict-Governed`. Governance level is project-type dependent, user-confirmed, and only enforceable when strict governance is declared or clearly required by policy.
+
 ## Enforcement Principle
 
 `PROJECT_CONTEXT.md` enforcement should depend on project classification and risk level.
@@ -14,7 +16,30 @@ The goal is not to make `PROJECT_CONTEXT.md` universally mandatory. The goal is 
 - moderate coordination work should receive stronger recommendations without default blocking
 - real-world, real-data, compliance-sensitive, destructive, or release-critical work should require `PROJECT_CONTEXT.md` as a gated validation item
 
-The Steward owns classification and context sufficiency. The Governor should only participate in blocking enforcement after the project is classified as strict-governed, a maintainer explicitly requests strict enforcement, or release governance requires it.
+The Steward owns classification and context sufficiency. The Steward should recommend, not automatically impose, a governance level unless project risk clearly requires strict governance. The user or maintainer confirms the intended governance level. The Governor should only participate in blocking enforcement after the project is classified as strict-governed, a maintainer explicitly requests strict enforcement, or release governance requires it.
+
+## Optional Project Governance Ruleset
+
+Use this ruleset to choose the default governance level before turning `PROJECT_CONTEXT.md` into an enforcement gate.
+
+| Project Type | Recommended Governance Level | Validation Behavior |
+| --- | --- | --- |
+| School project | Advisory | Warning only |
+| Learning repo | Advisory | Warning only |
+| Prototype | Advisory | Warning only |
+| Sandbox or trial project | Advisory | Warning only |
+| Portfolio project intended for reuse | Recommended | Strong warning, non-blocking |
+| Internal tool | Recommended | Strong warning unless configured strict |
+| Multi-agent development repo | Recommended or Strict-Governed | Depends on write permissions and risk |
+| Real-world application | Strict-Governed | Blocking validation |
+| Production project | Strict-Governed | Blocking validation |
+| Client-facing project | Strict-Governed | Blocking validation |
+| Project using real-world user or client data | Strict-Governed | Blocking validation |
+| Compliance-sensitive project | Strict-Governed | Blocking validation |
+| Destructive automation workflow | Strict-Governed | Blocking validation |
+| Release-critical repo | Strict-Governed | Blocking validation |
+
+This table is a default decision aid, not a universal override. Maintainers may choose a stricter path earlier, and The Governor may enforce stricter behavior only when `Strict-Governed` is declared or a release policy clearly requires it.
 
 ## Project Classification Levels
 
@@ -68,6 +93,7 @@ Behavior:
 - missing `PROJECT_CONTEXT.md` should be a blocking validation failure
 - incomplete `PROJECT_CONTEXT.md` should be a blocking validation failure when required sections are missing
 - governance enforcement should be treated as part of release and operational safety, not as optional documentation polish
+- strict mode should be treated as opt-in or policy-triggered, not as the universal default for every repository
 
 ## Risk Signals
 
@@ -145,7 +171,7 @@ The Steward workflow should be:
 2. classify project type
 3. identify risk signals
 4. recommend `Advisory`, `Recommended`, or `Strict-Governed`
-5. ask for or accept user direction
+5. present the recommendation as guidance and allow user or maintainer direction
 6. produce one of the following:
    - `PROJECT_CONTEXT.md`
    - decision summary
@@ -197,6 +223,7 @@ A client-facing automation system that handles credentials, user data, destructi
 This policy does not:
 
 - make `PROJECT_CONTEXT.md` universally mandatory
+- force every repository into `Strict-Governed`
 - hard-fail school, trial, prototype, or sandbox repos by default
 - modify CI in this phase
 - replace the Steward-led decision prompt

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -16,6 +16,7 @@
 - [ ] Promote Zed and Neovim scaffolds into host-native distribution or plugin flows after the editor packaging scaffolds stabilize.
 - [ ] Use `docs/governance/PROJECT_CONTEXT_DECISION_PROMPT.md` before proposing any hard enforcement path for `PROJECT_CONTEXT.md`.
 - [ ] Use `docs/governance/PROJECT_CONTEXT_ENFORCEMENT_POLICY.md` before making `PROJECT_CONTEXT.md` blocking for any repository class.
+- [ ] Use optional project governance ruleset defaults before treating `PROJECT_CONTEXT.md` as universally strict across prototypes, school repos, sandboxes, or learning projects.
 - [ ] Apply `docs/project/SCAFFOLD_ADAPTER_GRADUATION_CRITERIA.md` before promoting any scaffold-only adapter support level.
 - [ ] Add an optional cross-platform CLI validator.
 - [ ] Add an optional local-model retrieval index.

--- a/docs/templates/PROJECT_CONTEXT_TEMPLATE.md
+++ b/docs/templates/PROJECT_CONTEXT_TEMPLATE.md
@@ -32,7 +32,14 @@ Unknown
 Unknown
 
 ## Governance Level
-Advisory
+- Advisory
+- Recommended
+- Strict-Governed
+
+Guidance:
+- Choose Advisory for school, prototype, sandbox, learning, or trial projects.
+- Choose Recommended for reusable, internal, or moderate-coordination projects.
+- Choose Strict-Governed for real-world, production, client-facing, real-data, compliance-sensitive, destructive, or release-critical projects.
 
 ## Safety Boundaries
 Unknown

--- a/skills/the-steward/SKILL.md
+++ b/skills/the-steward/SKILL.md
@@ -79,6 +79,8 @@ For context-sensitive classification and future blocking behavior, use `docs/gov
 
 When drafting `PROJECT_CONTEXT.md`, start from `docs/templates/PROJECT_CONTEXT_TEMPLATE.md` and keep unknown items explicit instead of guessed.
 
+The Steward should recommend, not impose, governance level unless project risk clearly requires `Strict-Governed`. Present governance options, explain tradeoffs, and allow user or maintainer direction.
+
 When context is missing (and a review is required based on mode), return:
 ```
 DECISION: REVISION_REQUIRED


### PR DESCRIPTION
## Summary

This PR clarifies that `PROJECT_CONTEXT.md` governance enforcement is optional and project-type dependent, not universally strict.

The updated guidance makes the governance model explicit: The Steward recommends the governance level, the user or maintainer confirms it, and The Governor enforces only when `Strict-Governed` mode is declared or policy-triggered.

## Changes

- Clarified optional `PROJECT_CONTEXT.md` governance rulesets.
- Added project-type guidance for Advisory, Recommended, and Strict-Governed modes.
- Clarified that `Strict-Governed` mode is opt-in or policy-triggered, not universal.
- Clarified that real-world, production, client-facing, real-data, compliance-sensitive, destructive, or release-critical projects should use blocking validation.
- Clarified that school, prototype, sandbox, learning, and trial projects should remain Advisory and non-blocking by default.
- Updated `PROJECT_CONTEXT.md` template guidance.
- Updated Steward guidance so The Steward recommends governance level before enforcement.
- Updated related governance documentation, maturity notes, roadmap references, and `CHANGELOG.md`.

## Optional Governance Ruleset

| Project Type | Recommended Governance Level | Validation Behavior |
| --- | --- | --- |
| School project | Advisory | Warning only |
| Learning repo | Advisory | Warning only |
| Prototype | Advisory | Warning only |
| Sandbox or trial project | Advisory | Warning only |
| Portfolio project intended for reuse | Recommended | Strong warning, non-blocking |
| Internal tool | Recommended | Strong warning unless configured strict |
| Multi-agent development repo | Recommended or Strict-Governed | Depends on write permissions and risk |
| Real-world application | Strict-Governed | Blocking validation |
| Production project | Strict-Governed | Blocking validation |
| Client-facing project | Strict-Governed | Blocking validation |
| Project using real-world user or client data | Strict-Governed | Blocking validation |
| Compliance-sensitive project | Strict-Governed | Blocking validation |
| Destructive automation workflow | Strict-Governed | Blocking validation |
| Release-critical repo | Strict-Governed | Blocking validation |

## Validator Behavior

No validator code was changed in this PR.

`scripts/validate_project_context.py` was reviewed and already matches the intended policy behavior:

- Advisory: non-blocking
- Recommended: non-blocking strong warning
- Strict-Governed: blocking

## Changed Files

- `docs/governance/PROJECT_CONTEXT_ENFORCEMENT_POLICY.md`
- `docs/governance/PROJECT_CONTEXT_DECISION_PROMPT.md`
- `docs/templates/PROJECT_CONTEXT_TEMPLATE.md`
- `skills/the-steward/SKILL.md`
- `docs/MATURITY.md`
- `docs/project/ROADMAP.md`
- `CHANGELOG.md`

## Notes

- This PR does not make `PROJECT_CONTEXT.md` universally mandatory.
- This PR does not require root `PROJECT_CONTEXT.md`.
- This PR does not modify validator code.
- This PR does not modify CI workflows.
- This PR does not modify runtime code.
- This PR does not modify adapter code.
- This PR does not modify plugin manifests.
- This PR does not change version numbers.
- This PR is documentation, template guidance, and governance clarification only.

## Validation

Local clean validation could not be completed from the current checkout because the local repo state is on a dirty unrelated branch.

Local preflight result:

- [ ] `python scripts/preflight_sync_check.py`
  - Result: `BLOCKED`
  - Reason: local checkout was still on dirty branch `fix/runtime-ci-validation-gaps`; `origin/main` was unavailable; checkout was not clean for Phase 6 validation.

Not run from this local checkout:

- [ ] `python scripts/validate_project_context.py`
- [ ] `python scripts/validate_project_context.py --mode advisory`
- [ ] `python scripts/validate_project_context.py --mode recommended`
- [ ] `python scripts/validate_project_context.py --mode strict-governed`
- [ ] `python scripts/governance_check.py --strict`
- [ ] `python tests/behavior/run_tests.py`
- [ ] `git diff --check origin/main...HEAD`

## Expected Strict-Governed Note

The current local checkout does not have a root `PROJECT_CONTEXT.md`. If strict-governed validation fails because root `PROJECT_CONTEXT.md` is absent, that is expected policy-aligned behavior, not a regression.

## Stacking Note

This branch was applied on top of `governance/project-context-template-validator-alignment`. It should be cleanly validated after Phase 5 is merged into `main`, or the PR should remain stacked with Phase 5 as its base.
