### PR TITLE
docs(governance): define strictness level mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Portable Runtime is the first Orchestra release that normalizes the repository a
 - Added a shared `docs/project/SPECIALIST_AUTHORING_STANDARD.md` reference for future specialist authoring, with short cross-links from contributing, plugin-readiness, and manifest-schema documentation.
 
 ### Changed
+- Clarified Governance Strictness Levels as a derived scale over existing project type, operating mode, release stage, and risk classifications without changing governance semantics.
 - Integrated Release Mode governance docs so The Governor now treats app release compliance artifacts as required when applicable and returns `REVISION_REQUIRED` or `BLOCKED` when release-gate documentation is missing.
 - Strengthened Cloak's documentation-only frontend review contract with artifact-evidence requirements, clearer form and validation messaging review, explicit loading/empty/error/success/retry/permission-state review, sharper frontend handoff blueprint guidance, and matching tracked Codex export parity for the updated Cloak docs.
 - Normalized Conductor's skill documentation against the shared specialist authoring standard by clarifying activation conditions, supported work, scope enforcement, validation expectations, local-only safety, and direct-route versus orchestration versus reroute guidance, with matching tracked Codex export parity.

--- a/docs/governance/GOVERNANCE_LAYER.md
+++ b/docs/governance/GOVERNANCE_LAYER.md
@@ -160,6 +160,85 @@ Next Recommended Step:
 | `MEDIUM` | Internal tool, team project, third-party deps, limited exposure | Standard |
 | `HIGH` | Public release, PII, payments, AI outputs, legal/health/finance domain, commercial use | Expanded + human review |
 
