### PR TITLE
fix(artificer): phase 4B post-merge hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ Portable Runtime is the first Orchestra release that normalizes the repository a
 
 ## Pre-release Build History
 
+### Phase 4B Post-Merge Hardening
+
+- **Artificer Governance Validators:** Added rigorous rejection of ancestor-directory symlinks for governance registries, records, and pattern bundles.
+- **Artificer Governance Validators:** Corrected cross-platform list stability by introducing dual-key tuples `(item.name.casefold(), item.name)` in deterministic sort tie-breakers.
+
 ## v1.1.0 - Specialist Governance & Boundary Standard
 
 Specialist Governance & Boundary Standard is a documentation-, governance-, metadata-, and specialist-definition-focused release that builds on the `v1.0.0 Portable Runtime` baseline without changing runtime behavior, routing policy, validation logic, CI workflows, Dagger live-execution behavior, or governance decision semantics.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -6,12 +6,12 @@
 * **Base Branch:** `main`
 * **Current Release:** `v1.1.1`
 * **Target Patch:** `v1.1.2`
-* **Current Stable State:** Artificer Phase 4A completed through PR #162
-* **Current Task:** Artificer Phase 4B deterministic governance-record validation
-* **Mode:** Phase 4B implementation and audit
-* **Latest Validation:** Phase 4B validator and focused behavior coverage pass locally.
-* **Pending Next Steps:** Audit Phase 4B before commit and PR creation
-* **Most Recent Checkpoint:** 2026-07-12 - Phase 4B validation implemented.
+* **Current Stable State:** Artificer Phase 4B completed (including post-merge hardening)
+* **Current Task:** Artificer Phase 4C implementation
+* **Mode:** Phase 4C planning
+* **Latest Validation:** Phase 4B post-merge hardening passes strict governance checks.
+* **Pending Next Steps:** Begin Phase 4C planning.
+* **Most Recent Checkpoint:** 2026-07-12 - Phase 4B post-merge hardening implemented and validated.
 * **Related but Forbidden Repo for this task:** `C:\+AA`
 * **Active Governance Gates:**
 

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,18 +1,18 @@
 # Session Handoff
 
-- **Current Stable State:** Artificer Phase 4A completed through PR #162
-- **Current Task:** Artificer Phase 4B deterministic governance-record validation
+- **Current Stable State:** Artificer Phase 4B completed (including post-merge hardening)
+- **Current Task:** Artificer Phase 4C implementation
 - **Current Repo:** `C:\+conductor`
 - **Canonical Branch:** `main`
 - **Base Branch:** `main`
 - **Current Release:** `v1.1.1`
 - **Target Patch:** `v1.1.2`
-- **Mode:** Phase 4B implementation and audit
-- **Allowed Files:** Exact Phase 4B scope from the task brief only.
+- **Mode:** Phase 4C planning
+- **Allowed Files:** To be determined by Phase 4C scope.
 - **Forbidden Repo:** `C:\+AA`
-- **Last Validation:** Phase 4B validator and focused behavior coverage pass locally.
+- **Last Validation:** Phase 4B post-merge hardening passes strict governance checks.
 - **Known Risks:** Prompt-load thresholds remain advisory and current observed Groups A, B, C, and Grand Total exceed documented soft limits; no replacement baseline has been approved.
-- **Next Step:** Audit Phase 4B before commit and PR creation
+- **Next Step:** Begin Phase 4C planning.
 - **Fresh-Session Warning:** If the current conversation has long prior history from another repository, enter safe mode and request user confirmation before proceeding with implementation.
 
 ## Token Control Note

--- a/scripts/validate_artificer_governance_records.py
+++ b/scripts/validate_artificer_governance_records.py
@@ -198,10 +198,10 @@ def validate_registry_layout(repo_root: Path) -> list[ValidationFailure]:
     for name, (root, fixed_file) in REGISTRIES.items():
         root_path = repo_root / root
         failures.extend(_check_readme(repo_root, root))
-        if not root_path.is_dir():
-            failures.append(_failure(root, "Registry directory is missing", f"Create the required {root}/ directory."))
+        if root_path.is_symlink() or not root_path.is_dir():
+            failures.append(_failure(root, "Registry directory is missing or is a symbolic link", f"Create the required {root}/ directory as a regular directory."))
             continue
