### PR TITLE
chore(release): prepare v1.1.0 governance release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "orchestra",
       "source": "./",
       "description": "Governance-first specialist skill framework for routed, auditable AI coding workflows.",
-      "version": "1.0.0"
+      "version": "1.1.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra",
   "description": "Governance-first specialist skill framework for routed, auditable AI coding workflows.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "update_check": {
     "update_check_enabled": true,
     "update_check_channel": "stable",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,16 +15,16 @@ Portable Runtime is the first Orchestra release that normalizes the repository a
 
 ## Pre-release Build History
 
-## Unreleased
+## v1.1.0 - Specialist Governance & Boundary Standard
+
+Specialist Governance & Boundary Standard is a documentation-, governance-, metadata-, and specialist-definition-focused release that builds on the `v1.0.0 Portable Runtime` baseline without changing runtime behavior, routing policy, validation logic, CI workflows, Dagger live-execution behavior, or governance decision semantics.
 
 ### Added
-- Added an App Release Compliance Gate plus reusable privacy review, data inventory, IP clearance, privacy policy, terms, and retention/deletion governance templates for app and public release workflows.
 - Added a shared `docs/project/SPECIALIST_AUTHORING_STANDARD.md` reference for future specialist authoring, with short cross-links from contributing, plugin-readiness, and manifest-schema documentation.
 
 ### Changed
 - Clarified governance authority boundaries for Arbiter status vocabulary, Steward hygiene wording, and Governor/Cipher release-security ownership without changing governance semantics.
 - Clarified Governance Strictness Levels as a derived scale over existing project type, operating mode, release stage, and risk classifications without changing governance semantics.
-- Integrated Release Mode governance docs so The Governor now treats app release compliance artifacts as required when applicable and returns `REVISION_REQUIRED` or `BLOCKED` when release-gate documentation is missing.
 - Strengthened Cloak's documentation-only frontend review contract with artifact-evidence requirements, clearer form and validation messaging review, explicit loading/empty/error/success/retry/permission-state review, sharper frontend handoff blueprint guidance, and matching tracked Codex export parity for the updated Cloak docs.
 - Normalized Conductor's skill documentation against the shared specialist authoring standard by clarifying activation conditions, supported work, scope enforcement, validation expectations, local-only safety, and direct-route versus orchestration versus reroute guidance, with matching tracked Codex export parity.
 - Normalized Ponytail specialist documentation with explicit activation conditions, supported work, scope enforcement, validation expectations, local-only safety, and direct handoff boundaries for implementation-owned code changes, with matching tracked Codex export parity.
@@ -35,6 +35,15 @@ Portable Runtime is the first Orchestra release that normalizes the repository a
 - Normalized Scribe specialist documentation with explicit documentation ownership boundaries, activation conditions, validation expectations, output-format selection, and expanded handoff guidance while preserving its source-backed documentation scope.
 - Normalized Weaver specialist documentation with explicit diagram ownership boundaries, activation conditions, validation expectations, output-format selection, and expanded handoff guidance while preserving its visual-modeling scope.
 - Cleaned up cross-specialist consistency by aligning Scribe output-format headings and adding compact Cloak role-boundary and validation-expectation sections without changing specialist behavior.
+- Clarified Governor and Cipher skill-source authority boundaries between governance/compliance sufficiency and technical defensive security review.
+
+## Unreleased
+
+### Added
+- Added an App Release Compliance Gate plus reusable privacy review, data inventory, IP clearance, privacy policy, terms, and retention/deletion governance templates for app and public release workflows.
+
+### Changed
+- Integrated Release Mode governance docs so The Governor now treats app release compliance artifacts as required when applicable and returns `REVISION_REQUIRED` or `BLOCKED` when release-gate documentation is missing.
 
 ### Changed
 - Clarified optional project governance rulesets so `PROJECT_CONTEXT.md` enforcement depends on project type, risk level, and declared governance level.
