### PR TITLE
test: strengthen Artificer boundary regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ Specialist Governance & Boundary Standard is a documentation-, governance-, meta
 ## Unreleased
 
 ### Changed
+- Strengthened the Artificer boundary validator (`scripts/validate_artificer_internal.py`) by refactoring it into pure functions returning `ValidationFailure` dataclass instances, and introducing strict semantic checks requiring explicit Artificer-bound negative polarity.
+- Hardened the behavior test suite (`tests/behavior/test_artificer_internal.py`) by replacing placeholder `pass` blocks, ensuring all regression tests assert specific validator failures, adding a quality gate check on test source code, and verifying the entire repository via `validate_repository()`.
+- Added explicit no-self-implementation and no-self-approval contract checks and statements to `internal/artificer/ARTIFICER.md`.
 - Changed startup-state validation to use stable canonical-branch semantics instead of comparing committed files with the transient checkout branch.
 - Improved prompt-load reporting with Group B and Group C status output, largest-contributor reporting, clarified original versus observed baselines, focused regression coverage, and narrow repository-state alignment.
 

--- a/DECISION_LOG.md
+++ b/DECISION_LOG.md
@@ -150,3 +150,26 @@ Phase 2 introduces strict enforcement of the Artificer Phase 1 specification bou
 - tests/behavior/run_tests.py
 - PROJECT_STATE.md
 - SESSION_HANDOFF.md
+
+---
+
+## Date: 2026-07-11
+
+**Decision:**
+Strengthened the Artificer boundary validator and test suite to resolve false-positive tests identified during a post-merge audit. The validator has been refactored to expose pure, testable functions returning `ValidationFailure` dataclass instances. Documentation-boundary negative safety contracts now require explicit Artificer-bound prohibition statements.
+
+**Reason:**
+PR #158 successfully merged the Phase 2 validator, but subsequent audit revealed that some regression tests used placeholder `pass` blocks, did not assert validator responses, or allowed unrelated negative statements to satisfy negative safety contracts. A narrow follow-up PR was chosen instead of reverting. Passing tests now verify the entire repository via `validate_repository()`, and a quality gate prevents any placeholder or unasserted tests in the test suite.
+
+**Rejected Alternatives:**
+- Reverting PR #158 (rejected; the validator functionality is sound and integration is correct; fixing the tests directly is less disruptive).
+- Allowing implicit or general negative safety contracts (rejected; without explicit Artificer-bound prohibition statements, unrelated negative text can satisfy a contract, risking false-positives).
+
+**Affected Components:**
+- scripts/validate_artificer_internal.py
+- tests/behavior/test_artificer_internal.py
+- internal/artificer/ARTIFICER.md
+- CHANGELOG.md
+- DECISION_LOG.md
+- PROJECT_STATE.md
+- SESSION_HANDOFF.md

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -7,9 +7,9 @@
 * **Current Release:** `v1.1.1`
 * **Target Patch:** `v1.1.2`
 * **Current Stable State:** Artificer Phase 1 merged through PR #153.
-* **Current Task:** Artificer Phase 2 internal boundary and contract validation
+* **Current Task:** Strengthen Artificer validator regression coverage and semantic enforcement
 * **Related but Forbidden Repo for this task:** `C:\+AA`
-* **Latest Validation:** Pending Phase 2 implementation validation
+* **Latest Validation:** Pending follow-up remediation validation
 * **Active Governance Gates:**
 
   * Workspace Boundary Gate
@@ -21,8 +21,8 @@
   * Acme Readiness Gate Expansion
 * **Current Risks:** Prompt-load thresholds remain advisory and current observed Groups A, B, C, and Grand Total exceed soft limits; no re-baselining decision exists.
 * **Do-Not-Touch Areas:** Do not edit website repo files from this task (`C:\+AA`).
-* **Pending Next Steps:** Complete and merge the internal validator, then design Phase 3 source-intake and pattern-record instance validation
-* **Most Recent Checkpoint:** 2026-07-11 - Artificer branch semantics stabilized through PR #157
+* **Pending Next Steps:** Complete and merge the Artificer validator remediation, then proceed to Phase 3 instance validation
+* **Most Recent Checkpoint:** 2026-07-11 - Artificer Phase 2 merged through PR #158; regression audit identified false-positive tests
 
 ## Token Efficiency Rationale
 

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,17 +1,16 @@
 # Session Handoff
 
-- **Current Task:** Artificer Phase 2 internal boundary and contract validation
+- **Current Task:** Strengthen Artificer validator regression coverage and semantic enforcement
 - **Current Repo:** `C:\+conductor`
 - **Canonical Branch:** `main`
 - **Base Branch:** `main`
 - **Current Release:** `v1.1.1`
 - **Target Patch:** `v1.1.2`
-- **Mode:** Deterministic internal contract enforcement
+- **Mode:** Post-merge validator remediation
 - **Allowed Files:**
   - `scripts/validate_artificer_internal.py`
   - `tests/behavior/test_artificer_internal.py`
-  - `scripts/governance_check.py`
-  - `tests/behavior/run_tests.py`
+  - `internal/artificer/ARTIFICER.md`
   - `CHANGELOG.md`
   - `DECISION_LOG.md`
   - `PROJECT_STATE.md`
@@ -19,7 +18,7 @@
 - **Forbidden Repo:** `C:\+AA`
 - **Last Validation:** Behavior suite and runtime pytest suite passed locally.
 - **Known Risks:** Prompt-load thresholds remain advisory and current observed Groups A, B, C, and Grand Total exceed documented soft limits; no replacement baseline has been approved.
-- **Next Step:** Run the full baseline and merge feat/artificer-internal-boundary-validator
+- **Next Step:** Replace placeholder tests, strengthen polarity checks, run the full baseline, and open the follow-up pull request
 - **Fresh-Session Warning:** If the current conversation has long prior history from another repository, enter safe mode and request user confirmation before proceeding with implementation.
 
 ## Token Control Note

--- a/internal/artificer/ARTIFICER.md
+++ b/internal/artificer/ARTIFICER.md
@@ -19,10 +19,14 @@ Artificer is a maintainer-only internal specialist for the Orchestra ecosystem. 
 
 ## Non-Goals
 
-- Do NOT build user applications or websites.
-- Do NOT serve as a general-purpose coding specialist for arbitrary user queries.
-- Do NOT automate code cherry-picking, directory copies, or branch creations.
-- Do NOT execute build scripts, run tests, or install packages of external codebases.
+- Artificer must not build user applications or websites.
+- Artificer must not serve as a general-purpose coding specialist for arbitrary user queries.
+- Artificer must not automate code cherry-picking, directory copies, or branch creations.
+- Artificer must not execute build scripts, run tests, or install packages of external codebases.
+- Artificer must not implement its own recommendations or evolution proposals.
+- Artificer must not approve, adjudicate, or clear its own findings.
+- Artificer must not execute external or untrusted repository code.
+- Artificer must not install external repository dependencies or packages.
 
 ## Activation Rules
 
@@ -43,8 +47,8 @@ Artificer activates only when a maintainer explicitly asks to audit an external 
 
 ## Routing Restrictions
 
-Artificer is blocked from:
-- `plugin.json` (Public Manifest)
-- `SKILL_INDEX.md` and `ROUTING_MAP.md`
-- Runtime command routes in `orchestra_runtime/`
-- Adapter exports (e.g., `adapters/codex/skills/`)
+- Artificer must not register itself publicly.
+- Artificer must not expose itself through runtime or adapter surfaces.
+- Artificer is blocked from public manifests such as `plugin.json`, `SKILL_INDEX.md`, and `ROUTING_MAP.md`.
+- Artificer is prohibited from registering or executing command routes in `orchestra_runtime/`.
+- Artificer is prohibited from adapter exports in `adapters/codex/skills/`.

--- a/scripts/validate_artificer_internal.py
+++ b/scripts/validate_artificer_internal.py
@@ -5,6 +5,7 @@ import sys
 import json
 import re
 from pathlib import Path
+from dataclasses import dataclass
 
 REQUIRED_FILES = [
     "internal/artificer/ARTIFICER.md",
@@ -22,41 +23,49 @@ REQUIRED_FILES = [
     "docs/internal/SECURITY_BOUNDARIES.md"
 ]
 
+@dataclass(frozen=True)
+class ValidationFailure:
+    target: str
+    reason: str
+    remediation: str
+
+class ThrowingArgumentParser(argparse.ArgumentParser):
+    def error(self, message):
+        raise argparse.ArgumentError(None, message)
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="Artificer Internal Boundary and Contract Validator")
+    parser = ThrowingArgumentParser(description="Artificer Internal Boundary and Contract Validator")
     parser.add_argument("--repo-root", type=str, default=None, help="Root directory of the repository")
     return parser.parse_args()
 
-
-def validate_shared_schema(schema_dict, filename):
+def validate_shared_schema(schema_dict, filename) -> list[ValidationFailure]:
     failures = []
     if not isinstance(schema_dict, dict):
-        failures.append((filename, "Top-level structure is not a JSON object", "Change the top-level schema to a JSON object"))
+        failures.append(ValidationFailure(filename, "Top-level structure is not a JSON object", "Change the top-level schema to a JSON object"))
         return failures
 
     schema_url = schema_dict.get("$schema")
     if schema_url != "http://json-schema.org/draft-07/schema#":
-        failures.append((filename, f"Invalid $schema claim: {schema_url}", "Ensure '$schema' is 'http://json-schema.org/draft-07/schema#'"))
+        failures.append(ValidationFailure(filename, f"Invalid $schema claim: {schema_url}", "Ensure '$schema' is 'http://json-schema.org/draft-07/schema#'"))
 
     if schema_dict.get("type") != "object":
