### PR TITLE
Strengthen Cloak evidence review and handoff guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Portable Runtime is the first Orchestra release that normalizes the repository a
 
 ### Changed
 - Integrated Release Mode governance docs so The Governor now treats app release compliance artifacts as required when applicable and returns `REVISION_REQUIRED` or `BLOCKED` when release-gate documentation is missing.
+- Strengthened Cloak's documentation-only frontend review contract with artifact-evidence requirements, clearer form and validation messaging review, explicit loading/empty/error/success/retry/permission-state review, sharper frontend handoff blueprint guidance, and matching tracked Codex export parity for the updated Cloak docs.
 
 ### Changed
 - Clarified optional project governance rulesets so `PROJECT_CONTEXT.md` enforcement depends on project type, risk level, and declared governance level.

--- a/adapters/codex/skills/cloak/CHECKLIST.md
+++ b/adapters/codex/skills/cloak/CHECKLIST.md
@@ -4,9 +4,18 @@ Use only the sections relevant to the selected review mode. Unchecked items are 
 
 ## General UX
 - [ ] Identify the primary user, task, entry point, and success state.
+- [ ] Identify which artifact sources were actually reviewed before drawing conclusions.
 - [ ] Confirm the main action is discoverable and uses familiar language.
 - [ ] Check feedback, cancellation, recovery, loading, empty, and error states.
+- [ ] Check success, retry, and permission-denied states when the feature has them.
 - [ ] Remove steps and choices that do not support the task.
+
+## Artifact Evidence
+- [ ] Distinguish inspected evidence from assumptions and missing artifacts.
+- [ ] For Figma evidence, inspect tokens, components, variants, annotations, and linked guidance when available.
+- [ ] For Canva evidence, inspect brand guidance, templates, comments, or approvals only when they are relevant to the review.
+- [ ] For GitHub evidence, inspect screenshots, docs, stories, examples, issues, or PR context instead of inferring behavior from filenames alone.
+- [ ] Mark missing required artifacts as `NEEDS EVIDENCE`.
 
 ## Cognitive Load
 - [ ] Prefer recognition over recall.
@@ -54,6 +63,7 @@ Use only the sections relevant to the selected review mode. Unchecked items are 
 - [ ] Mark required and optional fields clearly.
 - [ ] Validate without erasing input.
 - [ ] Associate specific errors with affected fields.
+- [ ] Review user-facing validation copy, timing, placement, and recovery path.
 - [ ] Prevent duplicate submission and confirm destructive actions.
 - [ ] Confirm each user action has one authoritative interaction path after the change.
 - [ ] Flag duplicate or conflicting controls unless a staged migration is explicitly documented.
@@ -70,6 +80,7 @@ Use only the sections relevant to the selected review mode. Unchecked items are 
 - [ ] Maintain one clear source of truth for shared state.
 - [ ] Avoid duplicated business logic and unnecessary state synchronization.
 - [ ] Reuse framework features and project utilities.
+- [ ] Keep the review at user-visible behavior and handoff level unless Conductor routes architecture ownership elsewhere.
 
 ## JavaFX Screens
 - [ ] Use layout panes and constraints that survive resize and localization.
@@ -99,6 +110,7 @@ Use only the sections relevant to the selected review mode. Unchecked items are 
 - [ ] Highly visible focus states exist for interactive elements.
 - [ ] Full keyboard navigation is supported.
 - [ ] Loading, error, and empty states are designed and handled.
+- [ ] Success, retry, and permission states are designed and handled when the feature has them.
 - [ ] Error messaging is secure and does not leak system details.
 - [ ] Sensitive-data display is masked or privacy-aware.
 - [ ] Role-aware UI hides unauthorized actions (but relies on backend for enforcement).
@@ -109,6 +121,11 @@ Use only the sections relevant to the selected review mode. Unchecked items are 
 - [ ] Identify duplicated patterns, inconsistent variants, workarounds, and stale styles.
 - [ ] Separate intentional tradeoffs from accidental drift.
 - [ ] Prioritize debt affecting tasks, accessibility, responsiveness, or change cost.
+
+## Handoff Blueprint
+- [ ] Define the semantic structure and affected components clearly enough for implementation without writing code.
+- [ ] State design-system constraints, form and validation expectations, and visible state coverage.
+- [ ] Name the downstream owner for implementation, security, architecture, persistence, validation, diagrams, or long-form docs when those concerns appear.
 
 ## Specialist Handoff
 - [ ] Route diagram semantics and modeling to `weaver`.