+## Governance Strictness Levels
+
+Governance Strictness Levels (`GSL-0` through `GSL-5`) are a **derived scale**, not a new required project-context field. They do not replace `Project Type`, `Operating Mode`, `Release Stage`, `Risk Level`, `Data Sensitivity`, or any existing governance decision values. They normalize the existing inputs into a single shorthand for review depth, evidence expectations, and specialist involvement.
+
+Derivation rule:
+
+```text
+Governance Strictness Level = max(applicable mode baseline, release trigger, risk trigger, compliance/data trigger, continuity trigger)
+```
+
+Interpretation rules:
+- `Operating Mode` is the task-intent baseline.
+- `Release Stage` is the product or repository lifecycle state.
+- Other triggers may raise the derived level above the mode baseline.
+- Existing decision meanings remain unchanged: `APPROVED`, `ADVISORY_ONLY`, `REVISION_REQUIRED`, `BLOCKED`, `NOT_APPLICABLE`, `READY`, `READY_WITH_MINOR_FIXES`, and `HOLD` keep their current semantics.
+
+### Mode Baseline
+
+| Operating Mode | Typical Baseline |
+|---|---|
+| `Ideation` | `GSL-0` |
+| `Prototype` | `GSL-1` |
+| `Implementation` | `GSL-2` |
+| `Audit` | `GSL-3` |
+| `Release` | `GSL-4` |
+
+### Trigger Mapping Guide
+
+| Input or Trigger | Typical Signals | Derived Contribution |
+|---|---|---|
+| `Project Type` | `school`, `personal`, local `research` | Usually `GSL-0` to `GSL-2` |
+| `Project Type` | `internal`, team `open-source` development | Usually `GSL-2` to `GSL-3` |
+| `Project Type` | `commercial`, `client-facing`, public `open-source` distribution | Usually `GSL-3` to `GSL-4` |
+| `Operating Mode` | intent classification only | Sets the baseline before other triggers apply |
+| `Release Stage` | `prototype` | Usually `GSL-1` |
+| `Release Stage` | `development` | Usually `GSL-2` |
+| `Release Stage` | `staging` | Usually `GSL-3` |
+| `Release Stage` | `production` or externally committed `maintenance` | Usually `GSL-4`, or `GSL-5` if other high-impact triggers apply |
+| `LOW` / `MEDIUM` / `HIGH` Risk Level | existing risk model | `LOW` usually keeps work in `GSL-1` to `GSL-2`; `MEDIUM` often raises to `GSL-2` to `GSL-3`; `HIGH` often raises to `GSL-3` to `GSL-4` |
+| `Data Sensitivity` | `none`, `low`, non-sensitive | Usually no raise beyond `GSL-0` to `GSL-2` |
+| `Data Sensitivity` | `medium`, `sensitive` | Often raises to `GSL-2` or `GSL-3` |
+| `Data Sensitivity` | `high`, `PII`, `financial`, `health` | Often raises to `GSL-4` or `GSL-5` |
+| `Public Exposure` | local-only, private, internal-only | Usually no raise beyond `GSL-0` to `GSL-2` |
+| `Public Exposure` | client demo, limited external access, public claims, beta | Often raises to `GSL-3` |
+| `Public Exposure` | public release, external distribution, production-facing operation | Often raises to `GSL-4` or `GSL-5` |
+| `Compliance or Legal Sensitivity` | basic attribution or ordinary dependency review | Usually `GSL-1` to `GSL-2` |
+| `Compliance or Legal Sensitivity` | contractual review, privacy review, license compatibility, IP clearance | Often raises to `GSL-3` or `GSL-4` |
+| `Compliance or Legal Sensitivity` | regulated domain, uncertain obligations, or `human_review_required: true` | Raises to `GSL-5` |
+| `Destructive Potential` | no destructive path in scope | No raise by itself |
+| `Destructive Potential` | guarded local simulation, negative-path chaos work, Dagger review | Often raises to `GSL-3` or `GSL-4` when relevant |
+| `Destructive Potential` | live destructive path requested | Treat as high strictness. Dagger remains simulation-only here unless separately approved through its own guardrails |
+| `Continuity or Validation Gaps` | none | No raise by itself |
+| `Continuity or Validation Gaps` | missing validation, unclear source of truth, handoff risk, branch uncertainty | Often raises to `GSL-2` or `GSL-3` |
+| `Continuity or Validation Gaps` | unresolved evidence dispute, release handoff uncertainty, blocked source-of-truth conflict | Often raises to `GSL-4` or `GSL-5` until resolved |
+
+### Typical Profiles
+
+| Governance Strictness Level | Typical Profile |
+|---|---|
+| `GSL-0` | Ideation, brainstorming, rough planning, no blocking governance path |
+| `GSL-1` | School work, personal sandbox, local prototype, low-risk exploratory work |
+| `GSL-2` | Normal governed implementation with known context and limited exposure |
+| `GSL-3` | Elevated governance because of audit scope, staging, public claims, client-facing work, or material risk triggers |
+| `GSL-4` | Release-critical, production-facing, client delivery, public distribution, or other blocking governance path |
+| `GSL-5` | Maximum governance strictness due to compliance-sensitive domains, human review, destructive risk, or unresolved release evidence conflicts |
+
+### Specialist Involvement by GSL
+
+| Governance Strictness Level | Steward | Governor | Arbiter | Overseer | Dagger |
+|---|---|---|---|---|---|
+| `GSL-0` | Context hygiene only | Usually not required | Only if conflict exists | Optional | Not used |
+| `GSL-1` | Light continuity check | Advisory | Optional | Basic validation | Not used |
+| `GSL-2` | Required context check | Conditional | Conflict resolution if needed | Standard checks | Simulation only if relevant |
+| `GSL-3` | Required | Required for release/public claims or material compliance triggers | Required for unresolved conflicts or continuation gaps | Strict validation | Guardrail simulation if risky |
+| `GSL-4` | Required | Required and blocking | Required for evidence disputes, handoff risk, merge risk, or release uncertainty | Strict validation plus evidence | Required simulation when destructive potential exists; no live destructive execution |
+| `GSL-5` | Required | Maximum gate authority | Required for conflicts or source-of-truth disputes | Strict release readiness | Required guardrail proof; live destructive execution blocked unless separately approved |
+
+`GSL` changes review depth and specialist participation only. It does not create new decision values and does not override existing skill boundaries.
+
 ## Authority Flow
 
 1. **Request enters** the system.

--- a/docs/governance/GOVERNANCE_REVIEW_FLOW.md
+++ b/docs/governance/GOVERNANCE_REVIEW_FLOW.md
@@ -2,6 +2,14 @@
 
 Every request passes through this flow before execution begins. Review depth scales to project risk and the active operating mode.
 