-        entries = sorted((entry for entry in root_path.iterdir() if entry.name != "README.md"), key=lambda item: item.name.casefold())
+        entries = sorted((entry for entry in root_path.iterdir() if entry.name != "README.md"), key=lambda item: (item.name.casefold(), item.name))
         failures.extend(_casefold_collisions(entries, repo_root))
         for entry in entries:
             target = _rel(repo_root, entry)
@@ -214,7 +214,7 @@ def validate_registry_layout(repo_root: Path) -> list[ValidationFailure]:
                     continue
                 if not BUNDLE_RE.fullmatch(entry.name):
                     failures.append(_failure(target, "Bundle directory name is invalid", "Use <owner-slug>__<repository-slug>__<12-character-lowercase-sha>."))
-                children = sorted(entry.iterdir(), key=lambda item: item.name.casefold())
+                children = sorted(entry.iterdir(), key=lambda item: (item.name.casefold(), item.name))
                 if not children:
                     failures.append(_failure(target, "Bundle directory is empty", "Add the required governance JSON record."))
                 for child in children:
@@ -234,9 +234,9 @@ def validate_registry_layout(repo_root: Path) -> list[ValidationFailure]:
 def _source_index(repo_root: Path, schemas: dict[str, dict]) -> dict[str, SourceBundle]:
     bundles: dict[str, SourceBundle] = {}
     root = repo_root / RECORDS_DIR
-    if not root.is_dir():
+    if root.is_symlink() or not root.is_dir():
         return bundles
-    for bundle_dir in sorted(root.iterdir(), key=lambda item: item.name.casefold()):
+    for bundle_dir in sorted(root.iterdir(), key=lambda item: (item.name.casefold(), item.name)):
         if bundle_dir.name == "README.md" or not bundle_dir.is_dir() or bundle_dir.is_symlink():
             continue
         intake_path = bundle_dir / "source-intake.json"