-        failures.append((filename, "Top-level 'type' must be 'object'", "Set 'type' to 'object' at the root of the schema"))
+        failures.append(ValidationFailure(filename, "Top-level 'type' must be 'object'", "Set 'type' to 'object' at the root of the schema"))
 
     properties = schema_dict.get("properties")
     if not isinstance(properties, dict):
-        failures.append((filename, "'properties' must be a JSON object", "Define 'properties' as a JSON object"))
+        failures.append(ValidationFailure(filename, "'properties' must be a JSON object", "Define 'properties' as a JSON object"))
 
     required = schema_dict.get("required")
     if not isinstance(required, list):
-        failures.append((filename, "'required' must be a list", "Define 'required' as a list of property names"))
+        failures.append(ValidationFailure(filename, "'required' must be a list", "Define 'required' as a list of property names"))
     else:
         if isinstance(properties, dict):
             for req_field in required:
                 if req_field not in properties:
-                    failures.append((filename, f"Required field '{req_field}' not present in properties", f"Add '{req_field}' definition to properties"))
+                    failures.append(ValidationFailure(filename, f"Required field '{req_field}' not present in properties", f"Add '{req_field}' definition to properties"))
 
     if schema_dict.get("additionalProperties") is not False:
-        failures.append((filename, "'additionalProperties' must be false", "Set 'additionalProperties' to false"))
+        failures.append(ValidationFailure(filename, "'additionalProperties' must be false", "Set 'additionalProperties' to false"))
 
     def find_duplicate_enums(node, path=""):
         enum_dupes = []
@@ -74,10 +83,185 @@ def validate_shared_schema(schema_dict, filename):
 
     dupes = find_duplicate_enums(schema_dict)
     for path, enums in dupes:
-        failures.append((filename, f"Duplicate values found in enum array at '{path}': {enums}", f"Remove duplicate entries from the enum array at '{path}'"))
+        failures.append(ValidationFailure(filename, f"Duplicate values found in enum array at '{path}': {enums}", f"Remove duplicate entries from the enum array at '{path}'"))
 
     return failures
 
+def check_required_files(repo_root: Path) -> list[ValidationFailure]:
+    failures = []
+    for relative_path in REQUIRED_FILES:
+        full_path = repo_root / relative_path
+        if not full_path.exists():
+            failures.append(ValidationFailure(relative_path, "File does not exist", f"Create the missing specification file at {relative_path}"))
+        elif not full_path.is_file():
+            failures.append(ValidationFailure(relative_path, "Not a regular file", f"Ensure {relative_path} is a regular file and not a directory"))
+        else:
+            try:
+                content = full_path.read_text(encoding="utf-8")
+                if not content.strip():
+                    failures.append(ValidationFailure(relative_path, "File is empty", f"Add content to the required specification file {relative_path}"))
+            except UnicodeDecodeError:
+                failures.append(ValidationFailure(relative_path, "Cannot decode as UTF-8", f"Convert encoding of {relative_path} to UTF-8"))
+    return failures
+
+def validate_pattern_schema(repo_root: Path) -> list[ValidationFailure]:
+    failures = []
+    pattern_schema_path = repo_root / "internal/artificer/PATTERN_SCHEMA.json"
+    if not pattern_schema_path.is_file():
+        return failures
+
+    try:
+        content = pattern_schema_path.read_text(encoding="utf-8")
+        pattern_schema = json.loads(content)
+        failures.extend(validate_shared_schema(pattern_schema, "internal/artificer/PATTERN_SCHEMA.json"))
+
+        properties = pattern_schema.get("properties", {})
+        required = pattern_schema.get("required", [])
+
+        expected_props = {"name", "description", "source_file", "line_range", "classification", "assigned_specialist", "license_implications"}
+        if isinstance(properties, dict) and set(properties.keys()) != expected_props:
+            reason = f"Properties mismatch: expected {expected_props}, got {set(properties.keys())}"
+            failures.append(ValidationFailure("internal/artificer/PATTERN_SCHEMA.json", reason, "Ensure PATTERN_SCHEMA.json defines exactly the required properties"))
+
+        expected_req = {"name", "description", "source_file", "classification", "assigned_specialist"}
+        if set(required) != expected_req:
+            reason = f"Required list mismatch: expected {expected_req}, got {set(required)}"
+            failures.append(ValidationFailure("internal/artificer/PATTERN_SCHEMA.json", reason, "Ensure required list matches exactly the mandatory fields"))
+
+        class_enum = properties.get("classification", {}).get("enum", [])
+        expected_class_enum = ["REFERENCE_ONLY", "ADAPTED_PATTERN", "CODE_REUSE_REVIEW_REQUIRED", "TEST_CORPUS_CANDIDATE", "REJECTED", "DEFERRED", "DUPLICATE", "OUT_OF_SCOPE"]
+        if class_enum != expected_class_enum:
+            reason = "classification enum mismatch"
+            failures.append(ValidationFailure("internal/artificer/PATTERN_SCHEMA.json", reason, "Set classification enum to the exact expected values"))
+
+        spec_enum = properties.get("assigned_specialist", {}).get("enum", [])
+        expected_spec_enum = ["cloak", "cipher", "clockwork", "ponytail", "overseer", "dagger", "the-governor", "arbiter", "chronicler", "weaver", "scribe", "the-steward"]
+        if spec_enum != expected_spec_enum:
+            reason = "assigned_specialist enum mismatch"
+            failures.append(ValidationFailure("internal/artificer/PATTERN_SCHEMA.json", reason, "Set assigned_specialist enum to the exact expected values"))
+
+        if "artificer" in spec_enum:
+            reason = "assigned_specialist enum must never contain 'artificer'"
+            failures.append(ValidationFailure("internal/artificer/PATTERN_SCHEMA.json", reason, "Remove 'artificer' from the assigned_specialist enum list"))
+
+        lr_pattern = properties.get("line_range", {}).get("pattern")
+        if lr_pattern != r"^\d+-\d+$":
+            reason = "line_range pattern mismatch"
+            failures.append(ValidationFailure("internal/artificer/PATTERN_SCHEMA.json", reason, "Set line_range pattern to '^\\d+-\\d+$'"))
+    except Exception as e:
+        failures.append(ValidationFailure("internal/artificer/PATTERN_SCHEMA.json", f"JSON parsing failed: {e}", "Fix the JSON syntax of PATTERN_SCHEMA.json"))
+
+    return failures
+
+def validate_source_intake_schema(repo_root: Path) -> list[ValidationFailure]:
+    failures = []
+    source_schema_path = repo_root / "internal/artificer/SOURCE_INTAKE_SCHEMA.json"
+    if not source_schema_path.is_file():
+        return failures
+
+    try:
+        content = source_schema_path.read_text(encoding="utf-8")
+        source_schema = json.loads(content)
+        failures.extend(validate_shared_schema(source_schema, "internal/artificer/SOURCE_INTAKE_SCHEMA.json"))
+
+        properties = source_schema.get("properties", {})
+        required = source_schema.get("required", [])
+
+        expected_props = {"repository", "repository_owner", "canonical_url", "license", "default_branch", "reviewed_commit_sha", "review_date", "files_examined", "runtime_behavior_tested", "source_confidence"}
+        if isinstance(properties, dict) and set(properties.keys()) != expected_props:
+            reason = f"Properties mismatch: expected {expected_props}, got {set(properties.keys())}"
+            failures.append(ValidationFailure("internal/artificer/SOURCE_INTAKE_SCHEMA.json", reason, "Ensure SOURCE_INTAKE_SCHEMA.json defines exactly the required properties"))
+
+        expected_req = {"repository", "repository_owner", "canonical_url", "license", "reviewed_commit_sha", "review_date", "files_examined", "runtime_behavior_tested", "source_confidence"}
+        if set(required) != expected_req:
+            reason = f"Required list mismatch: expected {expected_req}, got {set(required)}"
+            failures.append(ValidationFailure("internal/artificer/SOURCE_INTAKE_SCHEMA.json", reason, "Ensure required list matches exactly the mandatory fields"))
+
+        commit_pattern = properties.get("reviewed_commit_sha", {}).get("pattern")
+        if commit_pattern != r"^[0-9a-fA-F]{40}$":
+            reason = "reviewed_commit_sha pattern mismatch"
+            failures.append(ValidationFailure("internal/artificer/SOURCE_INTAKE_SCHEMA.json", reason, "Set reviewed_commit_sha pattern to '^[0-9a-fA-F]{40}$'"))
+
+        date_format = properties.get("review_date", {}).get("format")
+        if date_format != "date":
+            reason = "review_date format mismatch"
+            failures.append(ValidationFailure("internal/artificer/SOURCE_INTAKE_SCHEMA.json", reason, "Set review_date format to 'date'"))
+
+        rbt_type = properties.get("runtime_behavior_tested", {}).get("type")
+        if rbt_type != "boolean":
+            reason = "runtime_behavior_tested type mismatch"
+            failures.append(ValidationFailure("internal/artificer/SOURCE_INTAKE_SCHEMA.json", reason, "Set runtime_behavior_tested type to 'boolean'"))
+
+        fe_type = properties.get("files_examined", {}).get("type")
+        if fe_type != "array":
+            reason = "files_examined type mismatch"
+            failures.append(ValidationFailure("internal/artificer/SOURCE_INTAKE_SCHEMA.json", reason, "Set files_examined type to 'array'"))
+
+        fe_items = properties.get("files_examined", {}).get("items", {})
+        fe_items_ap = fe_items.get("additionalProperties")
+        if fe_items_ap is not False:
+            reason = "files_examined items additionalProperties mismatch"
+            failures.append(ValidationFailure("internal/artificer/SOURCE_INTAKE_SCHEMA.json", reason, "Set files_examined items additionalProperties to false"))
+
+        sc_enum = properties.get("source_confidence", {}).get("enum", [])
+        expected_sc_enum = ["HIGH", "MEDIUM", "LOW"]
+        if sc_enum != expected_sc_enum:
+            reason = "Source confidence enum mismatch"
+            failures.append(ValidationFailure("internal/artificer/SOURCE_INTAKE_SCHEMA.json", reason, "Set source_confidence enum to exactly HIGH, MEDIUM, LOW"))
+    except Exception as e:
+        failures.append(ValidationFailure("internal/artificer/SOURCE_INTAKE_SCHEMA.json", f"JSON parsing failed: {e}", "Fix the JSON syntax of SOURCE_INTAKE_SCHEMA.json"))
+
+    return failures
+
+def normalize_contract_text(content: str) -> str:
+    content = content.lower()
+    content = re.sub(r"[`*_#>|-]+", " ", content)
+    content = re.sub(r"\s+", " ", content)
+    return content.strip()
+
+def get_sentences(content: str) -> list[str]:
+    content = re.sub(r"(?:^|\n)\s*#+\s+", ". ", content)
+    content = re.sub(r"(?:^|\n)\s*[-*+]\s+", ". ", content)
+    raw_sentences = re.split(r'[.;!\?\n]', content)
+    sentences = []
+    for s in raw_sentences:
+        norm = normalize_contract_text(s)
+        if norm:
+            sentences.append(norm)
+    return sentences
+
+def has_artificer_prohibition(
+    content: str,
+    action_pattern: str,
+    object_pattern: str | None = None,
+) -> bool:
+    sentences = get_sentences(content)
+    negatives = [
+        "must not",
+        "does not",
+        "do not",
+        "cannot",
+        "may not",
+        "never",
+        "is prohibited from",
+        "is blocked from"
+    ]
+    for s in sentences:
+        if "artificer" not in s:
+            continue
+        has_neg = False
+        for neg in negatives:
+            if neg in s:
+                has_neg = True
+                break
+        if not has_neg:
+            continue
+        if not re.search(action_pattern, s, re.IGNORECASE):
+            continue
+        if object_pattern and not re.search(object_pattern, s, re.IGNORECASE):
+            continue
+        return True
+    return False
 
 def check_artificer_md(content):
     missing = []
