### PR TITLE
Add Orchestra project context and governance CI validation

### DIFF
--- a/.github/workflows/governance-check.yml
+++ b/.github/workflows/governance-check.yml
@@ -53,6 +53,11 @@ jobs:
           python scripts/check_prompt_load_thresholds.py > artifacts/prompt_load_threshold_report.txt
           cat artifacts/prompt_load_threshold_report.txt
 
+      - name: Run Project Context Validation
+        run: |
+          python scripts/validate_project_context.py > artifacts/project_context_report.txt
+          cat artifacts/project_context_report.txt
+
       - name: Run Stage 1 Strict Governance Check
         run: |
           set +e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Portable Runtime is the first Orchestra release that normalizes the repository a
 ## Unreleased
 
 ### Changed
+- Clarified optional project governance rulesets so `PROJECT_CONTEXT.md` enforcement depends on project type, risk level, and declared governance level.
 - Wired `tests/runtime` into CI, enforced portable runtime coverage with `pytest-cov --cov-fail-under=90`, switched `validate.yml` to `python tests/behavior/run_tests.py`, and added runtime tests for alias loading, default-command fallback, and unresolved command-to-skill handling.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Portable Runtime is the first Orchestra release that normalizes the repository a
 - Wired `tests/runtime` into CI, enforced portable runtime coverage with `pytest-cov --cov-fail-under=90`, switched `validate.yml` to `python tests/behavior/run_tests.py`, and added runtime tests for alias loading, default-command fallback, and unresolved command-to-skill handling.
 
 ### Added
+- Added root `PROJECT_CONTEXT.md` for Orchestra and wired project-context validation into governance CI.
 - Added a reusable `PROJECT_CONTEXT.md` template and aligned the Python project-context validator with advisory, recommended, and strict-governed enforcement behavior.
 - Added a context-sensitive `PROJECT_CONTEXT.md` enforcement policy defining advisory, recommended, and strict-governed validation modes based on project type and risk level.
 - Added a Steward-led `PROJECT_CONTEXT.md` decision prompt for choosing advisory or governed project context workflows before introducing hard enforcement.

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -1,0 +1,64 @@
+# Orchestra Project Context
+
+## Project Name
+Orchestra
+
+## Project Purpose
+A governance-first specialist skill framework that routes complex AI-assisted software work through focused, auditable specialist skills, designed for compatibility across multiple IDEs and coding hosts.
+
+## Project Type
+Open-source developer tooling and AI orchestration framework
+
+## Current Stage
+v1.0.0 (Portable Runtime), publicly released, actively maintained
+
+## Primary Users
+Developers and maintainers who install Orchestra as a plugin, skill set, or runtime package inside a supported or scaffold-only IDE or coding host (Claude Code, Codex, Antigravity, Cursor, Windsurf, JetBrains, Zed, Neovim)
+
+## Data Sensitivity
+Not applicable by default. Orchestra itself does not store, process, or transmit end-user or client data. Data sensitivity depends on the downstream project a maintainer applies Orchestra to, per `docs/CONTRIBUTING.md` instructions to exclude private projects, personal data, and client details from the repository itself.
+
+## Runtime or Deployment Context
+Distributed via GitHub as a plugin or marketplace package (`.claude-plugin/`, `.codex-plugin/`) and as a Python runtime package (`orchestra_runtime/`). Consumed locally inside a developer's IDE or coding host; not deployed as a hosted service.
+
+## Governance Level
+Recommended
+
+Guidance used for this classification:
+- Orchestra is a public, multi-agent development repository with write-permission automation surfaces such as Dagger guardrails and state-lock scripts, which is a listed risk signal above pure Advisory.
+- Orchestra does not itself handle real end-user data, client data, production business data, or destructive-by-default operations, so automatic Strict-Governed classification is not required.
+- `main` is already governed by required pull-request review, required status checks (`governance-check`, `validate`, `Analyze (actions)`, `Analyze (python)`), and signed-commit expectations per `docs/CONTRIBUTING.md`, which is consistent with Recommended-tier coordination needs.
+- Maintainers may raise this to Strict-Governed later if adoption, write scope, or release criticality increases.
+
+## Safety Boundaries
+- Dagger guardrail system enforces warning-first, then blocking, behavior for governance-sensitive actions, per `docs/CONTRIBUTING.md`.
+- State-lock mechanism guards against concurrent write collisions.
+- Scaffold-only adapters (Cursor, Windsurf, JetBrains, Zed, Neovim) must not be represented as production-ready or marketplace-published until formally graduated per `docs/project/SCAFFOLD_ADAPTER_GRADUATION_CRITERIA.md`.
+- No vendoring of external plugin code, and no claiming unsupported compatibility or compliance, per `docs/CONTRIBUTING.md`.
+
+## Validation Requirements
+- `pytest tests/runtime` must pass with `--cov-fail-under=90` as enforced in CI via `validate.yml`.
+- `python tests/behavior/run_tests.py` must pass.
+- `python scripts/governance_check.py --strict` must pass as enforced in CI via `governance-check.yml`.
+- Manifest and packaging validators (`validate_claude_plugin.py`, `validate_ide_packaging.py`, `validate_manifest.py`, `validate_structure.py`) must pass.
+- `python scripts/preflight_sync_check.py` must be run against `origin/main` before starting a new local editing session, per `docs/CONTRIBUTING.md`.
+
+## Known Constraints
+- Cursor, Windsurf, JetBrains, Zed, and Neovim adapters are scaffold-only and not yet published to their respective marketplaces.
+- `tests/behavior/run-tests.ps1` is intentionally maintained in parallel with `run_tests.py` as the primary validation path for Windows environments, per `docs/MATURITY.md`.
+- Direct pushes to `main` are not part of the normal workflow; changes go through a branch and pull request except for documented maintainer bypass recovery cases.
+
+## Known Non-Goals
+- Orchestra does not store, process, or transmit end-user or client data itself.
+- Orchestra does not aim to make `PROJECT_CONTEXT.md` universally mandatory for every project that adopts it, per `docs/governance/PROJECT_CONTEXT_ENFORCEMENT_POLICY.md`.
+- This document does not modify CI enforcement on its own; wiring `validate_project_context.py` into a workflow is a separate, explicit step.
+
+## Maintainer Approval Rules
+- Changes to governance level, scaffold graduation status, or CI enforcement gates require pull-request review and at least one approval before merge, per `docs/CONTRIBUTING.md`.
+- Maintainer bypass is a recovery path for urgent ruleset repair, CI repair, or access recovery only, not a default development path, and must be documented afterward if it changes governance or CI behavior.
+
+## User or Maintainer Preferences
+Not yet decided. No project-specific maintainer preferences beyond `docs/CONTRIBUTING.md` are currently documented for this field.
+
+## Last Reviewed
+2026-07-06

