### PR TITLE
Implement Wave 5A cross-platform CI coverage hardening

### DIFF
--- a/.github/workflows/cross-platform-validation.yml
+++ b/.github/workflows/cross-platform-validation.yml
@@ -24,6 +24,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
+          - windows-latest
 
     steps:
       - name: Checkout Repository
@@ -36,16 +37,19 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install Dependencies
+        run: python -m pip install --upgrade pip pytest pytest-cov
+
       - name: Show Runtime
         run: |
-          uname -a
           python --version
           git --version
 
       - name: Create Artifacts Directory
-        run: mkdir -p artifacts
+        run: python -c "from pathlib import Path; Path('artifacts').mkdir(exist_ok=True)"
 
       - name: Verify POSIX Scripts
+        if: runner.os != 'Windows'
         run: |
           file scripts/check-stale-references.sh
           file scripts/validate-structure.sh
@@ -53,6 +57,7 @@ jobs:
           test -x scripts/validate-structure.sh
 
       - name: Run Native Validation
+        shell: bash
         run: |
           run_report () {
             name="$1"
@@ -72,6 +77,7 @@ jobs:
           run_report check_stale_references python scripts/check_stale_references.py
           run_report governance_report python scripts/governance_check.py --strict
           run_report behavior_tests python tests/behavior/run_tests.py
+          run_report runtime_tests python -m pytest tests/runtime --cov=orchestra_runtime --cov-fail-under=90 -q
           run_report codex_export python adapters/codex/validate_codex_export.py
           run_report router_benchmark python scripts/router_benchmark_runner.py
           run_report router_benchmark_negative python tests/behavior/test_router_benchmark_fixture_validation.py
@@ -88,6 +94,7 @@ jobs:
 
       - name: Generate CI Summary
         if: always()
+        shell: bash
         run: |
           echo "# Cross-platform Validation" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Specialist Governance & Boundary Standard is a documentation-, governance-, meta
 - Added an App Release Compliance Gate plus reusable privacy review, data inventory, IP clearance, privacy policy, terms, and retention/deletion governance templates for app and public release workflows.
 
 ### Changed
+- Added Windows coverage and runtime test execution to cross-platform CI validation.
 - Integrated Release Mode governance docs so The Governor now treats app release compliance artifacts as required when applicable and returns `REVISION_REQUIRED` or `BLOCKED` when release-gate documentation is missing.
 - Clarified optional project governance rulesets so `PROJECT_CONTEXT.md` enforcement depends on project type, risk level, and declared governance level.
 - Wired `tests/runtime` into CI, enforced portable runtime coverage with `pytest-cov --cov-fail-under=90`, switched `validate.yml` to `python tests/behavior/run_tests.py`, and added runtime tests for alias loading, default-command fallback, and unresolved command-to-skill handling.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -2,7 +2,7 @@
 
 - **Project Name:** Conductor
 - **Active Repo:** `C:\conductor`
-- **Current Branch:** `main`
+- **Current Branch:** `fix/wave5a-cross-platform-ci-coverage`
 - **Base Branch:** `main`
 - **Current Release:** `v1.1.1`
 - **Target Patch:** `v1.1.2`

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -2,7 +2,7 @@
 
 - **Current Task:** Wave 5A - Cross-platform CI coverage implementation planning
 - **Current Repo:** `C:\conductor`
-- **Current Branch:** `main`
+- **Current Branch:** `fix/wave5a-cross-platform-ci-coverage`
 - **Base Branch:** `main`
 - **Current Release:** `v1.1.1`
 - **Target Patch:** `v1.1.2`

--- a/docs/testing/CROSS_PLATFORM_CI_COVERAGE_AUDIT.md
+++ b/docs/testing/CROSS_PLATFORM_CI_COVERAGE_AUDIT.md
@@ -47,3 +47,7 @@ Tests were not run. (Initial audit mode only).
 
 ## 7. Recommended next action
 Implement the cross-platform coverage remediations in a follow-up wave. Update the `cross-platform-validation.yml` file to include `windows-latest` in the matrix, skip POSIX checks on Windows, and enforce full `pytest tests/runtime` execution across all platforms.
+
+## 8. Implementation Status
+*Note added during Wave 5A implementation:*
+The cross-platform coverage remediations recommended above were implemented in `fix/wave5a-cross-platform-ci-coverage`. Windows was added to the matrix, POSIX-only checks were skipped on Windows, and runtime tests were added to the native validation suite across all platforms.


### PR DESCRIPTION
## Summary

Implements Wave 5A cross-platform CI coverage hardening based on the completed audit in `docs/testing/CROSS_PLATFORM_CI_COVERAGE_AUDIT.md`.

This PR expands native validation coverage to Windows, adds runtime test execution to the cross-platform workflow, and preserves the existing strict governance and validation behavior.

## Changes

### Cross-platform validation workflow

Updated `.github/workflows/cross-platform-validation.yml` to:

- Add `windows-latest` to the native validation matrix.
- Keep `ubuntu-latest` and `macos-latest` coverage.
- Replace Unix-specific runtime display/setup commands with cross-platform-safe alternatives.
- Replace `mkdir -p artifacts` with a Python `Path(...).mkdir(...)` call.
- Skip POSIX-only script verification on Windows using `if: runner.os != 'Windows'`.
- Add a minimal dependency installation step for:
  - `pytest`
  - `pytest-cov`
- Add runtime tests to native validation:

```bash
python -m pytest tests/runtime --cov=orchestra_runtime --cov-fail-under=90 -q
```

### Audit and changelog
- Added a short implementation status note to `docs/testing/CROSS_PLATFORM_CI_COVERAGE_AUDIT.md`.
- Added a focused `CHANGELOG.md` bullet for the CI coverage hardening.

### Startup-state alignment
- Updated `PROJECT_STATE.md` and `SESSION_HANDOFF.md` branch claims for the active implementation branch.

## Preserved Validators

No existing validation commands were removed or weakened.

The workflow still runs:

- `python scripts/validate_structure.py`
- `python scripts/validate_manifest.py`
- `python scripts/check_stale_references.py`
- `python scripts/governance_check.py --strict`
- `python tests/behavior/run_tests.py`
- `python adapters/codex/validate_codex_export.py`
- router benchmark checks
- runtime guardrail
- prompt-load threshold checks
- `plugin.json` JSON validation
- `git diff --check`

## Scope

CI coverage hardening only.

No changes were made to:
- runtime behavior
- scripts
- tests
- adapters
- skills
- governance semantics
- package metadata
- release metadata

## Validation

Local validation passed:

- `python scripts/preflight_sync_check.py`
- `python scripts/validate_structure.py`
- `python scripts/validate_manifest.py`
- `python scripts/check_stale_references.py`
- `python scripts/governance_check.py --strict`
- `python adapters/codex/validate_codex_export.py`
- `python tests/behavior/run_tests.py`
- `python -m pytest tests/runtime --cov=orchestra_runtime --cov-fail-under=90 -q`
- `git diff --check`
- `git diff --stat`

Runtime tests passed: 43/43 with 95.51% coverage.

## Risk Notes

The workflow now explicitly uses `shell: bash` for the native validation script block. This is expected to work on GitHub-hosted `windows-latest` runners through Git Bash.

The first PR run is the real confirmation point for Windows shell compatibility.

### Post-merge note

After this PR merges, `PROJECT_STATE.md` and `SESSION_HANDOFF.md` may need a tiny follow-up commit on `main` to realign `Current Branch` back to `main`.