@@ -87,28 +271,23 @@ def check_artificer_md(content):
         missing.append("internal visibility")
     if not re.search(r"read-only", content, re.IGNORECASE):
         missing.append("read-only external-source auditing")
-    if not (re.search(r"no public routing", content, re.IGNORECASE) or re.search(r"blocked from.*routing", content, re.IGNORECASE) or re.search(r"routing restrictions", content, re.IGNORECASE)):
-        missing.append("no public routing")
-    if not (re.search(r"plugin\.json", content, re.IGNORECASE) or re.search(r"public manifest", content, re.IGNORECASE)):
-        missing.append("no manifest registration")
-    if not (re.search(r"orchestra_runtime", content, re.IGNORECASE) or re.search(r"runtime command", content, re.IGNORECASE)):
-        missing.append("no runtime route")
-    if not re.search(r"adapter", content, re.IGNORECASE):
-        missing.append("no adapter export")
-    if not (re.search(r"execute", content, re.IGNORECASE) or re.search(r"no code execution", content, re.IGNORECASE)):
+
+    if not has_artificer_prohibition(content, r"execute", r"code|script|binary|test|runner"):
         missing.append("no external code execution")
-    if not (re.search(r"install", content, re.IGNORECASE) or re.search(r"dependency", content, re.IGNORECASE)):
+    if not has_artificer_prohibition(content, r"install", r"dependency|package"):
         missing.append("no external dependency installation")
-    if not (re.search(r"copy", content, re.IGNORECASE) or re.search(r"cherry-pick", content, re.IGNORECASE)):
-        missing.append("no automatic code copying or cherry-picking")
-    if not (re.search(r"propose", content, re.IGNORECASE) or re.search(r"non-goals", content, re.IGNORECASE)):
+    if not has_artificer_prohibition(content, r"implement", r"recommendation|proposal|own|change|ui"):
         missing.append("no self-implementation")
-    if not (re.search(r"non-goals", content, re.IGNORECASE) or re.search(r"do not", content, re.IGNORECASE)):
+    if not has_artificer_prohibition(content, r"approve|adjudicate|clear", r"finding|evidence|own"):
         missing.append("no self-approval")
+    if not (has_artificer_prohibition(content, r"register", r"public|manifest") or has_artificer_prohibition(content, r"visibility|blocked", r"public|manifest|routing")):
+        missing.append("no manifest registration")
+    if not (has_artificer_prohibition(content, r"expose|route", r"runtime|adapter") or has_artificer_prohibition(content, r"visibility|blocked", r"runtime|adapter")):
+        missing.append("no runtime route")
+
     if not (re.search(r"cipher", content, re.IGNORECASE) and (re.search(r"hand", content, re.IGNORECASE) or re.search(r"off", content, re.IGNORECASE))):
         missing.append("Cipher handoff for security-relevant findings")
     return missing
-
 
 def check_security_boundaries_md(content):
     missing = []
@@ -130,13 +309,15 @@ def check_security_boundaries_md(content):
         missing.append("Execution outside the active Orchestra workspace statement")
     return missing
 
-
 def check_artificer_boundaries_md(content):
     missing = []
     specialists = ["Artificer", "Cloak", "Cipher", "Clockwork", "Ponytail", "Overseer", "Dagger", "Arbiter", "The Governor", "The Steward"]
     for spec in specialists:
         if not re.search(re.escape(spec), content, re.IGNORECASE):
             missing.append(f"Boundary entry for {spec}")
+
+    if re.search(r"map to\s+\*?\*?artificer\*?\*?\s+for.*code\s+changes|implementation\s+is\s+owned\s+by\s+artificer|artificer\s+implements", content, re.IGNORECASE):
+        missing.append("rejection of implementation ownership assigned to Artificer")
 
     if not (re.search(r"implement", content, re.IGNORECASE) or re.search(r"write.*code", content, re.IGNORECASE)):
         missing.append("Artificer does not implement source changes statement")
@@ -150,7 +331,6 @@ def check_artificer_boundaries_md(content):
         missing.append("Artificer does not perform live adversarial testing statement")
 
     return missing
-
 
 def check_evidence_requirements_md(content):
     missing = []
@@ -182,7 +362,6 @@ def check_evidence_requirements_md(content):
 
     return missing
 
