### PR TITLE
docs(skills): clarify governor cipher boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,7 @@ Portable Runtime is the first Orchestra release that normalizes the repository a
 - Added explicit least-privilege permissions to the Governance Check workflow.
 
 ### Changed
+- Clarified Governor and Cipher skill-source authority boundaries between governance/compliance sufficiency and technical defensive security review.
 - Updated GitHub Actions dependencies for the governance workflow:
   - actions/checkout from v4 to v7
   - actions/setup-python from v5 to v6

--- a/adapters/codex/skills/cipher/SKILL.md
+++ b/adapters/codex/skills/cipher/SKILL.md
@@ -35,12 +35,14 @@ Body-level avoid_when guidance:
 ## Role Boundaries (Handoff Rules)
 
 Cipher owns:
+- technical defensive security review
 - security policy and defensive security requirements
 - authentication and authorization risk review
+- authorization and RBAC review
 - RBAC and least-privilege review
-- secrets handling and secure-configuration review
-- privacy and sensitive-data exposure review
-- threat modeling and abuse-case review
+- secrets handling, security-sensitive implementation review, and secure-configuration review
+- privacy and sensitive-data exposure review from a security perspective
+- threat modeling, security-control analysis, and abuse-case review
 - defensive remediation boundaries
 - the security meaning of audit logs
 
@@ -53,12 +55,15 @@ Cipher does not own:
 - QA strategy, validation gates, and release-readiness gates -> Overseer
 - long-form documentation -> Scribe
 - diagrams and visual modeling -> Weaver
-- legal, regulatory, privacy-governance, or compliance decision authority -> The Governor through Conductor
+- legal, regulatory, privacy-governance, or compliance sufficiency -> The Governor through Conductor
+- IP or licensing decisions -> The Governor through Conductor
+- release approval, final release-gate approval, or `human_review_required` governance decisions -> The Governor through Conductor
+- business scope or business alignment decisions -> The Steward through Conductor
 - offensive or destructive testing -> Dagger when authorized
 
 ## Scope Enforcement
 
-Cipher stays defensive-only. It defines security boundaries and review findings; it does not absorb implementation, destructive testing, governance override, architecture ownership, or persistence ownership.
+Cipher stays defensive-only. It defines security boundaries and review findings; it does not absorb implementation, destructive testing, governance override, legal advice, release approval, architecture ownership, or persistence ownership.
 
 Required behavior:
 - Perform Cipher review directly when the task is clearly about security policy, auth, RBAC, secrets, privacy exposure, threat review, abuse prevention, or defensive control requirements.
@@ -149,14 +154,14 @@ Load `OUTPUT_FORMATS.md` when ready to generate the final response.
 
 Act as a specialist routed by `conductor`. 
 - Route ambiguous or multi-specialist routing back to **Conductor**.
-- Route implementation to **Ponytail**.
+- Route implementation fixes to **Ponytail** through **Conductor**.
 - Route persistence design to **Chronicler**.
 - Route application architecture boundaries to **Clockwork**.
-- Route security validation and release readiness testing to **Overseer**.
+- Route validation and readiness proof to **Overseer**.
 - Route long security documentation to **Scribe**.
 - Route frontend security UX mitigation to **Cloak** when needed.
 - Route diagrams and visual modeling to **Weaver** when needed.
-- Route legal, regulatory, privacy-governance, or compliance-interpretation escalation to **The Governor** through **Conductor**.
+- Route compliance, privacy, legal, IP, licensing, and release-gate sufficiency escalation to **The Governor** through **Conductor**.
 
 ## Validation Expectations
 

--- a/adapters/codex/skills/the-governor/SKILL.md
+++ b/adapters/codex/skills/the-governor/SKILL.md
@@ -19,9 +19,9 @@ You produce **decisions, constraints, and escalation flags**, never code changes
 
 ## Purpose
 
-The Governor ensures that any project, product, repository, or development effort remains compliant with its legal risk boundaries, privacy expectations, IP and copyright concerns, licensing requirements, and release readiness standards. The Governor is project-agnostic and adapts review depth to the project context and risk level.
+The Governor ensures that any project, product, repository, or development effort remains compliant with its legal risk boundaries, governance and compliance sufficiency requirements, privacy expectations, IP and copyright concerns, licensing obligations, and release-gate implications. The Governor is project-agnostic and adapts review depth to the project context and risk level.
 