--- a/adapters/codex/skills/cloak/FRONTEND_REVIEW_GUIDE.md
+++ b/adapters/codex/skills/cloak/FRONTEND_REVIEW_GUIDE.md
@@ -1,9 +1,11 @@
 # Frontend Review Guide
 
-1. Identify the target user, primary task, supported viewport, and available rendered states.
-2. Inspect the smallest relevant component, style, and state owner.
-3. Report confirmed task, accessibility, containment, consistency, and recovery issues by severity.
-4. Reuse native controls, current components, and existing tokens before adding code or dependencies.
-5. Verify build output and representative interaction states after implementation.
+1. Identify the artifact sources reviewed, the target user, the primary task, the supported viewport, and the available rendered states.
+2. Inspect the smallest relevant component, style, state owner, and design-system evidence before making recommendations.
+3. Review form usability, user-facing validation messaging, and the visible loading, empty, error, success, retry, and permission states that affect the task.
+4. Report confirmed task, accessibility, containment, consistency, recovery, and design-system issues by severity. Separate confirmed evidence from assumptions and `NEEDS EVIDENCE`.
+5. Produce a frontend handoff blueprint that names semantic structure, affected components, design-system constraints, responsive or accessibility rules, and downstream routing boundaries without writing production code.
+6. Reuse native controls, current components, and existing tokens before suggesting new variants or dependencies.
+7. Verify build output and representative interaction states after implementation.
 
-Route system diagrams to `weaver`, database semantics to `chronicler`, normal QA to `overseer`, and destructive guardrail pressure testing to gated `dagger`.
+Route implementation to `ponytail`, architecture and state ownership to `clockwork`, security policy to `cipher`, database semantics to `chronicler`, normal QA and validation gates to `overseer`, project documentation to `scribe`, system diagrams to `weaver`, and destructive guardrail pressure testing to gated `dagger`.

--- a/adapters/codex/skills/cloak/OUTPUT_FORMATS.md
+++ b/adapters/codex/skills/cloak/OUTPUT_FORMATS.md
@@ -6,15 +6,23 @@ Use for fast UI, layout, component, accessibility, or frontend specialist handof
 
 ```text
 TASK TYPE:
+EVIDENCE REVIEWED:
+ARTIFACT SOURCES:
 UI IMPACT:
 USER FLOW:
+DESIGN-SYSTEM FINDING:
 LAYOUT ISSUE:
 ACCESSIBILITY ISSUE:
+FORM / VALIDATION REVIEW:
+STATE COVERAGE REVIEW:
+PERMISSION-STATE REVIEW:
 RESPONSIVE RULE:
 COMPONENTS AFFECTED:
 VISUAL HIERARCHY FIX:
 INTERACTION FIX:
+BLUEPRINT CLARITY:
 SMALLEST SAFE UI CHANGE:
+HANDOFF BOUNDARIES:
 HANDOFF TO:
 ```
 
@@ -26,14 +34,20 @@ Use when the artifact is README.md, SKILL.md, documentation, Markdown files, usa
 
 ```text
 ARTIFACT TYPE:
+EVIDENCE BASIS:
+ARTIFACT REFERENCES:
 DOCUMENT GOAL:
 TARGET READER:
 SCAN HIERARCHY:
+DESIGN-SYSTEM EVIDENCE GAP:
 SECTION ORDER ISSUE:
 INFORMATION DENSITY ISSUE:
 NAVIGATION UX:
+FORM / VALIDATION FINDING:
+STATE COVERAGE GAP:
 MISSING SECTION:
 COGNITIVE LOAD ISSUE:
+ROUTING BOUNDARY ISSUE:
 SMALLEST SAFE CHANGE:
 HANDOFF TO:
 ```
@@ -49,6 +63,7 @@ Use only when the user explicitly requests a full UI/UX audit, scoring matrix, o
 
 ## Scope Reviewed
 - Artifact Type:
+- Artifact Sources:
 - Primary User Goal:
 - Target User:
 - Review Mode:
@@ -98,6 +113,14 @@ Reason:
 ## Accessibility Notes
 
 ## Information Architecture Notes
+
+## Design-System Evidence Notes
+
+## Form and Validation Notes
+
+## State Coverage Notes
+
+## Routing Boundary Notes
 
 ## Design Debt
 

--- a/adapters/codex/skills/cloak/SKILL.md
+++ b/adapters/codex/skills/cloak/SKILL.md
@@ -16,7 +16,7 @@ You own the visible layer's design: UI/UX requirements, accessibility requiremen
 
 ## Activation Conditions
 