--- a/docs/MATURITY.md
+++ b/docs/MATURITY.md
@@ -14,7 +14,7 @@ This document classifies the current maturity level of Orchestra's features and 
 ## Beta
 
 * **Governance Instruction Conformance Checks**: Static evaluation of `SKILL.md` instructions against behavioral expectation fixtures (e.g., verifying `BLOCKED`, `HOLD` states are documented).
-* **Project Context Governance Validator**: Validates `PROJECT_CONTEXT.md` presence and required sections against advisory, recommended, and strict-governed governance levels while preserving backward-compatible operating-mode calls.
+* **Project Context Governance Validator**: Validates `PROJECT_CONTEXT.md` presence and required sections against advisory, recommended, and strict-governed governance levels. Advisory and recommended paths remain non-blocking by default; strict-governed remains blocking when declared or explicitly requested.
 * **Codex Export Validation**: Alignment checks for exports specifically intended for the Codex adapter framework.
 
 ## Experimental

--- a/docs/governance/PROJECT_CONTEXT_DECISION_PROMPT.md
+++ b/docs/governance/PROJECT_CONTEXT_DECISION_PROMPT.md
@@ -58,6 +58,8 @@ The Steward must clearly separate:
 
 After intake, The Steward should provide one or two recommendations.
 
+The Steward should recommend, not impose, the governance level unless project risk or release policy clearly requires `Strict-Governed`. Use the optional ruleset in `docs/governance/PROJECT_CONTEXT_ENFORCEMENT_POLICY.md` to frame the default recommendation, then let the user or maintainer confirm or override it.
+
 ### Recommendation 1: Lightweight Advisory PROJECT_CONTEXT.md
 
 Use this when the project is low-to-medium risk, still evolving, single-maintainer, exploratory, or not yet ready for strict governance enforcement.
@@ -178,7 +180,7 @@ The Steward workflow for this phase is:
 2. identify only critical missing context
 3. recommend a lightweight advisory outline by default
 4. recommend a stricter governed outline only when justified by project risk or operating model
-5. let the user accept, refine, or override the recommendation
+5. present governance options and allow user or maintainer direction
 6. produce the requested output without changing CI or declaring `PROJECT_CONTEXT.md` mandatory
 
 ## Non-goal for This Phase

--- a/docs/governance/PROJECT_CONTEXT_ENFORCEMENT_POLICY.md
+++ b/docs/governance/PROJECT_CONTEXT_ENFORCEMENT_POLICY.md
@@ -6,6 +6,8 @@ This document defines a context-sensitive policy for when `PROJECT_CONTEXT.md` s
 
 The goal is not to make `PROJECT_CONTEXT.md` universally mandatory. The goal is to scale governance according to project type, coordination needs, and real-world risk.
 