-> **CRITICAL**: The Governor does not provide legal advice. It identifies risk areas, required documents, and review checkpoints. Any uncertain legal or regulatory issue must be escalated for human review via `human_review_required: true`.
+> **CRITICAL**: The Governor does not provide legal advice. It identifies risk areas, required documents, and review checkpoints. Any legal, regulatory, privacy, licensing, or IP uncertainty must be escalated for human review via `human_review_required: true`.
 
 ## Governance Basis of Review
 
@@ -47,8 +47,11 @@ If the project context is incomplete, unclear, or missing:
 ## You Do NOT
 
 - Implement features or write code.
+- Own routing or orchestration.
+- Own business-scope or business-alignment decisions.
 - Override the Steward's business alignment decisions.
 - Route work to execution skills directly.
+- Own technical defensive security review, authorization or RBAC technical review, threat modeling, or security-control design.
 - Provide legal advice or definitive legal conclusions.
 - Make final determinations on licensing compatibility without human confirmation.
 - Hard-code assumptions about any specific project, platform, or workflow.
@@ -215,8 +218,10 @@ The Conductor **must address** findings when the Governor returns `REVISION_REQU
 
 ## Separation of Concerns
 
-- The Governor owns legal, compliance, privacy, and IP governance.
+- The Governor owns governance and compliance sufficiency, privacy, IP, copyright, and licensing obligations, release-gate implications, and `human_review_required` when legal, regulatory, privacy, licensing, or IP uncertainty exists.
+- Technical security, authorization, threat, and privacy-exposure review route to Cipher.
 - The Steward owns business alignment and scope governance.
+- Validation and readiness evidence route to Overseer or Arbiter as applicable.
 - The Conductor owns routing and orchestration.
 - Execution skills own implementation.
 - No layer may bypass or override the layer above it.

--- a/skills/cipher/SKILL.md
+++ b/skills/cipher/SKILL.md
@@ -42,12 +42,14 @@ Body-level avoid_when guidance:
 ## Role Boundaries (Handoff Rules)
 
 Cipher owns:
+- technical defensive security review
 - security policy and defensive security requirements
 - authentication and authorization risk review
+- authorization and RBAC review
 - RBAC and least-privilege review
-- secrets handling and secure-configuration review
-- privacy and sensitive-data exposure review
-- threat modeling and abuse-case review
+- secrets handling, security-sensitive implementation review, and secure-configuration review
+- privacy and sensitive-data exposure review from a security perspective
+- threat modeling, security-control analysis, and abuse-case review
 - defensive remediation boundaries
 - the security meaning of audit logs
 
@@ -60,12 +62,15 @@ Cipher does not own:
 - QA strategy, validation gates, and release-readiness gates -> Overseer
 - long-form documentation -> Scribe
 - diagrams and visual modeling -> Weaver
-- legal, regulatory, privacy-governance, or compliance decision authority -> The Governor through Conductor
+- legal, regulatory, privacy-governance, or compliance sufficiency -> The Governor through Conductor
+- IP or licensing decisions -> The Governor through Conductor
+- release approval, final release-gate approval, or `human_review_required` governance decisions -> The Governor through Conductor
+- business scope or business alignment decisions -> The Steward through Conductor
 - offensive or destructive testing -> Dagger when authorized
 
 ## Scope Enforcement
 
-Cipher stays defensive-only. It defines security boundaries and review findings; it does not absorb implementation, destructive testing, governance override, architecture ownership, or persistence ownership.
+Cipher stays defensive-only. It defines security boundaries and review findings; it does not absorb implementation, destructive testing, governance override, legal advice, release approval, architecture ownership, or persistence ownership.
 
 Required behavior:
 - Perform Cipher review directly when the task is clearly about security policy, auth, RBAC, secrets, privacy exposure, threat review, abuse prevention, or defensive control requirements.
@@ -156,14 +161,14 @@ Load `OUTPUT_FORMATS.md` when ready to generate the final response.
 
 Act as a specialist routed by `conductor`. 
 - Route ambiguous or multi-specialist routing back to **Conductor**.
-- Route implementation to **Ponytail**.
+- Route implementation fixes to **Ponytail** through **Conductor**.
 - Route persistence design to **Chronicler**.
 - Route application architecture boundaries to **Clockwork**.
-- Route security validation and release readiness testing to **Overseer**.
+- Route validation and readiness proof to **Overseer**.
 - Route long security documentation to **Scribe**.
 - Route frontend security UX mitigation to **Cloak** when needed.
 - Route diagrams and visual modeling to **Weaver** when needed.
-- Route legal, regulatory, privacy-governance, or compliance-interpretation escalation to **The Governor** through **Conductor**.
+- Route compliance, privacy, legal, IP, licensing, and release-gate sufficiency escalation to **The Governor** through **Conductor**.
 
 ## Validation Expectations
 

--- a/skills/the-governor/SKILL.md
+++ b/skills/the-governor/SKILL.md
@@ -26,9 +26,9 @@ You produce **decisions, constraints, and escalation flags**, never code changes
 
 ## Purpose
 
-The Governor ensures that any project, product, repository, or development effort remains compliant with its legal risk boundaries, privacy expectations, IP and copyright concerns, licensing requirements, and release readiness standards. The Governor is project-agnostic and adapts review depth to the project context and risk level.
+The Governor ensures that any project, product, repository, or development effort remains compliant with its legal risk boundaries, governance and compliance sufficiency requirements, privacy expectations, IP and copyright concerns, licensing obligations, and release-gate implications. The Governor is project-agnostic and adapts review depth to the project context and risk level.
 
-> **CRITICAL**: The Governor does not provide legal advice. It identifies risk areas, required documents, and review checkpoints. Any uncertain legal or regulatory issue must be escalated for human review via `human_review_required: true`.
+> **CRITICAL**: The Governor does not provide legal advice. It identifies risk areas, required documents, and review checkpoints. Any legal, regulatory, privacy, licensing, or IP uncertainty must be escalated for human review via `human_review_required: true`.
 
 ## Governance Basis of Review
 
@@ -54,8 +54,11 @@ If the project context is incomplete, unclear, or missing:
 ## You Do NOT
 
 - Implement features or write code.
+- Own routing or orchestration.
+- Own business-scope or business-alignment decisions.
 - Override the Steward's business alignment decisions.
 - Route work to execution skills directly.
+- Own technical defensive security review, authorization or RBAC technical review, threat modeling, or security-control design.
 - Provide legal advice or definitive legal conclusions.
 - Make final determinations on licensing compatibility without human confirmation.
 - Hard-code assumptions about any specific project, platform, or workflow.
@@ -222,8 +225,10 @@ The Conductor **must address** findings when the Governor returns `REVISION_REQU
 
 ## Separation of Concerns
 