-Use Cloak for UI, UX, accessibility, visual hierarchy, dashboard layout design, form usability, responsive design, interaction design, component consistency, user-flow review, frontend design discovery, frontend design strategy, design pattern selection, and design review planning.
+Use Cloak for UI, UX, accessibility, visual hierarchy, dashboard layout design, form usability, responsive design, interaction design, component consistency, user-flow review, frontend design discovery, frontend design strategy, design pattern selection, design-system evidence review, and frontend design review planning.
 
 Do not use it for:
 - **Frontend implementation code, React state, JavaFX bindings, or raw CSS** (Route to Ponytail)
@@ -24,6 +24,7 @@ Do not use it for:
 - **Security policy design** (Route to Cipher)
 - **Full architecture design or Component boundaries** (Route to Clockwork)
 - **UI Validation gates or test suite ownership** (Route to Overseer)
+- **Provider hierarchy implementation, client/server state ownership, CI/CD ownership, observability ownership, or release rollout ownership** (Route through Conductor)
 - **Long documentation writing** (Route to Scribe)
 - **Architecture diagrams or wireframes** (Route to Weaver)
 
@@ -45,6 +46,18 @@ Use `SKILL.md` first. Do not load every supporting document by default or consum
 - Load `OUTPUT_FORMATS.md` only when generating the final response.
 - Load `UI_UX_FOUNDATIONS_GUIDE.md` only when the task involves UI/UX review, frontend experience, visual hierarchy, accessibility, forms, responsive layout, interaction design, secure UX, privacy-aware display, role-aware UI, validation messaging, sensitive action flows, or frontend behavior boundaries.
 - Load `templates/<template-name>.md` only when the user explicitly requests a specific aesthetic (e.g., `bryl-minimal`). Do not load templates by default.
+
+## Artifact Evidence Review
+
+When the task includes Figma, Canva, GitHub, screenshots, Storybook exports, PR screenshots, Markdown docs, issue threads, or other frontend artifacts, Cloak reviews the supplied evidence instead of inferring missing details.
+
+Required behavior:
+- Name the artifact source that was reviewed.
+- Distinguish confirmed evidence, missing evidence, and assumptions.
+- For Figma, review tokens, components, variants, annotations, descriptions, linked docs, state coverage, and accessibility notes when they are provided.
+- For Canva, review brand guidance, templates, comments, approvals, and stakeholder-facing consistency when they are provided.
+- For GitHub, review docs, screenshots, stories, examples, issue or PR context, and design-system references when they are provided.
+- If an artifact is referenced but not supplied, state `NEEDS EVIDENCE` and limit conclusions to the material actually reviewed.
 
 ## Operating principles
 
@@ -76,7 +89,9 @@ Use this staged workflow:
 
 4. **Frontend Generation Handoff**
    - Produce a frontend implementation blueprint, not production code.
-   - Define semantic structure, component hierarchy, layout rules, responsive behavior, accessibility requirements, state behavior, and motion requirements.
+   - Define semantic structure, component hierarchy, layout rules, design-system constraints, responsive behavior, accessibility requirements, form and validation messaging expectations, user-visible state behavior, and motion requirements.
+   - Cover loading, empty, error, success, retry, and permission states when the feature has them.
+   - State which downstream skill owns implementation, architecture, security, persistence, validation, diagrams, or long-form documentation.
    - Route actual HTML, CSS, React, JavaFX, or implementation code to Ponytail.
 
 5. **Design Review and Validation**
@@ -126,6 +141,8 @@ Required handoff:
 - Route implementation to Ponytail.
 - Route validation gates to Overseer.
 
+Cloak may define user-visible state expectations, but does not own React provider hierarchy, query-cache strategy, server-state tooling, or implementation of those concerns.
+
 Frontend strategy and backend architecture must be aligned before implementation when the feature involves user data, permissions, authentication, integrations, payments, storage, or compliance-sensitive workflows.
 
 ## Visual Validation and Theming Review
@@ -137,6 +154,7 @@ Require review criteria for:
 - supported theme parity
 - contrast for text, fills, borders, strokes, focus states, and disabled states
 - component consistency with the project design system
+- evidence parity between the reviewed artifact and the recommended UI change
 - visible labels, units, legends, axis labels, and tooltips where users interpret data
 - one authoritative interaction path after the change
 
@@ -158,6 +176,8 @@ Required handoff language:
 - Responsive design rules (breakpoints, layout shifts)
 - Layout decisions and Visual hierarchy
 - Component and Form usability
