### PR TITLE
feat(artificer): add deterministic audit report renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Specialist Governance & Boundary Standard is a documentation-, governance-, meta
 ## Unreleased
 
 ### Added
+- Added Phase 4C-A deterministic, read-only Markdown rendering for validated Artificer audit reports, with stdout-only CLI output, canonical ordering, Markdown safety, governance integration, and behavior coverage.
 - Added Phase 4A Artificer governance contracts, including native JSON schemas for Individual Source Audits (`AUDIT_REPORT_SCHEMA.json`), Orchestra Evolution Proposals (`EVOLUTION_PROPOSAL_SCHEMA.json`), Governance Decisions (`GOVERNANCE_DECISION_SCHEMA.json`), and Pattern Catalog Promotion Records (`PROMOTION_RECORD_SCHEMA.json`).
 - Established isolated read-only registries for Phase 4A records (`reviews/`, `decisions/`, `proposals/`, and `promotions/`).
 - Documented Phase 4A read-only and no-execution boundaries in `EXTERNAL_SOURCE_INTAKE.md`, `SECURITY_BOUNDARIES.md`, and `EVIDENCE_REQUIREMENTS.md`.

--- a/DECISION_LOG.md
+++ b/DECISION_LOG.md
@@ -255,3 +255,34 @@ The governance chain must remain traceable and fail closed without cloning, inst
 - tests/behavior/test_artificer_governance_records.py
 - scripts/governance_check.py
 - tests/behavior/run_tests.py
+
+---
+
+## Date: 2026-07-12
+
+**Decision:**
+Implemented Phase 4C-A as a standard-library-only, read-only renderer that
+validates the complete Phase 4B governance repository before converting one
+canonical audit JSON record into deterministic Markdown on standard output.
+
+**Reason:**
+Human-readable audit views must preserve validated JSON as the sole governance
+authority, remain independent of repository location and filesystem order, and
+create no Catalog, governance, source, or runtime writes.
+
+**Rejected Alternatives:**
+- Writing rendered Markdown files (rejected; Phase 4C-A is stdout-only).
+- Combining Catalog synchronization with rendering (rejected; Phase 4C-B owns
+  the separate Pattern Catalog gate).
+- Adding a Markdown or schema dependency (rejected; existing validation and the
+  Python standard library cover the required behavior).
+
+**Affected Components:**
+- scripts/render_artificer_audit_report.py
+- tests/behavior/test_artificer_audit_report_renderer.py
+- scripts/governance_check.py
+- scripts/test_governance_check.py
+- tests/behavior/run_tests.py
+- docs/internal/ARTIFICER_PHASE4_GOVERNANCE_CONTRACT.md
+- docs/internal/ARTIFICER_WORKFLOW.md
+- internal/artificer/reviews/README.md

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -6,11 +6,11 @@
 * **Base Branch:** `main`
 * **Current Release:** `v1.1.1`
 * **Target Patch:** `v1.1.2`
-* **Current Stable State:** Artificer Phase 4B completed (including post-merge hardening)
-* **Current Task:** Artificer Phase 4C implementation
-* **Mode:** Phase 4C planning
+* **Current Stable State:** Artificer Phase 4B completed through PR #164
+* **Current Task:** Artificer Phase 4C-A deterministic audit rendering
+* **Mode:** Phase 4C-A implementation and audit
 * **Latest Validation:** Phase 4B post-merge hardening passes strict governance checks.
-* **Pending Next Steps:** Begin Phase 4C planning.
+* **Pending Next Steps:** Audit Phase 4C-A implementation before staging or publication.
 * **Most Recent Checkpoint:** 2026-07-12 - Phase 4B post-merge hardening implemented and validated.
 * **Related but Forbidden Repo for this task:** `C:\+AA`
 * **Active Governance Gates:**

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,18 +1,18 @@
 # Session Handoff
 
-- **Current Stable State:** Artificer Phase 4B completed (including post-merge hardening)
-- **Current Task:** Artificer Phase 4C implementation
+- **Current Stable State:** Artificer Phase 4B completed through PR #164
+- **Current Task:** Artificer Phase 4C-A deterministic audit rendering
 - **Current Repo:** `C:\+conductor`
 - **Canonical Branch:** `main`
 - **Base Branch:** `main`
 - **Current Release:** `v1.1.1`
 - **Target Patch:** `v1.1.2`
-- **Mode:** Phase 4C planning
-- **Allowed Files:** To be determined by Phase 4C scope.
+- **Mode:** Phase 4C-A implementation and audit
+- **Allowed Files:** Phase 4C-A renderer, behavior tests, governance integration, and named documentation/state files only.
 - **Forbidden Repo:** `C:\+AA`
 - **Last Validation:** Phase 4B post-merge hardening passes strict governance checks.
 - **Known Risks:** Prompt-load thresholds remain advisory and current observed Groups A, B, C, and Grand Total exceed documented soft limits; no replacement baseline has been approved.
-- **Next Step:** Begin Phase 4C planning.
+- **Next Step:** Audit Phase 4C-A implementation before staging, commit, push, or PR creation.
 - **Fresh-Session Warning:** If the current conversation has long prior history from another repository, enter safe mode and request user confirmation before proceeding with implementation.
 
 ## Token Control Note

