### PR TITLE
fix: stabilize startup-state branch semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Specialist Governance & Boundary Standard is a documentation-, governance-, meta
 ## Unreleased
 
 ### Changed
+- Changed startup-state validation to use stable canonical-branch semantics instead of comparing committed files with the transient checkout branch.
 - Improved prompt-load reporting with Group B and Group C status output, largest-contributor reporting, clarified original versus observed baselines, focused regression coverage, and narrow repository-state alignment.
 
 ### Added

--- a/DECISION_LOG.md
+++ b/DECISION_LOG.md
@@ -108,3 +108,23 @@ Post-release audit confirmed core is healthy (42 runtime tests pass, strict gove
 - PROJECT_STATE.md
 - SESSION_HANDOFF.md
 - PROJECT_CONTEXT.md
+
+---
+
+## Date: 2026-07-11
+
+**Decision:**
+Transition from transient checkout branch validation to stable repository branch policy checking. The validator now parses and verifies `Canonical Branch` and `Base Branch` policy claims in committed files, rather than matching them against `git branch --show-current`.
+
+**Reason:**
+Transient checkout branches are runtime facts, not durable repository-memory facts. Validating them strictly against committed files forces developers to modify committed repository files for every temporary feature branch name, creating self-invalidating state as soon as a pull request merges into the default branch. Using `Canonical Branch: main` avoids making `main` stale immediately post-merge.
+
+**Rejected Alternatives:**
+- Advisory-only startup-state validation (rejected; strict startup-state validation remains required for version and baseline alignment).
+- Bypassing branch policy checks entirely.
+
+**Affected Components:**
+- scripts/governance_check.py
+- scripts/test_governance_check.py
+- PROJECT_STATE.md
+- SESSION_HANDOFF.md

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -2,14 +2,14 @@
 
 * **Project Name:** Conductor
 * **Active Repo:** `C:\+conductor`
-* **Current Branch:** `chore/post-artificer-main-realignment`
+* **Canonical Branch:** `main`
 * **Base Branch:** `main`
 * **Current Release:** `v1.1.1`
 * **Target Patch:** `v1.1.2`
 * **Current Stable State:** Artificer Phase 1 merged through PR #153.
-* **Current Task:** Post-Artificer main realignment and Phase 2 internal-boundary planning.
+* **Current Task:** Fix self-invalidating startup-state branch validation
 * **Related but Forbidden Repo for this task:** `C:\+AA`
-* **Latest Validation:** Structure, manifest, stale-reference, Codex export, behavior, and diff checks passed after the Artificer Phase 1 merge. Strict governance requires the startup-state branch claims to match the active realignment branch.
+* **Latest Validation:** Structure, manifest, stale-reference, Codex export, behavior, and diff checks passed after the Artificer Phase 1 merge.
 * **Active Governance Gates:**
 
   * Workspace Boundary Gate
@@ -21,8 +21,8 @@
   * Acme Readiness Gate Expansion
 * **Current Risks:** Prompt-load thresholds remain advisory and current observed Groups A, B, C, and Grand Total exceed soft limits; no re-baselining decision exists.
 * **Do-Not-Touch Areas:** Do not edit website repo files from this task (`C:\+AA`).
-* **Pending Next Steps:** Merge the post-Artificer startup-state realignment, then define the Phase 2 internal-boundary validator and focused behavior tests.
-* **Most Recent Checkpoint:** 2026-07-11 - Artificer Phase 1 merged through PR #153.
+* **Pending Next Steps:** Run the full baseline and merge fix/startup-state-branch-semantics
+* **Most Recent Checkpoint:** 2026-07-11 - Stabilizing startup-state branch semantics.
 
 ## Token Efficiency Rationale
 

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,19 +1,23 @@
 # Session Handoff
 
-- **Current Task:** Post-Artificer main realignment and Phase 2 internal-boundary planning
+- **Current Task:** Fix self-invalidating startup-state branch validation
 - **Current Repo:** `C:\+conductor`
-- **Current Branch:** `chore/post-artificer-main-realignment`
+- **Canonical Branch:** `main`
 - **Base Branch:** `main`
 - **Current Release:** `v1.1.1`
 - **Target Patch:** `v1.1.2`
-- **Mode:** Artificer Phase 1 merged; correcting startup-state records before Phase 2
+- **Mode:** Stable branch policy validation implementation
 - **Allowed Files:**
+  - `scripts/governance_check.py`
+  - `scripts/test_governance_check.py`
   - `PROJECT_STATE.md`
   - `SESSION_HANDOFF.md`
+  - `DECISION_LOG.md`
+  - `CHANGELOG.md`
 - **Forbidden Repo:** `C:\+AA`
-- **Last Validation:** Artificer Phase 1 pull-request validation passed; post-merge structure, manifest, stale-reference, Codex export, behavior, and diff checks passed. Strict governance requires the startup-state branch claims to be realigned.
+- **Last Validation:** Behavior suite and runtime pytest suite passed locally.
 - **Known Risks:** Prompt-load thresholds remain advisory and current observed Groups A, B, C, and Grand Total exceed documented soft limits; no replacement baseline has been approved.
-- **Next Step:** Complete startup-state realignment, rerun strict validation, commit, push, and open the narrow realignment pull request.
+- **Next Step:** Run the full baseline and merge fix/startup-state-branch-semantics
 - **Fresh-Session Warning:** If the current conversation has long prior history from another repository, enter safe mode and request user confirmation before proceeding with implementation.
 
 ## Token Control Note

--- a/scripts/governance_check.py
+++ b/scripts/governance_check.py
@@ -301,7 +301,17 @@ STARTUP_STATE_FILES = [
     "SESSION_HANDOFF.md",
 ]
 
-BRANCH_CLAIM_PATTERN = re.compile(
+CANONICAL_BRANCH_CLAIM_PATTERN = re.compile(
+    r"^\s*[-*]?\s*\*{0,2}Canonical\s+Branch:?\*{0,2}\s*[:`]*\s*`?([^`\n]+?)`?\s*$",
+    re.IGNORECASE,
+)
+
+BASE_BRANCH_CLAIM_PATTERN = re.compile(
+    r"^\s*[-*]?\s*\*{0,2}Base\s+Branch:?\*{0,2}\s*[:`]*\s*`?([^`\n]+?)`?\s*$",
+    re.IGNORECASE,
+)
+
+LEGACY_BRANCH_CLAIM_PATTERN = re.compile(
     r"^\s*[-*]?\s*\*{0,2}Current\s+Branch:?\*{0,2}\s*[:`]*\s*`?([^`\n]+?)`?\s*$",
     re.IGNORECASE,
 )
@@ -317,6 +327,24 @@ def get_current_git_branch(repo_root):
         return None
     branch = result.stdout.strip()
     return branch if branch else None
+
+
+def get_remote_default_branch(repo_root):
+    github_base = os.environ.get("GITHUB_BASE_REF")
+    if github_base:
+        return github_base.strip()
+
+    result = run_git(repo_root, "symbolic-ref", "refs/remotes/origin/HEAD")
+    if result.returncode == 0:
+        ref = result.stdout.strip()
+        if ref.startswith("refs/remotes/origin/"):
+            return ref[len("refs/remotes/origin/"):]
+
+    result = run_git(repo_root, "show-ref", "--verify", "refs/remotes/origin/main")
+    if result.returncode == 0:
+        return "main"
+
+    return None
 
 
 def get_plugin_version(repo_root):
@@ -335,26 +363,97 @@ def run_startup_state_claim_check(repo_root, counters, strict_mode):
 
     record_issue = record_failure if strict_mode else record_warning
 
-    current_branch = get_current_git_branch(repo_root)
     plugin_version = get_plugin_version(repo_root)
+    remote_default = get_remote_default_branch(repo_root)
 
     for memory_file in STARTUP_STATE_FILES:
         memory_path = Path(repo_root) / memory_file
         if not memory_path.is_file():
             continue
 
+        canonical_claims = []
+        base_claims = []
+        legacy_current_lines = []
+
         for line_number, line in enumerate(memory_path.read_text(encoding="utf-8").splitlines(), 1):
-            match = BRANCH_CLAIM_PATTERN.match(line)
-            if match and current_branch:
-                claimed_branch = match.group(1).strip()
-                if claimed_branch != current_branch:
-                    record_issue(
-                        counters,
-                        f"{memory_file}:{line_number}",
-                        f"Structured branch claim '{claimed_branch}' does not match current branch '{current_branch}'.",
-                        "Update the Current Branch field in the startup-state file to match the active branch.",
-                    )
-                    issues_found = True
+            legacy_match = LEGACY_BRANCH_CLAIM_PATTERN.match(line)
+            if legacy_match:
+                legacy_current_lines.append((line_number, legacy_match.group(1).strip()))
+
+            canonical_match = CANONICAL_BRANCH_CLAIM_PATTERN.match(line)
+            if canonical_match:
+                canonical_claims.append((line_number, canonical_match.group(1).strip()))
+
+            base_match = BASE_BRANCH_CLAIM_PATTERN.match(line)
+            if base_match:
+                base_claims.append((line_number, base_match.group(1).strip()))
+
+        if legacy_current_lines:
+            for line_num, val in legacy_current_lines:
+                record_issue(
+                    counters,
+                    f"{memory_file}:{line_num}",
+                    f"Legacy 'Current Branch' claim '{val}' exists in {memory_file}.",
+                    "Remove the legacy 'Current Branch' field and use 'Canonical Branch' instead.",
+                )
+                issues_found = True
+
+        if len(canonical_claims) == 0:
+            record_issue(
+                counters,
+                f"{memory_file}:1",
+                f"Missing required 'Canonical Branch' claim in {memory_file}.",
+                "Add 'Canonical Branch: main' to the startup-state file.",
+            )
+            issues_found = True
+        elif len(canonical_claims) > 1:
+            for line_num, val in canonical_claims:
+                record_issue(
+                    counters,
+                    f"{memory_file}:{line_num}",
+                    f"Duplicate 'Canonical Branch' claim '{val}' found in {memory_file}.",
+                    "Ensure exactly one 'Canonical Branch' claim exists in the startup-state file.",
+                )
+                issues_found = True
+
+        if len(base_claims) == 0:
+            record_issue(
+                counters,
+                f"{memory_file}:1",
+                f"Missing required 'Base Branch' claim in {memory_file}.",
+                "Add 'Base Branch: main' to the startup-state file.",
+            )
+            issues_found = True
+        elif len(base_claims) > 1:
+            for line_num, val in base_claims:
+                record_issue(
+                    counters,
+                    f"{memory_file}:{line_num}",
+                    f"Duplicate 'Base Branch' claim '{val}' found in {memory_file}.",
+                    "Ensure exactly one 'Base Branch' claim exists in the startup-state file.",
+                )
+                issues_found = True
+
+        if len(canonical_claims) == 1 and len(base_claims) == 1:
+            canonical_val = canonical_claims[0][1]
+            base_val = base_claims[0][1]
+            if canonical_val != base_val:
+                record_issue(
+                    counters,
+                    f"{memory_file}:{canonical_claims[0][0]}",
+                    f"Canonical Branch '{canonical_val}' and Base Branch '{base_val}' disagree.",
+                    "Update them to match (e.g., both should be 'main').",
+                )
+                issues_found = True
+
+            if remote_default and canonical_val != remote_default:
+                record_issue(
+                    counters,
+                    f"{memory_file}:{canonical_claims[0][0]}",
+                    f"Canonical Branch '{canonical_val}' conflicts with detected remote default branch '{remote_default}'.",
+                    "Ensure the Canonical Branch aligns with origin/HEAD.",
+                )
+                issues_found = True
 
     context_path = Path(repo_root) / "PROJECT_CONTEXT.md"
     if context_path.is_file() and plugin_version:
@@ -382,7 +481,7 @@ def run_startup_state_claim_check(repo_root, counters, strict_mode):
                 in_stage_section = False
 
     if not issues_found:
-        print_pass("startup-state-claims", "Structured branch and version claims match live repository state.")
+        print_pass("startup-state-claims", "Canonical branch and version claims match repository policy.")
 
 
 def run_strict_validators(repo_root, counters):

--- a/scripts/test_governance_check.py
+++ b/scripts/test_governance_check.py
@@ -46,6 +46,126 @@ def test_repo_memory_path_check():
         assert_equal("missing memory path error", counters["errors"], 1)
 
 
+def test_startup_state_claim_check():
+    with tempfile.TemporaryDirectory(prefix="governance-startup-test-") as temp_dir:
+        repo_root = Path(temp_dir)
+
+        def write_test_files(project_state_content, session_handoff_content, context_content=None, plugin_json_content=None):
+            if project_state_content is not None:
+                (repo_root / "PROJECT_STATE.md").write_text(project_state_content, encoding="utf-8")
+            else:
+                if (repo_root / "PROJECT_STATE.md").is_file():
+                    (repo_root / "PROJECT_STATE.md").unlink()
+            if session_handoff_content is not None:
+                (repo_root / "SESSION_HANDOFF.md").write_text(session_handoff_content, encoding="utf-8")
+            else:
+                if (repo_root / "SESSION_HANDOFF.md").is_file():
+                    (repo_root / "SESSION_HANDOFF.md").unlink()
+            if context_content is not None:
+                (repo_root / "PROJECT_CONTEXT.md").write_text(context_content, encoding="utf-8")
+            else:
+                if (repo_root / "PROJECT_CONTEXT.md").is_file():
+                    (repo_root / "PROJECT_CONTEXT.md").unlink()
+            if plugin_json_content is not None:
+                (repo_root / "plugin.json").write_text(plugin_json_content, encoding="utf-8")
+            else:
+                if (repo_root / "plugin.json").is_file():
+                    (repo_root / "plugin.json").unlink()
+
+        original_get_remote = gc.get_remote_default_branch
+        original_get_current = gc.get_current_git_branch
+        original_get_plugin_version = gc.get_plugin_version
+
+        mock_remote_default = "main"
+        mock_current_branch = "fix/example-feature"
+
+        gc.get_remote_default_branch = lambda r: mock_remote_default
+        gc.get_current_git_branch = lambda r: mock_current_branch
+
+        # 1. Canonical branch matches base branch (main) -> PASS
+        write_test_files(
+            "Canonical Branch: main\nBase Branch: main\n",
+            "Canonical Branch: main\nBase Branch: main\n"
+        )
+        counters = {"warnings": 0, "errors": 0}
+        gc.run_startup_state_claim_check(str(repo_root), counters, strict_mode=True)
+        assert_equal("canonical matches base - pass", counters["errors"], 0)
+
+        # 2. Canonical branch mismatch with base branch -> FAIL
+        write_test_files(
+            "Canonical Branch: main\nBase Branch: dev\n",
+            "Canonical Branch: main\nBase Branch: main\n"
+        )
+        counters = {"warnings": 0, "errors": 0}
+        gc.run_startup_state_claim_check(str(repo_root), counters, strict_mode=True)
+        assert_equal("canonical mismatch base - fail", counters["errors"] > 0, True)
+
+        # 3. Missing canonical branch -> FAIL
+        write_test_files(
+            "Base Branch: main\n",
+            "Canonical Branch: main\nBase Branch: main\n"
+        )
+        counters = {"warnings": 0, "errors": 0}
+        gc.run_startup_state_claim_check(str(repo_root), counters, strict_mode=True)
+        assert_equal("missing canonical - fail", counters["errors"] > 0, True)
+
+        # 4. Duplicate canonical branch claims -> FAIL
+        write_test_files(
+            "Canonical Branch: main\nCanonical Branch: main\nBase Branch: main\n",
+            "Canonical Branch: main\nBase Branch: main\n"
+        )
+        counters = {"warnings": 0, "errors": 0}
+        gc.run_startup_state_claim_check(str(repo_root), counters, strict_mode=True)
+        assert_equal("duplicate canonical - fail", counters["errors"] > 0, True)
+
+        # 5. Rejection of legacy Current Branch -> FAIL
+        write_test_files(
+            "Canonical Branch: main\nBase Branch: main\nCurrent Branch: fix/some-feature\n",
+            "Canonical Branch: main\nBase Branch: main\n"
+        )
+        counters = {"warnings": 0, "errors": 0}
+        gc.run_startup_state_claim_check(str(repo_root), counters, strict_mode=True)
+        assert_equal("rejection of legacy Current Branch - fail", counters["errors"] > 0, True)
+
+        # 6. Remote-default mismatch -> FAIL
+        mock_remote_default = "master"
+        write_test_files(
+            "Canonical Branch: main\nBase Branch: main\n",
+            "Canonical Branch: main\nBase Branch: main\n"
+        )
+        counters = {"warnings": 0, "errors": 0}
+        gc.run_startup_state_claim_check(str(repo_root), counters, strict_mode=True)
+        assert_equal("remote-default mismatch - fail", counters["errors"] > 0, True)
+
+        mock_remote_default = "main"
+
+        # 7. Version checks remain unchanged -> PASS and FAIL scenarios
+        plugin_json = '{"version": "1.1.2"}'
+        write_test_files(
+            "Canonical Branch: main\nBase Branch: main\n",
+            "Canonical Branch: main\nBase Branch: main\n",
+            context_content="## Current Stage\nv1.1.2 - Release\n",
+            plugin_json_content=plugin_json
+        )
+        counters = {"warnings": 0, "errors": 0}
+        gc.run_startup_state_claim_check(str(repo_root), counters, strict_mode=True)
+        assert_equal("version matches - pass", counters["errors"], 0)
+
+        write_test_files(
+            "Canonical Branch: main\nBase Branch: main\n",
+            "Canonical Branch: main\nBase Branch: main\n",
+            context_content="## Current Stage\nv1.1.1 - Release\n",
+            plugin_json_content=plugin_json
+        )
+        counters = {"warnings": 0, "errors": 0}
+        gc.run_startup_state_claim_check(str(repo_root), counters, strict_mode=True)
+        assert_equal("version mismatch - fail", counters["errors"] > 0, True)
+
+        gc.get_remote_default_branch = original_get_remote
+        gc.get_current_git_branch = original_get_current
+        gc.get_plugin_version = original_get_plugin_version
+
+
 def main():
     assert_equal("forbidden artifacts", gc.is_forbidden_repo_path("artifacts/governance_report.txt"), True)
     assert_equal("forbidden runtime folder", gc.is_forbidden_repo_path(".agents/skills/dagger/SKILL.md"), True)
@@ -62,6 +182,7 @@ def main():
     assert_equal("external path ignored", gc.is_repo_relative_memory_path("C:/conductor/scripts/governance_check.py"), False)
     test_tracked_repo_files_only()
     test_repo_memory_path_check()
+    test_startup_state_claim_check()
     print("Governance check helper tests passed.")
     sys.exit(0)
 


### PR DESCRIPTION
## Summary

Fixes the self-invalidating startup-state branch validation by transitioning from transient checkout branch matching to stable repository branch policy checking.

## Proposed Changes

### Validator Changes (`scripts/governance_check.py`)
- Replaced the transient `Current Branch` check with stable policy fields: `Canonical Branch` and `Base Branch`.
- Resolved the default remote branch using non-network dependent lookups:
  1. `GITHUB_BASE_REF`
  2. `refs/remotes/origin/HEAD`
  3. `refs/remotes/origin/main`
- Implemented robust error reporting to fail when:
  - `Canonical Branch` claim is missing
  - Duplicate canonical branch claims exist in the same file
  - Legacy `Current Branch` fields exist in memory files
  - `Canonical Branch` and `Base Branch` disagree
  - The canonical branch conflicts with a deterministically resolvable remote default branch
- Modified the success message to: `Canonical branch and version claims match repository policy.`

### Test Suite (`scripts/test_governance_check.py`)
- Added comprehensive regression coverage for:
  - Canonical branch matching the base branch (passes)
  - Canonical branch mismatching the base branch (fails)
  - Missing canonical branch (fails)
  - Duplicate canonical branch claims (fails)
  - Rejection of legacy `Current Branch` (fails)
  - Feature branches checkouts passing when committed canonical and base branches are `main` (passes)
  - Remote-default branch mismatch when deterministically available (fails)
  - Unchanged version check regressions (passes/fails)
- Eliminated all trailing whitespaces to pass strict `git diff --check`.

### Startup State & Documents
- Updated `PROJECT_STATE.md` and `SESSION_HANDOFF.md` to use:
  ```text
  Canonical Branch: main
  Base Branch: main
  ```
  and updated the active task description/next steps.
- Logged the architectural decision in `DECISION_LOG.md`.
- Added Unreleased entry in `CHANGELOG.md`.

## Verification Results
All validation suites passed successfully:
- `python scripts/test_governance_check.py` -> **PASSED**
- `python scripts/validate_structure.py` -> **PASSED**
- `python scripts/validate_manifest.py` -> **PASSED**
- `python scripts/check_stale_references.py` -> **PASSED**
- `python scripts/governance_check.py --strict` -> **PASSED** (0 Errors, 0 Warnings)
- `python adapters/codex/validate_codex_export.py` -> **PASSED**
- `python tests/behavior/run_tests.py` -> **PASSED**
- `python -m pytest tests/runtime --cov=orchestra_runtime --cov-report=term-missing --cov-fail-under=90` -> **PASSED** (Coverage: 95.51%)
- `git diff --check` -> **PASSED** (No trailing whitespaces found)