+## Governance Strictness Derivation Note
+
+Governance strictness is derived from the highest applicable trigger, not from a new input field. `Operating Mode` identifies task intent, while `Release Stage` identifies lifecycle state. The flow below does not change: the derived strictness only explains why a given request stays on a lightweight path or escalates to stricter governance depth.
+
+```text
+Governance Strictness Level = max(applicable mode baseline, release trigger, risk trigger, compliance/data trigger, continuity trigger)
+```
+
 ## Standard User Flow
 
 ```
@@ -114,6 +122,7 @@ Arbiter returns `READY`, `READY_WITH_MINOR_FIXES`, `HOLD`, or `BLOCKED`. `HOLD` 
 - Release Mode includes final release-gate review before public release, client delivery, production deployment, app store submission, or open-source distribution.
 - For app release workflows, The Governor must review the [App Release Compliance Gate](APP_RELEASE_COMPLIANCE_GATE.md).
 - Missing required privacy, data inventory, retention, deletion, account deletion documentation when accounts exist, platform disclosures, or IP clearance artifacts must return `REVISION_REQUIRED` or `BLOCKED`, depending on release context and severity.
+- Release Mode is task intent. `production` is release-stage state. They are related inputs, but they are not synonyms.
 
 ## Re-submission
 

--- a/docs/governance/GOVERNOR.md
+++ b/docs/governance/GOVERNOR.md
@@ -1,6 +1,6 @@
-# The Governor — Reference Summary
+# The Governor - Reference Summary
 
-> **Authoritative behavior is defined in [`skills/the-governor/SKILL.md`](../../.agents/skills/the-governor/SKILL.md).** This document is a human-facing quick reference only. Do not use it as a behavior source of truth.
+> **Authoritative behavior is defined in [`skills/the-governor/SKILL.md`](../../skills/the-governor/SKILL.md).** This document is a human-facing quick reference only. Do not use it as a behavior source of truth.
 
 The Governor is the legal, compliance, privacy, IP, copyright, and licensing governance authority. It sits above the Conductor and reviews every request after the Steward approves it.
 
@@ -16,6 +16,18 @@ The Governor is the legal, compliance, privacy, IP, copyright, and licensing gov
 **Risk levels**: `LOW` (lightweight), `MEDIUM` (standard), `HIGH` (expanded with human review).
 
 Sets `human_review_required: true` when legal interpretation is uncertain, regulatory applicability is unclear, license compatibility cannot be confirmed, or public release has compliance implications.
+
+## Governance Strictness Levels
+
+The Governor participates according to the derived `GSL` level:
+- `GSL-0`: usually not required unless a clear compliance or legal trigger is already present.
+- `GSL-1`: advisory or lightweight review.
+- `GSL-2`: conditional or standard review for privacy, licensing, dependencies, attribution, and compliance-sensitive changes.
+- `GSL-3`: required review for public claims, client-facing exposure, release-adjacent work, or material data/compliance triggers.
+- `GSL-4`: required and blocking review for release, public distribution, client delivery, production-facing release work, or equivalent high-impact exposure.
+- `GSL-5`: maximum gate authority when compliance sensitivity is high, legal or regulatory interpretation is uncertain, or `human_review_required: true` is triggered.
+
+The Governor owns compliance, privacy, IP, licensing, release/compliance review, and `human_review_required`. The Governor does not own business scope, implementation, validation execution, or routing.
 
 ## Release Mode App Compliance
 

--- a/docs/governance/RELEASE_GATES.md
+++ b/docs/governance/RELEASE_GATES.md
@@ -4,6 +4,15 @@ Release gates enforce governance compliance before any release. **Release Mode**
 
 For app, marketplace, and other public software releases, The Governor must also verify the [App Release Compliance Gate](APP_RELEASE_COMPLIANCE_GATE.md).
 
+## Governance Strictness Note
+
+Release Mode usually maps to `GSL-4` or `GSL-5`, depending on public exposure, data sensitivity, compliance sensitivity, and human-review triggers.
+
+`Release Mode` and `production` are related but not synonymous:
+- `Release Mode` is the active task intent for release, distribution, deployment, or delivery work.
+- `production` is a release-stage lifecycle state in the project context.
+- A production issue may still be handled outside Release Mode until a release or distribution step begins, while staging or external-delivery work may still enter Release Mode before production.
+
 ## Pre-Release Checklist
 
 | Gate | Authority | Must Pass |

--- a/docs/governance/STEWARD.md
+++ b/docs/governance/STEWARD.md
@@ -1,6 +1,6 @@
-# The Steward — Reference Summary
+# The Steward - Reference Summary
 
-> **Authoritative behavior is defined in [`skills/the-steward/SKILL.md`](../../.agents/skills/the-steward/SKILL.md).** This document is a human-facing quick reference only. Do not use it as a behavior source of truth.
+> **Authoritative behavior is defined in [`skills/the-steward/SKILL.md`](../../skills/the-steward/SKILL.md).** This document is a human-facing quick reference only. Do not use it as a behavior source of truth.
 
 The Steward is the business alignment, scope, requirements, and SDLC governance authority. It sits above the Conductor and reviews every request before it reaches the Conductor.
 
@@ -14,6 +14,18 @@ The Steward is the business alignment, scope, requirements, and SDLC governance 
 | `NOT_APPLICABLE` | Trivial request, passes through |
 
 **Risk levels**: `LOW` (objective and scope check), `MEDIUM` (full requirements and acceptance criteria), `HIGH` (stakeholder alignment, traceability, success metrics).
+
+## Governance Strictness Levels
+
+The Steward participates according to the derived `GSL` level:
+- `GSL-0`: context hygiene only.
+- `GSL-1`: light objective, scope, and continuity-hygiene check.
+- `GSL-2`: required context, scope, requirements, and SDLC-alignment check.
+- `GSL-3`: required full requirements, scope, and documentation alignment review.
+- `GSL-4`: required and blocking review for release, business readiness, or other high-impact governed work.
+- `GSL-5`: maximum strictness for complete objective, scope, traceability, and documentation readiness before governance-heavy work proceeds.
+
+The Steward owns objectives, scope, requirements, SDLC alignment, and continuity hygiene for sufficient context and documentation to continue safely. Arbiter still owns continuation verdicts, source-of-truth disputes, branch safety, and handoff readiness. The Steward does not own legal/compliance/IP review, implementation, validation execution, or routing.
 
 ## Boundaries
 

--- a/docs/setup/VALIDATION.md
+++ b/docs/setup/VALIDATION.md
@@ -12,6 +12,8 @@ Orchestra's rules are divided into clear enforcement levels to distinguish betwe
 - **Level 5: CI release gate**. (Enforced in CI) Build pipeline fails if structural validation or strict guardrails fail.
 - **Level 6: Host-integrated runtime blocker**. (Future) Host platform forcibly blocks output if policies are violated.
 
+These validation enforcement levels are separate from the governance-facing `Governance Strictness Levels` (`GSL-0` through `GSL-5`) described in `docs/governance/`. The enforcement ladder describes how validation is applied programmatically. The `GSL` scale describes derived governance review depth from existing project context. The two ladders should not be treated as interchangeable.
+
 ---
 
 ## 1. Primary Behavior Validation Runner (`run_tests.py`)


### PR DESCRIPTION
## Summary

Adds a docs-only Governance Strictness Levels clarification that maps existing Orchestra governance categories into a derived `GSL-0` through `GSL-5` scale.

This does not replace the existing Project Type, Operating Mode, Release Stage, or LOW/MEDIUM/HIGH Risk Level model. It clarifies how those existing inputs combine to determine governance strictness.

## Changes

- Added `Governance Strictness Levels` to `docs/governance/GOVERNANCE_LAYER.md`.
- Defined `GSL-0` through `GSL-5` as a derived governance scale.
- Added the derivation rule:

  `Governance Strictness Level = max(applicable mode baseline, release trigger, risk trigger, compliance/data trigger, continuity trigger)`

- Added trigger mapping for:
  - project type
  - operating mode
  - release stage
  - risk level
  - data sensitivity
  - public exposure
  - compliance or legal sensitivity
  - destructive potential
  - continuity or validation gaps
- Added a specialist involvement matrix for Steward, Governor, Arbiter, Overseer, and Dagger.
- Clarified derivation behavior in `GOVERNANCE_REVIEW_FLOW.md`.
- Clarified Release Mode mapping in `RELEASE_GATES.md`.
- Added GSL quick-reference notes to `GOVERNOR.md` and `STEWARD.md`.
- Corrected source-of-truth references from runtime `.agents` paths to repo-source `skills/...` paths.
- Added a collision-avoidance note in `docs/setup/VALIDATION.md` explaining that validation enforcement levels are separate from Governance Strictness Levels.
- Added a focused changelog entry.

## Scope

Documentation-only clarification.

No changes were made to:

- skills
- adapters
- tests
- scripts
- CI workflows
- runtime behavior
- plugin metadata
- routing policy
- decision vocabulary
- Dagger guardrail behavior

## Validation

- `python scripts/preflight_sync_check.py` before editing
- `python scripts/validate_structure.py`
- `python scripts/validate_manifest.py`
- `python scripts/check_stale_references.py`
- `python scripts/governance_check.py --strict`
- `python tests/behavior/evaluate_governance.py`
- `git diff --check`

## Notes

`python scripts/preflight_sync_check.py` passed before editing. After editing, it reported `BLOCKED` because the worktree contained the intended documentation changes. That is expected behavior for this guard.

`git diff --check` passed. LF/CRLF working-copy warnings were printed but did not block validation.

A later amend attempt was blocked by generated Python bytecode under `scripts/__pycache__`, not by the documentation patch. The original commit was already valid and has been pushed.