--- a/docs/internal/ARTIFICER_PHASE4_GOVERNANCE_CONTRACT.md
+++ b/docs/internal/ARTIFICER_PHASE4_GOVERNANCE_CONTRACT.md
@@ -62,7 +62,14 @@ There is no automatic cherry-picking of source code.
 Phase 4B provides deterministic validation for governance records and cross-record relationships, including reviews, decisions, proposals, and promotions. It validates only committed contracts and never rewrites source bundles, executes external code, or grants Artificer approval authority. Empty governance registries remain valid.
 
 ## 13. Phase 4C Renderer and Catalog-Gate Responsibilities
-Phase 4C owns markdown rendering for these records and the Pattern Catalog gate; Phase 4B does not mutate `PATTERN_CATALOG.md`.
+Phase 4C-A renders a validated `audit-report.json` record as deterministic
+Markdown. Rendering is read-only, writes only to standard output, and never
+updates governance JSON, source evidence, or `PATTERN_CATALOG.md`. Rendered
+Markdown is not governance authority; validated JSON records remain canonical.
+
+Phase 4C-B separately owns Pattern Catalog synchronization and its governance
+gate. Phase 4C-A grants no approval, implementation, promotion, or Catalog
+authority.
 
 ## 14. Phase 4.5 Pilot Sources
 The canonical Phase 4.5 pilot repositories are strictly defined as:

--- a/docs/internal/ARTIFICER_WORKFLOW.md
+++ b/docs/internal/ARTIFICER_WORKFLOW.md
@@ -2,7 +2,7 @@
 
 This document defines the structured workflow for importing and evaluating external design patterns to evolve Orchestra.
 
-Phase 4B validates reviews, governance decisions, proposals, promotions, and cross-record relationships deterministically. Empty governance registries remain valid; Artificer has no approval or implementation authority and never clones, installs, compiles, or executes external sources. Phase 4C owns rendering and the Pattern Catalog gate; Phase 4.5 owns the OpenHero and Strix pilot audits.
+Phase 4B validates reviews, governance decisions, proposals, promotions, and cross-record relationships deterministically. Empty governance registries remain valid; Artificer has no approval or implementation authority and never clones, installs, compiles, or executes external sources. Phase 4C-A provides read-only deterministic Markdown rendering of validated audit JSON to standard output. Rendered Markdown is not governance authority, JSON records remain canonical, and no Pattern Catalog mutation occurs. Phase 4C-B separately owns Pattern Catalog synchronization and gating; Phase 4.5 owns the OpenHero and Strix pilot audits.
 
 ## End-to-End Workflow Stages
 

--- a/internal/artificer/reviews/README.md
+++ b/internal/artificer/reviews/README.md
@@ -14,3 +14,17 @@ Files must be placed in a directory corresponding to the source bundle ID:
 *   **No Approval Authority**: No record in this registry grants Artificer approval or implementation authority.
 *   **No External Modifications**: No registry may modify an external repository.
 *   **Empty State**: An empty registry is valid.