+- Design-system artifact evidence review
+- User-facing validation and state-review guidance
 - Design-system consistency and Navigation usability
 
 ## Templates
@@ -227,8 +247,11 @@ Cloak owns:
 Cloak does not own:
 - backend/API security enforcement -> Cipher
 - actual implementation -> Ponytail
+- React state architecture, provider hierarchy, and data/cache implementation -> Clockwork or Ponytail as routed
 - architecture layering/component boundary decisions -> Clockwork
+- persistence, schema, and stored-record behavior -> Chronicler
 - test strategy/accessibility validation gates -> Overseer
+- CI/CD, release rollout, observability, and delivery governance -> Conductor with the correct specialist
 - database/persistence design -> Chronicler
 - long documentation -> Scribe
 - diagrams/user flow charts -> Weaver when visual modeling is needed

--- a/adapters/codex/skills/cloak/UI_UX_FOUNDATIONS_GUIDE.md
+++ b/adapters/codex/skills/cloak/UI_UX_FOUNDATIONS_GUIDE.md
@@ -9,6 +9,14 @@
 - **Destructive Actions**: Should use clear confirmation, review, and recovery affordances.
 - **Secure UX**: Must reduce accidental disclosure and user mistakes.
 
+## Design-System Evidence Review
+- **Evidence First**: Review the supplied artifact evidence before recommending changes.
+- **Figma Evidence**: Tokens, components, variants, annotations, and linked docs are valid evidence when provided.
+- **Canva Evidence**: Brand guidance, templates, comments, and approvals are valid evidence when provided.
+- **GitHub Evidence**: Docs, stories, screenshots, issue context, PR context, and design-system references are valid evidence when provided.
+- **Missing Inputs**: If a referenced artifact was not supplied, mark it as `NEEDS EVIDENCE` instead of inferring behavior.
+- **Review vs Ownership**: Cloak reviews the user-visible evidence and constraints; it does not take ownership of implementation, CI/CD, telemetry, or release rollout.
+
 ## Information Architecture & Layout
 - **Information Architecture**: Organize content logically so users can find what they need. Use clear navigation structures.
 - **Layout Structure**: Use grids, alignment, and whitespace to create an organized, readable interface.
@@ -22,11 +30,14 @@
 - **Interaction Design**: Controls should look clickable and behave predictably.
 - **User Feedback States**: Always provide visual feedback for interactions (e.g., hover, active, focus).
 - **State Management**: Account for empty, loading, error, and success states so the user is never left guessing.
+- **Extended State Review**: Cover retry and permission-denied states when they exist in the flow.
 - **Session State Indicators**: Make it clear if the user is logged in, and as which role.
 
 ## Forms & Validation
 - **Form Usability**: Keep forms concise. Group related inputs.
 - **Validation Messaging**: Provide clear, inline, and actionable validation messaging before and after submission.
+- **Validation Recovery**: Validation failures should preserve user input and make the recovery path obvious.
+- **Message Quality**: Errors should identify the problem, the affected field or action, and the next safe step.
 - **Safe Defaults**: Use default values that minimize risk and user effort.
 
 ## Accessibility Basics
@@ -41,6 +52,13 @@
 - **Sensitive-Data Masking**: Provide toggle visibility for sensitive inputs.
 - **Role-Aware UI Visibility**: Only show controls the user has permission to use.
 - **Permission-Aware Navigation**: Do not display navigation links to unauthorized areas.
+- **Permission-State Messaging**: When access is limited, make the user-visible reason and recovery path clear without exposing sensitive policy details.
 - **Secure Error Message UX**: Avoid giving attackers hints (e.g., "Invalid password" vs "User not found").
 - **Secure Onboarding/Recovery**: Provide safe, clear flows for login, onboarding, and password recovery.
 - **Audit Clarity**: Ensure actions that generate an audit log are clear to the user if relevant.
+
+## Handoff Blueprint Requirements
+- **Blueprint over Code**: Cloak hands off semantic structure, component intent, visible state expectations, and review findings, not production code.
+- **Design-System Constraints**: Name the token, component, and variant constraints that the implementation should preserve.
+- **State Coverage**: Call out loading, empty, error, success, retry, and permission states when relevant.
+- **Routing Boundaries**: Route implementation to Ponytail, architecture to Clockwork, security policy to Cipher, persistence to Chronicler, validation gates to Overseer, long-form docs to Scribe, and diagrams to Weaver.

