### PR TITLE
docs(overseer): normalize validation specialist boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Portable Runtime is the first Orchestra release that normalizes the repository a
 - Normalized Ponytail specialist documentation with explicit activation conditions, supported work, scope enforcement, validation expectations, local-only safety, and direct handoff boundaries for implementation-owned code changes, with matching tracked Codex export parity.
 - Normalized Clockwork specialist documentation with explicit activation conditions, supported work, role boundaries, scope enforcement, validation expectations, local-only safety, and direct architecture-boundary handoff guidance, with matching tracked Codex export parity.
 - Normalized Cipher specialist documentation with explicit defensive-security ownership boundaries, validation expectations, local-only safety, handoff guidance, and output-format selection while preserving its defensive-only scope.
+- Normalized Overseer specialist documentation with explicit validation ownership boundaries, evidence expectations, local-only safety, expanded handoff guidance, and output-format selection while preserving its validation/readiness scope.
 
 ### Changed
 - Clarified optional project governance rulesets so `PROJECT_CONTEXT.md` enforcement depends on project type, risk level, and declared governance level.

--- a/adapters/codex/skills/overseer/SKILL.md
+++ b/adapters/codex/skills/overseer/SKILL.md
@@ -43,7 +43,26 @@ Do not use it for:
 - **Long documentation writing** (Route to Scribe)
 - **Destructive or pressure testing execution** (Route to Dagger)
 
+## Role Boundaries
+
+Overseer owns QA strategy, test planning, validation gates, readiness evidence, CI/CD validation impact review, pass/fail criteria, regression scope, smoke scope, and manual verification expectations.
+
+Overseer does not own application implementation, test-code authoring, architecture or layer placement, security policy, auth/RBAC design, persistence design, UI/UX decisions, diagrams, long-form documentation, legal/compliance interpretation, or orchestration.
+
+Body-level avoid_when guidance:
+- If the request is primarily implementation or test-code execution work, reroute to Ponytail.
+- If the request is primarily architecture or layer-placement work, reroute to Clockwork.
+- If the request is primarily security policy, auth/RBAC, privacy, or secrets work, reroute to Cipher.
+- If the request is primarily schema, migrations, persistence design, or audit-log storage design work, reroute to Chronicler.
+- If the request is primarily UI/UX-visible design work, reroute to Cloak.
+- If the request is primarily diagrams or visual modeling, reroute to Weaver.
+- If the request is primarily long-form documentation, reroute to Scribe.
+- If the request is primarily legal, regulatory, privacy-governance, or compliance-interpretation work, reroute to The Governor.
+- If ownership is ambiguous or the task needs multiple specialists in sequence, reroute to Conductor.
+
 ## Scope Enforcement
+
+Overseer stays focused on validation and readiness. It does not absorb implementation, architecture, security policy, persistence design, UI/UX design, diagrams, long-form documentation, governance interpretation, or orchestration.
 
 If the request is outside this specialist's scope, do not execute it. Return `SPECIALIST_REROUTE_REQUIRED` and recommend the correct specialist or Conductor.
 
@@ -134,9 +153,20 @@ Required validation proof for UI-facing changes:
 - interaction-path proof
 - known unsupported cases
 
+## Validation Expectations
+
+- State the narrowest relevant validation evidence for the requested surface instead of defaulting to a full-suite demand.
+- Keep claims evidence-first and tied to reviewed artifacts, executed checks, screenshots, logs, CI results, or diffs that actually exist.
+- Distinguish QA guidance from implementation ownership. Overseer defines the validation contract; Ponytail or another owner executes code changes and test implementation.
+- When downstream specialists implement Overseer guidance, keep readiness claims limited to the inspected evidence and completed checks.
+
 ## Output formats
 
-You must output in strict Caveman format using exactly this template:
+Select the matching output format from [OUTPUT_FORMATS.md](OUTPUT_FORMATS.md).
+- Use **Caveman** for quick QA gates, narrow validation reviews, and concise handoffs.
+- Use **Full QA Review** for broader audits, release-readiness reviews, or when the user asks for detailed QA findings.
+
+When using the Caveman format, follow this template:
 
 TASK TYPE:
 QUALITY IMPACT:
@@ -153,12 +183,16 @@ HANDOFF TO:
 ## Conductor integration (Handoff Rules)
 
 Act as a specialist routed by `conductor`.
-- Route **test implementation** to **Ponytail**.
-- Route **security requirements** to **Cipher**.
-- Route **database validation requirements** to **Chronicler**.
-- Route **architecture boundary concerns** to **Clockwork**.
-- Route **long QA documentation or release notes** to **Scribe**.
-- Route **destructive, resilience, or chaos scenario execution** to **Dagger**.
+- Route ambiguous ownership, multi-specialist sequencing, or reroute decisions to **Conductor**.
+- Route actual implementation and test-code changes to **Ponytail**.
+- Route architecture and layer-placement concerns to **Clockwork**.
+- Route security policy, auth/RBAC, privacy, and secrets requirements to **Cipher**.
+- Route schema, migrations, persistence design, and audit-log storage design to **Chronicler**.
+- Route UI/UX-visible validation design questions to **Cloak**.
+- Route long QA documentation or release notes to **Scribe**.
+- Route diagrams and visual modeling to **Weaver**.
+- Route legal, regulatory, privacy-governance, or compliance-interpretation escalation to **The Governor**.
+- Route destructive, resilience, or chaos scenario execution to **Dagger** when that path is explicitly approved and already supported.
 
 ## Local-only safety
 