+
+## Phase 4C-A Read-Only Rendering
+
+Render one validated audit report to standard output:
+
+```powershell
+python scripts/render_artificer_audit_report.py `
+  --audit internal/artificer/reviews/<bundle-id>/audit-report.json
+```
+
+Use `--repo-root <path>` only when invoking the renderer outside the repository
+root. The renderer creates no file and never updates governance records or
+`docs/internal/PATTERN_CATALOG.md`. Rendered Markdown is a human-readable view,
+not governance authority; validated JSON records remain canonical.

--- a/scripts/governance_check.py
+++ b/scripts/governance_check.py
@@ -37,6 +37,7 @@ REQUIRED_VALIDATION_SCRIPTS = [
     "scripts/validate_artificer_internal.py",
     "scripts/validate_artificer_records.py",
     "scripts/validate_artificer_governance_records.py",
+    "scripts/render_artificer_audit_report.py",
 ]
 
 REPO_MEMORY_FILES = [

--- a/scripts/render_artificer_audit_report.py
+++ b/scripts/render_artificer_audit_report.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Render one validated Artificer audit report as deterministic Markdown."""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import validate_artificer_governance_records
+from validate_artificer_records import (
+    ValidatorConfigurationError,
+    load_json_without_duplicate_keys,
+    parse_line_range,
+)
+
+
+AUDIT_PATH_RE = re.compile(
+    r"^internal/artificer/reviews/([^/]+)/audit-report\.json$"
+)
+WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:")
+CONTROL_RE = re.compile(r"[\x00-\x1f]")
+MARKDOWN_RE = re.compile(r"([\\`*_{}\[\]()#+.!|<>-])")
+
+
+class AuditRenderError(Exception):
+    """Raised when an audit report cannot be safely rendered."""
+
+
+class AuditArgumentError(AuditRenderError):
+    """Raised when a CLI audit-path argument violates the path contract."""
+
+
+def _clean(value: object) -> str:
+    text = str(value)
+    text = text.replace("\r\n", " ")
+    text = text.replace("\r", " ")
+    text = text.replace("\n", " ")
+    text = text.replace("::", "&colon;&colon;")
+    return MARKDOWN_RE.sub(r"\\\1", text)
+
+
+def _table(rows: list[tuple[str, object]]) -> list[str]:
+    result = ["| Field | Value |", "| --- | --- |"]
+    result.extend(f"| {_clean(label)} | {_clean(value)} |" for label, value in rows)
+    return result
+
+
+def _audit_error(target: str, reason: str, remediation: str) -> AuditRenderError:
+    return AuditRenderError(
+        f"{target}: {reason} Remediation: {remediation}"
+    )
+
+
+def _audit_argument_error(
+    target: str, reason: str, remediation: str
+) -> AuditArgumentError:
+    return AuditArgumentError(
+        f"{target}: {reason} Remediation: {remediation}"
+    )
+
+
+def _relative_detail(repo_root: Path, value: object) -> str:
+    detail = str(value)
+    variants = {
+        str(repo_root),
+        str(repo_root.resolve()),
+        repo_root.as_posix(),
+        repo_root.resolve().as_posix(),
+    }
+    for variant in sorted(variants, key=len, reverse=True):
+        detail = detail.replace(f"{variant}/", "").replace(f"{variant}\\", "")
+        detail = detail.replace(variant, ".")
+    return detail
+
+
+def _validated_audit_path(
+    repo_root: Path, audit_path: Path | str
+) -> tuple[Path, str]:
+    value = audit_path.as_posix() if isinstance(audit_path, Path) else str(audit_path)
+    path = Path(value)
+    if (
+        not value
+        or path.is_absolute()
+        or WINDOWS_DRIVE_RE.match(value)
+        or "\\" in value
+        or CONTROL_RE.search(value)
+        or any(part in {"", ".", ".."} for part in value.split("/"))
+    ):
+        raise _audit_argument_error(
+            "--audit",
+            "audit path must be a repository-relative POSIX path",
+            "Use internal/artificer/reviews/<bundle-id>/audit-report.json.",
+        )
+
+    match = AUDIT_PATH_RE.fullmatch(value)
+    if not match:
+        raise _audit_argument_error(
+            value,
+            "audit path does not match the reviews registry contract",
+            "Use internal/artificer/reviews/<bundle-id>/audit-report.json.",
+        )
+
+    root = repo_root.resolve()
+    candidate = root.joinpath(*value.split("/"))
+    current = root
+    for part in value.split("/"):
+        current = current / part
+        if current.is_symlink():
+            raise _audit_error(
+                value,
+                "audit path or an ancestor directory is a symbolic link",
+                "Replace symbolic links with regular repository directories and files.",
+            )
+    try:
+        candidate.resolve(strict=True).relative_to(root)
+    except (FileNotFoundError, ValueError):
+        raise _audit_error(
+            value,
+            "audit file is missing or resolves outside the repository",
+            "Restore the validated audit report beneath internal/artificer/reviews/.",
+        ) from None
+    if not candidate.is_file():
+        raise _audit_error(
+            value,
+            "audit path is not a regular file",
+            "Provide a regular audit-report.json file.",
+        )
+    return candidate, match.group(1)
+
+
+def _load_json(path: Path, target: str, repo_root: Path) -> dict:
+    try:
+        return load_json_without_duplicate_keys(path)
+    except (ValueError, ValidatorConfigurationError) as exc:
+        raise _audit_error(
+            target,
+            f"audit record cannot be read: {_relative_detail(repo_root, exc)}",
+            "Fix the audit JSON and re-run Phase 4B validation.",
+        ) from None
+
+
+def render_audit_report(repo_root: Path, audit_path: Path) -> str:
+    """Return deterministic Markdown for one validated audit report."""
+    root = Path(repo_root).resolve()
+    failures = validate_artificer_governance_records.validate_repository(root)
+    if failures:
+        failure = failures[0]
+        raise _audit_error(
+            failure.target,
+            "repository governance validation failed: "
+            f"{_relative_detail(root, failure.reason)}",
+            _relative_detail(root, failure.remediation),
+        )
+
+    audit_file, bundle_id = _validated_audit_path(root, audit_path)
+    target = audit_path.as_posix() if isinstance(audit_path, Path) else str(audit_path)
+    audit = _load_json(audit_file, target, root)
+    if audit.get("source_bundle_id") != bundle_id:
+        raise _audit_error(
+            target,
+            "source_bundle_id does not match the audit bundle directory",
+            "Set source_bundle_id to the containing bundle ID.",
+        )
+
+    findings = sorted(
+        audit["findings"],
+        key=lambda item: (item["finding_id"].casefold(), item["finding_id"]),
+    )
+    lines = [
+        f"# Artificer Audit Report: {_clean(audit['source_repository'])}",
+        "",
+        "## Audit Metadata",
+        "",
+        *_table(
+            [
+                ("Audit Report ID", audit["audit_report_id"]),
+                ("Source Bundle", audit["source_bundle_id"]),
+                ("Source Repository", audit["source_repository"]),
+                ("Reviewed Commit", audit["reviewed_commit_sha"]),
+                ("Audit Date", audit["audit_date"]),
+                ("Source Intake", audit["source_intake_path"]),
+            ]
+        ),
+        "",
+        "## Executive Summary",
+        "",
+        _clean(audit["executive_summary"]),
+        "",
+        "## Findings",
+    ]
+
+    for finding in findings:
+        pattern_path = finding["pattern_record_path"]
+        pattern = _load_json(
+            root.joinpath(*pattern_path.split("/")), pattern_path, root
+        )
+        evidence = sorted(
+            finding["evidence"],
+            key=lambda item: (
+                item["bucket"].casefold(),
+                item["bucket"],
+                item["source_file"].casefold(),
+                item["source_file"],
+                *(parse_line_range(item["line_range"]) or (0, 0)),
+                item["summary"].casefold(),
+                item["summary"],
+            ),
+        )
+        lines.extend(
+            [
+                "",
+                f"### {_clean(finding['finding_id'])}: {_clean(finding['title'])}",
+                "",
+                *_table(
+                    [
+                        ("Pattern Record", pattern_path),
+                        ("Pattern Name", pattern["name"]),
+                        ("Assigned Specialist", finding["assigned_specialist"]),
+                        ("Risk Level", finding["risk_level"]),
+                    ]
+                ),
+                "",
+                "#### Finding",
+                "",
+                _clean(finding["finding"]),
+                "",
+                "#### Recommendation",
+                "",
+                _clean(finding["recommendation"]),
+                "",
+                "#### Evidence",
+                "",
+                "| Bucket | Source File | Line Range | Summary |",
+                "| --- | --- | --- | --- |",
+                *(
+                    f"| {_clean(item['bucket'])} | {_clean(item['source_file'])} | "
+                    f"{_clean(item['line_range'])} | {_clean(item['summary'])} |"
+                    for item in evidence
+                ),
+            ]
+        )
+
+    license_analysis = audit["license_analysis"]
+    security_review = audit["security_review"]
+    limitations = sorted(
+        audit["limitations"], key=lambda value: (value.casefold(), value)
+    )
+    lines.extend(
+        [
+            "",
+            "## License Analysis",
+            "",
+            *_table(
+                [
+                    ("Detected License", license_analysis["detected_license"]),
+                    (
+                        "Compatibility Assessment",
+                        license_analysis["compatibility_assessment"],
+                    ),
+                    (
+                        "Governor Review Required",
+                        str(license_analysis["governor_review_required"]).lower(),
+                    ),
+                    ("Summary", license_analysis["summary"]),
+                ]
+            ),
+            "",
+            "## Security Review",
+            "",
+            *_table(
+                [
+                    (
+                        "External Execution Performed",
+                        str(security_review["external_execution_performed"]).lower(),
+                    ),
+                    ("Summary", security_review["summary"]),
+                ]
+            ),
+            "",
+            "## Limitations",
+            "",
+            *(
+                [f"- {_clean(value)}" for value in limitations]
+                if limitations
+                else ["None recorded."]
+            ),
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Render a validated Artificer audit report as Markdown."
+    )
+    parser.add_argument("--audit", required=True)
+    parser.add_argument("--repo-root", default=None)
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        return 0 if exc.code == 0 else 2
+
+    repo_root = (
+        Path(args.repo_root)
+        if args.repo_root
+        else Path(__file__).resolve().parent.parent
+    )
+    try:
+        output = render_audit_report(repo_root, args.audit)
+    except AuditArgumentError as exc:
+        print(f"Invalid argument: {exc}", file=sys.stderr)
+        return 2
+    except ValidatorConfigurationError as exc:
+        detail = _relative_detail(repo_root, exc)
+        print(
+            f"Configuration error: {detail} Remediation: Restore valid Phase 3 and Phase 4 schema contracts.",
+            file=sys.stderr,
+        )
+        return 2
+    except AuditRenderError as exc:
+        print(f"Render failed: {exc}", file=sys.stderr)
+        return 1
+    sys.stdout.write(output)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_governance_check.py
+++ b/scripts/test_governance_check.py
@@ -37,6 +37,12 @@ def test_artificer_governance_validator_is_registered():
     assert_equal("strict governance validator", script in gc.STRICT_VALIDATOR_SCRIPTS, True)
 
 
+def test_artificer_audit_renderer_is_registered_read_only():
+    script = "scripts/render_artificer_audit_report.py"
+    assert_equal("required audit renderer", script in gc.REQUIRED_VALIDATION_SCRIPTS, True)
+    assert_equal("renderer is not a strict validator", script in gc.STRICT_VALIDATOR_SCRIPTS, False)
+
+
 def test_repo_memory_path_check():
     with tempfile.TemporaryDirectory(prefix="governance-memory-test-") as temp_dir:
         repo_root = Path(temp_dir)
@@ -187,6 +193,8 @@ def main():
     assert_equal("repo path detection", gc.is_repo_relative_memory_path("scripts/governance_check.py"), True)
     assert_equal("external path ignored", gc.is_repo_relative_memory_path("C:/conductor/scripts/governance_check.py"), False)
     test_tracked_repo_files_only()
+    test_artificer_governance_validator_is_registered()
+    test_artificer_audit_renderer_is_registered_read_only()
     test_repo_memory_path_check()
     test_startup_state_claim_check()
     print("Governance check helper tests passed.")

--- a/tests/behavior/run_tests.py
+++ b/tests/behavior/run_tests.py
@@ -24,7 +24,8 @@ def main():
         {"Name": "validate_artificer_records.py", "Path": "scripts/validate_artificer_records.py"},
         {"Name": "test_artificer_records.py", "Path": "tests/behavior/test_artificer_records.py"},
         {"Name": "validate_artificer_governance_records.py", "Path": "scripts/validate_artificer_governance_records.py"},
-        {"Name": "test_artificer_governance_records.py", "Path": "tests/behavior/test_artificer_governance_records.py"}
+        {"Name": "test_artificer_governance_records.py", "Path": "tests/behavior/test_artificer_governance_records.py"},
+        {"Name": "test_artificer_audit_report_renderer.py", "Path": "tests/behavior/test_artificer_audit_report_renderer.py"}
     ]
     
     failed = False

