### PR TITLE
Harden safe update workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Specialist Governance & Boundary Standard is a documentation-, governance-, meta
 - Integrated Release Mode governance docs so The Governor now treats app release compliance artifacts as required when applicable and returns `REVISION_REQUIRED` or `BLOCKED` when release-gate documentation is missing.
 - Hardened release-surface and startup-state validation by aligning Codex metadata to v1.1.0, removing the drifted example manifest, adding `.codex-plugin/plugin.json` to update consistency checks, and checking structured branch/version claims in repo memory files.
 - Converted PowerShell and shell validation entrypoints into thin wrappers around canonical Python validators to prevent cross-platform validation drift.
+- Hardened update and rollback guidance by requiring fast-forward-only pulls, running canonical validation after updates, and documenting recovery-branch creation before hard resets.
 
 ### Changed
 - Clarified optional project governance rulesets so `PROJECT_CONTEXT.md` enforcement depends on project type, risk level, and declared governance level.

--- a/docs/setup/INSTALLATION.md
+++ b/docs/setup/INSTALLATION.md
@@ -182,12 +182,15 @@ If you prefer to manually handle the update sequence:
 1. Ensure your working tree is clean.
 2. Pull the latest changes:
    ```sh
-   git pull origin main
+   git pull --ff-only origin main
    ```
 3. Run the validation checks manually to ensure metadata and routing consistency:
    ```sh
-   powershell -ExecutionPolicy Bypass -File .\scripts\validate-manifest.ps1
-   powershell -ExecutionPolicy Bypass -File .\scripts\validate-structure.ps1
+   python scripts/validate_structure.py
+   python scripts/validate_manifest.py
+   python scripts/check_stale_references.py
+   python scripts/governance_check.py --strict
+   python adapters/codex/validate_codex_export.py
    ```
 
 ### Rollback Instructions
@@ -195,8 +198,9 @@ If you prefer to manually handle the update sequence:
 If a safe update or manual pull introduces a breaking change or validation failure, you can roll back the repository to the last known good commit:
 
 1. Identify the previous stable commit hash using `git log`.
-2. Reset the repository:
+2. Create a recovery branch and reset the repository:
    ```sh
+   git branch recovery-before-rollback
    git reset --hard <PREVIOUS_COMMIT_HASH>
    ```
 3. Reload or restart your agent workspace (Antigravity or Codex) to revert the ecosystem behavior.