+`PROJECT_CONTEXT.md` is recommended for governed projects, but not every project should be treated as `Strict-Governed`. Governance level is project-type dependent, user-confirmed, and only enforceable when strict governance is declared or clearly required by policy.
+
 ## Enforcement Principle
 
 `PROJECT_CONTEXT.md` enforcement should depend on project classification and risk level.
@@ -14,7 +16,30 @@ The goal is not to make `PROJECT_CONTEXT.md` universally mandatory. The goal is 
 - moderate coordination work should receive stronger recommendations without default blocking
 - real-world, real-data, compliance-sensitive, destructive, or release-critical work should require `PROJECT_CONTEXT.md` as a gated validation item
 
-The Steward owns classification and context sufficiency. The Governor should only participate in blocking enforcement after the project is classified as strict-governed, a maintainer explicitly requests strict enforcement, or release governance requires it.
+The Steward owns classification and context sufficiency. The Steward should recommend, not automatically impose, a governance level unless project risk clearly requires strict governance. The user or maintainer confirms the intended governance level. The Governor should only participate in blocking enforcement after the project is classified as strict-governed, a maintainer explicitly requests strict enforcement, or release governance requires it.
+
+## Optional Project Governance Ruleset
+
+Use this ruleset to choose the default governance level before turning `PROJECT_CONTEXT.md` into an enforcement gate.
+
+| Project Type | Recommended Governance Level | Validation Behavior |
+| --- | --- | --- |
+| School project | Advisory | Warning only |
+| Learning repo | Advisory | Warning only |
+| Prototype | Advisory | Warning only |
+| Sandbox or trial project | Advisory | Warning only |
+| Portfolio project intended for reuse | Recommended | Strong warning, non-blocking |
+| Internal tool | Recommended | Strong warning unless configured strict |
+| Multi-agent development repo | Recommended or Strict-Governed | Depends on write permissions and risk |
+| Real-world application | Strict-Governed | Blocking validation |
+| Production project | Strict-Governed | Blocking validation |
+| Client-facing project | Strict-Governed | Blocking validation |
+| Project using real-world user or client data | Strict-Governed | Blocking validation |
+| Compliance-sensitive project | Strict-Governed | Blocking validation |
+| Destructive automation workflow | Strict-Governed | Blocking validation |
+| Release-critical repo | Strict-Governed | Blocking validation |
+
+This table is a default decision aid, not a universal override. Maintainers may choose a stricter path earlier, and The Governor may enforce stricter behavior only when `Strict-Governed` is declared or a release policy clearly requires it.
 
 ## Project Classification Levels
 
@@ -68,6 +93,7 @@ Behavior:
 - missing `PROJECT_CONTEXT.md` should be a blocking validation failure
 - incomplete `PROJECT_CONTEXT.md` should be a blocking validation failure when required sections are missing
 - governance enforcement should be treated as part of release and operational safety, not as optional documentation polish
+- strict mode should be treated as opt-in or policy-triggered, not as the universal default for every repository
 
 ## Risk Signals
 
@@ -145,7 +171,7 @@ The Steward workflow should be:
 2. classify project type
 3. identify risk signals
 4. recommend `Advisory`, `Recommended`, or `Strict-Governed`
-5. ask for or accept user direction
+5. present the recommendation as guidance and allow user or maintainer direction
 6. produce one of the following:
    - `PROJECT_CONTEXT.md`
    - decision summary
@@ -197,6 +223,7 @@ A client-facing automation system that handles credentials, user data, destructi
 This policy does not:
 
 - make `PROJECT_CONTEXT.md` universally mandatory
+- force every repository into `Strict-Governed`
 - hard-fail school, trial, prototype, or sandbox repos by default
 - modify CI in this phase
 - replace the Steward-led decision prompt

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -16,6 +16,7 @@
 - [ ] Promote Zed and Neovim scaffolds into host-native distribution or plugin flows after the editor packaging scaffolds stabilize.
 - [ ] Use `docs/governance/PROJECT_CONTEXT_DECISION_PROMPT.md` before proposing any hard enforcement path for `PROJECT_CONTEXT.md`.
 - [ ] Use `docs/governance/PROJECT_CONTEXT_ENFORCEMENT_POLICY.md` before making `PROJECT_CONTEXT.md` blocking for any repository class.
+- [ ] Use optional project governance ruleset defaults before treating `PROJECT_CONTEXT.md` as universally strict across prototypes, school repos, sandboxes, or learning projects.
 - [ ] Apply `docs/project/SCAFFOLD_ADAPTER_GRADUATION_CRITERIA.md` before promoting any scaffold-only adapter support level.
 - [ ] Add an optional cross-platform CLI validator.
 - [ ] Add an optional local-model retrieval index.