--- a/skills/cloak/CHECKLIST.md
+++ b/skills/cloak/CHECKLIST.md
@@ -4,9 +4,18 @@ Use only the sections relevant to the selected review mode. Unchecked items are 
 
 ## General UX
 - [ ] Identify the primary user, task, entry point, and success state.
+- [ ] Identify which artifact sources were actually reviewed before drawing conclusions.
 - [ ] Confirm the main action is discoverable and uses familiar language.
 - [ ] Check feedback, cancellation, recovery, loading, empty, and error states.
+- [ ] Check success, retry, and permission-denied states when the feature has them.
 - [ ] Remove steps and choices that do not support the task.
+
+## Artifact Evidence
+- [ ] Distinguish inspected evidence from assumptions and missing artifacts.
+- [ ] For Figma evidence, inspect tokens, components, variants, annotations, and linked guidance when available.
+- [ ] For Canva evidence, inspect brand guidance, templates, comments, or approvals only when they are relevant to the review.
+- [ ] For GitHub evidence, inspect screenshots, docs, stories, examples, issues, or PR context instead of inferring behavior from filenames alone.
+- [ ] Mark missing required artifacts as `NEEDS EVIDENCE`.
 
 ## Cognitive Load
 - [ ] Prefer recognition over recall.
@@ -54,6 +63,7 @@ Use only the sections relevant to the selected review mode. Unchecked items are 
 - [ ] Mark required and optional fields clearly.
 - [ ] Validate without erasing input.
 - [ ] Associate specific errors with affected fields.
+- [ ] Review user-facing validation copy, timing, placement, and recovery path.
 - [ ] Prevent duplicate submission and confirm destructive actions.
 - [ ] Confirm each user action has one authoritative interaction path after the change.
 - [ ] Flag duplicate or conflicting controls unless a staged migration is explicitly documented.
@@ -70,6 +80,7 @@ Use only the sections relevant to the selected review mode. Unchecked items are 
 - [ ] Maintain one clear source of truth for shared state.
 - [ ] Avoid duplicated business logic and unnecessary state synchronization.
 - [ ] Reuse framework features and project utilities.
+- [ ] Keep the review at user-visible behavior and handoff level unless Conductor routes architecture ownership elsewhere.
 
 ## JavaFX Screens
 - [ ] Use layout panes and constraints that survive resize and localization.
@@ -99,6 +110,7 @@ Use only the sections relevant to the selected review mode. Unchecked items are 
 - [ ] Highly visible focus states exist for interactive elements.
 - [ ] Full keyboard navigation is supported.
 - [ ] Loading, error, and empty states are designed and handled.
+- [ ] Success, retry, and permission states are designed and handled when the feature has them.
 - [ ] Error messaging is secure and does not leak system details.
 - [ ] Sensitive-data display is masked or privacy-aware.
 - [ ] Role-aware UI hides unauthorized actions (but relies on backend for enforcement).
@@ -109,6 +121,11 @@ Use only the sections relevant to the selected review mode. Unchecked items are 
 - [ ] Identify duplicated patterns, inconsistent variants, workarounds, and stale styles.
 - [ ] Separate intentional tradeoffs from accidental drift.
 - [ ] Prioritize debt affecting tasks, accessibility, responsiveness, or change cost.
+
+## Handoff Blueprint
+- [ ] Define the semantic structure and affected components clearly enough for implementation without writing code.
+- [ ] State design-system constraints, form and validation expectations, and visible state coverage.
+- [ ] Name the downstream owner for implementation, security, architecture, persistence, validation, diagrams, or long-form docs when those concerns appear.
 
 ## Specialist Handoff
 - [ ] Route diagram semantics and modeling to `weaver`.

--- a/skills/cloak/FRONTEND_REVIEW_GUIDE.md
+++ b/skills/cloak/FRONTEND_REVIEW_GUIDE.md
@@ -1,9 +1,11 @@
 # Frontend Review Guide
 
-1. Identify the target user, primary task, supported viewport, and available rendered states.
-2. Inspect the smallest relevant component, style, and state owner.
-3. Report confirmed task, accessibility, containment, consistency, and recovery issues by severity.
-4. Reuse native controls, current components, and existing tokens before adding code or dependencies.
-5. Verify build output and representative interaction states after implementation.
+1. Identify the artifact sources reviewed, the target user, the primary task, the supported viewport, and the available rendered states.
+2. Inspect the smallest relevant component, style, state owner, and design-system evidence before making recommendations.
+3. Review form usability, user-facing validation messaging, and the visible loading, empty, error, success, retry, and permission states that affect the task.
+4. Report confirmed task, accessibility, containment, consistency, recovery, and design-system issues by severity. Separate confirmed evidence from assumptions and `NEEDS EVIDENCE`.
+5. Produce a frontend handoff blueprint that names semantic structure, affected components, design-system constraints, responsive or accessibility rules, and downstream routing boundaries without writing production code.
+6. Reuse native controls, current components, and existing tokens before suggesting new variants or dependencies.
+7. Verify build output and representative interaction states after implementation.
 