-
 def check_artificer_workflow_md(content):
     missing = []
     stages = [
@@ -201,7 +380,6 @@ def check_artificer_workflow_md(content):
         missing.append("Specialist-owned implementation statement")
 
     return missing
-
 
 def check_output_formats_md(content):
     missing = []
@@ -224,165 +402,8 @@ def check_output_formats_md(content):
 
     return missing
 
-
-def main():
-    args = parse_args()
-    if args.repo_root:
-        repo_root = Path(args.repo_root)
-    else:
-        repo_root = Path(__file__).resolve().parent.parent
-
+def check_documentation_contracts(repo_root: Path) -> list[ValidationFailure]:
     failures = []
-
-    # [1] Required Internal Files
-    print("[1] Required Internal Files")
-    for relative_path in REQUIRED_FILES:
-        full_path = repo_root / relative_path
-        if not full_path.exists():
-            failures.append((relative_path, "File does not exist", f"Create the missing specification file at {relative_path}"))
-            print(f"[FAIL] {relative_path}: File does not exist.")
-        elif not full_path.is_file():
-            failures.append((relative_path, "Not a regular file", f"Ensure {relative_path} is a regular file and not a directory"))
-            print(f"[FAIL] {relative_path}: Not a regular file.")
-        else:
-            try:
-                content = full_path.read_text(encoding="utf-8")
-                if not content.strip():
-                    failures.append((relative_path, "File is empty", f"Add content to the required specification file {relative_path}"))
-                    print(f"[FAIL] {relative_path}: File is empty.")
-                else:
-                    print(f"[PASS] {relative_path}: File exists and is non-empty.")
-            except UnicodeDecodeError:
-                failures.append((relative_path, "Cannot decode as UTF-8", f"Convert encoding of {relative_path} to UTF-8"))
-                print(f"[FAIL] {relative_path}: Cannot decode as UTF-8.")
-
-    # [2] JSON Schema Contracts
-    print("\n[2] JSON Schema Contracts")
-    pattern_schema_path = repo_root / "internal/artificer/PATTERN_SCHEMA.json"
-    if pattern_schema_path.is_file():
-        try:
-            pattern_schema = json.loads(pattern_schema_path.read_text(encoding="utf-8"))
-            shared_fails = validate_shared_schema(pattern_schema, "internal/artificer/PATTERN_SCHEMA.json")
-            for f_target, f_reason, f_remedy in shared_fails:
-                failures.append((f_target, f_reason, f_remedy))
-                print(f"[FAIL] {f_target}: {f_reason}.")
-
-            properties = pattern_schema.get("properties", {})
-            required = pattern_schema.get("required", [])
-
-            expected_props = {"name", "description", "source_file", "line_range", "classification", "assigned_specialist", "license_implications"}
-            if isinstance(properties, dict) and set(properties.keys()) != expected_props:
-                reason = f"Properties mismatch: expected {expected_props}, got {set(properties.keys())}"
-                failures.append(("internal/artificer/PATTERN_SCHEMA.json", reason, "Ensure PATTERN_SCHEMA.json defines exactly the required properties"))
-                print(f"[FAIL] internal/artificer/PATTERN_SCHEMA.json: {reason}.")
-
-            expected_req = {"name", "description", "source_file", "classification", "assigned_specialist"}
-            if set(required) != expected_req:
-                reason = f"Required list mismatch: expected {expected_req}, got {set(required)}"
-                failures.append(("internal/artificer/PATTERN_SCHEMA.json", reason, "Ensure required list matches exactly the mandatory fields"))
-                print(f"[FAIL] internal/artificer/PATTERN_SCHEMA.json: {reason}.")
-
-            class_enum = properties.get("classification", {}).get("enum", [])
-            expected_class_enum = ["REFERENCE_ONLY", "ADAPTED_PATTERN", "CODE_REUSE_REVIEW_REQUIRED", "TEST_CORPUS_CANDIDATE", "REJECTED", "DEFERRED", "DUPLICATE", "OUT_OF_SCOPE"]
-            if class_enum != expected_class_enum:
-                reason = f"Classification enum mismatch: expected {expected_class_enum}, got {class_enum}"
-                failures.append(("internal/artificer/PATTERN_SCHEMA.json", reason, "Set classification enum to the exact expected values"))
-                print(f"[FAIL] internal/artificer/PATTERN_SCHEMA.json: {reason}.")
-
-            spec_enum = properties.get("assigned_specialist", {}).get("enum", [])
-            expected_spec_enum = ["cloak", "cipher", "clockwork", "ponytail", "overseer", "dagger", "the-governor", "arbiter", "chronicler", "weaver", "scribe", "the-steward"]
-            if spec_enum != expected_spec_enum:
-                reason = f"Assigned specialist enum mismatch: expected {expected_spec_enum}, got {spec_enum}"
-                failures.append(("internal/artificer/PATTERN_SCHEMA.json", reason, "Set assigned_specialist enum to the exact expected values"))
-                print(f"[FAIL] internal/artificer/PATTERN_SCHEMA.json: {reason}.")
-
-            if "artificer" in spec_enum:
-                reason = "assigned_specialist enum must never contain 'artificer'"
-                failures.append(("internal/artificer/PATTERN_SCHEMA.json", reason, "Remove 'artificer' from the assigned_specialist enum list"))
-                print(f"[FAIL] internal/artificer/PATTERN_SCHEMA.json: {reason}.")
-
-            lr_pattern = properties.get("line_range", {}).get("pattern")
-            if lr_pattern != r"^\d+-\d+$":
-                reason = f"line_range pattern mismatch: expected r'^\\d+-\\d+$', got {lr_pattern!r}"
-                failures.append(("internal/artificer/PATTERN_SCHEMA.json", reason, "Set line_range pattern to '^\\d+-\\d+$'"))
-                print(f"[FAIL] internal/artificer/PATTERN_SCHEMA.json: {reason}.")
-
-            if not shared_fails and len(failures) == 0:
-                print("[PASS] internal/artificer/PATTERN_SCHEMA.json: Schema is valid and compliant.")
-        except Exception as e:
-            failures.append(("internal/artificer/PATTERN_SCHEMA.json", f"JSON parsing failed: {e}", "Fix the JSON syntax of PATTERN_SCHEMA.json"))
-            print(f"[FAIL] internal/artificer/PATTERN_SCHEMA.json: JSON parsing failed.")
-
-    source_schema_path = repo_root / "internal/artificer/SOURCE_INTAKE_SCHEMA.json"
-    if source_schema_path.is_file():
-        try:
-            source_schema = json.loads(source_schema_path.read_text(encoding="utf-8"))
-            shared_fails = validate_shared_schema(source_schema, "internal/artificer/SOURCE_INTAKE_SCHEMA.json")
-            for f_target, f_reason, f_remedy in shared_fails:
-                failures.append((f_target, f_reason, f_remedy))
-                print(f"[FAIL] {f_target}: {f_reason}.")
-
-            properties = source_schema.get("properties", {})
-            required = source_schema.get("required", [])
-
-            expected_props = {"repository", "repository_owner", "canonical_url", "license", "default_branch", "reviewed_commit_sha", "review_date", "files_examined", "runtime_behavior_tested", "source_confidence"}
-            if isinstance(properties, dict) and set(properties.keys()) != expected_props:
-                reason = f"Properties mismatch: expected {expected_props}, got {set(properties.keys())}"
-                failures.append(("internal/artificer/SOURCE_INTAKE_SCHEMA.json", reason, "Ensure SOURCE_INTAKE_SCHEMA.json defines exactly the required properties"))
-                print(f"[FAIL] internal/artificer/SOURCE_INTAKE_SCHEMA.json: {reason}.")
-
-            expected_req = {"repository", "repository_owner", "canonical_url", "license", "reviewed_commit_sha", "review_date", "files_examined", "runtime_behavior_tested", "source_confidence"}
-            if set(required) != expected_req:
-                reason = f"Required list mismatch: expected {expected_req}, got {set(required)}"
-                failures.append(("internal/artificer/SOURCE_INTAKE_SCHEMA.json", reason, "Ensure required list matches exactly the mandatory fields"))
-                print(f"[FAIL] internal/artificer/SOURCE_INTAKE_SCHEMA.json: {reason}.")
-
-            commit_pattern = properties.get("reviewed_commit_sha", {}).get("pattern")
-            if commit_pattern != r"^[0-9a-fA-F]{40}$":
-                reason = f"reviewed_commit_sha pattern mismatch: expected '^[0-9a-fA-F]{40}$', got {commit_pattern!r}"
-                failures.append(("internal/artificer/SOURCE_INTAKE_SCHEMA.json", reason, "Set reviewed_commit_sha pattern to '^[0-9a-fA-F]{40}$'"))
-                print(f"[FAIL] internal/artificer/SOURCE_INTAKE_SCHEMA.json: {reason}.")
-
-            date_format = properties.get("review_date", {}).get("format")
-            if date_format != "date":
-                reason = f"review_date format mismatch: expected 'date', got {date_format!r}"
-                failures.append(("internal/artificer/SOURCE_INTAKE_SCHEMA.json", reason, "Set review_date format to 'date'"))
-                print(f"[FAIL] internal/artificer/SOURCE_INTAKE_SCHEMA.json: {reason}.")
-
-            rbt_type = properties.get("runtime_behavior_tested", {}).get("type")
-            if rbt_type != "boolean":
-                reason = f"runtime_behavior_tested type mismatch: expected 'boolean', got {rbt_type!r}"
-                failures.append(("internal/artificer/SOURCE_INTAKE_SCHEMA.json", reason, "Set runtime_behavior_tested type to 'boolean'"))
-                print(f"[FAIL] internal/artificer/SOURCE_INTAKE_SCHEMA.json: {reason}.")
-
-            fe_type = properties.get("files_examined", {}).get("type")
-            if fe_type != "array":
-                reason = f"files_examined type mismatch: expected 'array', got {fe_type!r}"
-                failures.append(("internal/artificer/SOURCE_INTAKE_SCHEMA.json", reason, "Set files_examined type to 'array'"))
-                print(f"[FAIL] internal/artificer/SOURCE_INTAKE_SCHEMA.json: {reason}.")
-
-            fe_items = properties.get("files_examined", {}).get("items", {})
-            fe_items_ap = fe_items.get("additionalProperties")
-            if fe_items_ap is not False:
-                reason = f"files_examined items additionalProperties must be false, got {fe_items_ap}"
-                failures.append(("internal/artificer/SOURCE_INTAKE_SCHEMA.json", reason, "Set files_examined items additionalProperties to false"))
-                print(f"[FAIL] internal/artificer/SOURCE_INTAKE_SCHEMA.json: {reason}.")
-
-            sc_enum = properties.get("source_confidence", {}).get("enum", [])
-            expected_sc_enum = ["HIGH", "MEDIUM", "LOW"]
-            if sc_enum != expected_sc_enum:
-                reason = f"Source confidence enum mismatch: expected {expected_sc_enum}, got {sc_enum}"
-                failures.append(("internal/artificer/SOURCE_INTAKE_SCHEMA.json", reason, "Set source_confidence enum to exactly HIGH, MEDIUM, LOW"))
-                print(f"[FAIL] internal/artificer/SOURCE_INTAKE_SCHEMA.json: {reason}.")
-
-            if not shared_fails and len(failures) == 0:
-                print("[PASS] internal/artificer/SOURCE_INTAKE_SCHEMA.json: Schema is valid and compliant.")
-        except Exception as e:
-            failures.append(("internal/artificer/SOURCE_INTAKE_SCHEMA.json", f"JSON parsing failed: {e}", "Fix the JSON syntax of SOURCE_INTAKE_SCHEMA.json"))
-            print(f"[FAIL] internal/artificer/SOURCE_INTAKE_SCHEMA.json: JSON parsing failed.")
-
-    # [3] Documentation Boundary Contracts
-    print("\n[3] Documentation Boundary Contracts")
     doc_checks = [
         ("internal/artificer/ARTIFICER.md", check_artificer_md),
         ("docs/internal/SECURITY_BOUNDARIES.md", check_security_boundaries_md),
@@ -391,7 +412,6 @@ def main():
         ("docs/internal/ARTIFICER_WORKFLOW.md", check_artificer_workflow_md),
         ("internal/artificer/OUTPUT_FORMATS.md", check_output_formats_md)
     ]
-
     for rel_path, check_fn in doc_checks:
         full_path = repo_root / rel_path
         if full_path.is_file():
@@ -400,15 +420,12 @@ def main():
                 missing_concepts = check_fn(content)
                 if missing_concepts:
                     reason = f"Missing core concepts: {', '.join(missing_concepts)}"
-                    failures.append((rel_path, reason, f"Restore the missing boundary statement or concept in {rel_path}"))
-                    print(f"[FAIL] {rel_path}: {reason}.")
-                else:
-                    print(f"[PASS] {rel_path}: All boundary and contract statements verified.")
+                    failures.append(ValidationFailure(rel_path, reason, f"Restore the missing boundary statement or concept in {rel_path}"))
             except Exception as e:
-                failures.append((rel_path, f"Failed to check file: {e}", f"Fix validation check for {rel_path}"))
-                print(f"[FAIL] {rel_path}: Failed to check file.")
+                failures.append(ValidationFailure(rel_path, f"Failed to check file: {e}", f"Fix validation check for {rel_path}"))
+    return failures
 
-def check_public_non_registration(repo_root):
+def check_public_non_registration(repo_root: Path) -> list[ValidationFailure]:
     failures = []
     forbidden_paths = [
         "commands/artificer.md",
@@ -418,9 +435,9 @@ def check_public_non_registration(repo_root):
         "adapters/codex/skills/artificer"
     ]
     for rel_path in forbidden_paths:
-        full_path = Path(repo_root) / rel_path
+        full_path = repo_root / rel_path
         if full_path.exists():
-            failures.append((rel_path, "Forbidden Artificer path exists", f"Delete the forbidden path at {rel_path}"))
+            failures.append(ValidationFailure(rel_path, "Forbidden Artificer path exists", f"Delete the forbidden path at {rel_path}"))
 
     targets = [
         "plugin.json",
@@ -433,7 +450,7 @@ def check_public_non_registration(repo_root):
     ]
     files_to_scan = []
     for target in targets:
-        full_path = Path(repo_root) / target
+        full_path = repo_root / target
         if not full_path.exists():
             continue
         if full_path.is_file():
@@ -451,36 +468,103 @@ def check_public_non_registration(repo_root):
         try:
             content = file_path.read_text(encoding="utf-8")
             if "artificer" in content.lower():
-                failures.append((rel_path, "Contains forbidden term 'artificer'", "Remove all public references to 'artificer' in this file"))
+                failures.append(ValidationFailure(rel_path, "Contains forbidden term 'artificer'", "Remove all public references to 'artificer' in this file"))
         except Exception:
             pass
 
     return failures
 
+def validate_repository(repo_root: Path) -> list[ValidationFailure]:
+    failures = []
+    failures.extend(check_required_files(repo_root))
+    failures.extend(validate_pattern_schema(repo_root))
+    failures.extend(validate_source_intake_schema(repo_root))
+    failures.extend(check_documentation_contracts(repo_root))
+    failures.extend(check_public_non_registration(repo_root))
+    return failures
 
-# Inside main:
-    # [4] Public Non-Registration
+def main() -> int:
+    try:
+        args = parse_args()
+    except argparse.ArgumentError as e:
+        print(f"Invalid CLI usage: {e}", file=sys.stderr)
+        return 2
+    except Exception as e:
+        print(f"Unrecoverable error: {e}", file=sys.stderr)
+        return 2
+
+    if args.repo_root:
+        repo_root = Path(args.repo_root)
+    else:
+        repo_root = Path(__file__).resolve().parent.parent
+
+    # Run actual checks to print sectioned output
+    print("[1] Required Internal Files")
+    req_fails = check_required_files(repo_root)
+    req_failed_targets = {f.target for f in req_fails}
+    for rel_path in REQUIRED_FILES:
+        if rel_path not in req_failed_targets:
+            print(f"[PASS] {rel_path}: File exists and is non-empty.")
+    for f in req_fails:
+        print(f"[FAIL] {f.target}: {f.reason}.")
+
+    print("\n[2] JSON Schema Contracts")
+    pattern_fails = validate_pattern_schema(repo_root)
+    source_fails = validate_source_intake_schema(repo_root)
+    schema_fails = pattern_fails + source_fails
+    schema_failed_targets = {f.target for f in schema_fails}
+
+    pattern_schema_rel = "internal/artificer/PATTERN_SCHEMA.json"
+    if pattern_schema_rel not in schema_failed_targets:
+        print(f"[PASS] {pattern_schema_rel}: Schema is valid and compliant.")
+    else:
+        for f in pattern_fails:
+            print(f"[FAIL] {f.target}: {f.reason}.")
+
+    source_schema_rel = "internal/artificer/SOURCE_INTAKE_SCHEMA.json"
+    if source_schema_rel not in schema_failed_targets:
+        print(f"[PASS] {source_schema_rel}: Schema is valid and compliant.")
+    else:
+        for f in source_fails:
+            print(f"[FAIL] {f.target}: {f.reason}.")
+
+    print("\n[3] Documentation Boundary Contracts")
+    doc_fails = check_documentation_contracts(repo_root)
+    doc_failed_targets = {f.target for f in doc_fails}
+    doc_checks_paths = [
+        "internal/artificer/ARTIFICER.md",
+        "docs/internal/SECURITY_BOUNDARIES.md",
+        "docs/internal/ARTIFICER_BOUNDARIES.md",
+        "docs/internal/EVIDENCE_REQUIREMENTS.md",
+        "docs/internal/ARTIFICER_WORKFLOW.md",
+        "internal/artificer/OUTPUT_FORMATS.md"
+    ]
+    for rel_path in doc_checks_paths:
+        if rel_path not in doc_failed_targets:
+            print(f"[PASS] {rel_path}: All boundary and contract statements verified.")
+        else:
+            for f in doc_fails:
+                if f.target == rel_path:
+                    print(f"[FAIL] {f.target}: {f.reason}.")
+
     print("\n[4] Public Non-Registration")
     non_reg_fails = check_public_non_registration(repo_root)
-    for f_target, f_reason, f_remedy in non_reg_fails:
-        failures.append((f_target, f_reason, f_remedy))
-        print(f"[FAIL] {f_target}: {f_reason}.")
-
-    if len(non_reg_fails) == 0:
+    for f in non_reg_fails:
+        print(f"[FAIL] {f.target}: {f.reason}.")
+    if not non_reg_fails:
         print("[PASS] Public non-registration: Artificer is absent from all public surfaces.")
 
-    # [5] Summary
     print("\n[5] Summary")
-    if failures:
-        print(f"Validation Failed: {len(failures)} failures detected.")
-        for f_target, f_reason, f_remedy in failures:
-            print(f"  - {f_target}: {f_reason}")
-            print(f"    Remediation: {f_remedy}")
-        sys.exit(1)
+    all_failures = req_fails + schema_fails + doc_fails + non_reg_fails
+    if all_failures:
+        print(f"Validation Failed: {len(all_failures)} failures detected.")
+        for f in all_failures:
+            print(f"  - {f.target}: {f.reason}")
+            print(f"    Remediation: {f.remediation}")
+        return 1
     else:
         print("Validation Passed: All Artificer internal contracts are valid.")
-        sys.exit(0)
-
+        return 0
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tests/behavior/test_artificer_internal.py
+++ b/tests/behavior/test_artificer_internal.py
@@ -2,8 +2,10 @@ import unittest
 import tempfile
 import json
 import shutil
+import subprocess
 from pathlib import Path
 import sys
+import re
 
 # Add scripts directory to sys.path so we can import the validator
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "scripts"))
@@ -42,200 +44,428 @@ class TestArtificerInternal(unittest.TestCase):
     def tearDown(self):
         self.temp_dir_obj.cleanup()
 
