### PR TITLE
Honor adapter-provided runtime context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Specialist Governance & Boundary Standard is a documentation-, governance-, meta
 - Hardened release-surface and startup-state validation by aligning Codex metadata to v1.1.0, removing the drifted example manifest, adding `.codex-plugin/plugin.json` to update consistency checks, and checking structured branch/version claims in repo memory files.
 - Converted PowerShell and shell validation entrypoints into thin wrappers around canonical Python validators to prevent cross-platform validation drift.
 - Hardened update and rollback guidance by requiring fast-forward-only pulls, running canonical validation after updates, and documenting recovery-branch creation before hard resets.
+- Fixed runtime context assembly so adapter-provided ContextPackage metadata is preserved and enriched instead of bypassed during execution.
 - Clarified optional project governance rulesets so `PROJECT_CONTEXT.md` enforcement depends on project type, risk level, and declared governance level.
 - Wired `tests/runtime` into CI, enforced portable runtime coverage with `pytest-cov --cov-fail-under=90`, switched `validate.yml` to `python tests/behavior/run_tests.py`, and added runtime tests for alias loading, default-command fallback, and unresolved command-to-skill handling.
 

--- a/orchestra_runtime/services.py
+++ b/orchestra_runtime/services.py
@@ -100,17 +100,17 @@ class ContextAssembler:
         self._manifest_repository = manifest_repository
 
     def assemble(self, adapter: IIDEAdapter, prompt: str, metadata: dict | None = None) -> ContextPackage:
-        manifest = self._manifest_repository.load_manifest()
-        merged_metadata = dict(metadata or {})
+        context = adapter.provide_context(prompt, metadata)
+        merged_metadata = dict(context.metadata)
         merged_metadata.setdefault("governance_validated", False)
         merged_metadata.setdefault("destructive_validated", False)
         merged_metadata.setdefault("dry_run", False)
         return ContextPackage(
-            adapter_name=adapter.adapter_name,
-            prompt=prompt,
-            project_root=self._manifest_repository.repo_root,
-            available_commands=adapter.expose_commands(),
-            manifest_version=str(manifest.get("version", "")),
+            adapter_name=context.adapter_name,
+            prompt=context.prompt,
+            project_root=context.project_root,
+            available_commands=context.available_commands,
+            manifest_version=context.manifest_version,
             metadata=merged_metadata,
         )
 

--- a/tests/runtime/test_adapter_contracts.py
+++ b/tests/runtime/test_adapter_contracts.py
@@ -94,3 +94,27 @@ def test_parse_command_falls_back_to_default_command_for_unmatched_prompt():
     assert command.adapter_name == "codex"
     assert command.name == adapter.default_command
     assert command.metadata == {"source": "test"}
+
+
+def test_context_assembler_preserves_adapter_provided_context_metadata():
+    from orchestra_runtime.adapters import BaseAdapter
+    from orchestra_runtime.models import ContextPackage
+
+    class TestAdapter(BaseAdapter):
+        def provide_context(self, prompt: str, metadata: dict | None = None) -> ContextPackage:
+            context = super().provide_context(prompt, metadata)
+            context.metadata["custom_flag"] = "present"
+            return context
+
+    repo_root = Path(__file__).resolve().parents[2]
+    repository = ManifestRepository(repo_root)
+    assembler = ContextAssembler(repository)
+    adapter = TestAdapter(repository)
+
+    context = assembler.assemble(adapter, "test prompt", {"caller_flag": "present"})
+
+    assert context.metadata.get("custom_flag") == "present"
+    assert context.metadata.get("caller_flag") == "present"
+    assert "governance_validated" in context.metadata
+    assert "destructive_validated" in context.metadata
+    assert "dry_run" in context.metadata


### PR DESCRIPTION
## Summary

Implements Wave 4 of the `v1.1.1` post-release hardening track.

This patch fixes the runtime adapter context contract so `ContextAssembler` starts from the `ContextPackage` returned by `adapter.provide_context(prompt, metadata)` instead of synthesizing a disconnected context.

## Changes

- Updated `ContextAssembler.assemble` to call `adapter.provide_context(prompt, metadata)`.
- Preserved adapter-provided `ContextPackage` fields and metadata.
- Added runtime metadata defaults using `setdefault()`:
  - `governance_validated`
  - `destructive_validated`
  - `dry_run`
- Added a focused runtime test proving adapter-provided metadata survives context assembly.
- Added a changelog entry for the runtime context contract fix.

## Scope

This is a narrow runtime contract fix.

No changes were made to:

- routing policy
- governance decision semantics
- Dagger live-execution behavior
- skills
- adapter skill exports
- CI workflows
- release metadata
- architecture docs

## Validation

- `git diff --check`
- `pytest tests/runtime --cov=orchestra_runtime --cov-fail-under=90 -q`
- `python scripts/governance_check.py --strict`
- `python scripts/validate_structure.py`
- `python scripts/validate_manifest.py`
- `python scripts/check_stale_references.py`
- `python adapters/codex/validate_codex_export.py`
- `python tests/behavior/run_tests.py`

## Notes

Runtime tests passed: 43/43.

This patch aligns implementation with the existing adapter contract. It does not introduce new adapter behavior or alter routing semantics.

After this merges and passes the post-merge baseline, I’d recommend preparing the v1.1.1 patch release rather than continuing into the broader Wave 5 cleanup.