--- a/scripts/update-plugin.ps1
+++ b/scripts/update-plugin.ps1
@@ -65,9 +65,12 @@ try {
 
     if ($DryRun) {
         Write-ColorHost 'WARNING' "[DRY RUN] Would run: git fetch"
-        Write-ColorHost 'WARNING' "[DRY RUN] Would run: git pull origin $currentBranch"
-        Write-ColorHost 'WARNING' "[DRY RUN] Would run: .\scripts\validate-manifest.ps1"
-        Write-ColorHost 'WARNING' "[DRY RUN] Would run: .\scripts\validate-structure.ps1"
+        Write-ColorHost 'WARNING' "[DRY RUN] Would run: git pull --ff-only origin $currentBranch"
+        Write-ColorHost 'WARNING' "[DRY RUN] Would run: python scripts/validate_structure.py"
+        Write-ColorHost 'WARNING' "[DRY RUN] Would run: python scripts/validate_manifest.py"
+        Write-ColorHost 'WARNING' "[DRY RUN] Would run: python scripts/check_stale_references.py"
+        Write-ColorHost 'WARNING' "[DRY RUN] Would run: python scripts/governance_check.py --strict"
+        Write-ColorHost 'WARNING' "[DRY RUN] Would run: python adapters/codex/validate_codex_export.py"
         Write-ColorHost 'SUCCESS' "Dry run complete. No changes made."
         exit 0
     }
@@ -87,7 +90,7 @@ try {
     Write-ColorHost 'INFO' "Pulling latest changes for branch '$currentBranch'..."
     $prevErrorAction = $ErrorActionPreference
     $ErrorActionPreference = "Continue"
-    git pull origin $currentBranch
+    git pull --ff-only origin $currentBranch
     if ($LASTEXITCODE -ne 0) {
         Write-ColorHost 'ERROR' "git pull failed. Please check your network or resolve conflicts manually."
         exit 1
@@ -97,31 +100,25 @@ try {
     # 7. Run validations
     Write-ColorHost 'INFO' "Running validation scripts..."
     
-    $manifestScript = Join-Path $repoRoot "scripts\validate-manifest.ps1"
-    $structureScript = Join-Path $repoRoot "scripts\validate-structure.ps1"
+    Write-ColorHost 'INFO' "Running: python scripts/validate_structure.py"
+    & python scripts/validate_structure.py
+    if ($LASTEXITCODE -ne 0) { Write-ColorHost 'ERROR' "Validation failed! Rollback recommended."; exit 1 }
 
-    $psExe = (Get-Process -Id $PID).Path
-    if (Test-Path $manifestScript) {
-        Write-ColorHost 'INFO' "Validating manifest..."
-        & $psExe -ExecutionPolicy Bypass -File $manifestScript
-        if ($LASTEXITCODE -ne 0) {
-            Write-ColorHost 'ERROR' "Manifest validation failed! Rollback recommended."
-            exit 1
-        }
-    } else {
-        Write-ColorHost 'WARNING' "validate-manifest.ps1 not found."
-    }
+    Write-ColorHost 'INFO' "Running: python scripts/validate_manifest.py"
+    & python scripts/validate_manifest.py
+    if ($LASTEXITCODE -ne 0) { Write-ColorHost 'ERROR' "Validation failed! Rollback recommended."; exit 1 }
 
-    if (Test-Path $structureScript) {
-        Write-ColorHost 'INFO' "Validating structure..."
-        & $psExe -ExecutionPolicy Bypass -File $structureScript
-        if ($LASTEXITCODE -ne 0) {
-            Write-ColorHost 'ERROR' "Structure validation failed! Rollback recommended."
-            exit 1
-        }
-    } else {
-        Write-ColorHost 'WARNING' "validate-structure.ps1 not found."
-    }
+    Write-ColorHost 'INFO' "Running: python scripts/check_stale_references.py"
+    & python scripts/check_stale_references.py
+    if ($LASTEXITCODE -ne 0) { Write-ColorHost 'ERROR' "Validation failed! Rollback recommended."; exit 1 }
+
+    Write-ColorHost 'INFO' "Running: python scripts/governance_check.py --strict"
+    & python scripts/governance_check.py --strict
+    if ($LASTEXITCODE -ne 0) { Write-ColorHost 'ERROR' "Validation failed! Rollback recommended."; exit 1 }
+
+    Write-ColorHost 'INFO' "Running: python adapters/codex/validate_codex_export.py"
+    & python adapters/codex/validate_codex_export.py
+    if ($LASTEXITCODE -ne 0) { Write-ColorHost 'ERROR' "Validation failed! Rollback recommended."; exit 1 }
 
     Write-ColorHost 'SUCCESS' "Update and validation completed successfully!"
     Write-ColorHost 'INFO' "Next Steps:"


### PR DESCRIPTION
## Summary

Implements Wave 3 of the `v1.1.1` post-release hardening track.

This patch hardens the update script and manual update documentation to prevent unintended merge commits, improve post-update validation coverage, and make rollback guidance safer.

## Changes

- Updated `scripts/update-plugin.ps1` to use fast-forward-only pulls:
  - `git pull --ff-only origin $currentBranch`

- Replaced partial wrapper-based post-update validation with canonical Python validators:
  - `python scripts/validate_structure.py`
  - `python scripts/validate_manifest.py`
  - `python scripts/check_stale_references.py`
  - `python scripts/governance_check.py --strict`
  - `python adapters/codex/validate_codex_export.py`

- Updated the script’s `-DryRun` output to reflect the new fast-forward-only pull and canonical validation commands.

- Updated `docs/setup/INSTALLATION.md` manual update instructions to use:
  - `git pull --ff-only origin main`

- Updated manual validation instructions to use the canonical Python validation suite.

- Updated rollback guidance to create a recovery branch before destructive reset:
  - `git branch recovery-before-rollback`
  - `git reset --hard <PREVIOUS_COMMIT_HASH>`

- Added a focused `CHANGELOG.md` entry.

## Scope

This is an update-safety and documentation hardening patch only.

No changes were made to:

- Python validators
- tests
- CI workflows
- runtime behavior
- governance decision semantics
- Dagger live-execution behavior
- routing policy
- skills
- adapter skill exports

## Validation

- `python scripts/preflight_sync_check.py`
- `python scripts/validate_structure.py`
- `python scripts/validate_manifest.py`
- `python scripts/check_stale_references.py`
- `python scripts/governance_check.py --strict`
- `python adapters/codex/validate_codex_export.py`
- `python tests/behavior/run_tests.py`
- `pytest tests/runtime --cov=orchestra_runtime --cov-fail-under=90 -q`
- `powershell -ExecutionPolicy Bypass -File scripts/update-plugin.ps1 -DryRun`
- `git diff --check`
- `git diff --stat`

## Notes

Runtime tests passed: 42/42 with 95.51% coverage.

The `update-plugin.ps1 -DryRun` command correctly refused to continue while the worktree contained the intended uncommitted Wave 3 changes. This confirms the dirty-worktree safety gate is active. It should be run again after merge from a clean worktree if a full dry-run path verification is needed.

After this merges, run the post-merge baseline on main, then we can move to Wave 4.