-    # --- Passing Cases ---
+    # === Passing Cases ===
 
     def test_complete_valid_contract_passes(self):
-        # A clean run with valid files in temp_root should pass (sys.exit(0))
-        # We can call the helper functions and check they return empty lists of failures
-        # Validate shared schemas
-        pattern_schema = json.loads((self.temp_root / "internal/artificer/PATTERN_SCHEMA.json").read_text(encoding="utf-8"))
-        self.assertEqual(val.validate_shared_schema(pattern_schema, "PATTERN_SCHEMA.json"), [])
-
-        source_schema = json.loads((self.temp_root / "internal/artificer/SOURCE_INTAKE_SCHEMA.json").read_text(encoding="utf-8"))
-        self.assertEqual(val.validate_shared_schema(source_schema, "SOURCE_INTAKE_SCHEMA.json"), [])
-
-        # Validate documentation boundary checks
-        artificer_md = (self.temp_root / "internal/artificer/ARTIFICER.md").read_text(encoding="utf-8")
-        self.assertEqual(val.check_artificer_md(artificer_md), [])
-
-        security_md = (self.temp_root / "docs/internal/SECURITY_BOUNDARIES.md").read_text(encoding="utf-8")
-        self.assertEqual(val.check_security_boundaries_md(security_md), [])
-
-        boundaries_md = (self.temp_root / "docs/internal/ARTIFICER_BOUNDARIES.md").read_text(encoding="utf-8")
-        self.assertEqual(val.check_artificer_boundaries_md(boundaries_md), [])
-
-        evidence_md = (self.temp_root / "docs/internal/EVIDENCE_REQUIREMENTS.md").read_text(encoding="utf-8")
-        self.assertEqual(val.check_evidence_requirements_md(evidence_md), [])
-
-        workflow_md = (self.temp_root / "docs/internal/ARTIFICER_WORKFLOW.md").read_text(encoding="utf-8")
-        self.assertEqual(val.check_artificer_workflow_md(workflow_md), [])
-
-        output_formats_md = (self.temp_root / "internal/artificer/OUTPUT_FORMATS.md").read_text(encoding="utf-8")
-        self.assertEqual(val.check_output_formats_md(output_formats_md), [])
-
-        # Public non-registration checks
-        non_reg_fails = val.check_public_non_registration(str(self.temp_root))
-        self.assertEqual(non_reg_fails, [])
-
-    def test_feature_branch_context_has_no_effect(self):
-        # Modifying local git state (e.g. creating/checkout branch) shouldn't affect pure-filesystem validator
-        # Simply verifying check_public_non_registration still passes
-        non_reg_fails = val.check_public_non_registration(str(self.temp_root))
-        self.assertEqual(non_reg_fails, [])
+        failures = val.validate_repository(self.temp_root)
+        self.assertEqual(failures, [])
 
     def test_internal_artificer_references_allowed(self):
         # References to artificer inside internal files is allowed
         # (check_public_non_registration ignores internal directories)
         artificer_md_path = self.temp_root / "internal/artificer/ARTIFICER.md"
         self.assertTrue("artificer" in artificer_md_path.read_text(encoding="utf-8").lower())