-Route system diagrams to `weaver`, database semantics to `chronicler`, normal QA to `overseer`, and destructive guardrail pressure testing to gated `dagger`.
+Route implementation to `ponytail`, architecture and state ownership to `clockwork`, security policy to `cipher`, database semantics to `chronicler`, normal QA and validation gates to `overseer`, project documentation to `scribe`, system diagrams to `weaver`, and destructive guardrail pressure testing to gated `dagger`.

--- a/skills/cloak/OUTPUT_FORMATS.md
+++ b/skills/cloak/OUTPUT_FORMATS.md
@@ -6,15 +6,23 @@ Use for fast UI, layout, component, accessibility, or frontend specialist handof
 
 ```text
 TASK TYPE:
+EVIDENCE REVIEWED:
+ARTIFACT SOURCES:
 UI IMPACT:
 USER FLOW:
+DESIGN-SYSTEM FINDING:
 LAYOUT ISSUE:
 ACCESSIBILITY ISSUE:
+FORM / VALIDATION REVIEW:
+STATE COVERAGE REVIEW:
+PERMISSION-STATE REVIEW:
 RESPONSIVE RULE:
 COMPONENTS AFFECTED:
 VISUAL HIERARCHY FIX:
 INTERACTION FIX:
+BLUEPRINT CLARITY:
 SMALLEST SAFE UI CHANGE:
+HANDOFF BOUNDARIES:
 HANDOFF TO:
 ```
 
@@ -26,14 +34,20 @@ Use when the artifact is README.md, SKILL.md, documentation, Markdown files, usa
 
 ```text
 ARTIFACT TYPE:
+EVIDENCE BASIS:
+ARTIFACT REFERENCES:
 DOCUMENT GOAL:
 TARGET READER:
 SCAN HIERARCHY:
+DESIGN-SYSTEM EVIDENCE GAP:
 SECTION ORDER ISSUE:
 INFORMATION DENSITY ISSUE:
 NAVIGATION UX:
+FORM / VALIDATION FINDING:
+STATE COVERAGE GAP:
 MISSING SECTION:
 COGNITIVE LOAD ISSUE:
+ROUTING BOUNDARY ISSUE:
 SMALLEST SAFE CHANGE:
 HANDOFF TO:
 ```
@@ -49,6 +63,7 @@ Use only when the user explicitly requests a full UI/UX audit, scoring matrix, o
 
 ## Scope Reviewed
 - Artifact Type:
+- Artifact Sources:
 - Primary User Goal:
 - Target User:
 - Review Mode:
@@ -98,6 +113,14 @@ Reason:
 ## Accessibility Notes
 
 ## Information Architecture Notes
+
+## Design-System Evidence Notes
+
+## Form and Validation Notes
+
+## State Coverage Notes
+
+## Routing Boundary Notes
 
 ## Design Debt
 

--- a/skills/cloak/SKILL.md
+++ b/skills/cloak/SKILL.md
@@ -23,7 +23,7 @@ You own the visible layer's design: UI/UX requirements, accessibility requiremen
 
 ## Activation Conditions
 
-Use Cloak for UI, UX, accessibility, visual hierarchy, dashboard layout design, form usability, responsive design, interaction design, component consistency, user-flow review, frontend design discovery, frontend design strategy, design pattern selection, and design review planning.
+Use Cloak for UI, UX, accessibility, visual hierarchy, dashboard layout design, form usability, responsive design, interaction design, component consistency, user-flow review, frontend design discovery, frontend design strategy, design pattern selection, design-system evidence review, and frontend design review planning.
 
 Do not use it for:
 - **Frontend implementation code, React state, JavaFX bindings, or raw CSS** (Route to Ponytail)
@@ -31,6 +31,7 @@ Do not use it for:
 - **Security policy design** (Route to Cipher)
 - **Full architecture design or Component boundaries** (Route to Clockwork)
 - **UI Validation gates or test suite ownership** (Route to Overseer)
+- **Provider hierarchy implementation, client/server state ownership, CI/CD ownership, observability ownership, or release rollout ownership** (Route through Conductor)
 - **Long documentation writing** (Route to Scribe)
 - **Architecture diagrams or wireframes** (Route to Weaver)
 