@@ -178,7 +187,6 @@ Portable Runtime is the first Orchestra release that normalizes the repository a
 - Added explicit least-privilege permissions to the Governance Check workflow.
 
 ### Changed
-- Clarified Governor and Cipher skill-source authority boundaries between governance/compliance sufficiency and technical defensive security review.
 - Updated GitHub Actions dependencies for the governance workflow:
   - actions/checkout from v4 to v7
   - actions/setup-python from v5 to v6

--- a/README.md
+++ b/README.md
@@ -124,13 +124,13 @@ flowchart LR
 
 Runtime-core-first refactor notes live in [docs/project/OOP_RUNTIME_ARCHITECTURE.md](docs/project/OOP_RUNTIME_ARCHITECTURE.md). The shared `orchestra_runtime/` layer owns manifest parsing, skill loading, routing, governance validation, execution flow, and audit logging, while host adapters stay thin. The versioned Portable Runtime Adapter Protocol is documented in [docs/project/PORTABLE_ADAPTER_PROTOCOL.md](docs/project/PORTABLE_ADAPTER_PROTOCOL.md).
 
-## v1.0.0 Portable Runtime
+## v1.1.0 Specialist Governance & Boundary Standard
 
-`v1.0.0 Portable Runtime` is the first Orchestra release built around a reusable runtime core plus thin host adapters.
+`v1.1.0 Specialist Governance & Boundary Standard` builds on the `v1.0.0 Portable Runtime` baseline with documentation-, governance-, metadata-, and specialist-definition-focused normalization.
 