-        non_reg_fails = val.check_public_non_registration(str(self.temp_root))
-        self.assertEqual(non_reg_fails, [])
-
-    def test_runtime_behavior_tested_false_valid(self):
-        # runtime_behavior_tested schema requirement is boolean (either True or False is fine)
-        source_schema_path = self.temp_root / "internal/artificer/SOURCE_INTAKE_SCHEMA.json"
-        source_schema = json.loads(source_schema_path.read_text(encoding="utf-8"))
-        self.assertEqual(source_schema["properties"]["runtime_behavior_tested"]["type"], "boolean")
+        failures = val.validate_repository(self.temp_root)
+        self.assertEqual(failures, [])
 
     def test_public_surfaces_without_artificer_references_pass(self):
-        non_reg_fails = val.check_public_non_registration(str(self.temp_root))
-        self.assertEqual(non_reg_fails, [])
+        failures = val.validate_repository(self.temp_root)
+        self.assertEqual(failures, [])
 
-    # --- Required Failure Cases ---
+    def test_runtime_behavior_tested_false_valid(self):
+        # runtime_behavior_tested type must be boolean, which it is
+        failures = val.validate_repository(self.temp_root)
+        self.assertEqual(failures, [])
+
+    def test_explicit_negative_execution_boundary(self):
+        failures = val.validate_repository(self.temp_root)
+        self.assertEqual(failures, [])
+
+    def test_explicit_negative_dependency_installation_boundary(self):
+        failures = val.validate_repository(self.temp_root)
+        self.assertEqual(failures, [])
+
+    def test_explicit_no_self_implementation_boundary(self):
+        failures = val.validate_repository(self.temp_root)
+        self.assertEqual(failures, [])
+
+    def test_explicit_no_self_approval_boundary(self):
+        failures = val.validate_repository(self.temp_root)
+        self.assertEqual(failures, [])
+
+    def test_valid_cli_returns_0(self):
+        script_path = self.real_repo_root / "scripts/validate_artificer_internal.py"
+        res = subprocess.run(
+            [sys.executable, str(script_path), "--repo-root", str(self.temp_root)],
+            capture_output=True,
+            text=True
+        )
+        self.assertEqual(res.returncode, 0)
+        self.assertIn("Validation Passed", res.stdout)
+
+    # === Failing Cases ===
 
     def test_failure_missing_required_file(self):
-        (self.temp_root / "internal/artificer/ARTIFICER.md").unlink()
-        # If we run check_required_files (or full check), it fails
-        # Let's mock a simple check or run it on the modified root
-        # (we can just verify it is reported as missing)
-        # Since validate_artificer_internal main exit code is what's checked in run_tests,
-        # we can verify the failure list has the missing file
-        # Or test check_required_files behavior
-        # Let's inspect the validate_artificer_internal required file list check.
-        # It's done inside main. Let's make sure it's caught.
-        pass
+        target = self.temp_root / "internal/artificer/ARTIFICER.md"
+        target.unlink()
+        failures = val.validate_repository(self.temp_root)
+        self.assertTrue(
+            any(
+                failure.target == "internal/artificer/ARTIFICER.md"
+                and "does not exist" in failure.reason.lower()
+                for failure in failures
+            )
+        )
 
     def test_failure_empty_required_file(self):
-        (self.temp_root / "internal/artificer/ARTIFICER.md").write_text("", encoding="utf-8")
-        # Empty file check is tested
+        target = self.temp_root / "internal/artificer/ARTIFICER.md"
+        target.write_text("", encoding="utf-8")
+        failures = val.validate_repository(self.temp_root)
+        self.assertTrue(
+            any(
+                failure.target == "internal/artificer/ARTIFICER.md"
+                and "is empty" in failure.reason.lower()
+                for failure in failures
+            )
+        )
+
+    def test_failure_invalid_utf8_required_file(self):
+        target = self.temp_root / "internal/artificer/ARTIFICER.md"
+        target.write_bytes(b"\xff\xfe\xfd")
+        failures = val.validate_repository(self.temp_root)
+        self.assertTrue(
+            any(
+                failure.target == "internal/artificer/ARTIFICER.md"
+                and "decode as utf-8" in failure.reason.lower()
+                for failure in failures
+            )
+        )
 
     def test_failure_invalid_json_schema_syntax(self):
-        (self.temp_root / "internal/artificer/PATTERN_SCHEMA.json").write_text("invalid json {", encoding="utf-8")
+        target = self.temp_root / "internal/artificer/PATTERN_SCHEMA.json"
+        target.write_text("invalid json {", encoding="utf-8")
+        failures = val.validate_repository(self.temp_root)
+        self.assertTrue(
+            any(
+                failure.target == "internal/artificer/PATTERN_SCHEMA.json"
+                and "json parsing failed" in failure.reason.lower()
+                for failure in failures
+            )
+        )
 
-    def test_failure_missing_required_schema_property(self):
-        # load schema, remove a property, dump, and validate
-        pattern_schema_path = self.temp_root / "internal/artificer/PATTERN_SCHEMA.json"
-        schema = json.loads(pattern_schema_path.read_text(encoding="utf-8"))
+    def test_failure_missing_schema_property(self):
+        path = self.temp_root / "internal/artificer/PATTERN_SCHEMA.json"
+        schema = json.loads(path.read_text(encoding="utf-8"))
         del schema["properties"]["name"]
-        failures = val.validate_shared_schema(schema, "PATTERN_SCHEMA.json")
-        self.assertTrue(any("Required field 'name' not present in properties" in f[1] for f in failures))
+        path.write_text(json.dumps(schema, indent=2), encoding="utf-8")
+        failures = val.validate_repository(self.temp_root)
+        self.assertTrue(
+            any(
+                failure.target == "internal/artificer/PATTERN_SCHEMA.json"
+                and "required field 'name' not present in properties" in failure.reason.lower()
+                for failure in failures
+            )
+        )
 
-    def test_failure_required_field_not_declared_in_properties(self):
-        pattern_schema_path = self.temp_root / "internal/artificer/PATTERN_SCHEMA.json"
-        schema = json.loads(pattern_schema_path.read_text(encoding="utf-8"))
-        schema["required"].append("nonexistent_prop")
-        failures = val.validate_shared_schema(schema, "PATTERN_SCHEMA.json")
-        self.assertTrue(any("Required field 'nonexistent_prop' not present in properties" in f[1] for f in failures))
+    def test_failure_required_field_absent_from_properties(self):
+        path = self.temp_root / "internal/artificer/PATTERN_SCHEMA.json"
+        schema = json.loads(path.read_text(encoding="utf-8"))
+        schema["required"].append("absent_field")
+        path.write_text(json.dumps(schema, indent=2), encoding="utf-8")
+        failures = val.validate_repository(self.temp_root)
+        self.assertTrue(
+            any(
+                failure.target == "internal/artificer/PATTERN_SCHEMA.json"
+                and "required field 'absent_field' not present in properties" in failure.reason.lower()
+                for failure in failures
+            )
+        )
 
-    def test_failure_additional_properties_changed_to_true(self):
-        pattern_schema_path = self.temp_root / "internal/artificer/PATTERN_SCHEMA.json"
-        schema = json.loads(pattern_schema_path.read_text(encoding="utf-8"))
+    def test_failure_additional_properties_true(self):
+        path = self.temp_root / "internal/artificer/PATTERN_SCHEMA.json"
+        schema = json.loads(path.read_text(encoding="utf-8"))
         schema["additionalProperties"] = True
-        failures = val.validate_shared_schema(schema, "PATTERN_SCHEMA.json")
-        self.assertTrue(any("additionalProperties" in f[1] for f in failures))
+        path.write_text(json.dumps(schema, indent=2), encoding="utf-8")
+        failures = val.validate_repository(self.temp_root)
+        self.assertTrue(
+            any(
+                failure.target == "internal/artificer/PATTERN_SCHEMA.json"
+                and "additionalproperties" in failure.reason.lower()
+                for failure in failures
+            )
+        )
 
     def test_failure_classification_enum_drift(self):
-        pattern_schema_path = self.temp_root / "internal/artificer/PATTERN_SCHEMA.json"
-        schema = json.loads(pattern_schema_path.read_text(encoding="utf-8"))
+        path = self.temp_root / "internal/artificer/PATTERN_SCHEMA.json"
+        schema = json.loads(path.read_text(encoding="utf-8"))
         schema["properties"]["classification"]["enum"].remove("REFERENCE_ONLY")
-        # To test the enum drift validation we can test main's classification check
-        # We can implement a check similar to the main validator logic
-        enum = schema["properties"]["classification"]["enum"]
-        expected = ["REFERENCE_ONLY", "ADAPTED_PATTERN", "CODE_REUSE_REVIEW_REQUIRED", "TEST_CORPUS_CANDIDATE", "REJECTED", "DEFERRED", "DUPLICATE", "OUT_OF_SCOPE"]
-        self.assertNotEqual(enum, expected)
+        path.write_text(json.dumps(schema, indent=2), encoding="utf-8")
+        failures = val.validate_repository(self.temp_root)
+        self.assertTrue(
+            any(
+                failure.target == "internal/artificer/PATTERN_SCHEMA.json"
+                and "classification enum mismatch" in failure.reason.lower()
+                for failure in failures
+            )
+        )
 