@@ -52,6 +53,18 @@ Use `SKILL.md` first. Do not load every supporting document by default or consum
 - Load `OUTPUT_FORMATS.md` only when generating the final response.
 - Load `UI_UX_FOUNDATIONS_GUIDE.md` only when the task involves UI/UX review, frontend experience, visual hierarchy, accessibility, forms, responsive layout, interaction design, secure UX, privacy-aware display, role-aware UI, validation messaging, sensitive action flows, or frontend behavior boundaries.
 - Load `templates/<template-name>.md` only when the user explicitly requests a specific aesthetic (e.g., `bryl-minimal`). Do not load templates by default.
+
+## Artifact Evidence Review
+
+When the task includes Figma, Canva, GitHub, screenshots, Storybook exports, PR screenshots, Markdown docs, issue threads, or other frontend artifacts, Cloak reviews the supplied evidence instead of inferring missing details.
+
+Required behavior:
+- Name the artifact source that was reviewed.
+- Distinguish confirmed evidence, missing evidence, and assumptions.
+- For Figma, review tokens, components, variants, annotations, descriptions, linked docs, state coverage, and accessibility notes when they are provided.
+- For Canva, review brand guidance, templates, comments, approvals, and stakeholder-facing consistency when they are provided.
+- For GitHub, review docs, screenshots, stories, examples, issue or PR context, and design-system references when they are provided.
+- If an artifact is referenced but not supplied, state `NEEDS EVIDENCE` and limit conclusions to the material actually reviewed.
 
 ## Operating principles
 
@@ -83,7 +96,9 @@ Use this staged workflow:
 
 4. **Frontend Generation Handoff**
    - Produce a frontend implementation blueprint, not production code.
-   - Define semantic structure, component hierarchy, layout rules, responsive behavior, accessibility requirements, state behavior, and motion requirements.
+   - Define semantic structure, component hierarchy, layout rules, design-system constraints, responsive behavior, accessibility requirements, form and validation messaging expectations, user-visible state behavior, and motion requirements.
+   - Cover loading, empty, error, success, retry, and permission states when the feature has them.
+   - State which downstream skill owns implementation, architecture, security, persistence, validation, diagrams, or long-form documentation.
    - Route actual HTML, CSS, React, JavaFX, or implementation code to Ponytail.
 
 5. **Design Review and Validation**
@@ -133,6 +148,8 @@ Required handoff:
 - Route implementation to Ponytail.
 - Route validation gates to Overseer.
 
+Cloak may define user-visible state expectations, but does not own React provider hierarchy, query-cache strategy, server-state tooling, or implementation of those concerns.
+
 Frontend strategy and backend architecture must be aligned before implementation when the feature involves user data, permissions, authentication, integrations, payments, storage, or compliance-sensitive workflows.
 
 ## Visual Validation and Theming Review
@@ -144,6 +161,7 @@ Require review criteria for:
 - supported theme parity
 - contrast for text, fills, borders, strokes, focus states, and disabled states
 - component consistency with the project design system
+- evidence parity between the reviewed artifact and the recommended UI change
 - visible labels, units, legends, axis labels, and tooltips where users interpret data
 - one authoritative interaction path after the change
 
@@ -165,6 +183,8 @@ Required handoff language:
 - Responsive design rules (breakpoints, layout shifts)
 - Layout decisions and Visual hierarchy
 - Component and Form usability
+- Design-system artifact evidence review
+- User-facing validation and state-review guidance
 - Design-system consistency and Navigation usability
 
 ## Templates
@@ -234,8 +254,11 @@ Cloak owns:
 Cloak does not own:
 - backend/API security enforcement -> Cipher
 - actual implementation -> Ponytail
+- React state architecture, provider hierarchy, and data/cache implementation -> Clockwork or Ponytail as routed
 - architecture layering/component boundary decisions -> Clockwork
+- persistence, schema, and stored-record behavior -> Chronicler
 - test strategy/accessibility validation gates -> Overseer
+- CI/CD, release rollout, observability, and delivery governance -> Conductor with the correct specialist
 - database/persistence design -> Chronicler
 - long documentation -> Scribe
 - diagrams/user flow charts -> Weaver when visual modeling is needed

--- a/skills/cloak/UI_UX_FOUNDATIONS_GUIDE.md
+++ b/skills/cloak/UI_UX_FOUNDATIONS_GUIDE.md
@@ -9,6 +9,14 @@
 - **Destructive Actions**: Should use clear confirmation, review, and recovery affordances.
 - **Secure UX**: Must reduce accidental disclosure and user mistakes.
 
