### PR TITLE
feat(artificer): add Phase 4B governance validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,10 @@ Specialist Governance & Boundary Standard is a documentation-, governance-, meta
 - Established isolated read-only registries for Phase 4A records (`reviews/`, `decisions/`, `proposals/`, and `promotions/`).
 - Documented Phase 4A read-only and no-execution boundaries in `EXTERNAL_SOURCE_INTAKE.md`, `SECURITY_BOUNDARIES.md`, and `EVIDENCE_REQUIREMENTS.md`.
 - Added Phase 3 Artificer record-instance validator (`scripts/validate_artificer_records.py`) with Draft-7 schema subset validation, POSIX-safe repository path constraints, and cross-record registry bundle verification.
-- Added 54 behavior tests (`tests/behavior/test_artificer_records.py`) providing a rigorous regression matrix that executes real validator instances against real schema copies for passing/failing conditions, empty examined-ranges, cross-platform paths, and strict schema configurations.
+- Added 61 behavior tests (`tests/behavior/test_artificer_records.py`) providing a rigorous regression matrix that executes real validator instances against real schema copies for passing/failing conditions, empty examined-ranges, cross-platform paths, and strict schema configurations.
 - Wired `scripts/validate_artificer_records.py` into the CI governance script and automated runner `tests/behavior/run_tests.py`.
+- Added Phase 4B deterministic governance-record validation for audit reports, decisions, proposals, promotions, and cross-record integrity.
+- Added Phase 4B behavior coverage and strict-governance/behavior-runner integration without external execution or Pattern Catalog mutation.
 
 ### Changed
 - Completed specialist-boundary polarity enforcement in the Artificer boundary validator (`scripts/validate_artificer_internal.py`), refactoring keyword-only checks in `check_artificer_boundaries_md()` to require explicit Artificer-bound negative polarity.

--- a/DECISION_LOG.md
+++ b/DECISION_LOG.md
@@ -225,10 +225,10 @@ To assure that governance standards strictly enforce metadata shape, registry fo
 Implemented the Phase 4A Artificer Governance Contracts foundation. Created native JSON schemas for Audit Reports, Evolution Proposals, Governance Decisions, and Promotion Records, separating governance outcomes from extraction classification. Created isolated read-only registries for the new records and explicitly documented the Phase 4 no-execution and read-only boundaries.
 
 **Reason:**
-Phase 4 separates extraction taxonomy from governance decisions, ensuring a robust, contract-only governance foundation. It avoids altering the legacy Phase 3 schemas and validators (`scripts/validate_artificer_internal.py`), preserving backwards compatibility with existing governance infrastructure while defining the strict Phase 4 boundaries through new, explicit schemas and registry structures.
+Phase 4 separates extraction taxonomy from governance decisions, ensuring a robust, contract-only governance foundation. Phase 4A made narrow, required changes to `internal/artificer/SOURCE_INTAKE_SCHEMA.json`, `internal/artificer/PATTERN_SCHEMA.json`, `scripts/validate_artificer_internal.py`, and focused regression tests to require `default_branch` and separate extraction classifications from governance outcomes.
 
 **Rejected Alternatives:**
-- Modifying legacy schemas and validators (rejected; doing so would break existing tests and validators explicitly forbidden in the original Phase 4A scope).
+- Broad legacy-validator refactoring (rejected; only the narrow contract and boundary changes required by Phase 4A were made).
 
 **Affected Components:**
 - internal/artificer/AUDIT_REPORT_SCHEMA.json
@@ -239,3 +239,19 @@ Phase 4 separates extraction taxonomy from governance decisions, ensuring a robu
 - docs/internal/EVIDENCE_REQUIREMENTS.md
 - internal/artificer/CHECKLIST.md
 - docs/internal/PATTERN_CLASSIFICATION.md
+
+---
+
+## Date: 2026-07-12
+
+**Decision:**
+Implemented the separate Phase 4B governance-record validator with deterministic registry-layout, schema, semantic, and cross-record checks for audits, decisions, proposals, and promotions.
+
+**Reason:**
+The governance chain must remain traceable and fail closed without cloning, installing, compiling, or executing external sources. Phase 4B does not mutate the Pattern Catalog; strict governance and behavior runners execute the validator.
+
+**Affected Components:**
+- scripts/validate_artificer_governance_records.py
+- tests/behavior/test_artificer_governance_records.py
+- scripts/governance_check.py
+- tests/behavior/run_tests.py

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -6,11 +6,12 @@
 * **Base Branch:** `main`
 * **Current Release:** `v1.1.1`
 * **Target Patch:** `v1.1.2`
-* **Current Stable State:** Artificer Phase 3 completed through PR #161.
-* **Current Task:** Artificer Phase 4A Governance Contracts and Registry Design.
-* **Latest Validation:** Phase 4A schemas and contracts implemented. All legacy Phase 3 validators pass.
-* **Pending Next Steps:** Run full validation matrix and report back for Phase 4A audit approval.
-* **Most Recent Checkpoint:** 2026-07-12 - Phase 4A contracts and registries established.
+* **Current Stable State:** Artificer Phase 4A completed through PR #162
+* **Current Task:** Artificer Phase 4B deterministic governance-record validation
+* **Mode:** Phase 4B implementation and audit
+* **Latest Validation:** Phase 4B validator and focused behavior coverage pass locally.
+* **Pending Next Steps:** Audit Phase 4B before commit and PR creation
+* **Most Recent Checkpoint:** 2026-07-12 - Phase 4B validation implemented.
 * **Related but Forbidden Repo for this task:** `C:\+AA`
 * **Active Governance Gates:**
 

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,28 +1,18 @@
 # Session Handoff
 
-- **Current Task:** Complete Phase 4A Governance Contracts and Registry Design
+- **Current Stable State:** Artificer Phase 4A completed through PR #162
+- **Current Task:** Artificer Phase 4B deterministic governance-record validation
 - **Current Repo:** `C:\+conductor`
 - **Canonical Branch:** `main`
 - **Base Branch:** `main`
 - **Current Release:** `v1.1.1`
 - **Target Patch:** `v1.1.2`
-- **Mode:** Phase 4A Review
-- **Allowed Files:**
-  - `scripts/validate_artificer_records.py`
-  - `tests/behavior/test_artificer_records.py`
-  - `scripts/governance_check.py`
-  - `tests/behavior/run_tests.py`
-  - `internal/artificer/records/README.md`
-  - `docs/internal/EXTERNAL_SOURCE_INTAKE.md`
-  - `docs/internal/PATTERN_CATALOG.md`
-  - `CHANGELOG.md`
-  - `DECISION_LOG.md`
-  - `PROJECT_STATE.md`
-  - `SESSION_HANDOFF.md`
+- **Mode:** Phase 4B implementation and audit
+- **Allowed Files:** Exact Phase 4B scope from the task brief only.
 - **Forbidden Repo:** `C:\+AA`
-- **Last Validation:** Legacy Phase 3 validators pass locally after restoring `scripts/validate_artificer_internal.py`.
+- **Last Validation:** Phase 4B validator and focused behavior coverage pass locally.
 - **Known Risks:** Prompt-load thresholds remain advisory and current observed Groups A, B, C, and Grand Total exceed documented soft limits; no replacement baseline has been approved.
-- **Next Step:** Run the full validation matrix as instructed and await user approval before committing Phase 4A changes.
+- **Next Step:** Audit Phase 4B before commit and PR creation
 - **Fresh-Session Warning:** If the current conversation has long prior history from another repository, enter safe mode and request user confirmation before proceeding with implementation.
 
 ## Token Control Note

--- a/docs/internal/ARTIFICER_PHASE4_GOVERNANCE_CONTRACT.md
+++ b/docs/internal/ARTIFICER_PHASE4_GOVERNANCE_CONTRACT.md
@@ -59,10 +59,10 @@ Do not clone, fetch, install, compile, or execute the external repository inside
 There is no automatic cherry-picking of source code.
 
 ## 12. Phase 4B Validator Responsibilities
-Phase 4B will introduce deterministic validation for governance records and cross-record relationships, including reviews, decisions, proposals, and promotions. Phase 4A focuses exclusively on the source-intake and pattern contracts and schemas; it does not validate those governance records, decisions, reviews, proposals, or promotions.
+Phase 4B provides deterministic validation for governance records and cross-record relationships, including reviews, decisions, proposals, and promotions. It validates only committed contracts and never rewrites source bundles, executes external code, or grants Artificer approval authority. Empty governance registries remain valid.
 
 ## 13. Phase 4C Renderer and Catalog-Gate Responsibilities
-Phase 4C will introduce markdown rendering for these records and implement the catalog-gate to prevent unapproved implementations.
+Phase 4C owns markdown rendering for these records and the Pattern Catalog gate; Phase 4B does not mutate `PATTERN_CATALOG.md`.
 
 ## 14. Phase 4.5 Pilot Sources
 The canonical Phase 4.5 pilot repositories are strictly defined as:
