### PR TITLE
docs(governance): clarify authority boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Portable Runtime is the first Orchestra release that normalizes the repository a
 - Added a shared `docs/project/SPECIALIST_AUTHORING_STANDARD.md` reference for future specialist authoring, with short cross-links from contributing, plugin-readiness, and manifest-schema documentation.
 
 ### Changed
+- Clarified governance authority boundaries for Arbiter status vocabulary, Steward hygiene wording, and Governor/Cipher release-security ownership without changing governance semantics.
 - Clarified Governance Strictness Levels as a derived scale over existing project type, operating mode, release stage, and risk classifications without changing governance semantics.
 - Integrated Release Mode governance docs so The Governor now treats app release compliance artifacts as required when applicable and returns `REVISION_REQUIRED` or `BLOCKED` when release-gate documentation is missing.
 - Strengthened Cloak's documentation-only frontend review contract with artifact-evidence requirements, clearer form and validation messaging review, explicit loading/empty/error/success/retry/permission-state review, sharper frontend handoff blueprint guidance, and matching tracked Codex export parity for the updated Cloak docs.

--- a/docs/governance/GOVERNANCE_LAYER.md
+++ b/docs/governance/GOVERNANCE_LAYER.md
@@ -231,11 +231,11 @@ Interpretation rules:
 | Governance Strictness Level | Steward | Governor | Arbiter | Overseer | Dagger |
 |---|---|---|---|---|---|
 | `GSL-0` | Context hygiene only | Usually not required | Only if conflict exists | Optional | Not used |
-| `GSL-1` | Light continuity check | Advisory | Optional | Basic validation | Not used |
-| `GSL-2` | Required context check | Conditional | Conflict resolution if needed | Standard checks | Simulation only if relevant |
-| `GSL-3` | Required | Required for release/public claims or material compliance triggers | Required for unresolved conflicts or continuation gaps | Strict validation | Guardrail simulation if risky |
-| `GSL-4` | Required | Required and blocking | Required for evidence disputes, handoff risk, merge risk, or release uncertainty | Strict validation plus evidence | Required simulation when destructive potential exists; no live destructive execution |
-| `GSL-5` | Required | Maximum gate authority | Required for conflicts or source-of-truth disputes | Strict release readiness | Required guardrail proof; live destructive execution blocked unless separately approved |
+| `GSL-1` | Light objective, requirements, and documentation hygiene check | Advisory | Optional | Basic validation | Not used |
+| `GSL-2` | Required context, objective, requirements, and documentation hygiene check | Conditional | Conflict resolution if needed | Standard checks | Simulation only if relevant |
+| `GSL-3` | Required full objective, scope, requirements, and documentation hygiene review | Required for release/public claims or material compliance triggers | Required for unresolved conflicts or continuation gaps | Strict validation | Guardrail simulation if risky |
+| `GSL-4` | Required and blocking objective, scope, requirements, and documentation readiness review | Required and blocking | Required for evidence disputes, handoff risk, merge risk, or release uncertainty | Strict validation plus evidence | Required simulation when destructive potential exists; no live destructive execution |
+| `GSL-5` | Maximum strictness for objective, scope, requirements, traceability, and documentation readiness | Maximum gate authority | Required for conflicts or source-of-truth disputes | Strict release readiness | Required guardrail proof; live destructive execution blocked unless separately approved |
 
 `GSL` changes review depth and specialist participation only. It does not create new decision values and does not override existing skill boundaries.
 
@@ -268,6 +268,8 @@ The Governor adds `human_review_required` for uncertain legal, regulatory, priva
 
 Arbiter adds continuation verdicts: `READY`, `READY_WITH_MINOR_FIXES`, `HOLD`, and `BLOCKED`.
 