+## Design-System Evidence Review
+- **Evidence First**: Review the supplied artifact evidence before recommending changes.
+- **Figma Evidence**: Tokens, components, variants, annotations, and linked docs are valid evidence when provided.
+- **Canva Evidence**: Brand guidance, templates, comments, and approvals are valid evidence when provided.
+- **GitHub Evidence**: Docs, stories, screenshots, issue context, PR context, and design-system references are valid evidence when provided.
+- **Missing Inputs**: If a referenced artifact was not supplied, mark it as `NEEDS EVIDENCE` instead of inferring behavior.
+- **Review vs Ownership**: Cloak reviews the user-visible evidence and constraints; it does not take ownership of implementation, CI/CD, telemetry, or release rollout.
+
 ## Information Architecture & Layout
 - **Information Architecture**: Organize content logically so users can find what they need. Use clear navigation structures.
 - **Layout Structure**: Use grids, alignment, and whitespace to create an organized, readable interface.
@@ -22,11 +30,14 @@
 - **Interaction Design**: Controls should look clickable and behave predictably.
 - **User Feedback States**: Always provide visual feedback for interactions (e.g., hover, active, focus).
 - **State Management**: Account for empty, loading, error, and success states so the user is never left guessing.
+- **Extended State Review**: Cover retry and permission-denied states when they exist in the flow.
 - **Session State Indicators**: Make it clear if the user is logged in, and as which role.
 
 ## Forms & Validation
 - **Form Usability**: Keep forms concise. Group related inputs.
 - **Validation Messaging**: Provide clear, inline, and actionable validation messaging before and after submission.
+- **Validation Recovery**: Validation failures should preserve user input and make the recovery path obvious.
+- **Message Quality**: Errors should identify the problem, the affected field or action, and the next safe step.
 - **Safe Defaults**: Use default values that minimize risk and user effort.
 
 ## Accessibility Basics
@@ -41,6 +52,13 @@
 - **Sensitive-Data Masking**: Provide toggle visibility for sensitive inputs.
 - **Role-Aware UI Visibility**: Only show controls the user has permission to use.
 - **Permission-Aware Navigation**: Do not display navigation links to unauthorized areas.
+- **Permission-State Messaging**: When access is limited, make the user-visible reason and recovery path clear without exposing sensitive policy details.
 - **Secure Error Message UX**: Avoid giving attackers hints (e.g., "Invalid password" vs "User not found").
 - **Secure Onboarding/Recovery**: Provide safe, clear flows for login, onboarding, and password recovery.
 - **Audit Clarity**: Ensure actions that generate an audit log are clear to the user if relevant.
+
+## Handoff Blueprint Requirements
+- **Blueprint over Code**: Cloak hands off semantic structure, component intent, visible state expectations, and review findings, not production code.
+- **Design-System Constraints**: Name the token, component, and variant constraints that the implementation should preserve.
+- **State Coverage**: Call out loading, empty, error, success, retry, and permission states when relevant.
+- **Routing Boundaries**: Route implementation to Ponytail, architecture to Clockwork, security policy to Cipher, persistence to Chronicler, validation gates to Overseer, long-form docs to Scribe, and diagrams to Weaver.


### PR DESCRIPTION
## Summary
- strengthen the source `skills/cloak` docs for evidence-driven frontend review only
- add matching Codex export parity updates under `adapters/codex/skills/cloak`
- keep Cloak out of implementation, provider/state ownership, CI/CD, observability, release rollout, and test-gate ownership

## What changed
- added Figma, Canva, and GitHub artifact evidence requirements to the Cloak skill docs
- expanded form usability, validation messaging, and loading/empty/error/success/retry/permission-state review guidance
- clarified frontend handoff blueprint expectations and downstream routing boundaries
- refreshed the tracked Codex export copies for the same five Cloak docs

## Validation
- `python scripts/validate_manifest.py`
- `python adapters/codex/validate_codex_export.py`
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts\refresh-installed-integrations.ps1 -Target Codex -CodexRepoPath C:\conductor -Force`
- `git diff --check`

## Scope
- source docs: `skills/cloak/SKILL.md`, `OUTPUT_FORMATS.md`, `CHECKLIST.md`, `UI_UX_FOUNDATIONS_GUIDE.md`, `FRONTEND_REVIEW_GUIDE.md`
- tracked export parity: matching files under `adapters/codex/skills/cloak/`
