### PR TITLE
docs(skills): align specialist boundary consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Portable Runtime is the first Orchestra release that normalizes the repository a
 - Normalized Chronicler specialist documentation with explicit persistence ownership boundaries, supported work, validation expectations, output-format selection, and expanded handoff guidance while preserving its database and data-integrity scope.
 - Normalized Scribe specialist documentation with explicit documentation ownership boundaries, activation conditions, validation expectations, output-format selection, and expanded handoff guidance while preserving its source-backed documentation scope.
 - Normalized Weaver specialist documentation with explicit diagram ownership boundaries, activation conditions, validation expectations, output-format selection, and expanded handoff guidance while preserving its visual-modeling scope.
+- Cleaned up cross-specialist consistency by aligning Scribe output-format headings and adding compact Cloak role-boundary and validation-expectation sections without changing specialist behavior.
 
 ### Changed
 - Clarified optional project governance rulesets so `PROJECT_CONTEXT.md` enforcement depends on project type, risk level, and declared governance level.

--- a/adapters/codex/skills/cloak/SKILL.md
+++ b/adapters/codex/skills/cloak/SKILL.md
@@ -221,6 +221,18 @@ Before applying a template, ensure:
 8. Component Consistency & Design Systems
 9. Responsiveness (mobile behavior)
 
+## Role Boundaries
+
+Cloak owns UI/UX review, layout and visual hierarchy, accessibility review, frontend experience behavior, secure UX affordances, privacy-aware display patterns, and user-facing validation or error messaging.
+
+Cloak does not own implementation, architecture layering, persistence design, security policy enforcement, QA strategy or release-readiness gates, long-form documentation, diagram production, or orchestration. Keep those boundaries with the owning specialist named in the handoff section below.
+
+## Validation Expectations
+
+- Base Cloak findings on the reviewed UI artifact, screen, design-system evidence, screenshot, or source material that actually exists.
+- Keep claims limited to confirmed visual, accessibility, interaction, and user-facing state evidence. Do not claim implementation or validation results that were not reviewed or run.
+- When downstream implementation or release validation is needed, keep Cloak scoped to the design requirement and hand off execution or validation ownership to Ponytail or Overseer as already defined.
+
 ## Output formats
 
 Load `OUTPUT_FORMATS.md` when ready to generate the final response. Use the template that matches the selected mode:

--- a/adapters/codex/skills/scribe/OUTPUT_FORMATS.md
+++ b/adapters/codex/skills/scribe/OUTPUT_FORMATS.md
@@ -1,6 +1,6 @@
 # Output Formats
 
-## MODE 1: Long Documentation
+## Mode 1
 
 Use for final documentation or detailed audits.
 
@@ -45,7 +45,7 @@ Reason:
 ## Final Recommendation
 ```
 
-## MODE 2: Standard Documentation
+## Mode 2
 
 Use for standard documentation audits.
 
@@ -70,7 +70,7 @@ Confidence Level: High / Medium / Low
 -
 ```
 
-## MODE 3: Short Documentation
+## Mode 3
 
 Use for quick audits.
 

--- a/skills/cloak/SKILL.md
+++ b/skills/cloak/SKILL.md
@@ -228,6 +228,18 @@ Before applying a template, ensure:
 8. Component Consistency & Design Systems
 9. Responsiveness (mobile behavior)
 
+## Role Boundaries
+
+Cloak owns UI/UX review, layout and visual hierarchy, accessibility review, frontend experience behavior, secure UX affordances, privacy-aware display patterns, and user-facing validation or error messaging.
+
+Cloak does not own implementation, architecture layering, persistence design, security policy enforcement, QA strategy or release-readiness gates, long-form documentation, diagram production, or orchestration. Keep those boundaries with the owning specialist named in the handoff section below.
+
+## Validation Expectations
+
+- Base Cloak findings on the reviewed UI artifact, screen, design-system evidence, screenshot, or source material that actually exists.
+- Keep claims limited to confirmed visual, accessibility, interaction, and user-facing state evidence. Do not claim implementation or validation results that were not reviewed or run.
+- When downstream implementation or release validation is needed, keep Cloak scoped to the design requirement and hand off execution or validation ownership to Ponytail or Overseer as already defined.
+
 ## Output formats
 
 Load `OUTPUT_FORMATS.md` when ready to generate the final response. Use the template that matches the selected mode:

--- a/skills/scribe/OUTPUT_FORMATS.md
+++ b/skills/scribe/OUTPUT_FORMATS.md
@@ -1,6 +1,6 @@
 # Output Formats
 
-## MODE 1: Long Documentation
+## Mode 1
 
 Use for final documentation or detailed audits.
 
@@ -45,7 +45,7 @@ Reason:
 ## Final Recommendation
 ```
 
-## MODE 2: Standard Documentation
+## Mode 2
 
 Use for standard documentation audits.
 
@@ -70,7 +70,7 @@ Confidence Level: High / Medium / Low
 -
 ```
 
-## MODE 3: Short Documentation
+## Mode 3
 
 Use for quick audits.
 


### PR DESCRIPTION
## Summary

Cleans up the final cross-specialist consistency drift after the specialist normalization pass.

## Changes

- Aligned Scribe output-format headings with declared format names: `Mode 1`, `Mode 2`, and `Mode 3`.
- Updated both source and tracked Codex export copies of Scribe output formats.
- Added a compact `Role Boundaries` section to Cloak.
- Added a compact `Validation Expectations` section to Cloak.
- Preserved Cloak’s existing routing, workflow stages, handoff ownership, and output modes.
- Added a changelog entry for the consistency cleanup.

## Validation

- `python scripts/validate_structure.py`
- `python scripts/validate_manifest.py`
- `python scripts/check_stale_references.py`
- `python scripts/governance_check.py --strict`
- `python adapters/codex/validate_codex_export.py`
- `git diff --check`

## Scope

Documentation-only consistency cleanup. No runtime, manifest, metadata, test, CI, validation-script, routing-policy, governance-policy, export-validator, or unrelated specialist changes.