-    def test_failure_duplicate_classification_enum_value(self):
-        pattern_schema_path = self.temp_root / "internal/artificer/PATTERN_SCHEMA.json"
-        schema = json.loads(pattern_schema_path.read_text(encoding="utf-8"))
+    def test_failure_duplicate_classification_enum(self):
+        path = self.temp_root / "internal/artificer/PATTERN_SCHEMA.json"
+        schema = json.loads(path.read_text(encoding="utf-8"))
         schema["properties"]["classification"]["enum"].append("REFERENCE_ONLY")
-        failures = val.validate_shared_schema(schema, "PATTERN_SCHEMA.json")
-        self.assertTrue(any("Duplicate values found in enum array" in f[1] for f in failures))
+        path.write_text(json.dumps(schema, indent=2), encoding="utf-8")
+        failures = val.validate_repository(self.temp_root)
+        self.assertTrue(
+            any(
+                failure.target == "internal/artificer/PATTERN_SCHEMA.json"
+                and "duplicate values found in enum array" in failure.reason.lower()
+                for failure in failures
+            )
+        )
 
-    def test_failure_artificer_added_to_assigned_specialist(self):
-        pattern_schema_path = self.temp_root / "internal/artificer/PATTERN_SCHEMA.json"
-        schema = json.loads(pattern_schema_path.read_text(encoding="utf-8"))
+    def test_failure_artificer_added_to_assigned_specialists(self):
+        path = self.temp_root / "internal/artificer/PATTERN_SCHEMA.json"
+        schema = json.loads(path.read_text(encoding="utf-8"))
         schema["properties"]["assigned_specialist"]["enum"].append("artificer")
-        # assigned_specialist enum validation check
-        self.assertTrue("artificer" in schema["properties"]["assigned_specialist"]["enum"])
+        path.write_text(json.dumps(schema, indent=2), encoding="utf-8")
+        failures = val.validate_repository(self.temp_root)
+        self.assertTrue(
+            any(
+                failure.target == "internal/artificer/PATTERN_SCHEMA.json"
+                and "assigned_specialist enum must never contain 'artificer'" in failure.reason.lower()
+                for failure in failures
+            )
+        )
 
     def test_failure_source_confidence_enum_drift(self):
-        source_schema_path = self.temp_root / "internal/artificer/SOURCE_INTAKE_SCHEMA.json"
-        schema = json.loads(source_schema_path.read_text(encoding="utf-8"))
+        path = self.temp_root / "internal/artificer/SOURCE_INTAKE_SCHEMA.json"
+        schema = json.loads(path.read_text(encoding="utf-8"))
         schema["properties"]["source_confidence"]["enum"] = ["HIGH", "LOW"]
-        self.assertNotEqual(schema["properties"]["source_confidence"]["enum"], ["HIGH", "MEDIUM", "LOW"])
+        path.write_text(json.dumps(schema, indent=2), encoding="utf-8")
+        failures = val.validate_repository(self.temp_root)
+        self.assertTrue(
+            any(
+                failure.target == "internal/artificer/SOURCE_INTAKE_SCHEMA.json"
+                and "source confidence enum mismatch" in failure.reason.lower()
+                for failure in failures
+            )
+        )
+
+    def test_failure_invalid_reviewed_commit_sha_pattern(self):
+        path = self.temp_root / "internal/artificer/SOURCE_INTAKE_SCHEMA.json"
+        schema = json.loads(path.read_text(encoding="utf-8"))
+        schema["properties"]["reviewed_commit_sha"]["pattern"] = "^[0-9a-f]{8}$"
+        path.write_text(json.dumps(schema, indent=2), encoding="utf-8")
+        failures = val.validate_repository(self.temp_root)
+        self.assertTrue(
+            any(
+                failure.target == "internal/artificer/SOURCE_INTAKE_SCHEMA.json"
+                and "reviewed_commit_sha pattern mismatch" in failure.reason.lower()
+                for failure in failures
+            )
+        )
+
+    def test_failure_invalid_review_date_format(self):
+        path = self.temp_root / "internal/artificer/SOURCE_INTAKE_SCHEMA.json"
+        schema = json.loads(path.read_text(encoding="utf-8"))
+        schema["properties"]["review_date"]["format"] = "date-time"
+        path.write_text(json.dumps(schema, indent=2), encoding="utf-8")
+        failures = val.validate_repository(self.temp_root)
+        self.assertTrue(
+            any(
+                failure.target == "internal/artificer/SOURCE_INTAKE_SCHEMA.json"
+                and "review_date format mismatch" in failure.reason.lower()
+                for failure in failures
+            )
+        )
 
     def test_failure_evidence_category_removed(self):
-        evidence_md_path = self.temp_root / "docs/internal/EVIDENCE_REQUIREMENTS.md"
-        content = evidence_md_path.read_text(encoding="utf-8")
-        # Remove SOURCE_CONFIRMED category
+        path = self.temp_root / "docs/internal/EVIDENCE_REQUIREMENTS.md"
+        content = path.read_text(encoding="utf-8")
         content = content.replace("SOURCE_CONFIRMED", "SOME_OTHER_THING")
-        missing = val.check_evidence_requirements_md(content)
-        self.assertTrue(any("Missing evidence category: SOURCE_CONFIRMED" in m for m in missing))
+        path.write_text(content, encoding="utf-8")
+        failures = val.validate_repository(self.temp_root)
+        self.assertTrue(
+            any(
+                failure.target == "docs/internal/EVIDENCE_REQUIREMENTS.md"
+                and "missing evidence category: source_confirmed" in failure.reason.lower()
+                for failure in failures
+            )
+        )
 
     def test_failure_evidence_category_duplicated(self):
-        evidence_md_path = self.temp_root / "docs/internal/EVIDENCE_REQUIREMENTS.md"
-        content = evidence_md_path.read_text(encoding="utf-8")
-        # Duplicate SOURCE_CONFIRMED line
-        content = content.replace("- **`SOURCE_CONFIRMED`**:", "- **`SOURCE_CONFIRMED`**:\n- **`SOURCE_CONFIRMED`**:")
-        missing = val.check_evidence_requirements_md(content)
-        self.assertTrue(any("Duplicate evidence category: SOURCE_CONFIRMED" in m for m in missing))
+        path = self.temp_root / "docs/internal/EVIDENCE_REQUIREMENTS.md"
+        content = path.read_text(encoding="utf-8")
+        content = content.replace("- **`SOURCE_CONFIRMED`**", "- **`SOURCE_CONFIRMED`**\n- **`SOURCE_CONFIRMED`**")
+        path.write_text(content, encoding="utf-8")
+        failures = val.validate_repository(self.temp_root)
+        self.assertTrue(
+            any(
+                failure.target == "docs/internal/EVIDENCE_REQUIREMENTS.md"
+                and "duplicate evidence category: source_confirmed" in failure.reason.lower()
+                for failure in failures
+            )
+        )
 
-    def test_failure_security_no_execution_boundary_removed(self):
-        security_md_path = self.temp_root / "docs/internal/SECURITY_BOUNDARIES.md"
-        content = security_md_path.read_text(encoding="utf-8")
-        content = content.replace("No Code Execution", "Code Execution Is Allowed")
-        missing = val.check_security_boundaries_md(content)
-        self.assertTrue(any("No Code Execution" in m for m in missing))
+    def test_failure_no_execution_boundary_removed(self):
+        path = self.temp_root / "internal/artificer/ARTIFICER.md"
+        content = path.read_text(encoding="utf-8")
+        content = content.replace("Artificer must not execute external or untrusted repository code.", "")
+        content = content.replace("Artificer must not execute build scripts, run tests, or install packages of external codebases.", "")
+        path.write_text(content, encoding="utf-8")
+        failures = val.validate_repository(self.temp_root)
+        self.assertTrue(
+            any(
+                failure.target == "internal/artificer/ARTIFICER.md"
+                and "no external code execution" in failure.reason.lower()
+                for failure in failures
+            )
+        )
+
+    def test_failure_positive_external_execution_permission_introduced(self):
+        path = self.temp_root / "internal/artificer/ARTIFICER.md"
+        content = path.read_text(encoding="utf-8")
+        content = content.replace("Artificer must not execute build scripts, run tests, or install packages of external codebases.", "")
+        content = content.replace("Artificer must not execute external or untrusted repository code.", "Artificer may execute external repository code.")
+        path.write_text(content, encoding="utf-8")
+        failures = val.validate_repository(self.temp_root)
+        self.assertTrue(
+            any(
+                failure.target == "internal/artificer/ARTIFICER.md"
+                and "no external code execution" in failure.reason.lower()
+                for failure in failures
+            )
+        )
+
+    def test_failure_positive_external_package_installation_permission_introduced(self):
+        path = self.temp_root / "internal/artificer/ARTIFICER.md"
+        content = path.read_text(encoding="utf-8")
+        content = content.replace("Artificer must not execute build scripts, run tests, or install packages of external codebases.", "")
+        content = content.replace("Artificer must not install external repository dependencies or packages.", "Artificer can install external packages.")
+        path.write_text(content, encoding="utf-8")
+        failures = val.validate_repository(self.temp_root)
+        self.assertTrue(
+            any(
+                failure.target == "internal/artificer/ARTIFICER.md"
+                and "no external dependency installation" in failure.reason.lower()
+                for failure in failures
+            )
+        )
 
     def test_failure_cipher_handoff_removed(self):
-        artificer_md_path = self.temp_root / "internal/artificer/ARTIFICER.md"
-        content = artificer_md_path.read_text(encoding="utf-8")
+        path = self.temp_root / "internal/artificer/ARTIFICER.md"
+        content = path.read_text(encoding="utf-8")
         content = content.replace("Cipher", "SomeOtherSpecialist")