--- a/docs/templates/PROJECT_CONTEXT_TEMPLATE.md
+++ b/docs/templates/PROJECT_CONTEXT_TEMPLATE.md
@@ -32,7 +32,14 @@ Unknown
 Unknown
 
 ## Governance Level
-Advisory
+- Advisory
+- Recommended
+- Strict-Governed
+
+Guidance:
+- Choose Advisory for school, prototype, sandbox, learning, or trial projects.
+- Choose Recommended for reusable, internal, or moderate-coordination projects.
+- Choose Strict-Governed for real-world, production, client-facing, real-data, compliance-sensitive, destructive, or release-critical projects.
 
 ## Safety Boundaries
 Unknown

--- a/skills/the-steward/SKILL.md
+++ b/skills/the-steward/SKILL.md
@@ -79,6 +79,8 @@ For context-sensitive classification and future blocking behavior, use `docs/gov
 
 When drafting `PROJECT_CONTEXT.md`, start from `docs/templates/PROJECT_CONTEXT_TEMPLATE.md` and keep unknown items explicit instead of guessed.
 
+The Steward should recommend, not impose, governance level unless project risk clearly requires `Strict-Governed`. Present governance options, explain tradeoffs, and allow user or maintainer direction.
+
 When context is missing (and a review is required based on mode), return:
 ```
 DECISION: REVISION_REQUIRED


### PR DESCRIPTION
## Summary

This PR adds a root `PROJECT_CONTEXT.md` for Orchestra and wires project-context validation into `governance-check.yml`.

The repository now declares its own governance level in the file itself:

- `Governance Level: Recommended`

CI does not hardcode `--governance-level`. The validator reads governance level from `PROJECT_CONTEXT.md`, so if maintainers later raise Orchestra to `Strict-Governed`, the same workflow step will enforce that automatically without workflow changes.

## Changes

- Added root `PROJECT_CONTEXT.md` for Orchestra.
- Set Orchestra governance level to `Recommended`.
- Updated the project-context header to `# Orchestra Project Context`.
- Set `## Last Reviewed` to `2026-07-06`.
- Added project-context validation to `.github/workflows/governance-check.yml`.
- Kept workflow validation generic: no hardcoded `--governance-level` flag.
- Updated `CHANGELOG.md`.

## Why Recommended

`Recommended` fits Orchestra because:

- it is a public multi-agent development repository with governance and guarded write-automation surfaces
- it requires coordination and review discipline
- it does not itself store or process real end-user or client data
- it is not a hosted production service
- maintainers can raise it to `Strict-Governed` later if release criticality, adoption, or write scope increases

## CI Behavior

The workflow now runs:

```bash
python scripts/validate_project_context.py > artifacts/project_context_report.txt
cat artifacts/project_context_report.txt
```

No `--governance-level` flag is passed.

Expected behavior:

- file-declared `Governance Level` controls validation mode
- `Recommended` remains non-blocking by policy for missing strict-only requirements
- if the file is later changed to `Strict-Governed`, the same workflow step will become stricter automatically

## Changed Files

- `PROJECT_CONTEXT.md`
- `.github/workflows/governance-check.yml`
- `CHANGELOG.md`

## Notes

- This PR does not modify runtime code.
- This PR does not modify adapter code.
- This PR does not modify plugin manifests.
- This PR does not change version numbers.
- This PR does not hardcode governance level in CI.
- This PR relies on the file-declared governance level instead.

## Validation

Local clean validation could not be completed from the current checkout because the local repository state is still on an unrelated dirty branch and local preflight is blocked.

Local preflight result:

- [ ] `python scripts/preflight_sync_check.py`
  - Result: `BLOCKED`
  - Reason: local checkout remained on dirty branch `fix/runtime-ci-validation-gaps`; `origin/main` was unavailable; checkout was not clean for Phase 7 validation.

Additional local note:

- The current local checkout still uses an older validator snapshot, so local command output there is not representative of the Phase 7 branch.
- On the Phase 7 branch, file-declared governance level is intended to take precedence over CLI mode.

Not run from this local checkout:

- [ ] `python scripts/validate_project_context.py`
- [ ] `python scripts/governance_check.py --strict`
- [ ] `python tests/behavior/run_tests.py`
- [ ] `git diff --check origin/main...HEAD`

## File-Declared Governance Precedence

The Phase 7 validator behavior is intended to prefer the `Governance Level` declared in `PROJECT_CONTEXT.md` over CLI mode shorthand. That is acceptable here because CI should follow repository-declared governance, not a workflow hardcode.