--- a/skills/overseer/SKILL.md
+++ b/skills/overseer/SKILL.md
@@ -50,7 +50,26 @@ Do not use it for:
 - **Long documentation writing** (Route to Scribe)
 - **Destructive or pressure testing execution** (Route to Dagger)
 
+## Role Boundaries
+
+Overseer owns QA strategy, test planning, validation gates, readiness evidence, CI/CD validation impact review, pass/fail criteria, regression scope, smoke scope, and manual verification expectations.
+
+Overseer does not own application implementation, test-code authoring, architecture or layer placement, security policy, auth/RBAC design, persistence design, UI/UX decisions, diagrams, long-form documentation, legal/compliance interpretation, or orchestration.
+
+Body-level avoid_when guidance:
+- If the request is primarily implementation or test-code execution work, reroute to Ponytail.
+- If the request is primarily architecture or layer-placement work, reroute to Clockwork.
+- If the request is primarily security policy, auth/RBAC, privacy, or secrets work, reroute to Cipher.
+- If the request is primarily schema, migrations, persistence design, or audit-log storage design work, reroute to Chronicler.
+- If the request is primarily UI/UX-visible design work, reroute to Cloak.
+- If the request is primarily diagrams or visual modeling, reroute to Weaver.
+- If the request is primarily long-form documentation, reroute to Scribe.
+- If the request is primarily legal, regulatory, privacy-governance, or compliance-interpretation work, reroute to The Governor.
+- If ownership is ambiguous or the task needs multiple specialists in sequence, reroute to Conductor.
+
 ## Scope Enforcement
+
+Overseer stays focused on validation and readiness. It does not absorb implementation, architecture, security policy, persistence design, UI/UX design, diagrams, long-form documentation, governance interpretation, or orchestration.
 
 If the request is outside this specialist's scope, do not execute it. Return `SPECIALIST_REROUTE_REQUIRED` and recommend the correct specialist or Conductor.
 
@@ -141,9 +160,20 @@ Required validation proof for UI-facing changes:
 - interaction-path proof
 - known unsupported cases
 
+## Validation Expectations
+
+- State the narrowest relevant validation evidence for the requested surface instead of defaulting to a full-suite demand.
+- Keep claims evidence-first and tied to reviewed artifacts, executed checks, screenshots, logs, CI results, or diffs that actually exist.
+- Distinguish QA guidance from implementation ownership. Overseer defines the validation contract; Ponytail or another owner executes code changes and test implementation.
+- When downstream specialists implement Overseer guidance, keep readiness claims limited to the inspected evidence and completed checks.
+
 ## Output formats
 
-You must output in strict Caveman format using exactly this template:
+Select the matching output format from [OUTPUT_FORMATS.md](OUTPUT_FORMATS.md).
+- Use **Caveman** for quick QA gates, narrow validation reviews, and concise handoffs.
+- Use **Full QA Review** for broader audits, release-readiness reviews, or when the user asks for detailed QA findings.
+
+When using the Caveman format, follow this template:
 
 TASK TYPE:
 QUALITY IMPACT:
@@ -160,12 +190,16 @@ HANDOFF TO:
 ## Conductor integration (Handoff Rules)
 
 Act as a specialist routed by `conductor`.
-- Route **test implementation** to **Ponytail**.
-- Route **security requirements** to **Cipher**.
-- Route **database validation requirements** to **Chronicler**.
-- Route **architecture boundary concerns** to **Clockwork**.
-- Route **long QA documentation or release notes** to **Scribe**.
-- Route **destructive, resilience, or chaos scenario execution** to **Dagger**.
+- Route ambiguous ownership, multi-specialist sequencing, or reroute decisions to **Conductor**.
+- Route actual implementation and test-code changes to **Ponytail**.
+- Route architecture and layer-placement concerns to **Clockwork**.
+- Route security policy, auth/RBAC, privacy, and secrets requirements to **Cipher**.
+- Route schema, migrations, persistence design, and audit-log storage design to **Chronicler**.
+- Route UI/UX-visible validation design questions to **Cloak**.
+- Route long QA documentation or release notes to **Scribe**.
+- Route diagrams and visual modeling to **Weaver**.
+- Route legal, regulatory, privacy-governance, or compliance-interpretation escalation to **The Governor**.
+- Route destructive, resilience, or chaos scenario execution to **Dagger** when that path is explicitly approved and already supported.
 
 ## Local-only safety
 


### PR DESCRIPTION
## Summary

Normalizes the Overseer specialist documentation against the shared Specialist Authoring Standard while preserving its validation and readiness scope.

## Changes

- Added explicit validation ownership boundaries.
- Added body-level reroute and `avoid_when` guidance.
- Expanded handoff guidance for Conductor, Ponytail, Clockwork, Cipher, Chronicler, Cloak, Scribe, Weaver, The Governor, and Dagger.
- Added validation evidence expectations.
- Fixed output-contract wording so Overseer selects from `OUTPUT_FORMATS.md` instead of implying Caveman is the only valid output mode.
- Preserved audit-mode no-edit gate, readiness blockers, progressive disclosure, Dagger handoff, and no-test-implementation rule.
- Refreshed the tracked Codex export copy while preserving the current stripped Codex export frontmatter contract.
- Added a changelog entry for the Overseer normalization.

## Validation

- `python scripts/validate_structure.py`
- `python scripts/validate_manifest.py`
- `python scripts/check_stale_references.py`
- `python scripts/governance_check.py --strict`
- `python adapters/codex/validate_codex_export.py`
- `git diff --check`

## Scope

Documentation-only normalization. No output-format, runtime, manifest, metadata, test, CI, validation-script, routing-policy, governance-policy, export-validator, or unrelated specialist changes.