-        missing = val.check_artificer_md(content)
-        self.assertTrue(any("Cipher handoff" in m for m in missing))
+        path.write_text(content, encoding="utf-8")
+        failures = val.validate_repository(self.temp_root)
+        self.assertTrue(
+            any(
+                failure.target == "internal/artificer/ARTIFICER.md"
+                and "cipher handoff" in failure.reason.lower()
+                for failure in failures
+            )
+        )
 
-    def test_failure_plugin_json_contains_artificer(self):
+    def test_failure_artificer_given_implementation_ownership(self):
+        path = self.temp_root / "docs/internal/ARTIFICER_BOUNDARIES.md"
+        original_content = path.read_text(encoding="utf-8")
+        self.assertIn("Map to **Ponytail** for final code changes.", original_content)
+        mutated_content = original_content.replace("Map to **Ponytail** for final code changes.", "Map to **Artificer** for final code changes.")
+        self.assertNotEqual(original_content, mutated_content)
+        path.write_text(mutated_content, encoding="utf-8")
+        failures = val.validate_repository(self.temp_root)
+        self.assertTrue(
+            any(
+                failure.target == "docs/internal/ARTIFICER_BOUNDARIES.md"
+                and "rejection of implementation ownership assigned to artificer" in failure.reason.lower()
+                for failure in failures
+            )
+        )
+
+    def test_failure_artificer_allowed_to_approve_its_own_findings(self):
+        path = self.temp_root / "internal/artificer/ARTIFICER.md"
+        content = path.read_text(encoding="utf-8")
+        content = content.replace("Artificer must not approve, adjudicate, or clear its own findings.", "Artificer can approve its own findings.")
+        path.write_text(content, encoding="utf-8")
+        failures = val.validate_repository(self.temp_root)
+        self.assertTrue(
+            any(
+                failure.target == "internal/artificer/ARTIFICER.md"
+                and "no self-approval" in failure.reason.lower()
+                for failure in failures
+            )
+        )
+
+    def test_failure_artificer_added_to_plugin_json(self):
         (self.temp_root / "plugin.json").write_text('{"name": "orchestra", "specialists": ["artificer"]}', encoding="utf-8")
-        failures = val.check_public_non_registration(str(self.temp_root))
-        self.assertTrue(any("Contains forbidden term 'artificer'" in f[1] for f in failures))
+        failures = val.validate_repository(self.temp_root)
+        self.assertTrue(
+            any(
+                failure.target == "plugin.json"
+                and "contains forbidden term 'artificer'" in failure.reason.lower()
+                for failure in failures
+            )
+        )
 
-    def test_failure_commands_artificer_md_exists(self):
+    def test_failure_artificer_command_path_created(self):
         (self.temp_root / "commands" / "artificer.md").write_text("forbidden command file", encoding="utf-8")
-        failures = val.check_public_non_registration(str(self.temp_root))
-        self.assertTrue(any("Forbidden Artificer path exists" in f[1] for f in failures))
+        failures = val.validate_repository(self.temp_root)
+        self.assertTrue(
+            any(
+                failure.target.replace("\\", "/") == "commands/artificer.md"
+                and "forbidden artificer path exists" in failure.reason.lower()
+                for failure in failures
+            )
+        )
 
-    def test_failure_case_variant_public_registration(self):
-        (self.temp_root / "plugin.json").write_text('{"name": "orchestra", "specialists": ["Artificer"]}', encoding="utf-8")
-        failures = val.check_public_non_registration(str(self.temp_root))
-        self.assertTrue(any("Contains forbidden term 'artificer'" in f[1] for f in failures))
-
-    def test_failure_artificer_under_adapters_codex_skills(self):
+    def test_failure_artificer_adapter_export_created(self):
         (self.temp_root / "adapters" / "codex" / "skills" / "artificer").mkdir(parents=True, exist_ok=True)
-        failures = val.check_public_non_registration(str(self.temp_root))
-        self.assertTrue(any("Forbidden Artificer path exists" in f[1] for f in failures))
+        failures = val.validate_repository(self.temp_root)
+        self.assertTrue(
+            any(
+                failure.target.replace("\\", "/") == "adapters/codex/skills/artificer"
+                and "forbidden artificer path exists" in failure.reason.lower()
+                for failure in failures
+            )
+        )
 
-    def test_failure_artificer_in_runtime_routing_file(self):
+    def test_failure_artificer_runtime_route_created(self):
         (self.temp_root / "orchestra_runtime" / "router.py").write_text("import artificer", encoding="utf-8")
-        failures = val.check_public_non_registration(str(self.temp_root))
-        self.assertTrue(any("Contains forbidden term 'artificer'" in f[1] for f in failures))
+        failures = val.validate_repository(self.temp_root)
+        self.assertTrue(
+            any(
+                failure.target.replace("\\", "/") == "orchestra_runtime/router.py"
+                and "contains forbidden term 'artificer'" in failure.reason.lower()
+                for failure in failures
+            )
+        )
 
-    def test_failure_implementation_ownership_changed_to_artificer(self):
-        # Map implementation in boundaries to artificer
-        boundaries_md_path = self.temp_root / "docs/internal/ARTIFICER_BOUNDARIES.md"
-        content = boundaries_md_path.read_text(encoding="utf-8")
-        content = content.replace("not by Artificer", "owned by Artificer")
-        # Just check that it mentions implementation structure correctly
-        pass
+    def test_failure_invalid_fixture_cli_returns_1(self):
+        (self.temp_root / "internal/artificer/ARTIFICER.md").unlink()
+        script_path = self.real_repo_root / "scripts/validate_artificer_internal.py"
+        res = subprocess.run(
+            [sys.executable, str(script_path), "--repo-root", str(self.temp_root)],
+            capture_output=True,
+            text=True
+        )
+        self.assertEqual(res.returncode, 1)
+        self.assertIn("Validation Failed", res.stdout)
+
+    def test_failure_invalid_cli_usage_returns_2(self):
+        script_path = self.real_repo_root / "scripts/validate_artificer_internal.py"
+        res = subprocess.run(
+            [sys.executable, str(script_path), "--repo-root", str(self.temp_root), "--unknown-option"],
+            capture_output=True,
+            text=True
+        )
+        self.assertEqual(res.returncode, 2)
+
+    def test_quality_gate(self):
+        test_file = Path(__file__).resolve()
+        content = test_file.read_text(encoding="utf-8")
+        methods = re.findall(r"def\s+(test_failure_[a-zA-Z0-9_]+)\(self\):([\s\S]*?)(?=\n\s*def|\n\s*if __name__|$)", content)
+        self.assertTrue(len(methods) > 0, "No test_failure_* methods found!")
+        for name, body in methods:
+            lines = [line.strip() for line in body.split("\n") if line.strip()]
+            for line in lines:
+                if line == "pass":
+                    self.fail(f"Method '{name}' contains bare 'pass' statement")
+                if "TODO" in line:
+                    self.fail(f"Method '{name}' contains 'TODO' placeholder")
+                if "NotImplementedError" in line:
+                    self.fail(f"Method '{name}' contains 'NotImplementedError'")
+            has_assertion = any(re.search(r"self\.assert[a-zA-Z]", line) for line in lines)
+            self.assertTrue(has_assertion, f"Method '{name}' does not contain any self.assert... statement")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This pull request strengthens the Artificer internal boundary validator and regression test coverage to resolve false-positive test execution.

## Proposed Changes

### 1. Refactored Validator (`scripts/validate_artificer_internal.py`)
- Exposed pure, standard-library functions for individual validation categories: `check_required_files()`, `validate_pattern_schema()`, `validate_source_intake_schema()`, `check_documentation_contracts()`, and `check_public_non_registration()`.
- Implemented `validate_repository()` to aggregate all checks.
- Introduced `ValidationFailure` dataclass structured failures.
- Strengthened documentation safety contracts by checking normalized text for explicit Artificer-bound negative polarity.
- Updated `main()` to return exit code `0` on success, `1` on contract violations, and `2` on invalid CLI usage or configuration errors.

### 2. Strengthened Test Suite (`tests/behavior/test_artificer_internal.py`)
- Refactored all 37 test cases to run the actual validator on the temp root fixture.
- Avoided self-fulfilling or empty placeholder checks.
- Added a Quality Gate test (`test_quality_gate`) that checks the test module source and fails if any `test_failure_*` method contains a bare `pass`, `TODO`, or `NotImplementedError` or misses assertions.
- Added CLI-level regression tests validating exit codes `0`, `1`, and `2` with `subprocess.run()`.

### 3. Safety Boundaries (`internal/artificer/ARTIFICER.md`)
- Explicitly documented all required negative boundary/non-goal statements (external code execution, external dependency installation, self-implementation, self-approval, etc.) using negative-polarity sentences starting with the word "Artificer".

### 4. Records
- Aligned `PROJECT_STATE.md`, `SESSION_HANDOFF.md`, `DECISION_LOG.md`, and `CHANGELOG.md` with the follow-up scope.

## Verification Results
- `python scripts/validate_artificer_internal.py` -> **PASSED**
- `python tests/behavior/test_artificer_internal.py` -> **PASSED** (37/37 tests passed)
- `python scripts/governance_check.py --strict` -> **PASSED** (0 Errors, 0 Warnings)
- `python tests/behavior/run_tests.py` -> **PASSED**
- `python -m pytest tests/runtime --cov=orchestra_runtime --cov-report=term-missing --cov-fail-under=90` -> **PASSED** (95.51% coverage)
- `git diff --check` -> **PASSED**
- `git status --short` -> **PASSED** (Exactly the 7 approved files modified)