@@ -245,10 +245,10 @@ def _source_index(repo_root: Path, schemas: dict[str, dict]) -> dict[str, Source
             intake = load_json_without_duplicate_keys(intake_path)
         except (ValueError, ValidatorConfigurationError):
             continue
-        if validate_instance(intake, schemas["intake"], _rel(repo_root, intake_path)) or not patterns_dir.is_dir():
+        if validate_instance(intake, schemas["intake"], _rel(repo_root, intake_path)) or patterns_dir.is_symlink() or not patterns_dir.is_dir():
             continue
         patterns: dict[str, dict] = {}
-        for pattern_path in sorted(patterns_dir.glob("*.json"), key=lambda item: item.name.casefold()):
+        for pattern_path in sorted(patterns_dir.glob("*.json"), key=lambda item: (item.name.casefold(), item.name)):
             try:
                 pattern = load_json_without_duplicate_keys(pattern_path)
             except (ValueError, ValidatorConfigurationError):
@@ -279,10 +279,10 @@ def _load_audits(repo_root: Path, schemas: dict[str, dict], index: dict[str, Sou
     audits: dict[str, tuple[dict, str]] = {}
     failures: list[ValidationFailure] = []
     root = repo_root / REGISTRIES["reviews"][0]
-    if not root.is_dir():
+    if root.is_symlink() or not root.is_dir():
         return audits, failures
     seen: set[str] = set()
-    for bundle_dir in sorted(root.iterdir(), key=lambda item: item.name.casefold()):
+    for bundle_dir in sorted(root.iterdir(), key=lambda item: (item.name.casefold(), item.name)):
         path = bundle_dir / "audit-report.json"
         if bundle_dir.name == "README.md" or not path.is_file() or path.is_symlink():
             continue
@@ -370,13 +370,13 @@ def _load_decisions(repo_root: Path, schemas: dict[str, dict], index: dict[str, 
     decisions: dict[str, tuple[dict, str]] = {}
     failures: list[ValidationFailure] = []
     root = repo_root / REGISTRIES["decisions"][0]
-    if not root.is_dir():
+    if root.is_symlink() or not root.is_dir():
         return decisions, failures
     seen: set[str] = set()
-    for bundle_dir in sorted(root.iterdir(), key=lambda item: item.name.casefold()):
+    for bundle_dir in sorted(root.iterdir(), key=lambda item: (item.name.casefold(), item.name)):
         if bundle_dir.name == "README.md" or not bundle_dir.is_dir() or bundle_dir.is_symlink():
             continue
-        for path in sorted(bundle_dir.glob("*.json"), key=lambda item: item.name.casefold()):
+        for path in sorted(bundle_dir.glob("*.json"), key=lambda item: (item.name.casefold(), item.name)):
             record, record_failures = _load_record(path, schemas["decision"], repo_root)
             failures.extend(record_failures)
             if record is None:
@@ -462,10 +462,10 @@ def _load_proposals(repo_root: Path, schemas: dict[str, dict], index: dict[str, 
     proposals: dict[str, dict] = {}
     failures: list[ValidationFailure] = []
     root = repo_root / REGISTRIES["proposals"][0]
-    if not root.is_dir():
+    if root.is_symlink() or not root.is_dir():
         return proposals, failures
     seen: set[str] = set()
-    for path in sorted(root.glob("*.json"), key=lambda item: item.name.casefold()):
+    for path in sorted(root.glob("*.json"), key=lambda item: (item.name.casefold(), item.name)):
         record, record_failures = _load_record(path, schemas["proposal"], repo_root)
         failures.extend(record_failures)
         if record is None:
@@ -539,11 +539,11 @@ def _load_proposals(repo_root: Path, schemas: dict[str, dict], index: dict[str, 
 def _load_promotions(repo_root: Path, schemas: dict[str, dict], index: dict[str, SourceBundle], decisions: dict[str, tuple[dict, str]], proposals: dict[str, dict], allowlist: set[str]) -> list[ValidationFailure]:
     failures: list[ValidationFailure] = []
     root = repo_root / REGISTRIES["promotions"][0]
-    if not root.is_dir():
+    if root.is_symlink() or not root.is_dir():
         return failures
     promotion_ids: set[str] = set()
     catalog_ids: set[str] = set()
-    for path in sorted(root.glob("*.json"), key=lambda item: item.name.casefold()):
+    for path in sorted(root.glob("*.json"), key=lambda item: (item.name.casefold(), item.name)):
         record, record_failures = _load_record(path, schemas["promotion"], repo_root)
         failures.extend(record_failures)
         if record is None:
@@ -612,7 +612,17 @@ def validate_repository(repo_root: Path) -> list[ValidationFailure]:
     proposals, proposal_failures = _load_proposals(repo_root, schemas, index, audits, decisions, allowlist)
     promotion_failures = _load_promotions(repo_root, schemas, index, decisions, proposals, allowlist)
     failures.extend(audit_failures + decision_failures + proposal_failures + promotion_failures)
-    return sorted(failures, key=lambda item: (item.target.casefold(), item.reason.casefold(), item.remediation.casefold()))
+    return sorted(
+        failures,
+        key=lambda item: (
+            item.target.casefold(),
+            item.target,
+            item.reason.casefold(),
+            item.reason,
+            item.remediation.casefold(),
+            item.remediation,
+        ),
+    )
 
 
 def _print_failure(failure: ValidationFailure) -> None:

--- a/scripts/validate_artificer_governance_records.py
+++ b/scripts/validate_artificer_governance_records.py
@@ -601,10 +601,60 @@ def _load_promotions(repo_root: Path, schemas: dict[str, dict], index: dict[str,
     return failures
 
 
+def validate_source_registry_layout(
+    repo_root: Path,
+) -> list[ValidationFailure]:
+    failures: list[ValidationFailure] = []
+    records_root = repo_root / RECORDS_DIR
+
+    if records_root.is_symlink():
+        failures.append(
+            _failure(
+                RECORDS_DIR,
+                "Source records directory must not be a symbolic link",
+                (
+                    "Replace internal/artificer/records with a regular "
+                    "repository directory."
+                ),
+            )
+        )
+        return failures
+
+    if not records_root.is_dir():
+        return failures
+
+    for bundle_dir in sorted(
+        records_root.iterdir(),
+        key=lambda item: (item.name.casefold(), item.name),
+    ):
+        if (
+            bundle_dir.name == "README.md"
+            or bundle_dir.is_symlink()
+            or not bundle_dir.is_dir()
+        ):
+            continue
+
+        patterns_dir = bundle_dir / "patterns"
+        if patterns_dir.is_symlink():
+            failures.append(
+                _failure(
+                    _rel(repo_root, patterns_dir),
+                    "Source pattern directory must not be a symbolic link",
+                    (
+                        "Replace the source-bundle patterns link with a "
+                        "regular directory."
+                    ),
+                )
+            )
+
+    return failures
+
+
 def validate_repository(repo_root: Path) -> list[ValidationFailure]:
     """Return deterministic Phase 4B governance-record validation failures."""
     schemas = _load_schemas(repo_root)
     failures = validate_registry_layout(repo_root)
+    failures.extend(validate_source_registry_layout(repo_root))
     index = _source_index(repo_root, schemas)
     allowlist = _specialist_allowlist(schemas["pattern"])
     audits, audit_failures = _load_audits(repo_root, schemas, index, allowlist)

--- a/tests/behavior/test_artificer_governance_records.py
+++ b/tests/behavior/test_artificer_governance_records.py
@@ -395,14 +395,26 @@ class GovernanceRecordsTests(unittest.TestCase):
             self.skipTest(
                 "filesystem is case-insensitive in the temporary directory"
             )
-        collision_path = paths["proposal"].with_name("Proposal-1.json")
-        shutil.copy2(paths["proposal"], collision_path)
-        self.assert_validation_failure(
-            root,
+        collision_path1 = paths["proposal"].with_name("Proposal-1.json")
+        shutil.copy2(paths["proposal"], collision_path1)
+        failures1 = validator.validate_repository(root)
+        self.assert_failure(
+            failures1,
             target_contains="proposal-1.json",
             reason_contains="Case-insensitive filename collision",
-            remediation_contains="case sensitivity",
         )
+        collision_path1.unlink()
+
+        # Opposite creation order
+        collision_path2 = paths["proposal"].with_name("PROPOSAL-1.json")
+        shutil.copy2(paths["proposal"], collision_path2)
+        failures2 = validator.validate_repository(root)
+        self.assert_failure(
+            failures2,
+            target_contains="PROPOSAL-1.json",
+            reason_contains="Case-insensitive filename collision",
+        )
+        self.assertEqual(len(failures1), len(failures2))
 
     def test_registry_symlink_fails_when_supported(self):
         root, _ = self.with_repo("audit")
@@ -417,6 +429,51 @@ class GovernanceRecordsTests(unittest.TestCase):
             reason_contains="Symbolic links are not permitted in governance registries",
             remediation_contains="Replace the symbolic link",
         )
+
+    def test_registry_ancestor_symlinks_fail_when_supported(self):
+        root, _ = self.with_repo("audit")
+        reviews_dir = root / "internal/artificer/reviews"
+        temp_reviews = root / "temp_reviews"
+        shutil.move(str(reviews_dir), str(temp_reviews))
+        try:
+            reviews_dir.symlink_to(temp_reviews, target_is_directory=True)
+        except OSError as exc:
+            shutil.move(str(temp_reviews), str(reviews_dir))
+            self.skipTest(f"symbolic links unsupported: {exc}")
+        self.assert_validation_failure(
+            root,
+            target_contains="internal/artificer/reviews",
+            reason_contains="Registry directory is missing or is a symbolic link",
+            remediation_contains="Create the required internal/artificer/reviews/ directory as a regular directory.",
+        )
+        reviews_dir.unlink()
+        shutil.move(str(temp_reviews), str(reviews_dir))
+
+        records_dir = root / "internal/artificer/records"
+        temp_records = root / "temp_records"
+        shutil.move(str(records_dir), str(temp_records))
+        records_dir.symlink_to(temp_records, target_is_directory=True)
+        self.assert_validation_failure(
+            root,
+            target_contains="audit-report.json",
+            reason_contains="Source bundle 'orchestra__orchestra__0123456789ab' is missing",
+            remediation_contains="Restore a valid Phase 3 source bundle",
+        )
+        records_dir.unlink()
+        shutil.move(str(temp_records), str(records_dir))
+
+        patterns_dir = records_dir / BUNDLE / "patterns"
+        temp_patterns = root / "temp_patterns"
+        shutil.move(str(patterns_dir), str(temp_patterns))
+        patterns_dir.symlink_to(temp_patterns, target_is_directory=True)
+        self.assert_validation_failure(
+            root,
+            target_contains="audit-report.json",
+            reason_contains="Source bundle 'orchestra__orchestra__0123456789ab' is missing",
+            remediation_contains="Restore a valid Phase 3 source bundle",
+        )
+        patterns_dir.unlink()
+        shutil.move(str(temp_patterns), str(patterns_dir))
 
     def test_record_safety_schema_and_date_failures(self):
         cases = [

--- a/tests/behavior/test_artificer_governance_records.py
+++ b/tests/behavior/test_artificer_governance_records.py
@@ -244,16 +244,16 @@ class GovernanceRecordsTests(unittest.TestCase):
         root = Path(temp.name)
         return root, fixture_repo(root, chain, governor_required)
 
-    def assert_validation_failure(
+    def assert_failure(
         self,
-        root: Path,
+        failures: list[validator.ValidationFailure],
         *,
         target_contains: str,
         reason_contains: str,
         remediation_contains: str | None = None,
     ) -> None:
-        failures = validator.validate_repository(root)
         self.assertTrue(failures, "Expected validation to fail")
+
         matching = [
             failure
             for failure in failures
@@ -264,6 +264,7 @@ class GovernanceRecordsTests(unittest.TestCase):
                 or remediation_contains in failure.remediation
             )
         ]
+
         self.assertTrue(
             matching,
             (
@@ -273,9 +274,26 @@ class GovernanceRecordsTests(unittest.TestCase):
                 f"remediation_contains={remediation_contains!r}\n"
                 "Actual failures:\n"
                 + "\n".join(
-                    f"{f.target}: {f.reason} | {f.remediation}" for f in failures
+                    f"{failure.target}: {failure.reason} | "
+                    f"{failure.remediation}"
+                    for failure in failures
                 )
             ),
+        )
+
+    def assert_validation_failure(
+        self,
+        root: Path,
+        *,
+        target_contains: str,
+        reason_contains: str,
+        remediation_contains: str | None = None,
+    ) -> None:
+        self.assert_failure(
+            validator.validate_repository(root),
+            target_contains=target_contains,
+            reason_contains=reason_contains,
+            remediation_contains=remediation_contains,
         )
 
     def capture_main(self, argv: list[str]) -> tuple[int, str]:
@@ -386,35 +404,61 @@ class GovernanceRecordsTests(unittest.TestCase):
         )
 
     def test_registry_case_insensitive_collision_end_to_end_when_supported(self):
-        root, paths = self.with_repo("proposal")
-        probe = root / "CaseProbe"
+        root1, paths1 = self.with_repo("proposal")
+        root2, paths2 = self.with_repo("proposal")
+
+        probe = root1 / "CaseProbe"
         probe.write_text("probe", encoding="utf-8")
-        case_sensitive = not (root / "caseprobe").exists()
+        case_sensitive = not (root1 / "caseprobe").exists()
         probe.unlink()
+
         if not case_sensitive:
             self.skipTest(
                 "filesystem is case-insensitive in the temporary directory"
             )
-        collision_path1 = paths["proposal"].with_name("Proposal-1.json")
-        shutil.copy2(paths["proposal"], collision_path1)
-        failures1 = validator.validate_repository(root)
+
+        def create_collision_fixture(
+            root: Path,
+            proposal_path: Path,
+            order: list[str],
+        ) -> None:
+            content = proposal_path.read_bytes()
+            proposal_path.unlink()
+
+            for filename in order:
+                proposal_path.with_name(filename).write_bytes(content)
+
+        create_collision_fixture(
+            root1,
+            paths1["proposal"],
+            ["proposal-1.json", "Proposal-1.json"],
+        )
+        create_collision_fixture(
+            root2,
+            paths2["proposal"],
+            ["Proposal-1.json", "proposal-1.json"],
+        )
+
+        failures1 = validator.validate_repository(root1)
+        failures2 = validator.validate_repository(root2)
+
         self.assert_failure(
             failures1,
             target_contains="proposal-1.json",
             reason_contains="Case-insensitive filename collision",
+            remediation_contains="case sensitivity",
         )
-        collision_path1.unlink()
 
-        # Opposite creation order
-        collision_path2 = paths["proposal"].with_name("PROPOSAL-1.json")
-        shutil.copy2(paths["proposal"], collision_path2)
-        failures2 = validator.validate_repository(root)
-        self.assert_failure(
-            failures2,
-            target_contains="PROPOSAL-1.json",
-            reason_contains="Case-insensitive filename collision",
-        )
-        self.assertEqual(len(failures1), len(failures2))
+        rendered1 = [
+            (item.target, item.reason, item.remediation)
+            for item in failures1
+        ]
+        rendered2 = [
+            (item.target, item.reason, item.remediation)
+            for item in failures2
+        ]
+
+        self.assertEqual(rendered1, rendered2)
 
     def test_registry_symlink_fails_when_supported(self):
         root, _ = self.with_repo("audit")
@@ -455,9 +499,11 @@ class GovernanceRecordsTests(unittest.TestCase):
         records_dir.symlink_to(temp_records, target_is_directory=True)
         self.assert_validation_failure(
             root,
-            target_contains="audit-report.json",
-            reason_contains="Source bundle 'orchestra__orchestra__0123456789ab' is missing",
-            remediation_contains="Restore a valid Phase 3 source bundle",
+            target_contains="internal/artificer/records",
+            reason_contains=(
+                "Source records directory must not be a symbolic link"
+            ),
+            remediation_contains="regular repository directory",
         )
         records_dir.unlink()
         shutil.move(str(temp_records), str(records_dir))
@@ -468,9 +514,13 @@ class GovernanceRecordsTests(unittest.TestCase):
         patterns_dir.symlink_to(temp_patterns, target_is_directory=True)
         self.assert_validation_failure(
             root,
-            target_contains="audit-report.json",
-            reason_contains="Source bundle 'orchestra__orchestra__0123456789ab' is missing",
-            remediation_contains="Restore a valid Phase 3 source bundle",
+            target_contains=(
+                f"internal/artificer/records/{BUNDLE}/patterns"
+            ),
+            reason_contains=(
+                "Source pattern directory must not be a symbolic link"
+            ),
+            remediation_contains="regular directory",
         )
         patterns_dir.unlink()
         shutil.move(str(temp_patterns), str(patterns_dir))


### PR DESCRIPTION
## Summary

Hardens the Artificer Phase 4B governance-record validator after the post-merge audit of PR #163.

This update closes two cross-platform boundary gaps identified during audit:

* ancestor-directory symbolic links were not fully rejected;
* case-only filename collisions did not have a complete deterministic sort tie-breaker.

It also synchronizes the repository state documents to reflect that Phase 4B is complete and Phase 4C is the next planned stage.

## What Changed

### Registry-boundary hardening

Updated:

* `scripts/validate_artificer_governance_records.py`

The validator now explicitly rejects symbolic links used as:

* governance registry roots;
* the Phase 3 source-records root;
* source-bundle `patterns/` directories.

This prevents validation from following ancestor-directory links outside the intended Artificer record boundaries.

Existing child-entry symlink protections remain in place.

### Deterministic cross-platform ordering

Updated registry and validation-result sorting to use both the case-folded and exact value as deterministic keys.

This removes ambiguity when filenames differ only by capitalization, such as:

```text
proposal-1.json
Proposal-1.json
```

The validator now produces stable ordering regardless of filesystem enumeration order or file creation order.

### Regression coverage

Updated:

* `tests/behavior/test_artificer_governance_records.py`

Added focused tests for:

* symlinked governance registry roots;
* a symlinked Phase 3 records root;
* symlinked source-bundle `patterns/` directories;
* identical case-collision output across opposite file creation orders;
* deterministic ordering of case-only filename collisions.

The existing Windows-safe helper coverage remains in place for filesystems that cannot create case-only filename pairs.

### Repository state alignment

Updated:

* `PROJECT_STATE.md`
* `SESSION_HANDOFF.md`
* `CHANGELOG.md`

The repository now records:

* Artificer Phase 4B as completed through PR #163;
* Phase 4B post-merge hardening as validated;
* Phase 4C design and implementation planning as the next stage.

## Validation

The complete validation matrix passed:

* Python compilation checks
* Phase 4B governance-record validator
* Phase 4B focused behavior suite
* Integrated behavior validation suite
* Strict governance validation
* Cross-platform validation
* `git diff --check`

Strict governance result:

```text
Summary: 0 Errors, 0 Warnings
Status: Stage 1 strict deterministic gates
```

## Scope Boundaries

This pull request does not:

* change any Artificer JSON schema;
* modify the Pattern Catalog;
* create audit, decision, proposal, or promotion records;
* implement Phase 4C rendering or Catalog gates;
* modify runtime, adapters, public routing, manifests, or CI workflows;
* clone, install, compile, or execute external repositories;
* grant Artificer approval or implementation authority.

## Relationship to Phase 4B

This is a narrow post-merge hardening follow-up to:

* PR #163 — Phase 4B governance-record validation

It does not expand Phase 4B scope. It strengthens the existing filesystem boundaries, deterministic output guarantees, and repository state accuracy before Phase 4C begins.

## Next Phase

After this pull request is merged, Phase 4C can proceed with:

* deterministic human-readable audit rendering;
* governed Pattern Catalog promotion controls;
* Catalog lifecycle synchronization;
* enforcement preventing unapproved promotion or implementation.