-- `orchestra_runtime/` is the single source of truth for shared orchestration behavior.
-- `PRAP v1` gives adapters one stable metadata and capability contract.
-- Codex, Claude Code, Antigravity, Cursor, Windsurf, VS Code, JetBrains, Zed, and Neovim all map into shared runtime models without duplicating business logic.
+- Specialist boundaries were normalized across the documented specialist surfaces, with tracked Codex export parity where applicable.
+- Governance strictness levels and authority boundaries were clarified without changing governance semantics.
+- Runtime behavior, routing policy, validation logic, CI workflows, and Dagger live-execution behavior remain unchanged.
 
 ```mermaid
 flowchart LR

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -1,6 +1,6 @@
 # Codex Adapter for Orchestra
 
-This adapter provides a Codex-compatible export of the Orchestra v1.0.0 Portable Runtime skills.
+This adapter provides a Codex-compatible export of the Orchestra `v1.1.0 Specialist Governance & Boundary Standard` skills.
 
 ## Purpose
 

--- a/adapters/cursor/package.json
+++ b/adapters/cursor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-cursor-scaffold",
   "displayName": "Orchestra Cursor Scaffold",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "description": "Scaffold-only Cursor packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/jetbrains/package.json
+++ b/adapters/jetbrains/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-jetbrains-scaffold",
   "displayName": "Orchestra JetBrains Scaffold",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "description": "Scaffold-only JetBrains packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/jetbrains/plugin.xml
+++ b/adapters/jetbrains/plugin.xml
@@ -2,7 +2,7 @@
   <id>com.baelfyre.orchestra.scaffold</id>
   <name>Orchestra JetBrains Scaffold</name>
   <vendor>Baelfyre</vendor>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <description>Scaffold-only JetBrains packaging metadata for Orchestra runtime adapter integration.</description>
   <depends>com.intellij.modules.platform</depends>
   <extensions defaultExtensionNs="com.intellij">

--- a/adapters/neovim/package.json
+++ b/adapters/neovim/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-neovim-scaffold",
   "displayName": "Orchestra Neovim Scaffold",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "description": "Scaffold-only Neovim packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/vscode/package.json
+++ b/adapters/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-vscode-scaffold",
   "displayName": "Orchestra VS Code Scaffold",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "description": "Scaffold-only VS Code packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/windsurf/package.json
+++ b/adapters/windsurf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-windsurf-scaffold",
   "displayName": "Orchestra Windsurf Scaffold",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "description": "Scaffold-only Windsurf packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/zed/package.json
+++ b/adapters/zed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-zed-scaffold",
   "displayName": "Orchestra Zed Scaffold",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "description": "Scaffold-only Zed packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/docs/project/V1_READINESS_CHECKLIST.md
+++ b/docs/project/V1_READINESS_CHECKLIST.md
@@ -1,6 +1,6 @@
-# V1.0.0 Readiness Checklist
+# V1.1.0 Specialist Governance & Boundary Standard Readiness Checklist
 
-Before tagging the `v1.0.0` release of the Orchestra, the following checks must all pass:
+Before tagging the `v1.1.0 Specialist Governance & Boundary Standard` release of the Orchestra, the following checks must all pass:
 
 - [x] **Markdown-first architecture preserved**: No compiled code, binary requirements, or forced dependencies.
 - [x] **All manifest-declared skills present**: The current plugin manifest, skill folders, and command surfaces validate together, including Conductor, governance authorities, specialists, and Ponytail.

--- a/docs/releases/v1.1.0-specialist-governance-boundary-standard.md
+++ b/docs/releases/v1.1.0-specialist-governance-boundary-standard.md
@@ -1,0 +1,63 @@
+# Orchestra v1.1.0: Specialist Governance & Boundary Standard
+
+## Release Summary
+
+`v1.1.0 Specialist Governance & Boundary Standard` prepares the next Orchestra release around specialist-boundary normalization, governance authority clarification, release metadata alignment, and current-release documentation updates.
+
+This release is documentation-, governance-, metadata-, and specialist-definition-focused. It does not change runtime behavior, routing policy, validation logic, CI workflows, Dagger live-execution behavior, or governance decision semantics.
+
+## Release Theme
+
+- Specialist Governance & Boundary Standard
+
+## Completed Scope
+
+- Specialist boundary normalization
+- Specialist authoring standard alignment
+- Cross-specialist consistency cleanup
+- Governance Strictness Levels clarification
+- Governance authority boundary clarification
+- Governor/Cipher authority boundary clarification
+- Codex export parity where applicable
+
+## Governance and Specialist Improvements
+
+- Specialist-facing documentation now uses more explicit ownership boundaries, activation conditions, validation expectations, local-only safety guidance, and handoff rules.
+- Governance documentation now distinguishes authority boundaries and strictness levels more clearly without changing the underlying governance decisions.
+- Release-facing metadata and current-release wording now align on the `1.1.0` release number and `Specialist Governance & Boundary Standard` theme.
+
+## Validation Expectations
+
+Run the release-prep validation baseline on the release branch:
+
+```bash
+git status --short --branch
+python scripts/preflight_sync_check.py
+python scripts/validate_structure.py
+python scripts/validate_manifest.py
+python scripts/check_stale_references.py
+python scripts/governance_check.py --strict
+python adapters/codex/validate_codex_export.py
+python tests/behavior/run_tests.py
+git diff --check
+git diff --stat
+```
+
+`run_tests.py` may print the intentional internal negative-path `SESSION_HANDOFF.md:2: scripts/missing.py` fixture, but the suite is expected to finish with `Validation suite PASSED!` and exit code `0`.
+
+## Non-Goals
+
+- No runtime behavior changes
+- No routing policy changes
+- No validation script or validation logic changes
+- No CI workflow changes
+- No Dagger live-execution behavior changes
+- No governance decision semantic changes
+- No skill behavior changes
+- No adapter contract changes beyond version metadata
+
+## Upgrade and Compatibility Notes
+
+- `v1.1.0` keeps the `v1.0.0 Portable Runtime` compatibility baseline.
+- Supported host and IDE surfaces remain the same as the existing compatibility documentation.
+- Existing install and refresh commands remain unchanged; this release updates metadata and current-release wording rather than host behavior.

--- a/docs/setup/COMPATIBILITY.md
+++ b/docs/setup/COMPATIBILITY.md
@@ -1,6 +1,6 @@
 # Compatibility
 
-Orchestra `v1.0.0 Portable Runtime` is Markdown-first and runtime-core-first. Hosts integrate through thin adapters and, where available, scaffold packaging metadata that points back to the shared runtime.
+Orchestra `v1.1.0 Specialist Governance & Boundary Standard` keeps the Markdown-first, runtime-core-first baseline from `v1.0.0 Portable Runtime`. Hosts still integrate through thin adapters and, where available, scaffold packaging metadata that points back to the shared runtime.
 
 Scaffold-only hosts are not yet full support claims. Promotion requirements and graduation order live in `docs/project/SCAFFOLD_ADAPTER_GRADUATION_CRITERIA.md`.
 

--- a/docs/setup/INSTALLATION.md
+++ b/docs/setup/INSTALLATION.md
@@ -2,9 +2,9 @@
 
 Orchestra can be installed in several ways depending on your AI host or IDE:
 
-## Portable Runtime Release
+## Current Release
 
-`v1.0.0 Portable Runtime` standardizes Orchestra around a shared runtime core plus thin host adapters.
+`v1.1.0 Specialist Governance & Boundary Standard` builds on the `v1.0.0 Portable Runtime` baseline and focuses on documentation, governance, metadata, and specialist-definition normalization.
 
 | Host | Install Surface | Current Status |
 |---|---|---|

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "name": "conductor",
     "display_name": "Orchestra",
     "description": "An installable AI workflow plugin that routes tasks through focused specialist skills. See SKILL_INDEX.md and ROUTING_MAP.md for detailed routing behavior.",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "license": "MIT",
     "repository": "https://github.com/Baelfyre/Orchestra",
     "icon_path": "assets/icons/conductor.ico",


### PR DESCRIPTION
## Summary

Prepares the `v1.1.0 Specialist Governance & Boundary Standard` release.

This is a doc-and-metadata-only release preparation branch. It updates release metadata, adds the v1.1.0 changelog section, creates the dedicated release note, and refreshes active-release wording in the approved user-facing docs.

## Changes

- Bumped approved manifest/package/plugin metadata from `1.0.0` to `1.1.0`.
- Added `## v1.1.0 - Specialist Governance & Boundary Standard` to `CHANGELOG.md`.
- Promoted the relevant specialist/governance bullets out of `Unreleased`.
- Added `docs/releases/v1.1.0-specialist-governance-boundary-standard.md`.
- Updated active-release wording in:
  - `README.md`
  - `adapters/codex/README.md`
  - `docs/setup/INSTALLATION.md`
  - `docs/setup/COMPATIBILITY.md`
  - `docs/project/V1_READINESS_CHECKLIST.md`

## Scope

Doc-and-metadata-only release prep.

No changes were made to:

- `skills/`
- `adapters/codex/skills/`
- `docs/governance/`
- scripts
- tests
- CI workflows
- runtime behavior
- routing policy
- validation logic
- governance semantics
- Dagger live-execution behavior

## Validation

- `python scripts/preflight_sync_check.py`
- `python scripts/validate_structure.py`
- `python scripts/validate_manifest.py`
- `python scripts/check_stale_references.py`
- `python scripts/governance_check.py --strict`
- `python adapters/codex/validate_codex_export.py`
- `python tests/behavior/run_tests.py`
- `git diff --check`

## Notes

`run_tests.py` prints the known intentional negative-path fixture:

`[FAIL] SESSION_HANDOFF.md:2: scripts/missing.py`

The full suite still completed with `Validation suite PASSED!` and exit code `0`.

`git diff --check` passed. LF-to-CRLF working-copy warnings were reported but did not block validation.