+For governance-effectiveness calibration, Arbiter may also use `READY_WITH_REQUIRED_FIXES`. This does not replace the continuation verdict set above and does not create a new governance decision meaning.
+
 ## Default Output Format
 
 ```
@@ -294,7 +296,7 @@ REQUIRED_ACTIONS: [actions needed or "none"]
 |---|---|---|
 | The Steward | Business goals, scope, requirements, SDLC | Legal, compliance, IP, licensing, implementation |
 | The Governor | Legal, compliance, privacy, IP, licensing | Business alignment, scope, implementation |
-| Arbiter | Continuity, validation state, branch safety, source of truth, handoff readiness | Feature implementation, architecture design, legal compliance, business scope |
+| Arbiter | Continuity, validation state, branch safety, source of truth, handoff and merge readiness | Feature implementation, architecture design, legal compliance, business scope |
 | Conductor | Routing, orchestration, skill selection | Governance decisions, implementation |
 | Execution Skills | Implementation, code changes | Governance, routing |
 

--- a/docs/governance/GOVERNOR.md
+++ b/docs/governance/GOVERNOR.md
@@ -9,6 +9,7 @@ The Governor is the legal, compliance, privacy, IP, copyright, and licensing gov
 | Decision | Meaning |
 |---|---|
 | `APPROVED` | Passes to the Conductor |
+| `ADVISORY_ONLY` | Advice given, exploration unblocked |
 | `REVISION_REQUIRED` | Returns with remediation steps |
 | `BLOCKED` | Conductor cannot proceed |
 | `NOT_APPLICABLE` | No compliance concerns identified |
@@ -27,7 +28,9 @@ The Governor participates according to the derived `GSL` level:
 - `GSL-4`: required and blocking review for release, public distribution, client delivery, production-facing release work, or equivalent high-impact exposure.
 - `GSL-5`: maximum gate authority when compliance sensitivity is high, legal or regulatory interpretation is uncertain, or `human_review_required: true` is triggered.
 
-The Governor owns compliance, privacy, IP, licensing, release/compliance review, and `human_review_required`. The Governor does not own business scope, implementation, validation execution, or routing.
+The Governor owns governance and compliance sufficiency, privacy, IP, licensing obligations, release-gate implications, and `human_review_required`. The Governor does not own technical defensive security review, implementation, routing, or business-scope decisions.
+
+Technical security, authorization, threat, and privacy-exposure review routes to `Cipher`.
 
 ## Release Mode App Compliance
 

--- a/docs/governance/RELEASE_GATES.md
+++ b/docs/governance/RELEASE_GATES.md
@@ -40,6 +40,8 @@ Release Mode usually maps to `GSL-4` or `GSL-5`, depending on public exposure, d
 | No unresolved Arbiter `HOLD` verdicts | Arbiter | Yes |
 | No pending `human_review_required` flags | The Governor | Yes |
 
+For release gating, The Governor decides whether security, privacy, and compliance governance is sufficiently addressed to proceed. `Cipher` owns the technical defensive security review, security-control findings, and related remediation boundaries that may feed that release decision.
+
 ## Gate Enforcement
 
 - **Release Mode Enforcement**: The Conductor and Governance authorities (The Steward, The Governor, and Arbiter) enforce complete Basis of Review and continuation-state checks for all release activities. Bypassing compliance, scope, validation, or continuity checks is prohibited.

--- a/docs/governance/STEWARD.md
+++ b/docs/governance/STEWARD.md
@@ -9,6 +9,7 @@ The Steward is the business alignment, scope, requirements, and SDLC governance 
 | Decision | Meaning |
 |---|---|
 | `APPROVED` | Passes to the Governor |
+| `ADVISORY_ONLY` | Advice given, exploration unblocked |
 | `REVISION_REQUIRED` | Returns to requester with findings |
 | `BLOCKED` | Conductor cannot proceed |
 | `NOT_APPLICABLE` | Trivial request, passes through |
@@ -19,13 +20,13 @@ The Steward is the business alignment, scope, requirements, and SDLC governance 
 
 The Steward participates according to the derived `GSL` level:
 - `GSL-0`: context hygiene only.
-- `GSL-1`: light objective, scope, and continuity-hygiene check.
+- `GSL-1`: light objective, scope, requirements, and documentation-hygiene check.
 - `GSL-2`: required context, scope, requirements, and SDLC-alignment check.
 - `GSL-3`: required full requirements, scope, and documentation alignment review.
 - `GSL-4`: required and blocking review for release, business readiness, or other high-impact governed work.
 - `GSL-5`: maximum strictness for complete objective, scope, traceability, and documentation readiness before governance-heavy work proceeds.
 
-The Steward owns objectives, scope, requirements, SDLC alignment, and continuity hygiene for sufficient context and documentation to continue safely. Arbiter still owns continuation verdicts, source-of-truth disputes, branch safety, and handoff readiness. The Steward does not own legal/compliance/IP review, implementation, validation execution, or routing.
+The Steward owns business alignment, objectives, scope, requirements, acceptance criteria, and SDLC documentation, plus the context, objective, requirements, and documentation hygiene needed for governance review. Arbiter owns continuity verdicts, validation state, source-of-truth conflicts, branch safety, and handoff and merge readiness. The Steward does not own legal/compliance/IP review, implementation, validation execution, or routing.
 
 ## Boundaries
 


### PR DESCRIPTION
## Summary

Clarifies governance authority boundaries across the governance documentation without changing governance semantics.

## Changes

- Clarified Arbiter’s status vocabulary in the governance layer.
- Preserved Arbiter’s continuation verdict set:
  - `READY`
  - `READY_WITH_MINOR_FIXES`
  - `HOLD`
  - `BLOCKED`
- Added a calibration-only note for Arbiter’s `READY_WITH_REQUIRED_FIXES` usage.
- Reworded Steward references from “continuity hygiene” to context, objective, requirements, and documentation hygiene.
- Preserved Arbiter as the owner of continuity verdicts, validation state, source-of-truth conflicts, branch safety, and handoff/merge readiness.
- Clarified Governor vs Cipher release-security ownership:
  - Governor owns governance/compliance sufficiency and release-gate implications.
  - Cipher owns technical defensive security review and security-control findings.
- Added the required changelog entry.

## Scope

Documentation-only clarification.

No changes were made to:

- skills
- adapters
- tests
- scripts
- CI workflows
- runtime behavior
- plugin metadata
- routing policy
- decision vocabulary
- Dagger live-execution restrictions

## Validation

- `python scripts/preflight_sync_check.py`
- `python scripts/validate_structure.py`
- `python scripts/validate_manifest.py`
- `python scripts/check_stale_references.py`
- `python scripts/governance_check.py --strict`
- `python tests/behavior/evaluate_governance.py`
- `git diff --check`

## Notes

`git diff --check` passed. LF-to-CRLF working-copy warnings were reported but did not block validation.

This patch clarifies documentation boundaries only. It does not add new enforcement beyond the existing validators.