### PR TITLE
Prepare v1.1.1 Post-Release Hardening release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra",
   "description": "Governance-first specialist skill framework for routed, auditable AI coding workflows.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "update_check": {
     "update_check_enabled": true,
     "update_check_channel": "stable",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conductor",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "An installable AI workflow plugin that routes complex software tasks through focused specialist skills for architecture, UI/UX, documentation, diagrams, databases, QA, security, and gated resilience review.",
   "author": {
     "name": "Baelfyre",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@ Specialist Governance & Boundary Standard is a documentation-, governance-, meta
 - Cleaned up cross-specialist consistency by aligning Scribe output-format headings and adding compact Cloak role-boundary and validation-expectation sections without changing specialist behavior.
 - Clarified Governor and Cipher skill-source authority boundaries between governance/compliance sufficiency and technical defensive security review.
 
+## v1.1.1 - Post-Release Hardening
+
+### Changed
+- Hardened release-surface and startup-state validation by aligning Codex metadata to v1.1.0, removing the drifted example manifest, adding `.codex-plugin/plugin.json` to update consistency checks, and checking structured branch/version claims in repo memory files.
+- Converted PowerShell and shell validation entrypoints into thin wrappers around canonical Python validators to prevent cross-platform validation drift.
+- Hardened update and rollback guidance by requiring fast-forward-only pulls, running canonical validation after updates, and documenting recovery-branch creation before hard resets.
+- Fixed runtime context assembly so adapter-provided ContextPackage metadata is preserved and enriched instead of bypassed during execution.
+
 ## Unreleased
 
 ### Added
@@ -44,10 +52,6 @@ Specialist Governance & Boundary Standard is a documentation-, governance-, meta
 
 ### Changed
 - Integrated Release Mode governance docs so The Governor now treats app release compliance artifacts as required when applicable and returns `REVISION_REQUIRED` or `BLOCKED` when release-gate documentation is missing.
-- Hardened release-surface and startup-state validation by aligning Codex metadata to v1.1.0, removing the drifted example manifest, adding `.codex-plugin/plugin.json` to update consistency checks, and checking structured branch/version claims in repo memory files.
-- Converted PowerShell and shell validation entrypoints into thin wrappers around canonical Python validators to prevent cross-platform validation drift.
-- Hardened update and rollback guidance by requiring fast-forward-only pulls, running canonical validation after updates, and documenting recovery-branch creation before hard resets.
-- Fixed runtime context assembly so adapter-provided ContextPackage metadata is preserved and enriched instead of bypassed during execution.
 - Clarified optional project governance rulesets so `PROJECT_CONTEXT.md` enforcement depends on project type, risk level, and declared governance level.
 - Wired `tests/runtime` into CI, enforced portable runtime coverage with `pytest-cov --cov-fail-under=90`, switched `validate.yml` to `python tests/behavior/run_tests.py`, and added runtime tests for alias loading, default-command fallback, and unresolved command-to-skill handling.
 

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -10,7 +10,7 @@ A governance-first specialist skill framework that routes complex AI-assisted so
 Open-source developer tooling and AI orchestration framework
 
 ## Current Stage
-v1.1.0 (Specialist Governance & Boundary Standard), publicly released, actively maintained
+v1.1.1 (Specialist Governance & Boundary Standard), publicly released, actively maintained
 
 ## Primary Users
 Developers and maintainers who install Orchestra as a plugin, skill set, or runtime package inside a supported or scaffold-only IDE or coding host (Claude Code, Codex, Antigravity, Cursor, Windsurf, JetBrains, Zed, Neovim)

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -2,7 +2,7 @@
 
 - **Project Name:** Conductor
 - **Active Repo:** `C:\conductor`
-- **Current Branch:** `main`
+- **Current Branch:** `release/v1.1.1-post-release-hardening`
 - **Base Branch:** `main`
 - **Current Release:** `v1.1.0`
 - **Target Patch:** `v1.1.1`

--- a/README.md
+++ b/README.md
@@ -124,10 +124,11 @@ flowchart LR
 
 Runtime-core-first refactor notes live in [docs/project/OOP_RUNTIME_ARCHITECTURE.md](docs/project/OOP_RUNTIME_ARCHITECTURE.md). The shared `orchestra_runtime/` layer owns manifest parsing, skill loading, routing, governance validation, execution flow, and audit logging, while host adapters stay thin. The versioned Portable Runtime Adapter Protocol is documented in [docs/project/PORTABLE_ADAPTER_PROTOCOL.md](docs/project/PORTABLE_ADAPTER_PROTOCOL.md).
 
-## v1.1.0 Specialist Governance & Boundary Standard
+## v1.1.1 Post-Release Hardening
 
-`v1.1.0 Specialist Governance & Boundary Standard` builds on the `v1.0.0 Portable Runtime` baseline with documentation-, governance-, metadata-, and specialist-definition-focused normalization.
+`v1.1.1 Post-Release Hardening` is a targeted patch release that builds on the `v1.1.0 Specialist Governance & Boundary Standard` baseline to close post-release hardening gaps (validation, startup-state accuracy, update safety, and runtime context-contract alignment).
 
+Historical `v1.1.0` highlights:
 - Specialist boundaries were normalized across the documented specialist surfaces, with tracked Codex export parity where applicable.
 - Governance strictness levels and authority boundaries were clarified without changing governance semantics.
 - Runtime behavior, routing policy, validation logic, CI workflows, and Dagger live-execution behavior remain unchanged.

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -2,7 +2,7 @@
 
 - **Current Task:** Wave 1 - Release-surface and startup-state drift remediation
 - **Current Repo:** `C:\conductor`
-- **Current Branch:** `main`
+- **Current Branch:** `release/v1.1.1-post-release-hardening`
 - **Base Branch:** `main`
 - **Current Release:** `v1.1.0`
 - **Target Patch:** `v1.1.1`

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -1,6 +1,6 @@
 # Codex Adapter for Orchestra
 
-This adapter provides a Codex-compatible export of the Orchestra `v1.1.0 Specialist Governance & Boundary Standard` skills.
+This adapter provides a Codex-compatible export of the Orchestra `v1.1.1 Post-Release Hardening` skills.
 
 ## Purpose
 

--- a/adapters/cursor/package.json
+++ b/adapters/cursor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-cursor-scaffold",
   "displayName": "Orchestra Cursor Scaffold",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "description": "Scaffold-only Cursor packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/jetbrains/package.json
+++ b/adapters/jetbrains/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-jetbrains-scaffold",
   "displayName": "Orchestra JetBrains Scaffold",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "description": "Scaffold-only JetBrains packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/jetbrains/plugin.xml
+++ b/adapters/jetbrains/plugin.xml
@@ -2,7 +2,7 @@
   <id>com.baelfyre.orchestra.scaffold</id>
   <name>Orchestra JetBrains Scaffold</name>
   <vendor>Baelfyre</vendor>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <description>Scaffold-only JetBrains packaging metadata for Orchestra runtime adapter integration.</description>
   <depends>com.intellij.modules.platform</depends>
   <extensions defaultExtensionNs="com.intellij">

--- a/adapters/neovim/package.json
+++ b/adapters/neovim/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-neovim-scaffold",
   "displayName": "Orchestra Neovim Scaffold",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "description": "Scaffold-only Neovim packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/vscode/package.json
+++ b/adapters/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-vscode-scaffold",
   "displayName": "Orchestra VS Code Scaffold",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "description": "Scaffold-only VS Code packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/windsurf/package.json
+++ b/adapters/windsurf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-windsurf-scaffold",
   "displayName": "Orchestra Windsurf Scaffold",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "description": "Scaffold-only Windsurf packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/zed/package.json
+++ b/adapters/zed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-zed-scaffold",
   "displayName": "Orchestra Zed Scaffold",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "description": "Scaffold-only Zed packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/docs/project/V1_READINESS_CHECKLIST.md
+++ b/docs/project/V1_READINESS_CHECKLIST.md
@@ -1,6 +1,6 @@
-# V1.1.0 Specialist Governance & Boundary Standard Readiness Checklist
+# V1.1.1 Post-Release Hardening Readiness Checklist
 
-Before tagging the `v1.1.0 Specialist Governance & Boundary Standard` release of the Orchestra, the following checks must all pass:
+Before tagging the `v1.1.1 Post-Release Hardening` release of the Orchestra, the following checks must all pass:
 
 - [x] **Markdown-first architecture preserved**: No compiled code, binary requirements, or forced dependencies.
 - [x] **All manifest-declared skills present**: The current plugin manifest, skill folders, and command surfaces validate together, including Conductor, governance authorities, specialists, and Ponytail.

--- a/docs/releases/v1.1.1-post-release-hardening.md
+++ b/docs/releases/v1.1.1-post-release-hardening.md
@@ -1,0 +1,34 @@
+# Orchestra v1.1.1: Post-Release Hardening
+
+**v1.1.1** is a targeted patch release focused on post-release validation, metadata consistency, startup-state accuracy, update safety, and runtime adapter context-contract alignment.
+
+## Release Theme
+This release is dedicated to closing hardening gaps identified during the v1.1.0 rollout. It hardens project-level workflows without altering core functionality, governance boundaries, or runtime orchestration semantics.
+
+## Completed Scope
+- **Release-Surface and Startup-State Validation:**
+  - Aligned Codex export metadata up to v1.1.0 and removed drifted documentation artifacts.
+  - Validates structured branch and version claims directly in repo memory files to prevent handoff drift.
+- **Validator Wrapper Parity Remediation:**
+  - Converted legacy PowerShell and Bash validation scripts into thin wrappers around the canonical Python validators to eliminate cross-platform drift.
+- **Safe Update Workflow Hardening:**
+  - Updated installation and update scripts to use `git pull --ff-only` to prevent unintended merge commits.
+  - Formalized rollback instructions to demand a `recovery-before-rollback` branch prior to hard resets.
+- **Runtime Adapter Context Contract Fix:**
+  - Repaired a gap where `ContextAssembler` bypassed `adapter.provide_context()`. The runtime now cleanly preserves adapter-provided context values while seamlessly injecting its own execution metadata defaults.
+
+## Validation Expectations
+- `python scripts/governance_check.py --strict` accurately catches stale repository memory branch/version claims.
+- Safe update `-DryRun` gates cleanly intercept dirty worktrees.
+- All IDE scaffold packages successfully validate with `v1.1.1` versions.
+
+## Non-Goals
+This is a documentation-and-metadata-only patch release. **No changes** were made to:
+- Routing policy
+- Governance decision semantics
+- Dagger live-execution behavior
+- Skill instructions or boundaries
+- CI workflow behavior
+
+## Upgrade / Compatibility Notes
+This patch is fully backwards compatible with `v1.1.0`. All manual update guidance now emphasizes fast-forward safety. If downgrading, please branch a recovery reference as documented in `docs/setup/INSTALLATION.md`.

--- a/docs/setup/COMPATIBILITY.md
+++ b/docs/setup/COMPATIBILITY.md
@@ -1,6 +1,6 @@
 # Compatibility
 
-Orchestra `v1.1.0 Specialist Governance & Boundary Standard` keeps the Markdown-first, runtime-core-first baseline from `v1.0.0 Portable Runtime`. Hosts still integrate through thin adapters and, where available, scaffold packaging metadata that points back to the shared runtime.
+Orchestra `v1.1.1 Post-Release Hardening` keeps the Markdown-first, runtime-core-first baseline from `v1.0.0 Portable Runtime` and `v1.1.0`. Hosts still integrate through thin adapters and, where available, scaffold packaging metadata that points back to the shared runtime.
 
 Scaffold-only hosts are not yet full support claims. Promotion requirements and graduation order live in `docs/project/SCAFFOLD_ADAPTER_GRADUATION_CRITERIA.md`.
 

--- a/docs/setup/INSTALLATION.md
+++ b/docs/setup/INSTALLATION.md
@@ -4,7 +4,7 @@ Orchestra can be installed in several ways depending on your AI host or IDE:
 
 ## Current Release
 
-`v1.1.0 Specialist Governance & Boundary Standard` builds on the `v1.0.0 Portable Runtime` baseline and focuses on documentation, governance, metadata, and specialist-definition normalization.
+`v1.1.1 Post-Release Hardening` builds on the `v1.1.0` baseline and focuses on post-release validation, startup-state accuracy, update safety, and runtime adapter context-contract alignment.
 
 | Host | Install Surface | Current Status |
 |---|---|---|

--- a/plugin.json
+++ b/plugin.json
@@ -1,246 +1,246 @@
 {
-    "name": "conductor",
-    "display_name": "Orchestra",
-    "description": "An installable AI workflow plugin that routes tasks through focused specialist skills. See SKILL_INDEX.md and ROUTING_MAP.md for detailed routing behavior.",
-    "version": "1.1.0",
-    "license": "MIT",
-    "repository": "https://github.com/Baelfyre/Orchestra",
-    "icon_path": "assets/icons/conductor.ico",
-    "logo_path": "assets/logo/orchestra.ico",
-    "update_check": {
-        "update_check_enabled": true,
-        "update_check_channel": "stable",
-        "update_check_frequency": "manual"
+  "name": "conductor",
+  "display_name": "Orchestra",
+  "description": "An installable AI workflow plugin that routes tasks through focused specialist skills. See SKILL_INDEX.md and ROUTING_MAP.md for detailed routing behavior.",
+  "version": "1.1.1",
+  "license": "MIT",
+  "repository": "https://github.com/Baelfyre/Orchestra",
+  "icon_path": "assets/icons/conductor.ico",
+  "logo_path": "assets/logo/orchestra.ico",
+  "update_check": {
+    "update_check_enabled": true,
+    "update_check_channel": "stable",
+    "update_check_frequency": "manual"
+  },
+  "safety_note": "The dagger skill and resilience-check command execute destructive, negative, fuzz, adversarial QA, and failure-mode testing. They require explicit user approval, non-production scope, and a passing scripts/dagger_guardrail.py validation before execution. WARNING: Phase 2 allows simulation only and blocks live destructive execution. Do not proceed in a production environment.",
+  "commands": [
+    "conductor",
+    "arbiter",
+    "clockwork",
+    "review-architecture",
+    "cloak",
+    "review-ui",
+    "chronicler",
+    "review-db",
+    "scribe",
+    "review-docs",
+    "weaver",
+    "diagram-check",
+    "overseer",
+    "qa-check",
+    "cipher",
+    "security-check",
+    "dagger",
+    "resilience-check"
+  ],
+  "skills": [
+    {
+      "primary_use": "Business alignment validation, scope validation, requirements traceability, SDLC documentation completeness, acceptance criteria review",
+      "slug": "the-steward",
+      "description": "Business alignment and scope governance authority. See docs/governance/GOVERNANCE_LAYER.md for governance behavior.",
+      "avoid_when": "Legal, regulatory, privacy, licensing, or IP compliance review is needed (route to the-governor)",
+      "skill_path": "skills/the-steward/SKILL.md",
+      "role": "Business Alignment and Scope Governance Authority",
+      "name": "the-steward",
+      "activation_level": "Governor",
+      "depends_on": "None",
+      "icon_path": "assets/icons/the-steward.ico",
+      "output_formats": [
+        "Governance Review"
+      ]
     },
-    "safety_note": "The dagger skill and resilience-check command execute destructive, negative, fuzz, adversarial QA, and failure-mode testing. They require explicit user approval, non-production scope, and a passing scripts/dagger_guardrail.py validation before execution. WARNING: Phase 2 allows simulation only and blocks live destructive execution. Do not proceed in a production environment.",
-    "commands": [
-        "conductor",
-        "arbiter",
-        "clockwork",
-        "review-architecture",
-        "cloak",
-        "review-ui",
-        "chronicler",
-        "review-db",
-        "scribe",
-        "review-docs",
-        "weaver",
-        "diagram-check",
-        "overseer",
-        "qa-check",
-        "cipher",
-        "security-check",
-        "dagger",
-        "resilience-check"
-    ],
-    "skills": [
-        {
-            "primary_use": "Business alignment validation, scope validation, requirements traceability, SDLC documentation completeness, acceptance criteria review",
-            "slug": "the-steward",
-            "description": "Business alignment and scope governance authority. See docs/governance/GOVERNANCE_LAYER.md for governance behavior.",
-            "avoid_when": "Legal, regulatory, privacy, licensing, or IP compliance review is needed (route to the-governor)",
-            "skill_path": "skills/the-steward/SKILL.md",
-            "role": "Business Alignment and Scope Governance Authority",
-            "name": "the-steward",
-            "activation_level": "Governor",
-            "depends_on": "None",
-            "icon_path": "assets/icons/the-steward.ico",
-            "output_formats": [
-                "Governance Review"
-            ]
-        },
-        {
-            "primary_use": "Legal compliance validation, privacy risk review, IP and copyright review, open-source license compatibility, Terms of Service and Privacy Policy impact, audit documentation, security governance",
-            "slug": "the-governor",
-            "description": "Legal, regulatory, privacy, IP, and compliance governance authority. Does not provide legal advice. Sits above Conductor. See docs/governance/GOVERNANCE_LAYER.md.",
-            "avoid_when": "Business alignment, scope, requirements, or SDLC review is needed (route to the-steward)",
-            "skill_path": "skills/the-governor/SKILL.md",
-            "role": "Legal, Compliance, Privacy, and IP Governance Authority",
-            "name": "the-governor",
-            "activation_level": "Governor",
-            "depends_on": "None",
-            "icon_path": "assets/icons/the-governor.ico",
-            "output_formats": [
-                "Governance Review"
-            ]
-        },
-        {
-            "primary_use": "Continuity review, validation-state review, branch and merge readiness, source-of-truth checks, handoff readiness, access/visibility closeout",
-            "slug": "arbiter",
-            "description": "Workflow continuity, validation, and transition governance specialist. See SKILL_INDEX.md.",
-            "avoid_when": "Designing architecture, implementing features, writing documentation content, or replacing normal QA ownership",
-            "skill_path": "skills/arbiter/SKILL.md",
-            "role": "Workflow Continuity, Validation, and Transition Governance Specialist",
-            "name": "arbiter",
-            "activation_level": "Governance",
-            "depends_on": "conductor",
-            "icon_path": "assets/icons/arbiter.ico",
-            "output_formats": [
-                "Continuity Review",
-                "Governance Effectiveness Review"
-            ]
-        },
-        {
-            "primary_use": "QA strategy, test planning, validation gates, release readiness, CI/CD validation, persona validation",
-            "slug": "overseer",
-            "description": "QA, Test Strategy, Validation, CI, and Release Readiness Specialist. See SKILL_INDEX.md.",
-            "avoid_when": "Implementing test code, architecture design, security policy, or long documentation",
-            "skill_path": "skills/overseer/SKILL.md",
-            "role": "QA, Test Strategy, Validation, CI, and Release Readiness Specialist",
-            "name": "overseer",
-            "activation_level": "Specialist",
-            "depends_on": "None",
-            "icon_path": "assets/icons/overseer.ico",
-            "output_formats": [
-                "Caveman",
-                "Full QA Review"
-            ]
-        },
-        {
-            "primary_use": "Project orientation, multi-skill routing, workflow planning, access/visibility routing",
-            "slug": "conductor",
-            "description": "Routing and orchestration layer. Chooses the smallest effective skill stack. See ROUTING_MAP.md and SKILL_INDEX.md for detailed routing behavior.",
-            "avoid_when": "A single obvious specialist suffices",
-            "skill_path": "skills/conductor/SKILL.md",
-            "role": "Routing and orchestration layer",
-            "name": "conductor",
-            "activation_level": "Commander",
-            "depends_on": "None",
-            "icon_path": "assets/icons/conductor.ico",
-            "output_formats": [
-                "Routing Plan",
-                "Prompts"
-            ]
-        },
-        {
-            "primary_use": "Security policy, RBAC, authorization, authentication risk, privacy, secrets, visibility/access-control",
-            "slug": "cipher",
-            "description": "Security, Privacy, Access Control, and Threat Review Specialist. Do not use for offensive or destructive testing. See SKILL_INDEX.md.",
-            "avoid_when": "Offensive testing is needed, or for implementation, database design, or application architecture",
-            "skill_path": "skills/cipher/SKILL.md",
-            "role": "Security, Privacy, Access Control, and Threat Review Specialist",
-            "name": "cipher",
-            "activation_level": "Specialist",
-            "depends_on": "None",
-            "icon_path": "assets/icons/cipher.ico",
-            "output_formats": [
-                "Caveman",
-                "Full Security Review"
-            ]
-        },
-        {
-            "primary_use": "UI, UX, accessibility, visual hierarchy, responsive layout, interaction design",
-            "slug": "cloak",
-            "description": "UI/UX, Accessibility, Responsive Layout, and Frontend Design Specialist. See SKILL_INDEX.md.",
-            "avoid_when": "Frontend implementation code, backend logic, security policy, or architecture diagrams",
-            "skill_path": "skills/cloak/SKILL.md",
-            "role": "UI/UX, Accessibility, Responsive Layout, and Frontend Design Specialist",
-            "name": "cloak",
-            "activation_level": "Specialist",
-            "depends_on": "None",
-            "icon_path": "assets/icons/cloak.ico",
-            "output_formats": [
-                "QUICK_UI_HANDOFF",
-                "DOCUMENT_REVIEW",
-                "FORMAL_UI_AUDIT"
-            ]
-        },
-        {
-            "primary_use": "Chaos scenarios, resilience weaknesses, failure-paths, negative tests, guardrail gaps",
-            "slug": "dagger",
-            "description": "Chaos and resilience specialist. Generates controlled failure paths. Operates strictly within safety boundaries and never executes unauthorized, destructive, or production-impacting tests. See SKILL_INDEX.md.",
-            "avoid_when": "Code implementation, QA test planning, CI validation, security policy, database design",
-            "skill_path": "skills/dagger/SKILL.md",
-            "role": "Chaos, Resilience, and Adversarial Scenario Specialist",
-            "name": "dagger",
-            "activation_level": "Gated",
-            "depends_on": "conductor",
-            "icon_path": "assets/icons/dagger.ico",
-            "output_formats": [
-                "Caveman"
-            ]
-        },
-        {
-            "primary_use": "SQL schemas, NoSQL documents, JSON, ORM, migrations, constraints, indexes, normalization",
-            "slug": "chronicler",
-            "description": "Data Persistence and Database Management Specialist. See SKILL_INDEX.md.",
-            "avoid_when": "Evaluating visible UI, testing plans, business workflows, architecture boundaries, or security policy",
-            "skill_path": "skills/chronicler/SKILL.md",
-            "role": "Data Persistence and Database Management Specialist",
-            "name": "chronicler",
-            "activation_level": "Specialist",
-            "depends_on": "None",
-            "icon_path": "assets/icons/chronicler.ico",
-            "output_formats": [
-                "Caveman",
-                "Normalization Output"
-            ]
-        },
-        {
-            "primary_use": "Visual modeling, UML, ERD, architecture, workflow, data-flow diagrams via Mermaid/PlantUML",
-            "slug": "weaver",
-            "description": "Visual Modeling and Diagram Generation Specialist. See SKILL_INDEX.md.",
-            "avoid_when": "Database design decisions, documentation prose, code implementation, security policy",
-            "skill_path": "skills/weaver/SKILL.md",
-            "role": "Visual Modeling and Diagram Generation Specialist",
-            "name": "weaver",
-            "activation_level": "Specialist",
-            "depends_on": "None",
-            "icon_path": "assets/icons/weaver.ico",
-            "output_formats": [
-                "Mermaid",
-                "PlantUML"
-            ]
-        },
-        {
-            "primary_use": "Documentation prose, READMEs, setup guides, release notes, SDLC, technical summaries",
-            "slug": "scribe",
-            "description": "Documentation and Knowledge Transfer Specialist. See SKILL_INDEX.md.",
-            "avoid_when": "Architecture decisions, database design, normalization analysis, UI design, diagram generation, or code implementation",
-            "skill_path": "skills/scribe/SKILL.md",
-            "role": "Documentation and Knowledge Transfer Specialist",
-            "name": "scribe",
-            "activation_level": "Specialist",
-            "depends_on": "None",
-            "icon_path": "assets/icons/scribe.ico",
-            "output_formats": [
-                "Mode 1",
-                "Mode 2",
-                "Mode 3"
-            ]
-        },
-        {
-            "primary_use": "OOP architecture, layered architecture, system design, refactoring",
-            "slug": "clockwork",
-            "description": "Engineering and Code Structure Specialist (OOP, layering, refactoring). See SKILL_INDEX.md.",
-            "avoid_when": "Modifying UI layouts, testing security boundaries, or writing documentation",
-            "skill_path": "skills/clockwork/SKILL.md",
-            "role": "Engineering / Code Structure",
-            "name": "clockwork",
-            "activation_level": "Specialist",
-            "depends_on": "None",
-            "icon_path": "assets/icons/clockwork.ico",
-            "output_formats": [
-                "Compact",
-                "Full"
-            ]
-        },
-        {
-            "primary_use": "Implementation, code editing, validation",
-            "slug": "ponytail",
-            "description": "Implementation and Navigation Specialist. Owns minimal safe edits. See SKILL_INDEX.md.",
-            "avoid_when": "Architecture design, UI/UX decisions, security policies",
-            "skill_path": "skills/ponytail/SKILL.md",
-            "role": "Implementation and Navigation Specialist",
-            "name": "ponytail",
-            "activation_level": "Specialist",
-            "depends_on": "None",
-            "icon_path": "assets/icons/ponytail.ico",
-            "output_formats": [
-                "IMPLEMENTATION_PLAN",
-                "CODE_REVIEW",
-                "QUICK_FIX"
-            ]
-        }
-    ]
+    {
+      "primary_use": "Legal compliance validation, privacy risk review, IP and copyright review, open-source license compatibility, Terms of Service and Privacy Policy impact, audit documentation, security governance",
+      "slug": "the-governor",
+      "description": "Legal, regulatory, privacy, IP, and compliance governance authority. Does not provide legal advice. Sits above Conductor. See docs/governance/GOVERNANCE_LAYER.md.",
+      "avoid_when": "Business alignment, scope, requirements, or SDLC review is needed (route to the-steward)",
+      "skill_path": "skills/the-governor/SKILL.md",
+      "role": "Legal, Compliance, Privacy, and IP Governance Authority",
+      "name": "the-governor",
+      "activation_level": "Governor",
+      "depends_on": "None",
+      "icon_path": "assets/icons/the-governor.ico",
+      "output_formats": [
+        "Governance Review"
+      ]
+    },
+    {
+      "primary_use": "Continuity review, validation-state review, branch and merge readiness, source-of-truth checks, handoff readiness, access/visibility closeout",
+      "slug": "arbiter",
+      "description": "Workflow continuity, validation, and transition governance specialist. See SKILL_INDEX.md.",
+      "avoid_when": "Designing architecture, implementing features, writing documentation content, or replacing normal QA ownership",
+      "skill_path": "skills/arbiter/SKILL.md",
+      "role": "Workflow Continuity, Validation, and Transition Governance Specialist",
+      "name": "arbiter",
+      "activation_level": "Governance",
+      "depends_on": "conductor",
+      "icon_path": "assets/icons/arbiter.ico",
+      "output_formats": [
+        "Continuity Review",
+        "Governance Effectiveness Review"
+      ]
+    },
+    {
+      "primary_use": "QA strategy, test planning, validation gates, release readiness, CI/CD validation, persona validation",
+      "slug": "overseer",
+      "description": "QA, Test Strategy, Validation, CI, and Release Readiness Specialist. See SKILL_INDEX.md.",
+      "avoid_when": "Implementing test code, architecture design, security policy, or long documentation",
+      "skill_path": "skills/overseer/SKILL.md",
+      "role": "QA, Test Strategy, Validation, CI, and Release Readiness Specialist",
+      "name": "overseer",
+      "activation_level": "Specialist",
+      "depends_on": "None",
+      "icon_path": "assets/icons/overseer.ico",
+      "output_formats": [
+        "Caveman",
+        "Full QA Review"
+      ]
+    },
+    {
+      "primary_use": "Project orientation, multi-skill routing, workflow planning, access/visibility routing",
+      "slug": "conductor",
+      "description": "Routing and orchestration layer. Chooses the smallest effective skill stack. See ROUTING_MAP.md and SKILL_INDEX.md for detailed routing behavior.",
+      "avoid_when": "A single obvious specialist suffices",
+      "skill_path": "skills/conductor/SKILL.md",
+      "role": "Routing and orchestration layer",
+      "name": "conductor",
+      "activation_level": "Commander",
+      "depends_on": "None",
+      "icon_path": "assets/icons/conductor.ico",
+      "output_formats": [
+        "Routing Plan",
+        "Prompts"
+      ]
+    },
+    {
+      "primary_use": "Security policy, RBAC, authorization, authentication risk, privacy, secrets, visibility/access-control",
+      "slug": "cipher",
+      "description": "Security, Privacy, Access Control, and Threat Review Specialist. Do not use for offensive or destructive testing. See SKILL_INDEX.md.",
+      "avoid_when": "Offensive testing is needed, or for implementation, database design, or application architecture",
+      "skill_path": "skills/cipher/SKILL.md",
+      "role": "Security, Privacy, Access Control, and Threat Review Specialist",
+      "name": "cipher",
+      "activation_level": "Specialist",
+      "depends_on": "None",
+      "icon_path": "assets/icons/cipher.ico",
+      "output_formats": [
+        "Caveman",
+        "Full Security Review"
+      ]
+    },
+    {
+      "primary_use": "UI, UX, accessibility, visual hierarchy, responsive layout, interaction design",
+      "slug": "cloak",
+      "description": "UI/UX, Accessibility, Responsive Layout, and Frontend Design Specialist. See SKILL_INDEX.md.",
+      "avoid_when": "Frontend implementation code, backend logic, security policy, or architecture diagrams",
+      "skill_path": "skills/cloak/SKILL.md",
+      "role": "UI/UX, Accessibility, Responsive Layout, and Frontend Design Specialist",
+      "name": "cloak",
+      "activation_level": "Specialist",
+      "depends_on": "None",
+      "icon_path": "assets/icons/cloak.ico",
+      "output_formats": [
+        "QUICK_UI_HANDOFF",
+        "DOCUMENT_REVIEW",
+        "FORMAL_UI_AUDIT"
+      ]
+    },
+    {
+      "primary_use": "Chaos scenarios, resilience weaknesses, failure-paths, negative tests, guardrail gaps",
+      "slug": "dagger",
+      "description": "Chaos and resilience specialist. Generates controlled failure paths. Operates strictly within safety boundaries and never executes unauthorized, destructive, or production-impacting tests. See SKILL_INDEX.md.",
+      "avoid_when": "Code implementation, QA test planning, CI validation, security policy, database design",
+      "skill_path": "skills/dagger/SKILL.md",
+      "role": "Chaos, Resilience, and Adversarial Scenario Specialist",
+      "name": "dagger",
+      "activation_level": "Gated",
+      "depends_on": "conductor",
+      "icon_path": "assets/icons/dagger.ico",
+      "output_formats": [
+        "Caveman"
+      ]
+    },
+    {
+      "primary_use": "SQL schemas, NoSQL documents, JSON, ORM, migrations, constraints, indexes, normalization",
+      "slug": "chronicler",
+      "description": "Data Persistence and Database Management Specialist. See SKILL_INDEX.md.",
+      "avoid_when": "Evaluating visible UI, testing plans, business workflows, architecture boundaries, or security policy",
+      "skill_path": "skills/chronicler/SKILL.md",
+      "role": "Data Persistence and Database Management Specialist",
+      "name": "chronicler",
+      "activation_level": "Specialist",
+      "depends_on": "None",
+      "icon_path": "assets/icons/chronicler.ico",
+      "output_formats": [
+        "Caveman",
+        "Normalization Output"
+      ]
+    },
+    {
+      "primary_use": "Visual modeling, UML, ERD, architecture, workflow, data-flow diagrams via Mermaid/PlantUML",
+      "slug": "weaver",
+      "description": "Visual Modeling and Diagram Generation Specialist. See SKILL_INDEX.md.",
+      "avoid_when": "Database design decisions, documentation prose, code implementation, security policy",
+      "skill_path": "skills/weaver/SKILL.md",
+      "role": "Visual Modeling and Diagram Generation Specialist",
+      "name": "weaver",
+      "activation_level": "Specialist",
+      "depends_on": "None",
+      "icon_path": "assets/icons/weaver.ico",
+      "output_formats": [
+        "Mermaid",
+        "PlantUML"
+      ]
+    },
+    {
+      "primary_use": "Documentation prose, READMEs, setup guides, release notes, SDLC, technical summaries",
+      "slug": "scribe",
+      "description": "Documentation and Knowledge Transfer Specialist. See SKILL_INDEX.md.",
+      "avoid_when": "Architecture decisions, database design, normalization analysis, UI design, diagram generation, or code implementation",
+      "skill_path": "skills/scribe/SKILL.md",
+      "role": "Documentation and Knowledge Transfer Specialist",
+      "name": "scribe",
+      "activation_level": "Specialist",
+      "depends_on": "None",
+      "icon_path": "assets/icons/scribe.ico",
+      "output_formats": [
+        "Mode 1",
+        "Mode 2",
+        "Mode 3"
+      ]
+    },
+    {
+      "primary_use": "OOP architecture, layered architecture, system design, refactoring",
+      "slug": "clockwork",
+      "description": "Engineering and Code Structure Specialist (OOP, layering, refactoring). See SKILL_INDEX.md.",
+      "avoid_when": "Modifying UI layouts, testing security boundaries, or writing documentation",
+      "skill_path": "skills/clockwork/SKILL.md",
+      "role": "Engineering / Code Structure",
+      "name": "clockwork",
+      "activation_level": "Specialist",
+      "depends_on": "None",
+      "icon_path": "assets/icons/clockwork.ico",
+      "output_formats": [
+        "Compact",
+        "Full"
+      ]
+    },
+    {
+      "primary_use": "Implementation, code editing, validation",
+      "slug": "ponytail",
+      "description": "Implementation and Navigation Specialist. Owns minimal safe edits. See SKILL_INDEX.md.",
+      "avoid_when": "Architecture design, UI/UX decisions, security policies",
+      "skill_path": "skills/ponytail/SKILL.md",
+      "role": "Implementation and Navigation Specialist",
+      "name": "ponytail",
+      "activation_level": "Specialist",
+      "depends_on": "None",
+      "icon_path": "assets/icons/ponytail.ico",
+      "output_formats": [
+        "IMPLEMENTATION_PLAN",
+        "CODE_REVIEW",
+        "QUICK_FIX"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Prepares the `v1.1.1 Post-Release Hardening` patch release.

This release captures Waves 1-4 of the post-`v1.1.0` hardening track:

- release-surface and startup-state validation hardening
- validator-wrapper parity remediation
- safe update workflow hardening
- runtime adapter context contract remediation

## Changes

### Version metadata

- Bumped release metadata from `1.1.0` to `1.1.1` across approved manifests and package metadata.
- Included `.codex-plugin/plugin.json` in the version bump.

### Changelog and release notes

- Added `## v1.1.1 - Post-Release Hardening` to `CHANGELOG.md`.
- Moved Wave 1-4 hardening entries out of `Unreleased`.
- Added `docs/releases/v1.1.1-post-release-hardening.md`.

### Current-release documentation

Updated active release wording to `v1.1.1 Post-Release Hardening` in:

- `README.md`
- `adapters/codex/README.md`
- `docs/setup/INSTALLATION.md`
- `docs/setup/COMPATIBILITY.md`
- `docs/project/V1_READINESS_CHECKLIST.md`

### Startup-state alignment

Updated startup-state files to satisfy structured branch/version claim validation:

- `PROJECT_CONTEXT.md`
- `PROJECT_STATE.md`
- `SESSION_HANDOFF.md`

## Scope

Doc-and-metadata-only release prep.

No changes were made to:

- runtime code
- tests
- scripts
- CI workflows
- skills
- adapter skill exports
- governance decision semantics
- routing policy
- Dagger live-execution behavior

## Validation

- `python scripts/preflight_sync_check.py`
- `python scripts/validate_structure.py`
- `python scripts/validate_manifest.py`
- `python scripts/check_stale_references.py`
- `python scripts/governance_check.py --strict`
- `python adapters/codex/validate_codex_export.py`
- `python tests/behavior/run_tests.py`
- `pytest tests/runtime --cov=orchestra_runtime --cov-fail-under=90 -q`
- `git diff --check`
- `git diff --stat`

## Notes

Runtime tests passed: 43/43 with 95.51% coverage.

The strict startup-state validator correctly required `PROJECT_CONTEXT.md`, `PROJECT_STATE.md`, and `SESSION_HANDOFF.md` to match the release branch and `v1.1.1` version during release prep.

After the PR merges, run one final baseline on main, update startup-state branch claims back to main if strict governance catches the release branch name, then tag v1.1.1.