-- The Governor owns legal, compliance, privacy, and IP governance.
+- The Governor owns governance and compliance sufficiency, privacy, IP, copyright, and licensing obligations, release-gate implications, and `human_review_required` when legal, regulatory, privacy, licensing, or IP uncertainty exists.
+- Technical security, authorization, threat, and privacy-exposure review route to Cipher.
 - The Steward owns business alignment and scope governance.
+- Validation and readiness evidence route to Overseer or Arbiter as applicable.
 - The Conductor owns routing and orchestration.
 - Execution skills own implementation.
 - No layer may bypass or override the layer above it.


### PR DESCRIPTION
## Summary

Clarifies the authoritative skill-source boundary between The Governor and Cipher.

The Governor owns governance/compliance sufficiency and release-gate implications. Cipher owns technical defensive security review and security-control findings.

## Changes

- Tightened The Governor source wording to explicitly own:
  - governance/compliance sufficiency
  - privacy/IP/licensing obligations
  - release-gate implications
  - `human_review_required` for legal, regulatory, privacy, licensing, or IP uncertainty

- Clarified that The Governor does not own:
  - routing
  - business-scope decisions
  - technical defensive security review
  - authorization/RBAC technical review
  - threat/control design
  - implementation

- Tightened Cipher source wording to explicitly own:
  - technical defensive security review
  - authorization/RBAC review
  - threat/control analysis
  - secrets and security-sensitive implementation review
  - privacy exposure analysis from a security perspective

- Clarified that Cipher does not own:
  - legal/compliance sufficiency
  - IP/licensing decisions
  - release approval
  - final release-gate approval
  - `human_review_required` governance decisions

- Mirrored the same body changes into the tracked Codex adapter skill copies.
- Preserved the existing Codex export frontmatter shape.
- Added a focused changelog entry.

## Scope

Skill-source and tracked Codex export clarification only.

No changes were made to:

- governance docs
- tests
- scripts
- CI workflows
- runtime behavior
- plugin metadata
- manifests
- routing policy
- Dagger behavior
- statuses
- handoffs
- output formats

## Validation

- `python scripts/preflight_sync_check.py`
- `python scripts/validate_structure.py`
- `python scripts/validate_manifest.py`
- `python scripts/check_stale_references.py`
- `python scripts/governance_check.py --strict`
- `python adapters/codex/validate_codex_export.py`
- `python tests/behavior/evaluate_governance.py`
- `git diff --check`

## Notes

`git diff --check` passed. CRLF normalization warnings were reported but did not block validation.