@@ -70,7 +70,7 @@ The canonical Phase 4.5 pilot repositories are strictly defined as:
 *   `usestrix/strix` (https://github.com/usestrix/strix)
 
 **Explicit constraints on pilot sources:**
-*   Neither repository is being audited in Phase 4A.
+*   Neither repository is being audited before Phase 4.5.
 *   No commit SHA is pinned yet.
 *   No files are copied.
 *   No external code is executed.

--- a/docs/internal/ARTIFICER_WORKFLOW.md
+++ b/docs/internal/ARTIFICER_WORKFLOW.md
@@ -2,7 +2,7 @@
 
 This document defines the structured workflow for importing and evaluating external design patterns to evolve Orchestra.
 
-Phase 4A ends after the source-intake and pattern schema contracts are defined and validated. Reviews, governance decisions, proposals, promotions, and cross-record relationships are not validated in Phase 4A; Phase 4B owns those governance-record checks.
+Phase 4B validates reviews, governance decisions, proposals, promotions, and cross-record relationships deterministically. Empty governance registries remain valid; Artificer has no approval or implementation authority and never clones, installs, compiles, or executes external sources. Phase 4C owns rendering and the Pattern Catalog gate; Phase 4.5 owns the OpenHero and Strix pilot audits.
 
 ## End-to-End Workflow Stages
 

--- a/internal/artificer/CHECKLIST.md
+++ b/internal/artificer/CHECKLIST.md
@@ -31,3 +31,8 @@ Use this checklist during every repository audit to evaluate design patterns for
 - [ ] Draft independent Governance Decisions (`GOVERNANCE_DECISION_SCHEMA.json`) for items that are blocked, rejected, deferred, or duplicate.
 - [ ] Route the proposal to Arbiter for validation check.
 - [ ] Route the proposal to Governor and Steward for business and legal clearance.
+
+## Phase 4B: Governance-Record Validation
+- [ ] Run `scripts/validate_artificer_governance_records.py` before governance review; empty governance registries are valid.
+- [ ] Confirm validation only reads committed records, performs no external execution, and grants Artificer no approval or implementation authority.
+- [ ] Leave Pattern Catalog rendering and catalog-gate work to Phase 4C; leave OpenHero and Strix pilot audits to Phase 4.5.

--- a/internal/artificer/decisions/README.md
+++ b/internal/artificer/decisions/README.md
@@ -10,7 +10,7 @@ Files must be placed in a directory corresponding to the source bundle ID, and n
 ## Requirements
 *   **Traceability**: Every decision must reference a specific pattern record and an audit report.
 *   **Manual Creation**: Records are manually created and reviewed by Arbiter, Governor, and Steward before a Maintainer decision.
-*   **Validation**: Phase 4B will introduce deterministic validation for these records.
+*   **Validation**: Phase 4B deterministically validates this registry, required reviews, and cross-record integrity.
 *   **No Approval Authority**: No record in this registry grants Artificer approval or implementation authority automatically.
 *   **No External Modifications**: No registry may modify an external repository.
 *   **Empty State**: An empty registry is valid.

--- a/internal/artificer/promotions/README.md
+++ b/internal/artificer/promotions/README.md
@@ -10,7 +10,7 @@ Files must be named using their catalog pattern ID:
 ## Requirements
 *   **Traceability**: Every promotion record must trace to a proposal ID, decision ID, source bundle, commit SHA, file, and line range.
 *   **Manual Creation**: Records are manually created and reviewed.
-*   **Validation**: Phase 4B will introduce deterministic validation for these records.
+*   **Validation**: Phase 4B deterministically validates this registry and does not mutate the Pattern Catalog; Phase 4C owns catalog rendering and gating.
 *   **No Approval Authority**: No record in this registry grants Artificer approval or implementation authority.
 *   **No External Modifications**: No registry may modify an external repository.
 *   **Empty State**: An empty registry is valid.

--- a/internal/artificer/proposals/README.md
+++ b/internal/artificer/proposals/README.md
@@ -10,7 +10,7 @@ Files must be named using their unique proposal ID:
 ## Requirements
 *   **Traceability**: Every proposal must trace back to governance decisions and audit reports.
 *   **Manual Creation**: Records are manually created and reviewed.
-*   **Validation**: Phase 4B will introduce deterministic validation for these records.
+*   **Validation**: Phase 4B deterministically validates this registry, approved decisions, and cross-record integrity.
 *   **No Approval Authority**: No record in this registry grants Artificer approval or implementation authority. The proposal is a design artifact only.
 *   **No External Modifications**: No registry may modify an external repository.
 *   **Empty State**: An empty registry is valid.

--- a/internal/artificer/reviews/README.md
+++ b/internal/artificer/reviews/README.md
@@ -10,7 +10,7 @@ Files must be placed in a directory corresponding to the source bundle ID:
 ## Requirements
 *   **Traceability**: Every report must trace back to a specific `source-intake.json` record via `source_intake_path` and `source_bundle_id`.
 *   **Manual Creation**: Records are manually created and reviewed.
-*   **Validation**: Phase 4B will introduce deterministic validation for these records.
+*   **Validation**: Phase 4B deterministically validates this registry, source traceability, and cross-record integrity.
 *   **No Approval Authority**: No record in this registry grants Artificer approval or implementation authority.
 *   **No External Modifications**: No registry may modify an external repository.
 *   **Empty State**: An empty registry is valid.

--- a/scripts/governance_check.py
+++ b/scripts/governance_check.py
@@ -36,6 +36,7 @@ REQUIRED_VALIDATION_SCRIPTS = [
     "tests/behavior/run_tests.py",
     "scripts/validate_artificer_internal.py",
     "scripts/validate_artificer_records.py",
+    "scripts/validate_artificer_governance_records.py",
 ]
 
 REPO_MEMORY_FILES = [
@@ -50,6 +51,7 @@ STRICT_VALIDATOR_SCRIPTS = [
     "scripts/validate_ide_packaging.py",
     "scripts/validate_artificer_internal.py",
     "scripts/validate_artificer_records.py",
+    "scripts/validate_artificer_governance_records.py",
 ]
 
 SIGNIFICANT_CHANGE_PATTERNS = [

--- a/scripts/test_governance_check.py
+++ b/scripts/test_governance_check.py
@@ -31,6 +31,12 @@ def test_tracked_repo_files_only():
         assert_equal("untracked artifact omitted", "artifacts/governance_report.txt" in tracked_paths, False)
 
 
+def test_artificer_governance_validator_is_registered():
+    script = "scripts/validate_artificer_governance_records.py"
+    assert_equal("required governance validator", script in gc.REQUIRED_VALIDATION_SCRIPTS, True)
+    assert_equal("strict governance validator", script in gc.STRICT_VALIDATOR_SCRIPTS, True)
+
+
 def test_repo_memory_path_check():
     with tempfile.TemporaryDirectory(prefix="governance-memory-test-") as temp_dir:
         repo_root = Path(temp_dir)

--- a/scripts/validate_artificer_governance_records.py
+++ b/scripts/validate_artificer_governance_records.py
@@ -1,0 +1,651 @@
+#!/usr/bin/env python3
+"""Deterministic validator for Artificer Phase 4B governance records."""
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+from validate_artificer_records import (
+    MAX_FILE_SIZE,
+    ValidationFailure,
+    ValidatorConfigurationError,
+    is_range_covered,
+    load_json_without_duplicate_keys,
+    parse_line_range,
+    validate_instance,
+    validate_schema_configuration,
+)
+
+
+ARTIFICER_DIR = "internal/artificer"
+RECORDS_DIR = f"{ARTIFICER_DIR}/records"
+REGISTRIES = {
+    "reviews": (f"{ARTIFICER_DIR}/reviews", "audit-report.json"),
+    "decisions": (f"{ARTIFICER_DIR}/decisions", None),
+    "proposals": (f"{ARTIFICER_DIR}/proposals", None),
+    "promotions": (f"{ARTIFICER_DIR}/promotions", None),
+}
+SCHEMAS = {
+    "audit": f"{ARTIFICER_DIR}/AUDIT_REPORT_SCHEMA.json",
+    "decision": f"{ARTIFICER_DIR}/GOVERNANCE_DECISION_SCHEMA.json",
+    "proposal": f"{ARTIFICER_DIR}/EVOLUTION_PROPOSAL_SCHEMA.json",
+    "promotion": f"{ARTIFICER_DIR}/PROMOTION_RECORD_SCHEMA.json",
+    "intake": f"{ARTIFICER_DIR}/SOURCE_INTAKE_SCHEMA.json",
+    "pattern": f"{ARTIFICER_DIR}/PATTERN_SCHEMA.json",
+}
+IDENTIFIER_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
+BUNDLE_RE = re.compile(r"^[a-z0-9._-]+__[a-z0-9._-]+__[0-9a-f]{12}$")
+WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:")
+CONTROL_RE = re.compile(r"[\x00-\x1f]")
+
+
+@dataclass(frozen=True)
+class SourceBundle:
+    bundle_id: str
+    intake: dict
+    patterns: dict[str, dict]
+
+
+def _rel(repo_root: Path, path: Path) -> str:
+    return path.relative_to(repo_root).as_posix()
+
+
+def _failure(target: str, reason: str, remediation: str) -> ValidationFailure:
+    return ValidationFailure(target, reason, remediation)
+
+
+def _sanitize_configuration_error(
+    schema_path: Path, relative_schema_path: str, error: Exception
+) -> str:
+    detail = str(error)
+    path_variants = {
+        str(schema_path),
+        str(schema_path.resolve()),
+        schema_path.as_posix(),
+        schema_path.resolve().as_posix(),
+    }
+    for path_variant in sorted(path_variants, key=len, reverse=True):
+        prefix = f"{path_variant}: "
+        if detail.startswith(prefix):
+            detail = detail[len(prefix) :]
+            break
+        detail = detail.replace(path_variant, relative_schema_path)
+    return detail
+
+
+def find_casefold_duplicate(values: list[str]) -> str | None:
+    seen: set[str] = set()
+    for value in values:
+        folded = value.casefold()
+        if folded in seen:
+            return value
+        seen.add(folded)
+    return None
+
+
+def _load_schema(repo_root: Path, path: str) -> dict:
+    schema_path = repo_root / path
+    if not schema_path.is_file():
+        raise ValidatorConfigurationError(f"Schema file missing: {path}")
+    try:
+        schema = load_json_without_duplicate_keys(schema_path)
+    except (ValueError, ValidatorConfigurationError) as exc:
+        detail = _sanitize_configuration_error(schema_path, path, exc)
+        raise ValidatorConfigurationError(
+            f"Schema file invalid: {path}: {detail}"
+        ) from exc
+    try:
+        validate_schema_configuration(schema, path)
+    except ValidatorConfigurationError as exc:
+        detail = _sanitize_configuration_error(schema_path, path, exc)
+        raise ValidatorConfigurationError(
+            f"Schema file invalid: {path}: {detail}"
+        ) from exc
+    return schema
+
+
+def _load_schemas(repo_root: Path) -> dict[str, dict]:
+    return {name: _load_schema(repo_root, path) for name, path in SCHEMAS.items()}
+
+
+def _safe_path(value: object, field: str, target: str) -> list[ValidationFailure]:
+    if not isinstance(value, str) or not value.strip():
+        return [_failure(target, f"{field} must be a non-empty repository-relative POSIX path", "Provide a non-empty relative path using '/'.")]
+    if CONTROL_RE.search(value) or "\\" in value or value.startswith("/") or WINDOWS_DRIVE_RE.match(value):
+        return [_failure(target, f"{field} '{value}' is not a safe repository-relative POSIX path", "Use a relative path with '/' separators and no control characters.")]
+    if any(part in {"", ".", ".."} for part in value.split("/")):
+        return [_failure(target, f"{field} '{value}' contains an unsafe path component", "Remove empty, '.' and '..' path components.")]
+    return []
+
+
+def _identifier(value: object, field: str, target: str) -> list[ValidationFailure]:
+    if not isinstance(value, str) or not IDENTIFIER_RE.fullmatch(value):
+        return [_failure(target, f"{field} must match {IDENTIFIER_RE.pattern}", "Use a lowercase identifier containing only a-z, 0-9, '.', '_' or '-'.")]
+    return []
+
+
+def _date(value: object, field: str, target: str) -> list[ValidationFailure]:
+    if not isinstance(value, str):
+        return []
+    try:
+        date.fromisoformat(value)
+    except ValueError:
+        return [_failure(target, f"{field} '{value}' is not a valid ISO calendar date", "Use YYYY-MM-DD with a real calendar date.")]
+    return []
+
+
+def _nonempty_strings(value: object, target: str, field: str = "") -> list[ValidationFailure]:
+    failures: list[ValidationFailure] = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            failures.extend(_nonempty_strings(child, target, key if not field else f"{field}.{key}"))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            failures.extend(_nonempty_strings(child, target, f"{field}[{index}]"))
+    elif isinstance(value, str) and not value.strip():
+        failures.append(_failure(target, f"{field} must not be empty after trimming", f"Provide a non-empty value for {field}."))
+    return failures
+
+
+def _specialist_allowlist(pattern_schema: dict) -> set[str]:
+    return set(pattern_schema["properties"]["assigned_specialist"]["enum"])
+
+
+def _valid_specialist(value: object, field: str, target: str, allowlist: set[str]) -> list[ValidationFailure]:
+    if value == "artificer":
+        return [_failure(target, f"{field} must not assign Artificer", "Assign a specialist from PATTERN_SCHEMA.json.")]
+    if value not in allowlist:
+        return [_failure(target, f"{field} '{value}' is not a valid assigned specialist", "Use an assigned_specialist enum value from PATTERN_SCHEMA.json.")]
+    return []
+
+
+def _load_record(path: Path, schema: dict, repo_root: Path) -> tuple[dict | None, list[ValidationFailure]]:
+    target = _rel(repo_root, path)
+    try:
+        record = load_json_without_duplicate_keys(path)
+    except (ValueError, ValidatorConfigurationError) as exc:
+        return None, [_failure(target, str(exc), "Fix the JSON record and re-run validation.")]
+    failures = validate_instance(record, schema, target)
+    failures.extend(_nonempty_strings(record, target))
+    return record, failures
+
+
+def _check_readme(repo_root: Path, root: str) -> list[ValidationFailure]:
+    path = repo_root / root / "README.md"
+    if path.is_symlink() or not path.is_file():
+        return [_failure(f"{root}/README.md", "Registry README.md is missing or is not a regular file", f"Create a regular {root}/README.md file.")]
+    if path.stat().st_size == 0:
+        return [_failure(f"{root}/README.md", "Registry README.md is empty", "Document the registry layout in README.md.")]
+    return []
+
+
+def _casefold_collisions(entries: list[Path], repo_root: Path) -> list[ValidationFailure]:
+    failures = []
+    seen_names: list[str] = []
+    for entry in entries:
+        if find_casefold_duplicate(seen_names + [entry.name]) is not None:
+            failures.append(_failure(_rel(repo_root, entry), f"Case-insensitive filename collision for '{entry.name}'", "Use unique names independent of filesystem case sensitivity."))
+        seen_names.append(entry.name)
+    return failures
+
+
+def validate_registry_layout(repo_root: Path) -> list[ValidationFailure]:
+    """Validate all governance registry layouts without reading record contents."""
+    failures: list[ValidationFailure] = []
+    for name, (root, fixed_file) in REGISTRIES.items():
+        root_path = repo_root / root
+        failures.extend(_check_readme(repo_root, root))
+        if not root_path.is_dir():
+            failures.append(_failure(root, "Registry directory is missing", f"Create the required {root}/ directory."))
+            continue
+        entries = sorted((entry for entry in root_path.iterdir() if entry.name != "README.md"), key=lambda item: item.name.casefold())
+        failures.extend(_casefold_collisions(entries, repo_root))
+        for entry in entries:
+            target = _rel(repo_root, entry)
+            if entry.is_symlink():
+                failures.append(_failure(target, "Symbolic links are not permitted in governance registries", "Replace the symbolic link with a regular file or directory."))
+                continue
+            if name in {"reviews", "decisions"}:
+                if not entry.is_dir():
+                    failures.append(_failure(target, "Registry root permits only bundle directories", "Move the record into a valid bundle directory."))
+                    continue
+                if not BUNDLE_RE.fullmatch(entry.name):
+                    failures.append(_failure(target, "Bundle directory name is invalid", "Use <owner-slug>__<repository-slug>__<12-character-lowercase-sha>."))
+                children = sorted(entry.iterdir(), key=lambda item: item.name.casefold())
+                if not children:
+                    failures.append(_failure(target, "Bundle directory is empty", "Add the required governance JSON record."))
+                for child in children:
+                    child_target = _rel(repo_root, child)
+                    if child.is_symlink() or child.is_dir():
+                        failures.append(_failure(child_target, "Nested directories and symbolic links are not permitted", "Use a regular JSON file directly in the bundle directory."))
+                    elif fixed_file and child.name != fixed_file:
+                        failures.append(_failure(child_target, f"Only '{fixed_file}' is permitted in this bundle", f"Rename the file to '{fixed_file}' and remove extra files."))
+                    elif not fixed_file and (child.suffix != ".json" or not IDENTIFIER_RE.fullmatch(child.stem)):
+                        failures.append(_failure(child_target, "Decision records must be named <pattern-slug>.json using a safe identifier", "Rename the record to a lowercase safe pattern slug ending in .json."))
+            else:
+                if entry.is_dir() or entry.suffix != ".json" or not IDENTIFIER_RE.fullmatch(entry.stem):
+                    failures.append(_failure(target, "Registry permits only regular <safe-id>.json files", "Replace directories or invalid files with a lowercase safe JSON filename."))
+    return failures
+
+
+def _source_index(repo_root: Path, schemas: dict[str, dict]) -> dict[str, SourceBundle]:
+    bundles: dict[str, SourceBundle] = {}
+    root = repo_root / RECORDS_DIR
+    if not root.is_dir():
+        return bundles
+    for bundle_dir in sorted(root.iterdir(), key=lambda item: item.name.casefold()):
+        if bundle_dir.name == "README.md" or not bundle_dir.is_dir() or bundle_dir.is_symlink():
+            continue
+        intake_path = bundle_dir / "source-intake.json"
+        patterns_dir = bundle_dir / "patterns"
+        try:
+            intake = load_json_without_duplicate_keys(intake_path)
+        except (ValueError, ValidatorConfigurationError):
+            continue
+        if validate_instance(intake, schemas["intake"], _rel(repo_root, intake_path)) or not patterns_dir.is_dir():
+            continue
+        patterns: dict[str, dict] = {}
+        for pattern_path in sorted(patterns_dir.glob("*.json"), key=lambda item: item.name.casefold()):
+            try:
+                pattern = load_json_without_duplicate_keys(pattern_path)
+            except (ValueError, ValidatorConfigurationError):
+                continue
+            if not validate_instance(pattern, schemas["pattern"], _rel(repo_root, pattern_path)):
+                patterns[_rel(repo_root, pattern_path)] = pattern
+        bundles[bundle_dir.name] = SourceBundle(bundle_dir.name, intake, patterns)
+    return bundles
+
+
+def _source_for(bundle_id: object, index: dict[str, SourceBundle], target: str) -> tuple[SourceBundle | None, list[ValidationFailure]]:
+    source = index.get(bundle_id) if isinstance(bundle_id, str) else None
+    if source is None:
+        return None, [_failure(target, f"Source bundle '{bundle_id}' is missing, malformed, or unreadable", "Restore a valid Phase 3 source bundle before referencing it from governance records.")]
+    return source, []
+
+
+def _examined_ranges(intake: dict) -> dict[str, list[tuple[int, int]]]:
+    result: dict[str, list[tuple[int, int]]] = {}
+    for entry in intake.get("files_examined", []):
+        if not isinstance(entry, dict) or not isinstance(entry.get("file_path"), str):
+            continue
+        result[entry["file_path"]] = [parsed for value in entry.get("line_ranges", []) if isinstance(value, str) and (parsed := parse_line_range(value))]
+    return result
+
+
+def _load_audits(repo_root: Path, schemas: dict[str, dict], index: dict[str, SourceBundle], allowlist: set[str]) -> tuple[dict[str, tuple[dict, str]], list[ValidationFailure]]:
+    audits: dict[str, tuple[dict, str]] = {}
+    failures: list[ValidationFailure] = []
+    root = repo_root / REGISTRIES["reviews"][0]
+    if not root.is_dir():
+        return audits, failures
+    seen: set[str] = set()
+    for bundle_dir in sorted(root.iterdir(), key=lambda item: item.name.casefold()):
+        path = bundle_dir / "audit-report.json"
+        if bundle_dir.name == "README.md" or not path.is_file() or path.is_symlink():
+            continue
+        record, record_failures = _load_record(path, schemas["audit"], repo_root)
+        failures.extend(record_failures)
+        if record is None:
+            continue
+        target = _rel(repo_root, path)
+        audit_id = record.get("audit_report_id")
+        failures.extend(_identifier(audit_id, "audit_report_id", target))
+        if isinstance(audit_id, str):
+            if audit_id.casefold() in seen:
+                failures.append(_failure(target, f"Duplicate case-insensitive audit_report_id '{audit_id}'", "Use a unique audit_report_id."))
+            seen.add(audit_id.casefold())
+            audits[audit_id] = (record, bundle_dir.name)
+        source, source_failures = _source_for(record.get("source_bundle_id"), index, target)
+        failures.extend(source_failures)
+        if record.get("source_bundle_id") != bundle_dir.name:
+            failures.append(_failure(target, "source_bundle_id does not match the audit-report directory", "Set source_bundle_id to the containing bundle ID."))
+        if source is None:
+            continue
+        expected_intake = f"{RECORDS_DIR}/{source.bundle_id}/source-intake.json"
+        if record.get("source_intake_path") != expected_intake:
+            failures.append(_failure(target, "source_intake_path does not exactly reference the source bundle intake", f"Set source_intake_path to '{expected_intake}'."))
+        if record.get("source_repository") != source.intake.get("repository"):
+            failures.append(_failure(target, "source_repository does not match source-intake.json", "Copy repository exactly from the source intake."))
+        if record.get("reviewed_commit_sha") != source.intake.get("reviewed_commit_sha"):
+            failures.append(_failure(target, "reviewed_commit_sha does not match source-intake.json", "Copy the reviewed commit SHA exactly from the source intake."))
+        failures.extend(_date(record.get("audit_date"), "audit_date", target))
+        if isinstance(record.get("audit_date"), str) and record["audit_date"] < source.intake.get("review_date", ""):
+            failures.append(_failure(target, "audit_date precedes the source intake review_date", "Use an audit_date on or after the source intake review_date."))
+        license_analysis = record.get("license_analysis", {})
+        if isinstance(license_analysis, dict):
+            if license_analysis.get("detected_license") != source.intake.get("license"):
+                failures.append(_failure(target, "license_analysis.detected_license does not match source intake license", "Copy the license exactly from source-intake.json."))
+            assessment = license_analysis.get("compatibility_assessment")
+            expected_review = assessment != "COMPATIBLE"
+            if isinstance(assessment, str) and license_analysis.get("governor_review_required") is not expected_review:
+                failures.append(_failure(target, "license compatibility assessment and governor_review_required are inconsistent", "Set governor_review_required false only for COMPATIBLE; set it true otherwise."))
+        security = record.get("security_review", {})
+        if isinstance(security, dict) and security.get("external_execution_performed") is not False:
+            failures.append(_failure(target, "security_review.external_execution_performed must be false", "Set external_execution_performed to false."))
+        examined = _examined_ranges(source.intake)
+        finding_ids: set[str] = set()
+        for number, finding in enumerate(record.get("findings", [])):
+            if not isinstance(finding, dict):
+                continue
+            finding_id = finding.get("finding_id")
+            failures.extend(_identifier(finding_id, f"findings[{number}].finding_id", target))
+            if isinstance(finding_id, str):
+                if finding_id.casefold() in finding_ids:
+                    failures.append(_failure(target, f"Duplicate finding_id '{finding_id}'", "Use unique finding IDs within the audit report."))
+                finding_ids.add(finding_id.casefold())
+            pattern_path = finding.get("pattern_record_path")
+            failures.extend(_safe_path(pattern_path, f"findings[{number}].pattern_record_path", target))
+            expected_prefix = f"{RECORDS_DIR}/{source.bundle_id}/patterns/"
+            if isinstance(pattern_path, str) and (not pattern_path.startswith(expected_prefix) or pattern_path not in source.patterns):
+                failures.append(_failure(target, f"findings[{number}].pattern_record_path does not reference an existing pattern in the same source bundle", "Reference a pattern JSON record from the audit source bundle."))
+            failures.extend(_valid_specialist(finding.get("assigned_specialist"), f"findings[{number}].assigned_specialist", target, allowlist))
+            pattern = source.patterns.get(pattern_path) if isinstance(pattern_path, str) else None
+            if pattern and finding.get("assigned_specialist") != pattern.get("assigned_specialist"):
+                failures.append(_failure(target, f"findings[{number}].assigned_specialist does not match the source pattern", "Use the source pattern assigned_specialist exactly."))
+            evidence = finding.get("evidence")
+            if not isinstance(evidence, list) or not evidence:
+                failures.append(_failure(target, f"findings[{number}].evidence must contain at least one item", "Add at least one traceable evidence item."))
+                continue
+            for evidence_number, item in enumerate(evidence):
+                if not isinstance(item, dict):
+                    continue
+                source_file = item.get("source_file")
+                line_range = item.get("line_range")
+                if source_file not in examined:
+                    failures.append(_failure(target, f"findings[{number}].evidence[{evidence_number}].source_file is not in files_examined", "Use a source file listed in source-intake.json files_examined."))
+                parsed = parse_line_range(line_range) if isinstance(line_range, str) else None
+                if parsed is None or parsed[0] < 1 or parsed[0] > parsed[1]:
+                    failures.append(_failure(target, f"findings[{number}].evidence[{evidence_number}].line_range is invalid", "Use a positive ordered start-end line range."))
+                elif source_file in examined and not is_range_covered(*parsed, examined[source_file]):
+                    failures.append(_failure(target, f"findings[{number}].evidence[{evidence_number}].line_range is outside files_examined coverage", "Use a line range covered by source-intake.json files_examined."))
+                if item.get("bucket") == "RUNTIME_CONFIRMED_BY_AUTHORIZED_EXTERNAL_VALIDATION" and source.intake.get("runtime_behavior_tested") is not True:
+                    failures.append(_failure(target, "Runtime-confirmed evidence requires source intake runtime_behavior_tested: true", "Use a non-runtime evidence bucket or record authorized isolated validation in source intake."))
+    return audits, failures
+
+
+def _load_decisions(repo_root: Path, schemas: dict[str, dict], index: dict[str, SourceBundle], audits: dict[str, tuple[dict, str]], allowlist: set[str]) -> tuple[dict[str, tuple[dict, str]], list[ValidationFailure]]:
+    decisions: dict[str, tuple[dict, str]] = {}
+    failures: list[ValidationFailure] = []
+    root = repo_root / REGISTRIES["decisions"][0]
+    if not root.is_dir():
+        return decisions, failures
+    seen: set[str] = set()
+    for bundle_dir in sorted(root.iterdir(), key=lambda item: item.name.casefold()):
+        if bundle_dir.name == "README.md" or not bundle_dir.is_dir() or bundle_dir.is_symlink():
+            continue
+        for path in sorted(bundle_dir.glob("*.json"), key=lambda item: item.name.casefold()):
+            record, record_failures = _load_record(path, schemas["decision"], repo_root)
+            failures.extend(record_failures)
+            if record is None:
+                continue
+            target = _rel(repo_root, path)
+            decision_id = record.get("decision_id")
+            failures.extend(_identifier(decision_id, "decision_id", target))
+            if isinstance(decision_id, str):
+                if decision_id.casefold() in seen:
+                    failures.append(_failure(target, f"Duplicate case-insensitive decision_id '{decision_id}'", "Use a unique decision_id."))
+                seen.add(decision_id.casefold())
+                decisions[decision_id] = (record, bundle_dir.name)
+            source, source_failures = _source_for(record.get("source_bundle_id"), index, target)
+            failures.extend(source_failures)
+            if record.get("source_bundle_id") != bundle_dir.name:
+                failures.append(_failure(target, "source_bundle_id does not match the decision directory", "Set source_bundle_id to the containing bundle ID."))
+            pattern_path = record.get("pattern_record_path")
+            failures.extend(_safe_path(pattern_path, "pattern_record_path", target))
+            pattern = source.patterns.get(pattern_path) if source and isinstance(pattern_path, str) else None
+            if source and pattern is None:
+                failures.append(_failure(target, "pattern_record_path does not reference a pattern in the same source bundle", "Reference an existing pattern record from the decision source bundle."))
+            if isinstance(pattern_path, str) and path.name != Path(pattern_path).name:
+                failures.append(_failure(target, "Decision filename does not match the referenced pattern filename", f"Rename the decision file to '{Path(pattern_path).name}'."))
+            failures.extend(_valid_specialist(record.get("assigned_specialist"), "assigned_specialist", target, allowlist))
+            audit_pair = audits.get(record.get("audit_report_id")) if isinstance(record.get("audit_report_id"), str) else None
+            if audit_pair is None or audit_pair[1] != bundle_dir.name:
+                failures.append(_failure(target, "audit_report_id does not resolve to an audit report in this source bundle", "Reference an existing audit report for the same source bundle."))
+                audit = None
+            else:
+                audit = audit_pair[0]
+            if pattern and record.get("assigned_specialist") != pattern.get("assigned_specialist"):
+                failures.append(_failure(target, "assigned_specialist does not match the source pattern", "Use the source pattern assigned_specialist exactly."))
+            if audit and pattern_path not in {item.get("pattern_record_path") for item in audit.get("findings", []) if isinstance(item, dict)}:
+                failures.append(_failure(target, "Referenced audit report has no finding for pattern_record_path", "Add a matching audit finding or reference the correct audit report."))
+            if audit and pattern_path:
+                audit_specialists = {item.get("assigned_specialist") for item in audit.get("findings", []) if isinstance(item, dict) and item.get("pattern_record_path") == pattern_path}
+                if audit_specialists and record.get("assigned_specialist") not in audit_specialists:
+                    failures.append(_failure(target, "assigned_specialist does not match the corresponding audit finding", "Use the audit finding assigned_specialist exactly."))
+            failures.extend(_date(record.get("decision_date"), "decision_date", target))
+            maintainer = record.get("maintainer_decision", {})
+            reviews = record.get("reviews", {})
+            if isinstance(maintainer, dict) and maintainer.get("decision_date") != record.get("decision_date"):
+                failures.append(_failure(target, "maintainer_decision.decision_date must equal decision_date", "Use the top-level decision_date in maintainer_decision."))
+            if audit and isinstance(record.get("decision_date"), str) and record["decision_date"] < audit.get("audit_date", ""):
+                failures.append(_failure(target, "decision_date precedes the audit_date", "Use a decision_date on or after the audit_date."))
+            if isinstance(reviews, dict):
+                for reviewer, review in reviews.items():
+                    if isinstance(review, dict):
+                        failures.extend(_date(review.get("review_date"), f"reviews.{reviewer}.review_date", target))
+                        if isinstance(review.get("review_date"), str) and isinstance(record.get("decision_date"), str) and review["review_date"] > record["decision_date"]:
+                            failures.append(_failure(target, f"reviews.{reviewer}.review_date is after decision_date", "Use a reviewer date on or before decision_date."))
+            if isinstance(maintainer, dict) and record.get("decision_status") != maintainer.get("status"):
+                failures.append(_failure(target, "decision_status must equal maintainer_decision.status", "Make the top-level and Maintainer statuses identical."))
+            statuses = {name: review.get("status") for name, review in reviews.items() if isinstance(review, dict)} if isinstance(reviews, dict) else {}
+            status = record.get("decision_status")
+            if status != "PENDING" and "PENDING" in statuses.values():
+                failures.append(_failure(target, "Final decision retains a PENDING reviewer", "Complete reviewer statuses before finalizing the decision."))
+            restriction = record.get("implementation_restriction")
+            if status in {"REJECTED", "BLOCKED"} and restriction != "IMPLEMENTATION_BLOCKED":
+                failures.append(_failure(target, f"{status} decisions require IMPLEMENTATION_BLOCKED", "Set implementation_restriction to IMPLEMENTATION_BLOCKED."))
+            if audit and isinstance(audit.get("license_analysis"), dict) and audit["license_analysis"].get("governor_review_required") and statuses.get("governor") == "NOT_REQUIRED":
+                failures.append(_failure(target, "Governor may not be NOT_REQUIRED when the audit requires Governor review", "Record Governor APPROVED, PENDING, REVISION_REQUIRED, or BLOCKED as appropriate."))
+            if status == "APPROVED":
+                required = {"arbiter": "APPROVED", "steward": "APPROVED"}
+                governor_required = bool(audit and audit.get("license_analysis", {}).get("governor_review_required"))
+                required["governor"] = "APPROVED" if governor_required else None
+                for reviewer, required_status in required.items():
+                    actual = statuses.get(reviewer)
+                    if required_status and actual != required_status:
+                        failures.append(_failure(target, f"APPROVED requires {reviewer} {required_status}", f"Set reviews.{reviewer}.status to {required_status}."))
+                    if reviewer == "governor" and not governor_required and actual not in {"APPROVED", "NOT_REQUIRED"}:
+                        failures.append(_failure(target, "APPROVED requires Governor APPROVED or NOT_REQUIRED", "Set reviews.governor.status to APPROVED or NOT_REQUIRED."))
+                if any(value in {"REVISION_REQUIRED", "BLOCKED"} for value in statuses.values()) or restriction == "IMPLEMENTATION_BLOCKED":
+                    failures.append(_failure(target, "APPROVED decision has a blocking reviewer status or implementation restriction", "Resolve blocking review results and use a non-blocked restriction."))
+                if pattern and pattern.get("classification") == "OUT_OF_SCOPE":
+                    failures.append(_failure(target, "OUT_OF_SCOPE patterns must not receive APPROVED decisions", "Use a non-approved decision status."))
+                if pattern and pattern.get("classification") == "REFERENCE_ONLY" and restriction != "CONCEPT_ONLY":
+                    failures.append(_failure(target, "Approved REFERENCE_ONLY patterns require CONCEPT_ONLY", "Set implementation_restriction to CONCEPT_ONLY."))
+    return decisions, failures
+
+
+def _load_proposals(repo_root: Path, schemas: dict[str, dict], index: dict[str, SourceBundle], audits: dict[str, tuple[dict, str]], decisions: dict[str, tuple[dict, str]], allowlist: set[str]) -> tuple[dict[str, dict], list[ValidationFailure]]:
+    proposals: dict[str, dict] = {}
+    failures: list[ValidationFailure] = []
+    root = repo_root / REGISTRIES["proposals"][0]
+    if not root.is_dir():
+        return proposals, failures
+    seen: set[str] = set()
+    for path in sorted(root.glob("*.json"), key=lambda item: item.name.casefold()):
+        record, record_failures = _load_record(path, schemas["proposal"], repo_root)
+        failures.extend(record_failures)
+        if record is None:
+            continue
+        target = _rel(repo_root, path)
+        proposal_id = record.get("proposal_id")
+        failures.extend(_identifier(proposal_id, "proposal_id", target))
+        if isinstance(proposal_id, str):
+            if proposal_id.casefold() in seen:
+                failures.append(_failure(target, f"Duplicate case-insensitive proposal_id '{proposal_id}'", "Use a unique proposal_id."))
+            seen.add(proposal_id.casefold())
+            proposals[proposal_id] = record
+            if path.name != f"{proposal_id}.json":
+                failures.append(_failure(target, "Proposal filename does not match proposal_id", f"Rename the file to '{proposal_id}.json'."))
+        audit_ids = record.get("source_audit_ids")
+        if not isinstance(audit_ids, list) or not audit_ids:
+            failures.append(_failure(target, "source_audit_ids must contain at least one audit ID", "Add one or more referenced audit_report_id values."))
+        elif len({item.casefold() for item in audit_ids if isinstance(item, str)}) != len(audit_ids):
+            failures.append(_failure(target, "source_audit_ids contains duplicate audit IDs", "Remove duplicate audit IDs."))
+        for audit_id in audit_ids if isinstance(audit_ids, list) else []:
+            if audit_id not in audits:
+                failures.append(_failure(target, f"source_audit_id '{audit_id}' does not resolve", "Reference an existing audit_report_id."))
+        selected = record.get("selected_patterns")
+        if not isinstance(selected, list) or not selected:
+            failures.append(_failure(target, "selected_patterns must contain at least one item", "Add an approved decision and pattern selection."))
+            continue
+        decision_ids: set[str] = set()
+        pattern_paths: set[str] = set()
+        for number, item in enumerate(selected):
+            if not isinstance(item, dict):
+                continue
+            decision_id = item.get("decision_id")
+            pattern_path = item.get("pattern_record_path")
+            if isinstance(decision_id, str) and decision_id.casefold() in decision_ids:
+                failures.append(_failure(target, f"selected_patterns[{number}].decision_id is duplicated", "Select each decision only once."))
+            if isinstance(decision_id, str):
+                decision_ids.add(decision_id.casefold())
+            if isinstance(pattern_path, str) and pattern_path.casefold() in pattern_paths:
+                failures.append(_failure(target, f"selected_patterns[{number}].pattern_record_path is duplicated", "Select each pattern only once."))
+            if isinstance(pattern_path, str):
+                pattern_paths.add(pattern_path.casefold())
+            pair = decisions.get(decision_id) if isinstance(decision_id, str) else None
+            if pair is None:
+                failures.append(_failure(target, f"selected_patterns[{number}].decision_id does not resolve", "Reference an existing approved decision."))
+                continue
+            decision, bundle_id = pair
+            if decision.get("decision_status") != "APPROVED" or decision.get("implementation_restriction") == "IMPLEMENTATION_BLOCKED":
+                failures.append(_failure(target, f"selected_patterns[{number}] must reference an approved non-blocked decision", "Reference a decision with decision_status APPROVED and a non-blocked restriction."))
+            if decision.get("audit_report_id") not in audit_ids:
+                failures.append(_failure(target, f"selected_patterns[{number}] decision audit is absent from source_audit_ids", "Add the decision audit_report_id to source_audit_ids."))
+            if pattern_path != decision.get("pattern_record_path"):
+                failures.append(_failure(target, f"selected_patterns[{number}].pattern_record_path does not match decision", "Copy pattern_record_path exactly from the referenced decision."))
+            failures.extend(_valid_specialist(item.get("owner_specialist"), f"selected_patterns[{number}].owner_specialist", target, allowlist))
+            if item.get("owner_specialist") != decision.get("assigned_specialist"):
+                failures.append(_failure(target, f"selected_patterns[{number}].owner_specialist does not match decision", "Use the decision assigned_specialist as owner_specialist."))
+            source = index.get(bundle_id)
+            pattern = source.patterns.get(pattern_path) if source and isinstance(pattern_path, str) else None
+            mechanism = item.get("evolution_mechanism")
+            restriction = decision.get("implementation_restriction")
+            if restriction == "CONCEPT_ONLY" and mechanism != "CONCEPTUAL_ADAPTATION":
+                failures.append(_failure(target, "CONCEPT_ONLY decisions permit only CONCEPTUAL_ADAPTATION", "Use evolution_mechanism CONCEPTUAL_ADAPTATION."))
+            if restriction == "FRESH_IMPLEMENTATION_REQUIRED" and mechanism == "DIRECT_REUSE_REVIEW_REQUIRED":
+                failures.append(_failure(target, "FRESH_IMPLEMENTATION_REQUIRED must not use DIRECT_REUSE_REVIEW_REQUIRED", "Use SAFE_REWRITE or CONCEPTUAL_ADAPTATION."))
+            if mechanism == "DIRECT_REUSE_REVIEW_REQUIRED" and (restriction != "CODE_REUSE_REVIEW_REQUIRED" or not pattern or pattern.get("classification") != "CODE_REUSE_REVIEW_REQUIRED"):
+                failures.append(_failure(target, "DIRECT_REUSE_REVIEW_REQUIRED requires a code-reuse decision and source classification", "Use CODE_REUSE_REVIEW_REQUIRED for both the decision restriction and source pattern classification."))
+            if mechanism == "TEST_CORPUS_ADAPTATION" and (not pattern or pattern.get("classification") != "TEST_CORPUS_CANDIDATE"):
+                failures.append(_failure(target, "TEST_CORPUS_ADAPTATION requires a TEST_CORPUS_CANDIDATE source pattern", "Use a test-corpus candidate pattern or another evolution mechanism."))
+    return proposals, failures
+
+
+def _load_promotions(repo_root: Path, schemas: dict[str, dict], index: dict[str, SourceBundle], decisions: dict[str, tuple[dict, str]], proposals: dict[str, dict], allowlist: set[str]) -> list[ValidationFailure]:
+    failures: list[ValidationFailure] = []
+    root = repo_root / REGISTRIES["promotions"][0]
+    if not root.is_dir():
+        return failures
+    promotion_ids: set[str] = set()
+    catalog_ids: set[str] = set()
+    for path in sorted(root.glob("*.json"), key=lambda item: item.name.casefold()):
+        record, record_failures = _load_record(path, schemas["promotion"], repo_root)
+        failures.extend(record_failures)
+        if record is None:
+            continue
+        target = _rel(repo_root, path)
+        for field, seen in (("promotion_id", promotion_ids), ("catalog_pattern_id", catalog_ids)):
+            value = record.get(field)
+            failures.extend(_identifier(value, field, target))
+            if isinstance(value, str):
+                if value.casefold() in seen:
+                    failures.append(_failure(target, f"Duplicate case-insensitive {field} '{value}'", f"Use a unique {field}."))
+                seen.add(value.casefold())
+        catalog_id = record.get("catalog_pattern_id")
+        if isinstance(catalog_id, str) and path.name != f"{catalog_id}.json":
+            failures.append(_failure(target, "Promotion filename does not match catalog_pattern_id", f"Rename the file to '{catalog_id}.json'."))
+        pair = decisions.get(record.get("decision_id")) if isinstance(record.get("decision_id"), str) else None
+        if pair is None or pair[0].get("decision_status") != "APPROVED":
+            failures.append(_failure(target, "decision_id must resolve to an approved decision", "Reference an existing approved governance decision."))
+            continue
+        decision, bundle_id = pair
+        proposal = proposals.get(record.get("proposal_id")) if isinstance(record.get("proposal_id"), str) else None
+        if proposal is None or proposal.get("proposal_status") != "APPROVED":
+            failures.append(_failure(target, "proposal_id must resolve to an approved proposal", "Reference an existing approved evolution proposal."))
+        elif not any(isinstance(item, dict) and item.get("decision_id") == record.get("decision_id") and item.get("pattern_record_path") == record.get("pattern_record_path") for item in proposal.get("selected_patterns", [])):
+            failures.append(_failure(target, "Proposal does not contain the exact decision and pattern pair", "Select the referenced decision and pattern in the proposal."))
+        if record.get("source_bundle_id") != bundle_id:
+            failures.append(_failure(target, "source_bundle_id does not match the decision", "Copy source_bundle_id exactly from the decision."))
+        if record.get("pattern_record_path") != decision.get("pattern_record_path"):
+            failures.append(_failure(target, "pattern_record_path does not match the decision", "Copy pattern_record_path exactly from the decision."))
+        failures.extend(_valid_specialist(record.get("assigned_specialist"), "assigned_specialist", target, allowlist))
+        if record.get("assigned_specialist") != decision.get("assigned_specialist"):
+            failures.append(_failure(target, "assigned_specialist does not match the decision", "Copy assigned_specialist exactly from the decision."))
+        source = index.get(bundle_id)
+        pattern = source.patterns.get(record.get("pattern_record_path")) if source and isinstance(record.get("pattern_record_path"), str) else None
+        if pattern and record.get("assigned_specialist") != pattern.get("assigned_specialist"):
+            failures.append(_failure(target, "assigned_specialist does not match the source pattern", "Use the source pattern assigned_specialist exactly."))
+        if proposal:
+            selected = next((item for item in proposal.get("selected_patterns", []) if isinstance(item, dict) and item.get("decision_id") == record.get("decision_id") and item.get("pattern_record_path") == record.get("pattern_record_path")), None)
+            if selected and record.get("assigned_specialist") != selected.get("owner_specialist"):
+                failures.append(_failure(target, "assigned_specialist does not match the proposal owner_specialist", "Use the proposal owner_specialist exactly."))
+        if source and pattern:
+            trace = record.get("source_traceability", {})
+            expected = {"repository": source.intake.get("repository"), "reviewed_commit_sha": source.intake.get("reviewed_commit_sha"), "source_file": pattern.get("source_file"), "line_range": pattern.get("line_range")}
+            for key, value in expected.items():
+                if not isinstance(trace, dict) or trace.get(key) != value:
+                    failures.append(_failure(target, f"source_traceability.{key} does not match source records", f"Copy source {key} exactly from the source record."))
+            attribution = record.get("license_and_attribution", {})
+            if not isinstance(attribution, dict) or attribution.get("original_license") != source.intake.get("license"):
+                failures.append(_failure(target, "license_and_attribution.original_license does not match source intake", "Copy the source intake license exactly."))
+        failures.extend(_date(record.get("approval_date"), "approval_date", target))
+        if isinstance(record.get("approval_date"), str) and record["approval_date"] < decision.get("decision_date", ""):
+            failures.append(_failure(target, "approval_date precedes the governance decision date", "Use an approval_date on or after decision_date."))
+        if record.get("automatic_promotion") is not False:
+            failures.append(_failure(target, "automatic_promotion must be false", "Set automatic_promotion to false."))
+    return failures
+
+
+def validate_repository(repo_root: Path) -> list[ValidationFailure]:
+    """Return deterministic Phase 4B governance-record validation failures."""
+    schemas = _load_schemas(repo_root)
+    failures = validate_registry_layout(repo_root)
+    index = _source_index(repo_root, schemas)
+    allowlist = _specialist_allowlist(schemas["pattern"])
+    audits, audit_failures = _load_audits(repo_root, schemas, index, allowlist)
+    decisions, decision_failures = _load_decisions(repo_root, schemas, index, audits, allowlist)
+    proposals, proposal_failures = _load_proposals(repo_root, schemas, index, audits, decisions, allowlist)
+    promotion_failures = _load_promotions(repo_root, schemas, index, decisions, proposals, allowlist)
+    failures.extend(audit_failures + decision_failures + proposal_failures + promotion_failures)
+    return sorted(failures, key=lambda item: (item.target.casefold(), item.reason.casefold(), item.remediation.casefold()))
+
+
+def _print_failure(failure: ValidationFailure) -> None:
+    print(f"[FAIL] {failure.target}: {failure.reason}")
+    print(f"       Remediation: {failure.remediation}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Artificer Governance-Record Validator")
+    parser.add_argument("--repo-root", default=None, help="Repository root (default: derived from script location)")
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        return 0 if exc.code == 0 else 2
+    repo_root = Path(args.repo_root).resolve() if args.repo_root else Path(__file__).resolve().parent.parent
+    for number, title in enumerate(("Governance Registry Layout", "Audit Reports", "Governance Decisions", "Evolution Proposals", "Promotion Records", "Cross-Record Integrity"), 1):
+        print(f"[{number}] {title}")
+    try:
+        failures = validate_repository(repo_root)
+    except ValidatorConfigurationError as exc:
+        print(f"[FAIL] Configuration error: {exc}")
+        print("       Remediation: Restore valid Phase 3 and Phase 4 schema contracts.")
+        return 2
+    if failures:
+        for failure in failures:
+            _print_failure(failure)
+        print("[7] Summary")
+        print(f"Validation Failed: {len(failures)} issue(s) found.")
+        return 1
+    print("[7] Summary")
+    print("Validation Passed: All Artificer governance records are valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_artificer_records.py
+++ b/scripts/validate_artificer_records.py
@@ -568,13 +568,12 @@ def _validate_source_intake_semantics(
             )
 
     # Optional default_branch — non-empty when present
-    if "default_branch" in instance:
-        db = instance["default_branch"]
-        if isinstance(db, str) and not db.strip():
-            _fail(
-                "'default_branch' must be non-empty when present",
-                "Provide a non-empty branch name or omit 'default_branch'.",
-            )
+    db = instance.get("default_branch", "")
+    if isinstance(db, str) and not db.strip():
+        _fail(
+            "'default_branch' must be non-empty after trimming",
+            "Provide a non-empty default branch.",
+        )
 
     # Repository format: owner/repository
     repo = instance.get("repository", "")

--- a/tests/behavior/run_tests.py
+++ b/tests/behavior/run_tests.py
@@ -22,7 +22,9 @@ def main():
         {"Name": "validate_artificer_internal.py", "Path": "scripts/validate_artificer_internal.py"},
         {"Name": "test_artificer_internal.py", "Path": "tests/behavior/test_artificer_internal.py"},
         {"Name": "validate_artificer_records.py", "Path": "scripts/validate_artificer_records.py"},
-        {"Name": "test_artificer_records.py", "Path": "tests/behavior/test_artificer_records.py"}
+        {"Name": "test_artificer_records.py", "Path": "tests/behavior/test_artificer_records.py"},
+        {"Name": "validate_artificer_governance_records.py", "Path": "scripts/validate_artificer_governance_records.py"},
+        {"Name": "test_artificer_governance_records.py", "Path": "tests/behavior/test_artificer_governance_records.py"}
     ]
     
     failed = False

--- a/tests/behavior/test_artificer_governance_records.py
+++ b/tests/behavior/test_artificer_governance_records.py
@@ -1,0 +1,1084 @@
+#!/usr/bin/env python3
+"""Behavior coverage for Artificer Phase 4B governance-record validation."""
+
+import contextlib
+import io
+import json
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+import validate_artificer_governance_records as validator  # noqa: E402
+
+
+BUNDLE = "owner__repository__aaaaaaaaaaaa"
+OTHER_BUNDLE = "owner__repository__bbbbbbbbbbbb"
+SHA = "a" * 40
+PATTERN_PATH = f"internal/artificer/records/{BUNDLE}/patterns/reference-pattern.json"
+OTHER_PATTERN_PATH = (
+    f"internal/artificer/records/{OTHER_BUNDLE}/patterns/reference-pattern.json"
+)
+
+PASSING_SCENARIOS = (
+    "empty registries",
+    "audit only",
+    "audit plus decision",
+    "complete chain",
+    "compatible license with Governor NOT_REQUIRED",
+    "required Governor review with Governor APPROVED",
+)
+
+
+def write_json(path: Path, value: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2), encoding="utf-8")
+
+
+def read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def update_json(path: Path, modify) -> None:
+    data = read_json(path)
+    modify(data)
+    write_json(path, data)
+
+
+def add_source_bundle(
+    root: Path,
+    bundle_id: str,
+    *,
+    repository: str = "owner/repository",
+    reviewed_commit_sha: str = SHA,
+    runtime_behavior_tested: bool = False,
+) -> None:
+    source = root / "internal/artificer/records" / bundle_id
+    intake = {
+        "repository": repository,
+        "repository_owner": "owner",
+        "canonical_url": f"https://example.test/{repository}",
+        "license": "MIT",
+        "default_branch": "main",
+        "reviewed_commit_sha": reviewed_commit_sha,
+        "review_date": "2026-07-01",
+        "files_examined": [{"file_path": "src/example.py", "line_ranges": ["1-100"]}],
+        "runtime_behavior_tested": runtime_behavior_tested,
+        "source_confidence": "HIGH",
+    }
+    pattern = {
+        "name": "Reference Pattern",
+        "description": "Source-backed pattern.",
+        "source_file": "src/example.py",
+        "line_range": "10-20",
+        "classification": "REFERENCE_ONLY",
+        "assigned_specialist": "ponytail",
+    }
+    write_json(source / "source-intake.json", intake)
+    write_json(source / "patterns/reference-pattern.json", pattern)
+
+
+def fixture_repo(
+    root: Path, chain: str = "complete", governor_required: bool = False
+) -> dict[str, Path]:
+    schemas = [
+        "AUDIT_REPORT_SCHEMA.json",
+        "GOVERNANCE_DECISION_SCHEMA.json",
+        "EVOLUTION_PROPOSAL_SCHEMA.json",
+        "PROMOTION_RECORD_SCHEMA.json",
+        "SOURCE_INTAKE_SCHEMA.json",
+        "PATTERN_SCHEMA.json",
+    ]
+    for schema in schemas:
+        target = root / "internal/artificer" / schema
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(REPO_ROOT / "internal/artificer" / schema, target)
+    for registry in ("records", "reviews", "decisions", "proposals", "promotions"):
+        path = root / "internal/artificer" / registry
+        path.mkdir(parents=True, exist_ok=True)
+        (path / "README.md").write_text("registry\n", encoding="utf-8")
+    add_source_bundle(root, BUNDLE)
+    paths = {
+        "audit": root / f"internal/artificer/reviews/{BUNDLE}/audit-report.json",
+        "decision": root / f"internal/artificer/decisions/{BUNDLE}/reference-pattern.json",
+        "proposal": root / "internal/artificer/proposals/proposal-1.json",
+        "promotion": root / "internal/artificer/promotions/catalog-pattern.json",
+    }
+    if chain == "empty":
+        return paths
+    assessment = "GOVERNOR_REVIEW_REQUIRED" if governor_required else "COMPATIBLE"
+    audit = {
+        "schema_version": "1.0",
+        "audit_report_id": "audit-1",
+        "source_bundle_id": BUNDLE,
+        "source_intake_path": f"internal/artificer/records/{BUNDLE}/source-intake.json",
+        "source_repository": "owner/repository",
+        "reviewed_commit_sha": SHA,
+        "audit_date": "2026-07-02",
+        "executive_summary": "Audit summary.",
+        "findings": [
+            {
+                "finding_id": "finding-1",
+                "pattern_record_path": PATTERN_PATH,
+                "title": "Finding",
+                "finding": "Observed behavior.",
+                "recommendation": "Use concept only.",
+                "assigned_specialist": "ponytail",
+                "risk_level": "LOW",
+                "evidence": [
+                    {
+                        "bucket": "SOURCE_CONFIRMED",
+                        "source_file": "src/example.py",
+                        "line_range": "10-20",
+                        "summary": "Observed.",
+                    }
+                ],
+            }
+        ],
+        "license_analysis": {
+            "detected_license": "MIT",
+            "compatibility_assessment": assessment,
+            "governor_review_required": governor_required,
+            "summary": "Recorded only.",
+        },
+        "security_review": {
+            "external_execution_performed": False,
+            "summary": "No external execution.",
+        },
+        "limitations": ["Static source evidence only."],
+    }
+    write_json(paths["audit"], audit)
+    if chain == "audit":
+        return paths
+    governor_status = "APPROVED" if governor_required else "NOT_REQUIRED"
+    decision = {
+        "schema_version": "1.0",
+        "decision_id": "decision-1",
+        "source_bundle_id": BUNDLE,
+        "pattern_record_path": PATTERN_PATH,
+        "audit_report_id": "audit-1",
+        "decision_status": "APPROVED",
+        "assigned_specialist": "ponytail",
+        "reviews": {
+            reviewer: {
+                "status": status,
+                "rationale": "Reviewed.",
+                "review_date": "2026-07-03",
+            }
+            for reviewer, status in {
+                "arbiter": "APPROVED",
+                "governor": governor_status,
+                "steward": "APPROVED",
+            }.items()
+        },
+        "maintainer_decision": {
+            "status": "APPROVED",
+            "rationale": "Approved.",
+            "decision_date": "2026-07-03",
+        },
+        "implementation_restriction": "CONCEPT_ONLY",
+        "decision_date": "2026-07-03",
+    }
+    write_json(paths["decision"], decision)
+    if chain == "decision":
+        return paths
+    proposal = {
+        "schema_version": "1.0",
+        "proposal_id": "proposal-1",
+        "title": "Proposal",
+        "objective": "Adapt concept.",
+        "source_audit_ids": ["audit-1"],
+        "selected_patterns": [
+            {
+                "decision_id": "decision-1",
+                "pattern_record_path": PATTERN_PATH,
+                "target_component": "validator",
+                "evolution_mechanism": "CONCEPTUAL_ADAPTATION",
+                "owner_specialist": "ponytail",
+                "rationale": "Approved concept.",
+            }
+        ],
+        "verification_plan": "Run tests.",
+        "governance_handoff": "Maintainer review.",
+        "proposal_status": "APPROVED",
+    }
+    write_json(paths["proposal"], proposal)
+    if chain == "proposal":
+        return paths
+    promotion = {
+        "schema_version": "1.0",
+        "promotion_id": "promotion-1",
+        "catalog_pattern_id": "catalog-pattern",
+        "decision_id": "decision-1",
+        "proposal_id": "proposal-1",
+        "source_bundle_id": BUNDLE,
+        "pattern_record_path": PATTERN_PATH,
+        "approval_date": "2026-07-04",
+        "promotion_status": "APPROVED",
+        "assigned_specialist": "ponytail",
+        "source_traceability": {
+            "repository": "owner/repository",
+            "reviewed_commit_sha": SHA,
+            "source_file": "src/example.py",
+            "line_range": "10-20",
+        },
+        "license_and_attribution": {
+            "original_license": "MIT",
+            "attribution_required": True,
+            "summary": "Retain attribution.",
+        },
+        "automatic_promotion": False,
+    }
+    write_json(paths["promotion"], promotion)
+    return paths
+
+
+class GovernanceRecordsTests(unittest.TestCase):
+    def with_repo(self, chain: str = "complete", governor_required: bool = False):
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        root = Path(temp.name)
+        return root, fixture_repo(root, chain, governor_required)
+
+    def assert_validation_failure(
+        self,
+        root: Path,
+        *,
+        target_contains: str,
+        reason_contains: str,
+        remediation_contains: str | None = None,
+    ) -> None:
+        failures = validator.validate_repository(root)
+        self.assertTrue(failures, "Expected validation to fail")
+        matching = [
+            failure
+            for failure in failures
+            if target_contains in failure.target
+            and reason_contains in failure.reason
+            and (
+                remediation_contains is None
+                or remediation_contains in failure.remediation
+            )
+        ]
+        self.assertTrue(
+            matching,
+            (
+                "Expected a matching validation failure.\n"
+                f"target_contains={target_contains!r}\n"
+                f"reason_contains={reason_contains!r}\n"
+                f"remediation_contains={remediation_contains!r}\n"
+                "Actual failures:\n"
+                + "\n".join(
+                    f"{f.target}: {f.reason} | {f.remediation}" for f in failures
+                )
+            ),
+        )
+
+    def capture_main(self, argv: list[str]) -> tuple[int, str]:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            exit_code = validator.main(argv)
+        return exit_code, stdout.getvalue() + stderr.getvalue()
+
+    def assert_relative_output(self, output: str, root: Path, expected_rel_path: str) -> None:
+        self.assertIn(expected_rel_path, output)
+        self.assertNotIn(str(root), output)
+        self.assertNotIn(str(root.resolve()), output)
+
+    def test_passing_empty_and_progressive_chains(self):
+        cases = [
+            ("empty registries", "empty", False),
+            ("audit only", "audit", False),
+            ("audit plus decision", "decision", False),
+            ("complete chain", "complete", False),
+            ("compatible license with Governor NOT_REQUIRED", "complete", False),
+            ("required Governor review with Governor APPROVED", "complete", True),
+        ]
+        for name, chain, governor_required in cases:
+            with self.subTest(name=name):
+                root, _ = self.with_repo(chain, governor_required)
+                self.assertEqual([], validator.validate_repository(root))
+
+    def test_registry_layout_failures(self):
+        cases = [
+            {
+                "name": "missing README",
+                "mutate": lambda root, paths: (root / "internal/artificer/reviews/README.md").unlink(),
+                "target_contains": "internal/artificer/reviews/README.md",
+                "reason_contains": "Registry README.md is missing",
+                "remediation_contains": "Create a regular",
+            },
+            {
+                "name": "unexpected root file",
+                "mutate": lambda root, paths: (root / "internal/artificer/reviews/unexpected.txt").write_text("x", encoding="utf-8"),
+                "target_contains": "internal/artificer/reviews/unexpected.txt",
+                "reason_contains": "Registry root permits only bundle directories",
+                "remediation_contains": "Move the record",
+            },
+            {
+                "name": "invalid bundle directory",
+                "mutate": lambda root, paths: (root / "internal/artificer/reviews/invalid").mkdir(),
+                "target_contains": "internal/artificer/reviews/invalid",
+                "reason_contains": "Bundle directory name is invalid",
+                "remediation_contains": "12-character-lowercase-sha",
+            },
+            {
+                "name": "empty bundle directory",
+                "mutate": lambda root, paths: (root / "internal/artificer/reviews/owner__empty__aaaaaaaaaaaa").mkdir(),
+                "target_contains": "internal/artificer/reviews/owner__empty__aaaaaaaaaaaa",
+                "reason_contains": "Bundle directory is empty",
+                "remediation_contains": "required governance JSON record",
+            },
+            {
+                "name": "nested directory",
+                "mutate": lambda root, paths: (root / f"internal/artificer/reviews/{BUNDLE}/nested").mkdir(),
+                "target_contains": f"internal/artificer/reviews/{BUNDLE}/nested",
+                "reason_contains": "Nested directories and symbolic links are not permitted",
+                "remediation_contains": "regular JSON file",
+            },
+            {
+                "name": "non-JSON file",
+                "mutate": lambda root, paths: (root / f"internal/artificer/decisions/{BUNDLE}/bad.txt").write_text("x", encoding="utf-8"),
+                "target_contains": f"internal/artificer/decisions/{BUNDLE}/bad.txt",
+                "reason_contains": "Decision records must be named <pattern-slug>.json",
+                "remediation_contains": "Rename the record",
+            },
+            {
+                "name": "proposal directory instead of JSON file",
+                "mutate": lambda root, paths: (root / "internal/artificer/proposals/bad").mkdir(),
+                "target_contains": "internal/artificer/proposals/bad",
+                "reason_contains": "Registry permits only regular <safe-id>.json files",
+                "remediation_contains": "Replace directories",
+            },
+            {
+                "name": "promotion directory instead of JSON file",
+                "mutate": lambda root, paths: (root / "internal/artificer/promotions/bad").mkdir(),
+                "target_contains": "internal/artificer/promotions/bad",
+                "reason_contains": "Registry permits only regular <safe-id>.json files",
+                "remediation_contains": "Replace directories",
+            },
+        ]
+        for case in cases:
+            with self.subTest(name=case["name"]):
+                root, paths = self.with_repo()
+                case["mutate"](root, paths)
+                self.assert_validation_failure(
+                    root,
+                    target_contains=case["target_contains"],
+                    reason_contains=case["reason_contains"],
+                    remediation_contains=case["remediation_contains"],
+                )
+
+    def test_find_casefold_duplicate_helper(self):
+        self.assertEqual(
+            "Proposal-A.json",
+            validator.find_casefold_duplicate(
+                ["proposal-a.json", "Proposal-A.json"]
+            ),
+        )
+        self.assertIsNone(
+            validator.find_casefold_duplicate(["proposal-a.json", "proposal-b.json"])
+        )
+
+    def test_registry_case_insensitive_collision_end_to_end_when_supported(self):
+        root, paths = self.with_repo("proposal")
+        probe = root / "CaseProbe"
+        probe.write_text("probe", encoding="utf-8")
+        case_sensitive = not (root / "caseprobe").exists()
+        probe.unlink()
+        if not case_sensitive:
+            self.skipTest(
+                "filesystem is case-insensitive in the temporary directory"
+            )
+        collision_path = paths["proposal"].with_name("Proposal-1.json")
+        shutil.copy2(paths["proposal"], collision_path)
+        self.assert_validation_failure(
+            root,
+            target_contains="Proposal-1.json",
+            reason_contains="Case-insensitive filename collision",
+            remediation_contains="case sensitivity",
+        )
+
+    def test_registry_symlink_fails_when_supported(self):
+        root, _ = self.with_repo("audit")
+        link = root / "internal/artificer/reviews/link"
+        try:
+            link.symlink_to(root / f"internal/artificer/reviews/{BUNDLE}", target_is_directory=True)
+        except OSError as exc:
+            self.skipTest(f"symbolic links unsupported: {exc}")
+        self.assert_validation_failure(
+            root,
+            target_contains="internal/artificer/reviews/link",
+            reason_contains="Symbolic links are not permitted in governance registries",
+            remediation_contains="Replace the symbolic link",
+        )
+
+    def test_record_safety_schema_and_date_failures(self):
+        cases = [
+            {
+                "name": "empty file",
+                "mutate": lambda path: path.write_bytes(b""),
+                "reason_contains": "file is empty",
+            },
+            {
+                "name": "malformed JSON",
+                "mutate": lambda path: path.write_text("{", encoding="utf-8"),
+                "reason_contains": "malformed JSON",
+            },
+            {
+                "name": "duplicate key",
+                "mutate": lambda path: path.write_text('{"x": 1, "x": 2}', encoding="utf-8"),
+                "reason_contains": "duplicate JSON key",
+            },
+            {
+                "name": "non-UTF-8",
+                "mutate": lambda path: path.write_bytes(b"\xff"),
+                "reason_contains": "file is not valid UTF-8",
+            },
+            {
+                "name": "oversized file",
+                "mutate": lambda path: path.write_bytes(b"x" * (validator.MAX_FILE_SIZE + 1)),
+                "reason_contains": "file exceeds maximum size",
+            },
+            {
+                "name": "top-level array",
+                "mutate": lambda path: path.write_text("[]", encoding="utf-8"),
+                "reason_contains": "top-level JSON value must be an object",
+            },
+            {
+                "name": "missing required field",
+                "mutate": lambda path: update_json(path, lambda data: data.pop("audit_date")),
+                "reason_contains": "missing required field 'audit_date'",
+            },
+            {
+                "name": "wrong type",
+                "mutate": lambda path: update_json(path, lambda data: data.__setitem__("findings", {})),
+                "reason_contains": "findings: expected array, got dict",
+            },
+            {
+                "name": "invalid enum",
+                "mutate": lambda path: update_json(path, lambda data: data.__setitem__("schema_version", "9")),
+                "reason_contains": "schema_version: value '9' is not one of the allowed enum values",
+            },
+            {
+                "name": "unexpected property",
+                "mutate": lambda path: update_json(path, lambda data: data.__setitem__("extra", True)),
+                "reason_contains": "unexpected additional property 'extra'",
+            },
+            {
+                "name": "invalid date",
+                "mutate": lambda path: update_json(path, lambda data: data.__setitem__("audit_date", "2026-02-30")),
+                "reason_contains": "audit_date: value '2026-02-30' is not a valid ISO date",
+            },
+        ]
+        for case in cases:
+            with self.subTest(name=case["name"]):
+                root, paths = self.with_repo("audit")
+                case["mutate"](paths["audit"])
+                self.assert_validation_failure(
+                    root,
+                    target_contains="audit-report.json",
+                    reason_contains=case["reason_contains"],
+                    remediation_contains="Fix the JSON record"
+                    if case["name"] in {"empty file", "malformed JSON", "duplicate key", "non-UTF-8", "oversized file", "top-level array"}
+                    else None,
+                )
+
+    def test_audit_cross_record_failures(self):
+        cases = [
+            {
+                "name": "bundle mismatch",
+                "mutate": lambda root, paths: (
+                    add_source_bundle(root, OTHER_BUNDLE),
+                    update_json(
+                        paths["audit"],
+                        lambda data: (
+                            data.__setitem__("source_bundle_id", OTHER_BUNDLE),
+                            data.__setitem__("source_intake_path", f"internal/artificer/records/{OTHER_BUNDLE}/source-intake.json"),
+                            data["findings"][0].__setitem__("pattern_record_path", OTHER_PATTERN_PATH),
+                        ),
+                    ),
+                ),
+                "reason_contains": "source_bundle_id does not match the audit-report directory",
+                "remediation_contains": "containing bundle ID",
+            },
+            {
+                "name": "missing source bundle",
+                "mutate": lambda root, paths: update_json(paths["audit"], lambda data: data.__setitem__("source_bundle_id", "missing__bundle__aaaaaaaaaaaa")),
+                "reason_contains": "Source bundle 'missing__bundle__aaaaaaaaaaaa' is missing",
+                "remediation_contains": "Restore a valid Phase 3 source bundle",
+            },
+            {
+                "name": "wrong source-intake path",
+                "mutate": lambda root, paths: update_json(paths["audit"], lambda data: data.__setitem__("source_intake_path", "wrong.json")),
+                "reason_contains": "source_intake_path does not exactly reference the source bundle intake",
+                "remediation_contains": "Set source_intake_path",
+            },
+            {
+                "name": "repository mismatch",
+                "mutate": lambda root, paths: update_json(paths["audit"], lambda data: data.__setitem__("source_repository", "other/repository")),
+                "reason_contains": "source_repository does not match source-intake.json",
+                "remediation_contains": "Copy repository exactly",
+            },
+            {
+                "name": "SHA mismatch",
+                "mutate": lambda root, paths: update_json(paths["audit"], lambda data: data.__setitem__("reviewed_commit_sha", "b" * 40)),
+                "reason_contains": "reviewed_commit_sha does not match source-intake.json",
+                "remediation_contains": "reviewed commit SHA exactly",
+            },
+            {
+                "name": "audit date before intake review date",
+                "mutate": lambda root, paths: update_json(paths["audit"], lambda data: data.__setitem__("audit_date", "2026-06-30")),
+                "reason_contains": "audit_date precedes the source intake review_date",
+                "remediation_contains": "on or after the source intake review_date",
+            },
+            {
+                "name": "missing pattern",
+                "mutate": lambda root, paths: update_json(paths["audit"], lambda data: data["findings"][0].__setitem__("pattern_record_path", PATTERN_PATH.replace("reference-pattern", "missing-pattern"))),
+                "reason_contains": "pattern_record_path does not reference an existing pattern in the same source bundle",
+                "remediation_contains": "Reference a pattern JSON record",
+            },
+            {
+                "name": "cross-bundle pattern",
+                "mutate": lambda root, paths: (
+                    add_source_bundle(root, OTHER_BUNDLE),
+                    update_json(paths["audit"], lambda data: data["findings"][0].__setitem__("pattern_record_path", OTHER_PATTERN_PATH)),
+                ),
+                "reason_contains": "pattern_record_path does not reference an existing pattern in the same source bundle",
+                "remediation_contains": "Reference a pattern JSON record",
+            },
+            {
+                "name": "duplicate finding ID",
+                "mutate": lambda root, paths: update_json(paths["audit"], lambda data: data["findings"].append(dict(data["findings"][0]))),
+                "reason_contains": "Duplicate finding_id 'finding-1'",
+                "remediation_contains": "Use unique finding IDs",
+            },
+            {
+                "name": "empty evidence",
+                "mutate": lambda root, paths: update_json(paths["audit"], lambda data: data["findings"][0].__setitem__("evidence", [])),
+                "reason_contains": "evidence must contain at least one item",
+                "remediation_contains": "Add at least one traceable evidence item",
+            },
+            {
+                "name": "evidence file not examined",
+                "mutate": lambda root, paths: update_json(paths["audit"], lambda data: data["findings"][0]["evidence"][0].__setitem__("source_file", "other.py")),
+                "reason_contains": "source_file is not in files_examined",
+                "remediation_contains": "Use a source file listed",
+            },
+            {
+                "name": "evidence range not covered",
+                "mutate": lambda root, paths: update_json(paths["audit"], lambda data: data["findings"][0]["evidence"][0].__setitem__("line_range", "101-102")),
+                "reason_contains": "line_range is outside files_examined coverage",
+                "remediation_contains": "covered by source-intake.json files_examined",
+            },
+            {
+                "name": "runtime evidence without authorization",
+                "mutate": lambda root, paths: update_json(paths["audit"], lambda data: data["findings"][0]["evidence"][0].__setitem__("bucket", "RUNTIME_CONFIRMED_BY_AUTHORIZED_EXTERNAL_VALIDATION")),
+                "reason_contains": "Runtime-confirmed evidence requires source intake runtime_behavior_tested: true",
+                "remediation_contains": "Use a non-runtime evidence bucket",
+            },
+            {
+                "name": "specialist mismatch",
+                "mutate": lambda root, paths: update_json(paths["audit"], lambda data: data["findings"][0].__setitem__("assigned_specialist", "cloak")),
+                "reason_contains": "assigned_specialist does not match the source pattern",
+                "remediation_contains": "Use the source pattern assigned_specialist exactly",
+            },
+            {
+                "name": "Artificer assignment",
+                "mutate": lambda root, paths: update_json(paths["audit"], lambda data: data["findings"][0].__setitem__("assigned_specialist", "artificer")),
+                "reason_contains": "must not assign Artificer",
+                "remediation_contains": "Assign a specialist",
+            },
+            {
+                "name": "license mismatch",
+                "mutate": lambda root, paths: update_json(paths["audit"], lambda data: data["license_analysis"].__setitem__("detected_license", "Apache-2.0")),
+                "reason_contains": "license_analysis.detected_license does not match source intake license",
+                "remediation_contains": "Copy the license exactly",
+            },
+            {
+                "name": "Governor-review Boolean inconsistency",
+                "mutate": lambda root, paths: update_json(paths["audit"], lambda data: data["license_analysis"].__setitem__("governor_review_required", True)),
+                "reason_contains": "license compatibility assessment and governor_review_required are inconsistent",
+                "remediation_contains": "Set governor_review_required false only for COMPATIBLE",
+            },
+        ]
+        for case in cases:
+            with self.subTest(name=case["name"]):
+                root, paths = self.with_repo("audit")
+                case["mutate"](root, paths)
+                self.assert_validation_failure(
+                    root,
+                    target_contains="audit-report.json",
+                    reason_contains=case["reason_contains"],
+                    remediation_contains=case["remediation_contains"],
+                )
+
+    def test_decision_cross_record_and_status_failures(self):
+        def duplicate_decision(paths: dict[str, Path]) -> None:
+            copy_path = paths["decision"].with_name("another.json")
+            data = read_json(paths["decision"])
+            data["decision_id"] = "decision-1"
+            write_json(copy_path, data)
+
+        cases = [
+            {
+                "name": "filename mismatch",
+                "mutate": lambda root, paths: paths["decision"].rename(paths["decision"].with_name("wrong.json")),
+                "target_contains": "wrong.json",
+                "reason_contains": "Decision filename does not match the referenced pattern filename",
+                "remediation_contains": "Rename the decision file",
+            },
+            {
+                "name": "missing audit",
+                "mutate": lambda root, paths: update_json(paths["decision"], lambda data: data.__setitem__("audit_report_id", "missing")),
+                "reason_contains": "audit_report_id does not resolve to an audit report in this source bundle",
+                "remediation_contains": "Reference an existing audit report",
+            },
+            {
+                "name": "missing corresponding finding",
+                "mutate": lambda root, paths: update_json(paths["audit"], lambda data: data["findings"].clear()),
+                "reason_contains": "Referenced audit report has no finding for pattern_record_path",
+                "remediation_contains": "Add a matching audit finding",
+            },
+            {
+                "name": "duplicate decision ID",
+                "mutate": lambda root, paths: duplicate_decision(paths),
+                "target_contains": "reference-pattern.json",
+                "reason_contains": "Duplicate case-insensitive decision_id 'decision-1'",
+                "remediation_contains": "Use a unique decision_id",
+            },
+            {
+                "name": "specialist mismatch",
+                "mutate": lambda root, paths: update_json(paths["decision"], lambda data: data.__setitem__("assigned_specialist", "cloak")),
+                "reason_contains": "assigned_specialist does not match the source pattern",
+                "remediation_contains": "Use the source pattern assigned_specialist exactly",
+            },
+            {
+                "name": "review date after decision",
+                "mutate": lambda root, paths: update_json(paths["decision"], lambda data: data["reviews"]["arbiter"].__setitem__("review_date", "2026-07-04")),
+                "reason_contains": "reviews.arbiter.review_date is after decision_date",
+                "remediation_contains": "on or before decision_date",
+            },
+            {
+                "name": "Maintainer date mismatch",
+                "mutate": lambda root, paths: update_json(paths["decision"], lambda data: data["maintainer_decision"].__setitem__("decision_date", "2026-07-04")),
+                "reason_contains": "maintainer_decision.decision_date must equal decision_date",
+                "remediation_contains": "top-level decision_date",
+            },
+            {
+                "name": "decision before audit",
+                "mutate": lambda root, paths: update_json(paths["decision"], lambda data: (data.__setitem__("decision_date", "2026-07-01"), data["maintainer_decision"].__setitem__("decision_date", "2026-07-01"))),
+                "reason_contains": "decision_date precedes the audit_date",
+                "remediation_contains": "on or after the audit_date",
+            },
+            {
+                "name": "decision/Maintainer status mismatch",
+                "mutate": lambda root, paths: update_json(paths["decision"], lambda data: data["maintainer_decision"].__setitem__("status", "REJECTED")),
+                "reason_contains": "decision_status must equal maintainer_decision.status",
+                "remediation_contains": "statuses identical",
+            },
+            {
+                "name": "final decision with pending reviewer",
+                "mutate": lambda root, paths: update_json(paths["decision"], lambda data: data["reviews"]["arbiter"].__setitem__("status", "PENDING")),
+                "reason_contains": "Final decision retains a PENDING reviewer",
+                "remediation_contains": "Complete reviewer statuses",
+            },
+            {
+                "name": "approval with revision-required reviewer",
+                "mutate": lambda root, paths: update_json(paths["decision"], lambda data: data["reviews"]["arbiter"].__setitem__("status", "REVISION_REQUIRED")),
+                "reason_contains": "APPROVED requires arbiter APPROVED",
+                "remediation_contains": "Set reviews.arbiter.status to APPROVED",
+            },
+            {
+                "name": "approval with blocked reviewer",
+                "mutate": lambda root, paths: update_json(paths["decision"], lambda data: data["reviews"]["arbiter"].__setitem__("status", "BLOCKED")),
+                "reason_contains": "APPROVED requires arbiter APPROVED",
+                "remediation_contains": "Set reviews.arbiter.status to APPROVED",
+            },
+            {
+                "name": "missing required Governor approval",
+                "mutate": lambda root, paths: update_json(paths["audit"], lambda data: (data["license_analysis"].__setitem__("compatibility_assessment", "GOVERNOR_REVIEW_REQUIRED"), data["license_analysis"].__setitem__("governor_review_required", True))),
+                "reason_contains": "Governor may not be NOT_REQUIRED when the audit requires Governor review",
+                "remediation_contains": "Record Governor APPROVED",
+            },
+            {
+                "name": "approval with implementation blocked",
+                "mutate": lambda root, paths: update_json(paths["decision"], lambda data: data.__setitem__("implementation_restriction", "IMPLEMENTATION_BLOCKED")),
+                "reason_contains": "APPROVED decision has a blocking reviewer status or implementation restriction",
+                "remediation_contains": "Resolve blocking review results",
+            },
+            {
+                "name": "rejected without implementation blocked",
+                "mutate": lambda root, paths: update_json(paths["decision"], lambda data: (data.__setitem__("decision_status", "REJECTED"), data["maintainer_decision"].__setitem__("status", "REJECTED"))),
+                "reason_contains": "REJECTED decisions require IMPLEMENTATION_BLOCKED",
+                "remediation_contains": "Set implementation_restriction to IMPLEMENTATION_BLOCKED",
+            },
+            {
+                "name": "blocked without implementation blocked",
+                "mutate": lambda root, paths: update_json(paths["decision"], lambda data: (data.__setitem__("decision_status", "BLOCKED"), data["maintainer_decision"].__setitem__("status", "BLOCKED"))),
+                "reason_contains": "BLOCKED decisions require IMPLEMENTATION_BLOCKED",
+                "remediation_contains": "Set implementation_restriction to IMPLEMENTATION_BLOCKED",
+            },
+            {
+                "name": "approved out-of-scope pattern",
+                "mutate": lambda root, paths: update_json(root / f"internal/artificer/records/{BUNDLE}/patterns/reference-pattern.json", lambda data: data.__setitem__("classification", "OUT_OF_SCOPE")),
+                "reason_contains": "OUT_OF_SCOPE patterns must not receive APPROVED decisions",
+                "remediation_contains": "Use a non-approved decision status",
+            },
+            {
+                "name": "reference-only approval without concept-only restriction",
+                "mutate": lambda root, paths: update_json(paths["decision"], lambda data: data.__setitem__("implementation_restriction", "FRESH_IMPLEMENTATION_REQUIRED")),
+                "reason_contains": "Approved REFERENCE_ONLY patterns require CONCEPT_ONLY",
+                "remediation_contains": "Set implementation_restriction to CONCEPT_ONLY",
+            },
+        ]
+        for case in cases:
+            with self.subTest(name=case["name"]):
+                root, paths = self.with_repo("decision")
+                case["mutate"](root, paths)
+                self.assert_validation_failure(
+                    root,
+                    target_contains=case.get(
+                        "target_contains", "reference-pattern.json"
+                    ),
+                    reason_contains=case["reason_contains"],
+                    remediation_contains=case["remediation_contains"],
+                )
+
+    def test_proposal_failures(self):
+        cases = [
+            {
+                "name": "filename mismatch",
+                "mutate": lambda root, paths: paths["proposal"].rename(paths["proposal"].with_name("wrong.json")),
+                "target_contains": "wrong.json",
+                "reason_contains": "Proposal filename does not match proposal_id",
+                "remediation_contains": "Rename the file",
+            },
+            {
+                "name": "empty audit list",
+                "mutate": lambda root, paths: update_json(paths["proposal"], lambda data: data.__setitem__("source_audit_ids", [])),
+                "reason_contains": "source_audit_ids must contain at least one audit ID",
+                "remediation_contains": "Add one or more",
+            },
+            {
+                "name": "duplicate audit ID",
+                "mutate": lambda root, paths: update_json(paths["proposal"], lambda data: data.__setitem__("source_audit_ids", ["audit-1", "audit-1"])),
+                "reason_contains": "source_audit_ids contains duplicate audit IDs",
+                "remediation_contains": "Remove duplicate",
+            },
+            {
+                "name": "missing audit",
+                "mutate": lambda root, paths: update_json(paths["proposal"], lambda data: data.__setitem__("source_audit_ids", ["missing"])),
+                "reason_contains": "source_audit_id 'missing' does not resolve",
+                "remediation_contains": "Reference an existing audit_report_id",
+            },
+            {
+                "name": "empty selected-pattern list",
+                "mutate": lambda root, paths: update_json(paths["proposal"], lambda data: data.__setitem__("selected_patterns", [])),
+                "reason_contains": "selected_patterns must contain at least one item",
+                "remediation_contains": "Add an approved decision",
+            },
+            {
+                "name": "duplicate decision",
+                "mutate": lambda root, paths: update_json(paths["proposal"], lambda data: data.__setitem__("selected_patterns", data["selected_patterns"] * 2)),
+                "reason_contains": "selected_patterns[1].decision_id is duplicated",
+                "remediation_contains": "Select each decision only once",
+            },
+            {
+                "name": "duplicate pattern",
+                "mutate": lambda root, paths: update_json(paths["proposal"], lambda data: data.__setitem__("selected_patterns", data["selected_patterns"] * 2)),
+                "reason_contains": "selected_patterns[1].pattern_record_path is duplicated",
+                "remediation_contains": "Select each pattern only once",
+            },
+            {
+                "name": "missing decision",
+                "mutate": lambda root, paths: update_json(paths["proposal"], lambda data: data["selected_patterns"][0].__setitem__("decision_id", "missing")),
+                "reason_contains": "selected_patterns[0].decision_id does not resolve",
+                "remediation_contains": "Reference an existing approved decision",
+            },
+            {
+                "name": "non-approved decision",
+                "mutate": lambda root, paths: update_json(paths["decision"], lambda data: (data.__setitem__("decision_status", "REJECTED"), data["maintainer_decision"].__setitem__("status", "REJECTED"), data.__setitem__("implementation_restriction", "IMPLEMENTATION_BLOCKED"))),
+                "reason_contains": "selected_patterns[0] must reference an approved non-blocked decision",
+                "remediation_contains": "decision_status APPROVED",
+            },
+            {
+                "name": "audit omitted from source-audit IDs",
+                "mutate": lambda root, paths: update_json(paths["proposal"], lambda data: data.__setitem__("source_audit_ids", ["audit-2"])),
+                "reason_contains": "selected_patterns[0] decision audit is absent from source_audit_ids",
+                "remediation_contains": "Add the decision audit_report_id",
+            },
+            {
+                "name": "pattern mismatch",
+                "mutate": lambda root, paths: update_json(paths["proposal"], lambda data: data["selected_patterns"][0].__setitem__("pattern_record_path", "wrong.json")),
+                "reason_contains": "selected_patterns[0].pattern_record_path does not match decision",
+                "remediation_contains": "Copy pattern_record_path exactly",
+            },
+            {
+                "name": "specialist mismatch",
+                "mutate": lambda root, paths: update_json(paths["proposal"], lambda data: data["selected_patterns"][0].__setitem__("owner_specialist", "cloak")),
+                "reason_contains": "selected_patterns[0].owner_specialist does not match decision",
+                "remediation_contains": "Use the decision assigned_specialist",
+            },
+            {
+                "name": "Artificer owner",
+                "mutate": lambda root, paths: update_json(paths["proposal"], lambda data: data["selected_patterns"][0].__setitem__("owner_specialist", "artificer")),
+                "reason_contains": "must not assign Artificer",
+                "remediation_contains": "Assign a specialist",
+            },
+            {
+                "name": "invalid conceptual mechanism",
+                "mutate": lambda root, paths: update_json(paths["proposal"], lambda data: data["selected_patterns"][0].__setitem__("evolution_mechanism", "SAFE_REWRITE")),
+                "reason_contains": "CONCEPT_ONLY decisions permit only CONCEPTUAL_ADAPTATION",
+                "remediation_contains": "Use evolution_mechanism CONCEPTUAL_ADAPTATION",
+            },
+            {
+                "name": "invalid fresh-implementation pairing",
+                "mutate": lambda root, paths: (
+                    update_json(paths["decision"], lambda data: data.__setitem__("implementation_restriction", "FRESH_IMPLEMENTATION_REQUIRED")),
+                    update_json(paths["proposal"], lambda data: data["selected_patterns"][0].__setitem__("evolution_mechanism", "DIRECT_REUSE_REVIEW_REQUIRED")),
+                ),
+                "reason_contains": "FRESH_IMPLEMENTATION_REQUIRED must not use DIRECT_REUSE_REVIEW_REQUIRED",
+                "remediation_contains": "Use SAFE_REWRITE or CONCEPTUAL_ADAPTATION",
+            },
+            {
+                "name": "invalid direct-reuse pairing",
+                "mutate": lambda root, paths: (
+                    update_json(paths["decision"], lambda data: data.__setitem__("implementation_restriction", "CODE_REUSE_REVIEW_REQUIRED")),
+                    update_json(paths["proposal"], lambda data: data["selected_patterns"][0].__setitem__("evolution_mechanism", "DIRECT_REUSE_REVIEW_REQUIRED")),
+                ),
+                "reason_contains": "DIRECT_REUSE_REVIEW_REQUIRED requires a code-reuse decision and source classification",
+                "remediation_contains": "Use CODE_REUSE_REVIEW_REQUIRED",
+            },
+            {
+                "name": "invalid test-corpus pairing",
+                "mutate": lambda root, paths: update_json(paths["proposal"], lambda data: data["selected_patterns"][0].__setitem__("evolution_mechanism", "TEST_CORPUS_ADAPTATION")),
+                "reason_contains": "TEST_CORPUS_ADAPTATION requires a TEST_CORPUS_CANDIDATE source pattern",
+                "remediation_contains": "Use a test-corpus candidate pattern",
+            },
+            {
+                "name": "blocked decision selection",
+                "mutate": lambda root, paths: update_json(paths["decision"], lambda data: data.__setitem__("implementation_restriction", "IMPLEMENTATION_BLOCKED")),
+                "reason_contains": "selected_patterns[0] must reference an approved non-blocked decision",
+                "remediation_contains": "decision_status APPROVED",
+            },
+        ]
+        for case in cases:
+            with self.subTest(name=case["name"]):
+                root, paths = self.with_repo("proposal")
+                case["mutate"](root, paths)
+                self.assert_validation_failure(
+                    root,
+                    target_contains=case.get("target_contains", "proposal-1.json"),
+                    reason_contains=case["reason_contains"],
+                    remediation_contains=case["remediation_contains"],
+                )
+
+    def test_promotion_failures(self):
+        def duplicate_promotion(paths: dict[str, Path]) -> None:
+            copy_path = paths["promotion"].with_name("another.json")
+            data = read_json(paths["promotion"])
+            data["catalog_pattern_id"] = "another"
+            write_json(copy_path, data)
+
+        cases = [
+            {
+                "name": "filename mismatch",
+                "mutate": lambda root, paths: paths["promotion"].rename(paths["promotion"].with_name("wrong.json")),
+                "target_contains": "wrong.json",
+                "reason_contains": "Promotion filename does not match catalog_pattern_id",
+                "remediation_contains": "Rename the file",
+            },
+            {
+                "name": "duplicate promotion ID",
+                "mutate": lambda root, paths: duplicate_promotion(paths),
+                "target_contains": "catalog-pattern.json",
+                "reason_contains": "Duplicate case-insensitive promotion_id 'promotion-1'",
+                "remediation_contains": "Use a unique promotion_id",
+            },
+            {
+                "name": "missing decision",
+                "mutate": lambda root, paths: update_json(paths["promotion"], lambda data: data.__setitem__("decision_id", "missing")),
+                "reason_contains": "decision_id must resolve to an approved decision",
+                "remediation_contains": "Reference an existing approved governance decision",
+            },
+            {
+                "name": "missing proposal",
+                "mutate": lambda root, paths: update_json(paths["promotion"], lambda data: data.__setitem__("proposal_id", "missing")),
+                "reason_contains": "proposal_id must resolve to an approved proposal",
+                "remediation_contains": "Reference an existing approved evolution proposal",
+            },
+            {
+                "name": "non-approved decision",
+                "mutate": lambda root, paths: update_json(paths["decision"], lambda data: (data.__setitem__("decision_status", "REJECTED"), data["maintainer_decision"].__setitem__("status", "REJECTED"), data.__setitem__("implementation_restriction", "IMPLEMENTATION_BLOCKED"))),
+                "reason_contains": "decision_id must resolve to an approved decision",
+                "remediation_contains": "Reference an existing approved governance decision",
+            },
+            {
+                "name": "non-approved proposal",
+                "mutate": lambda root, paths: update_json(paths["proposal"], lambda data: data.__setitem__("proposal_status", "REJECTED")),
+                "reason_contains": "proposal_id must resolve to an approved proposal",
+                "remediation_contains": "Reference an existing approved evolution proposal",
+            },
+            {
+                "name": "proposal missing the selected pair",
+                "mutate": lambda root, paths: update_json(paths["proposal"], lambda data: data["selected_patterns"].clear()),
+                "reason_contains": "Proposal does not contain the exact decision and pattern pair",
+                "remediation_contains": "Select the referenced decision and pattern",
+            },
+            {
+                "name": "bundle mismatch",
+                "mutate": lambda root, paths: update_json(paths["promotion"], lambda data: data.__setitem__("source_bundle_id", OTHER_BUNDLE)),
+                "reason_contains": "source_bundle_id does not match the decision",
+                "remediation_contains": "Copy source_bundle_id exactly",
+            },
+            {
+                "name": "pattern mismatch",
+                "mutate": lambda root, paths: update_json(paths["promotion"], lambda data: data.__setitem__("pattern_record_path", "wrong.json")),
+                "reason_contains": "pattern_record_path does not match the decision",
+                "remediation_contains": "Copy pattern_record_path exactly",
+            },
+            {
+                "name": "specialist mismatch",
+                "mutate": lambda root, paths: update_json(paths["promotion"], lambda data: data.__setitem__("assigned_specialist", "cloak")),
+                "reason_contains": "assigned_specialist does not match the decision",
+                "remediation_contains": "Copy assigned_specialist exactly",
+            },
+            {
+                "name": "repository mismatch",
+                "mutate": lambda root, paths: update_json(paths["promotion"], lambda data: data["source_traceability"].__setitem__("repository", "other/repo")),
+                "reason_contains": "source_traceability.repository does not match source records",
+                "remediation_contains": "Copy source repository exactly",
+            },
+            {
+                "name": "SHA mismatch",
+                "mutate": lambda root, paths: update_json(paths["promotion"], lambda data: data["source_traceability"].__setitem__("reviewed_commit_sha", "b" * 40)),
+                "reason_contains": "source_traceability.reviewed_commit_sha does not match source records",
+                "remediation_contains": "Copy source reviewed_commit_sha exactly",
+            },
+            {
+                "name": "source-file mismatch",
+                "mutate": lambda root, paths: update_json(paths["promotion"], lambda data: data["source_traceability"].__setitem__("source_file", "other.py")),
+                "reason_contains": "source_traceability.source_file does not match source records",
+                "remediation_contains": "Copy source source_file exactly",
+            },
+            {
+                "name": "line-range mismatch",
+                "mutate": lambda root, paths: update_json(paths["promotion"], lambda data: data["source_traceability"].__setitem__("line_range", "1-2")),
+                "reason_contains": "source_traceability.line_range does not match source records",
+                "remediation_contains": "Copy source line_range exactly",
+            },
+            {
+                "name": "license mismatch",
+                "mutate": lambda root, paths: update_json(paths["promotion"], lambda data: data["license_and_attribution"].__setitem__("original_license", "Apache-2.0")),
+                "reason_contains": "license_and_attribution.original_license does not match source intake",
+                "remediation_contains": "Copy the source intake license exactly",
+            },
+            {
+                "name": "approval before decision date",
+                "mutate": lambda root, paths: update_json(paths["promotion"], lambda data: data.__setitem__("approval_date", "2026-07-01")),
+                "reason_contains": "approval_date precedes the governance decision date",
+                "remediation_contains": "on or after decision_date",
+            },
+            {
+                "name": "automatic promotion set to true",
+                "mutate": lambda root, paths: update_json(paths["promotion"], lambda data: data.__setitem__("automatic_promotion", True)),
+                "reason_contains": "automatic_promotion must be false",
+                "remediation_contains": "Set automatic_promotion to false",
+            },
+        ]
+        for case in cases:
+            with self.subTest(name=case["name"]):
+                root, paths = self.with_repo()
+                case["mutate"](root, paths)
+                self.assert_validation_failure(
+                    root,
+                    target_contains=case.get("target_contains", "catalog-pattern.json"),
+                    reason_contains=case["reason_contains"],
+                    remediation_contains=case["remediation_contains"],
+                )
+
+    def test_cli_valid_repository_returns_zero(self):
+        root, _ = self.with_repo()
+        exit_code, output = self.capture_main(["--repo-root", str(root)])
+        self.assertEqual(0, exit_code)
+        self.assertIn("Validation Passed: All Artificer governance records are valid.", output)
+        self.assert_relative_output(output, root, "[7] Summary")
+
+    def test_cli_record_violation_returns_one_with_relative_output(self):
+        root, paths = self.with_repo("audit")
+        update_json(paths["audit"], lambda data: data.__setitem__("source_repository", "wrong/repository"))
+        exit_code, output = self.capture_main(["--repo-root", str(root)])
+        self.assertEqual(1, exit_code)
+        self.assertIn("[FAIL]", output)
+        self.assertIn("source_repository does not match source-intake.json", output)
+        self.assert_relative_output(output, root, f"internal/artificer/reviews/{BUNDLE}/audit-report.json")
+
+    def test_cli_missing_schema_returns_two_with_relative_output(self):
+        root, _ = self.with_repo()
+        (root / "internal/artificer/AUDIT_REPORT_SCHEMA.json").unlink()
+        exit_code, output = self.capture_main(["--repo-root", str(root)])
+        self.assertEqual(2, exit_code)
+        self.assertIn("[FAIL] Configuration error:", output)
+        self.assertIn("Schema file missing: internal/artificer/AUDIT_REPORT_SCHEMA.json", output)
+        self.assert_relative_output(output, root, "internal/artificer/AUDIT_REPORT_SCHEMA.json")
+
+    def test_cli_malformed_schema_returns_two_with_relative_output(self):
+        root, _ = self.with_repo()
+        (root / "internal/artificer/AUDIT_REPORT_SCHEMA.json").write_text("{", encoding="utf-8")
+        exit_code, output = self.capture_main(["--repo-root", str(root)])
+        self.assertEqual(2, exit_code)
+        self.assertIn("[FAIL] Configuration error:", output)
+        self.assertIn("Schema file invalid: internal/artificer/AUDIT_REPORT_SCHEMA.json", output)
+        self.assertIn("malformed JSON", output)
+        self.assert_relative_output(output, root, "internal/artificer/AUDIT_REPORT_SCHEMA.json")
+
+    def test_cli_unsupported_schema_configuration_returns_two_with_relative_output(self):
+        root, _ = self.with_repo()
+        schema_path = root / "internal/artificer/AUDIT_REPORT_SCHEMA.json"
+        update_json(schema_path, lambda data: data.__setitem__("unsupported_keyword", True))
+        exit_code, output = self.capture_main(["--repo-root", str(root)])
+        self.assertEqual(2, exit_code)
+        self.assertIn("[FAIL] Configuration error:", output)
+        self.assertIn("unsupported keyword 'unsupported_keyword'", output)
+        self.assert_relative_output(output, root, "internal/artificer/AUDIT_REPORT_SCHEMA.json")
+
+    def test_cli_unknown_argument_returns_two(self):
+        exit_code, output = self.capture_main(["--unknown"])
+        self.assertEqual(2, exit_code)
+        self.assertIn("unrecognized arguments: --unknown", output)
+
+    def test_cli_output_is_deterministic_and_failures_are_sorted(self):
+        root, paths = self.with_repo("audit")
+        update_json(paths["audit"], lambda data: data.__setitem__("source_repository", "wrong/repository"))
+        failures = validator.validate_repository(root)
+        self.assertEqual(
+            failures,
+            sorted(
+                failures,
+                key=lambda item: (
+                    item.target.casefold(),
+                    item.reason.casefold(),
+                    item.remediation.casefold(),
+                ),
+            ),
+        )
+        first_code, first_output = self.capture_main(["--repo-root", str(root)])
+        second_code, second_output = self.capture_main(["--repo-root", str(root)])
+        self.assertEqual(1, first_code)
+        self.assertEqual(1, second_code)
+        self.assertEqual(first_output, second_output)
+        self.assert_relative_output(
+            first_output,
+            root,
+            f"internal/artificer/reviews/{BUNDLE}/audit-report.json",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/behavior/test_artificer_governance_records.py
+++ b/tests/behavior/test_artificer_governance_records.py
@@ -399,7 +399,7 @@ class GovernanceRecordsTests(unittest.TestCase):
         shutil.copy2(paths["proposal"], collision_path)
         self.assert_validation_failure(
             root,
-            target_contains="Proposal-1.json",
+            target_contains="proposal-1.json",
             reason_contains="Case-insensitive filename collision",
             remediation_contains="case sensitivity",
         )

--- a/tests/behavior/test_artificer_records.py
+++ b/tests/behavior/test_artificer_records.py
@@ -188,6 +188,19 @@ class TestArtificerRecordsValidator(unittest.TestCase):
             reason_contains="missing required field 'default_branch'",
         )
 
+    def test_failure_blank_default_branch_requires_a_value(self):
+        bundle_dir = self._create_valid_bundle(include_pattern=False)
+        intake = self._valid_intake()
+        intake["default_branch"] = "  "
+        self._write_intake(bundle_dir.name, intake)
+        failures = validate_repository(self.repo_root)
+        self.assert_failure(
+            failures,
+            target_contains="source-intake.json",
+            reason_contains="default_branch' must be non-empty after trimming",
+        )
+        self.assertNotIn("omit", "\n".join(failure.remediation for failure in failures))
+
     def test_pass_git_url_and_trailing_slash_url(self):
         bundle_dir = self._create_valid_bundle(include_pattern=False)
         bundle_id = bundle_dir.name


### PR DESCRIPTION
## Summary

Implements Artificer Phase 4B deterministic validation for governance records and their cross-record relationships.

This phase validates audit reports, governance decisions, evolution proposals, and Pattern Catalog promotion records against the Phase 4A contracts while preserving Artificer’s read-only, non-approving, and non-executing boundaries.

## What Changed

### Governance-record validator

Added:

* `scripts/validate_artificer_governance_records.py`

The validator uses only the Python standard library and performs no network access, subprocess execution, external installation, or file mutation.

It validates:

* governance registry layouts;
* audit-report instances;
* governance-decision instances;
* evolution-proposal instances;
* promotion-record instances;
* source-bundle and pattern references;
* specialist ownership;
* governance status consistency;
* licensing and Governor-review requirements;
* source traceability;
* lifecycle and date relationships.

A completely empty governance registry remains valid.

### Cross-record integrity

The validator enforces the governed chain:

```text
Source Intake
→ Pattern Record
→ Audit Report
→ Governance Decision
→ Evolution Proposal
→ Promotion Record
```

Key controls include:

* audit records must resolve to their exact source bundle and commit;
* findings must reference existing patterns and examined evidence ranges;
* governance decisions must reference corresponding audit findings;
* approved decisions require consistent Arbiter, Governor, Steward, and Maintainer states;
* proposals may select only approved decisions;
* evolution mechanisms must match pattern classifications and implementation restrictions;
* promotions require approved decisions and approved proposals;
* promotion traceability must exactly match source repository, commit, file, line range, license, pattern, and specialist ownership;
* automatic promotion remains prohibited.

### Security and output hardening

* Registry traversal and symbolic links are rejected.
* Governance JSON is constrained to UTF-8, regular files, bounded size, unique keys, and strict schema properties.
* Validation failures use deterministic ordering.
* CLI output uses repository-relative paths.
* Missing, malformed, or unsupported schemas return configuration exit code `2`.
* Temporary and local absolute paths are removed from configuration-error output.

### Regression coverage

Added:

* `tests/behavior/test_artificer_governance_records.py`

Coverage includes:

* 17 test methods;
* 6 named passing scenarios;
* 89 named negative scenarios;
* 95 total named scenarios.

Negative cases assert the expected failure target, reason, and remediation rather than merely checking that some failure occurred.

One end-to-end case-insensitive filename-collision test is skipped on case-insensitive filesystems. The underlying case-folded collision logic remains directly tested on every platform.

### Governance integration

The Phase 4B validator is now integrated into:

* strict governance validation;
* required validation-script checks;
* governance helper regression tests;
* the complete behavior runner.

### Phase 3 alignment

Corrected the stale Phase 3 `default_branch` wording so the validator no longer suggests omitting a now-required field.

Added focused regression coverage for a blank `default_branch`.

### Documentation and state

Updated:

* Phase 4 governance contract;
* Artificer workflow;
* registry documentation;
* checklist;
* changelog;
* decision log;
* project state;
* session handoff.

The repository state now records Phase 4A as completed through PR #162 and Phase 4B as the active validation phase.

## Validation

* JSON schema syntax checks: passed
* Python compilation checks: passed
* Artificer internal validator: passed
* Artificer internal tests: **52 passed**
* Phase 3 record validator: passed
* Phase 3 record tests: **62 passed**
* Phase 4B governance validator: passed
* Phase 4B suite: **17 tests passed, 1 filesystem-dependent test skipped**
* Phase 4B named scenarios: **95**
* Governance helper tests: passed
* Strict governance: **0 errors, 0 warnings**
* Integrated behavior suite: passed
* Runtime suite: **43 passed**
* Runtime coverage: **95.51%**
* `git diff --check`: passed

## Scope Boundaries

This pull request does not:

* change the Phase 4 JSON schemas;
* modify the Pattern Catalog;
* render Markdown audit reports;
* implement the Phase 4C Catalog gate;
* create audit records for OpenHero or Strix;
* clone, install, compile, or execute external repositories;
* modify runtime, adapters, public routing, manifests, or CI workflows;
* grant Artificer approval or implementation authority.

## Next Phase

Phase 4C will implement:

* deterministic human-readable audit-report rendering;
* governed Pattern Catalog promotion controls;
* Catalog lifecycle synchronization;
* safeguards preventing unapproved implementation or promotion.