--- a/tests/behavior/test_artificer_audit_report_renderer.py
+++ b/tests/behavior/test_artificer_audit_report_renderer.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""Behavior coverage for deterministic Artificer audit rendering."""
+
+import contextlib
+import io
+import json
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import render_artificer_audit_report as renderer  # noqa: E402
+import test_artificer_governance_records as fixtures  # noqa: E402
+from validate_artificer_records import ValidatorConfigurationError  # noqa: E402
+
+
+AUDIT_REL = (
+    f"internal/artificer/reviews/{fixtures.BUNDLE}/audit-report.json"
+)
+PASSING_SCENARIOS = (
+    "valid audit-only governance chain",
+    "valid complete governance chain",
+    "multiple findings canonical order",
+    "multiple evidence items canonical order",
+    "empty limitations",
+    "Markdown-special characters",
+    "exact final newline",
+    "repeated runs",
+    "opposite JSON key insertion orders",
+    "opposite file creation orders",
+)
+NEGATIVE_SCENARIOS = (
+    "missing audit file",
+    "malformed audit JSON",
+    "schema-invalid audit",
+    "invalid source bundle",
+    "Phase 4B cross-record failure",
+    "absolute audit path",
+    "Windows drive path",
+    "backslash path",
+    "parent traversal",
+    "wrong registry",
+    "wrong filename",
+    "symlinked audit file",
+    "symlinked reviews root",
+    "symlinked bundle directory",
+    "missing schema",
+    "malformed schema",
+    "unsupported schema configuration",
+    "CLI invalid arguments",
+)
+
+
+def reverse_keys(value):
+    if isinstance(value, dict):
+        return {
+            key: reverse_keys(value[key])
+            for key in reversed(list(value.keys()))
+        }
+    if isinstance(value, list):
+        return [reverse_keys(item) for item in value]
+    return value
+
+
+class AuditReportRendererTests(unittest.TestCase):
+    def with_repo(self, chain: str = "audit"):
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        root = Path(temp.name)
+        return root, fixtures.fixture_repo(root, chain)
+
+    def render(self, root: Path) -> str:
+        return renderer.render_audit_report(root, Path(AUDIT_REL))
+
+    def capture_main(self, argv: list[str]) -> tuple[int, str, str]:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            exit_code = renderer.main(argv)
+        return exit_code, stdout.getvalue(), stderr.getvalue()
+
+    def assert_safe_failure(
+        self,
+        root: Path,
+        audit_path: Path | str,
+        *,
+        target: str,
+        reason: str,
+        remediation: str,
+    ) -> None:
+        with self.assertRaises(renderer.AuditRenderError) as raised:
+            renderer.render_audit_report(root, audit_path)
+        output = str(raised.exception)
+        self.assertIn(target, output)
+        self.assertIn(reason, output)
+        self.assertIn(remediation, output)
+        self.assertNotIn(str(root), output)
+        self.assertNotIn(root.as_posix(), output)
+
+    def add_second_finding(self, root: Path, paths: dict[str, Path]) -> None:
+        pattern_path = (
+            root
+            / "internal/artificer/records"
+            / fixtures.BUNDLE
+            / "patterns/alpha-pattern.json"
+        )
+        fixtures.write_json(
+            pattern_path,
+            {
+                "name": "Alpha Pattern",
+                "description": "Second pattern.",
+                "source_file": "src/example.py",
+                "line_range": "30-40",
+                "classification": "REFERENCE_ONLY",
+                "assigned_specialist": "cipher",
+            },
+        )
+        audit = fixtures.read_json(paths["audit"])
+        audit["findings"].append(
+            {
+                "finding_id": "alpha",
+                "pattern_record_path": (
+                    f"internal/artificer/records/{fixtures.BUNDLE}/patterns/"
+                    "alpha-pattern.json"
+                ),
+                "title": "Alpha title",
+                "finding": "Alpha finding.",
+                "recommendation": "Alpha recommendation.",
+                "assigned_specialist": "cipher",
+                "risk_level": "MEDIUM",
+                "evidence": [
+                    {
+                        "bucket": "STATIC_ANALYSIS",
+                        "source_file": "src/example.py",
+                        "line_range": "30-40",
+                        "summary": "Zulu evidence.",
+                    },
+                    {
+                        "bucket": "SOURCE_CONFIRMED",
+                        "source_file": "src/example.py",
+                        "line_range": "2-3",
+                        "summary": "Alpha evidence.",
+                    },
+                ],
+            }
+        )
+        fixtures.write_json(paths["audit"], audit)
+
+    def test_valid_audit_only_and_complete_chains(self):
+        for chain in ("audit", "complete"):
+            with self.subTest(chain=chain):
+                root, _ = self.with_repo(chain)
+                output = self.render(root)
+                self.assertTrue(output.startswith("# Artificer Audit Report:"))
+                headings = [
+                    "## Audit Metadata",
+                    "## Executive Summary",
+                    "## Findings",
+                    "## License Analysis",
+                    "## Security Review",
+                    "## Limitations",
+                ]
+                self.assertEqual(sorted(output.index(value) for value in headings), [output.index(value) for value in headings])
+
+    def test_findings_evidence_and_limitations_are_canonical(self):
+        root, paths = self.with_repo("audit")
+        self.add_second_finding(root, paths)
+        audit = fixtures.read_json(paths["audit"])
+        audit["limitations"] = ["zulu", "Alpha", "alpha"]
+        fixtures.write_json(paths["audit"], audit)
+        output = self.render(root)
+
+        self.assertLess(output.index("### alpha:"), output.index(r"### finding\-1:"))
+        alpha_section = output[output.index("### alpha:"):output.index(r"### finding\-1:")]
+        self.assertLess(alpha_section.index(r"SOURCE\_CONFIRMED"), alpha_section.index(r"STATIC\_ANALYSIS"))
+        self.assertIn("| Pattern Name | Alpha Pattern |", alpha_section)
+        self.assertLess(output.index("- Alpha"), output.index("- alpha"))
+        self.assertLess(output.index("- alpha"), output.index("- zulu"))
+
+    def test_empty_limitations_markdown_safety_and_final_newline(self):
+        root, paths = self.with_repo("audit")
+        audit = fixtures.read_json(paths["audit"])
+        audit["limitations"] = []
+        audit["executive_summary"] = (
+            "Keep  two spaces\tand a tab.\n"
+            "Replace only the newline. # heading | <tag> *bold* [link](x) ::directive"
+        )
+        audit["findings"][0]["title"] = "Title\n## injected"
+        fixtures.write_json(paths["audit"], audit)
+        output = self.render(root)
+
+        self.assertIn("None recorded.", output)
+        self.assertIn("Keep  two spaces\tand a tab", output)
+        self.assertIn(r"a tab\. Replace only the newline\.", output)
+        self.assertIn(r"\# heading \| \<tag\> \*bold\*", output)
+        self.assertIn("&colon;&colon;directive", output)
+        self.assertNotIn("::directive", output)
+        self.assertIn(r"### finding\-1: Title \#\# injected", output)
+        self.assertTrue(output.endswith("\n"))
+        self.assertFalse(output.endswith("\n\n"))
+        self.assertTrue(all(line == line.rstrip() for line in output.splitlines()))
+        self.assertNotIn(str(root), output)
+
+    def test_output_repeats_and_ignores_json_key_order(self):
+        root, paths = self.with_repo("audit")
+        first = self.render(root)
+        self.assertEqual(first, self.render(root))
+        fixtures.write_json(paths["audit"], reverse_keys(fixtures.read_json(paths["audit"])))
+        pattern = root / fixtures.PATTERN_PATH
+        fixtures.write_json(pattern, reverse_keys(fixtures.read_json(pattern)))
+        self.assertEqual(first, self.render(root))
+
+    def test_output_ignores_file_creation_order(self):
+        outputs = []
+        for reverse in (False, True):
+            root, paths = self.with_repo("audit")
+            self.add_second_finding(root, paths)
+            patterns = root / f"internal/artificer/records/{fixtures.BUNDLE}/patterns"
+            records = [(path.name, fixtures.read_json(path)) for path in patterns.glob("*.json")]
+            shutil.rmtree(patterns)
+            patterns.mkdir()
+            for name, data in sorted(records, reverse=reverse):
+                fixtures.write_json(patterns / name, data)
+            outputs.append(self.render(root))
+        self.assertEqual(outputs[0], outputs[1])
+
+    def test_invalid_governance_records_fail_closed(self):
+        cases = [
+            (
+                "missing audit file",
+                lambda root, paths: paths["audit"].unlink(),
+                f"internal/artificer/reviews/{fixtures.BUNDLE}",
+                "governance validation failed",
+                "required governance JSON record",
+            ),
+            (
+                "malformed audit JSON",
+                lambda root, paths: paths["audit"].write_text("{", encoding="utf-8"),
+                AUDIT_REL,
+                "governance validation failed",
+                "Fix the JSON record",
+            ),
+            (
+                "schema-invalid audit",
+                lambda root, paths: fixtures.update_json(paths["audit"], lambda value: value.pop("audit_report_id")),
+                AUDIT_REL,
+                "missing required field",
+                "Add the required field",
+            ),
+            (
+                "invalid source bundle",
+                lambda root, paths: fixtures.update_json(paths["audit"], lambda value: value.update(source_bundle_id=fixtures.OTHER_BUNDLE)),
+                AUDIT_REL,
+                "Source bundle",
+                "Restore a valid Phase 3 source bundle",
+            ),
+            (
+                "Phase 4B cross-record failure",
+                lambda root, paths: fixtures.update_json(paths["audit"], lambda value: value.update(audit_report_id="changed-audit")),
+                "internal/artificer/decisions",
+                "audit_report_id",
+                "existing audit report",
+            ),
+        ]
+        for name, mutate, target, reason, remediation in cases:
+            with self.subTest(name=name):
+                root, paths = self.with_repo("complete" if "cross-record" in name else "audit")
+                mutate(root, paths)
+                self.assert_safe_failure(
+                    root,
+                    Path(AUDIT_REL),
+                    target=target,
+                    reason=reason,
+                    remediation=remediation,
+                )
+
+    def test_invalid_audit_paths_fail_with_safe_remediation(self):
+        root, paths = self.with_repo("audit")
+        cases = [
+            ("absolute", paths["audit"], "--audit", "repository-relative POSIX path"),
+            ("drive", Path("C:/audit-report.json"), "--audit", "repository-relative POSIX path"),
+            ("backslash", r"internal\artificer\reviews\x\audit-report.json", "--audit", "repository-relative POSIX path"),
+            ("traversal", Path("internal/artificer/reviews/../audit-report.json"), "--audit", "repository-relative POSIX path"),
+            ("wrong registry", Path(f"internal/artificer/records/{fixtures.BUNDLE}/audit-report.json"), "internal/artificer/records", "reviews registry contract"),
+            ("wrong filename", Path(f"internal/artificer/reviews/{fixtures.BUNDLE}/report.json"), "report.json", "reviews registry contract"),
+        ]
+        for name, path, target, reason in cases:
+            with self.subTest(name=name):
+                self.assert_safe_failure(
+                    root,
+                    path,
+                    target=target,
+                    reason=reason,
+                    remediation="internal/artificer/reviews/<bundle-id>/audit-report.json",
+                )
+
+    def test_symlinked_audit_paths_fail_when_supported(self):
+        cases = ("audit file", "reviews root", "bundle directory")
+        for case in cases:
+            with self.subTest(case=case):
+                root, paths = self.with_repo("audit")
+                try:
+                    if case == "audit file":
+                        real = root / "real-audit.json"
+                        paths["audit"].replace(real)
+                        paths["audit"].symlink_to(real)
+                    elif case == "reviews root":
+                        reviews = root / "internal/artificer/reviews"
+                        real = root / "real-reviews"
+                        reviews.replace(real)
+                        reviews.symlink_to(real, target_is_directory=True)
+                    else:
+                        bundle = paths["audit"].parent
+                        real = root / "real-bundle"
+                        bundle.replace(real)
+                        bundle.symlink_to(real, target_is_directory=True)
+                except OSError as exc:
+                    self.skipTest(f"symbolic links unsupported: {exc}")
+                self.assert_safe_failure(
+                    root,
+                    Path(AUDIT_REL),
+                    target="internal/artificer/reviews",
+                    reason="governance validation failed",
+                    remediation="symbolic link",
+                )
+
+    def test_schema_configuration_errors_use_exit_two_without_path_leaks(self):
+        cases = [
+            ("missing", lambda path: path.unlink()),
+            ("malformed", lambda path: path.write_text("{", encoding="utf-8")),
+            (
+                "unsupported",
+                lambda path: fixtures.update_json(path, lambda value: value.update(minLength=1)),
+            ),
+        ]
+        for name, mutate in cases:
+            with self.subTest(name=name):
+                root, _ = self.with_repo("audit")
+                schema = root / "internal/artificer/AUDIT_REPORT_SCHEMA.json"
+                mutate(schema)
+                with self.assertRaises(ValidatorConfigurationError):
+                    self.render(root)
+                code, stdout, stderr = self.capture_main(
+                    ["--repo-root", str(root), "--audit", AUDIT_REL]
+                )
+                self.assertEqual(2, code)
+                self.assertEqual("", stdout)
+                self.assertIn("Configuration error", stderr)
+                self.assertIn("Remediation:", stderr)
+                self.assertIn("internal/artificer/AUDIT_REPORT_SCHEMA.json", stderr)
+                self.assertNotIn(str(root), stderr)
+                self.assertNotIn(root.as_posix(), stderr)
+
+    def test_cli_success_failure_and_invalid_arguments(self):
+        root, paths = self.with_repo("audit")
+        code, stdout, stderr = self.capture_main(
+            ["--repo-root", str(root), "--audit", AUDIT_REL]
+        )
+        self.assertEqual(0, code)
+        self.assertEqual(self.render(root), stdout)
+        self.assertEqual("", stderr)
+
+        paths["audit"].write_text("{", encoding="utf-8")
+        code, stdout, stderr = self.capture_main(
+            ["--repo-root", str(root), "--audit", AUDIT_REL]
+        )
+        self.assertEqual(1, code)
+        self.assertEqual("", stdout)
+        self.assertIn(AUDIT_REL, stderr)
+        self.assertIn("Remediation:", stderr)
+        self.assertNotIn(str(root), stderr)
+
+        code, stdout, stderr = self.capture_main([])
+        self.assertEqual(2, code)
+        self.assertEqual("", stdout)
+        self.assertIn("--audit", stderr)
+
+        invalid_paths = [
+            str(paths["audit"]),
+            "C:/audit-report.json",
+            r"internal\artificer\reviews\x\audit-report.json",
+            "internal/artificer/reviews/../audit-report.json",
+            f"internal/artificer/records/{fixtures.BUNDLE}/audit-report.json",
+            f"internal/artificer/reviews/{fixtures.BUNDLE}/report.json",
+        ]
+        for audit_path in invalid_paths:
+            with self.subTest(audit_path=audit_path):
+                valid_root, _ = self.with_repo("audit")
+                code, stdout, stderr = self.capture_main(
+                    ["--repo-root", str(valid_root), "--audit", audit_path]
+                )
+                self.assertEqual(2, code)
+                self.assertEqual("", stdout)
+                self.assertIn("Invalid argument:", stderr)
+                self.assertIn("Remediation:", stderr)
+                self.assertNotIn(str(valid_root), stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements Artificer Phase 4C-A by adding a deterministic, read-only Markdown renderer for validated Artificer audit-report records.

The renderer converts a governed `audit-report.json` record into human-readable Markdown while preserving the JSON governance records as the canonical source of truth.

This phase does not modify the Pattern Catalog or grant governance, approval, promotion, or implementation authority.

## What Changed

### Deterministic audit renderer

Added:

* `scripts/render_artificer_audit_report.py`

The renderer:

* validates the repository through the existing Phase 4B governance-record validator before rendering;
* reads one validated audit report from the reviews registry;
* enriches findings with the corresponding pattern name from the immutable Phase 3 pattern record;
* renders deterministic Markdown to standard output;
* performs no repository writes;
* performs no network or subprocess operations;
* installs no dependencies;
* executes no external code.

### Canonical Markdown output

The renderer produces the following fixed section order:

```text
# Artificer Audit Report: <source repository>

## Audit Metadata
## Executive Summary
## Findings
## License Analysis
## Security Review
## Limitations
```

Each rendered finding includes:

* finding ID and title;
* pattern record and pattern name;
* assigned specialist;
* risk level;
* objective finding;
* recommendation;
* categorized evidence.

### Deterministic ordering

Output ordering is canonicalized for:

* findings;
* evidence entries;
* limitations.

Sorting uses case-folded values with exact-value tie-breakers so output remains stable across operating systems, filesystem enumeration order, JSON key insertion order, and repeated runs.

The output contains:

* LF-compatible Markdown;
* exactly one final newline;
* no trailing whitespace;
* no timestamps;
* no absolute repository paths;
* no environment-dependent values.

### Markdown and text safety

Rendered record values are escaped before insertion into Markdown.

The renderer:

* prevents record values from injecting additional headings or directives;
* replaces CR and LF newlines with spaces;
* preserves repeated spaces and tabs;
* escapes Markdown control characters;
* prevents absolute local path leakage in errors.

### Audit-path validation

The `--audit` argument must use this exact repository-relative POSIX layout:

```text
internal/artificer/reviews/<bundle-id>/audit-report.json
```

The renderer rejects:

* absolute paths;
* Windows drive paths;
* backslash paths;
* `.` and `..` path components;
* control characters;
* files outside the reviews registry;
* alternate filenames;
* missing files;
* symbolic links in the audit path or its ancestors;
* non-regular files.

### CLI contract

Usage:

```powershell
python scripts/render_artificer_audit_report.py `
  --audit internal/artificer/reviews/<bundle-id>/audit-report.json
```

Optional:

```text
--repo-root <path>
```

The renderer writes successful output only to standard output.

Exit codes:

```text
0 — rendering succeeded
1 — repository validation or rendering failure
2 — invalid arguments or validator configuration failure
```

### Behavior coverage

Added:

* `tests/behavior/test_artificer_audit_report_renderer.py`

Coverage includes:

* valid audit-only and complete governance chains;
* canonical finding, evidence, and limitation ordering;
* empty limitations;
* Markdown-special characters;
* newline and whitespace preservation;
* exact final newline;
* repeated-render determinism;
* opposite JSON key insertion orders;
* opposite filesystem creation orders;
* malformed and schema-invalid records;
* invalid source and cross-record relationships;
* absolute, drive, backslash, traversal, wrong-registry, and wrong-filename arguments;
* symlinked audit files and ancestor directories;
* missing, malformed, and unsupported schemas;
* CLI success and exit-code behavior.

### Governance integration

Updated:

* `scripts/governance_check.py`
* `scripts/test_governance_check.py`
* `tests/behavior/run_tests.py`

The renderer is registered as a required repository script but is deliberately excluded from the strict validator list because it renders validated records and does not act as a repository validator.

### Documentation and state

Updated:

* `CHANGELOG.md`
* `DECISION_LOG.md`
* `PROJECT_STATE.md`
* `SESSION_HANDOFF.md`
* `docs/internal/ARTIFICER_PHASE4_GOVERNANCE_CONTRACT.md`
* `docs/internal/ARTIFICER_WORKFLOW.md`
* `internal/artificer/reviews/README.md`

The documentation now establishes that:

* Phase 4C-A renders validated audit records to deterministic Markdown;
* rendering is read-only;
* stdout is the only renderer output;
* JSON governance records remain canonical;
* rendered Markdown carries no independent governance authority;
* Pattern Catalog synchronization remains reserved for Phase 4C-B.

## Validation

The complete validation matrix passed:

* Renderer behavior tests: `10/10`
* Named passing scenarios: `10`
* Named negative scenarios: `24`
* Artificer internal tests: `52 passed`
* Artificer source-record tests: `62 passed`
* Artificer governance-record tests: `17 passed`, with one platform-dependent skip
* Integrated behavior suite: passed
* Strict governance: `0 errors, 0 warnings`
* Runtime tests: `43 passed`
* Runtime coverage: `95.51%`
* `git diff --check`: passed
* Working tree after commit: clean

## Scope Boundaries

This pull request does not:

* modify `docs/internal/PATTERN_CATALOG.md`;
* create or update promotion records;
* create pilot audit records;
* audit OpenHero or Strix;
* modify Artificer schemas;
* modify runtime or adapter behavior;
* modify GitHub Actions workflows;
* write rendered Markdown into the repository;
* execute, clone, fetch, install, or compile external repositories;
* grant Artificer approval, promotion, or implementation authority.

## Relationship to Previous Phases

This work builds on:

* Phase 4A governance contracts;
* Phase 4B governance-record validation;
* PR #164 Phase 4B post-merge hardening.

Phase 4B remains responsible for validating canonical JSON governance records. Phase 4C-A adds only deterministic human-readable rendering.

## Next Phase

After this pull request is merged, Phase 4C-B can implement the governed Pattern Catalog synchronization and validation gate while preserving manual promotion authority.
