### PR TITLE
feat(artificer): add Pattern Catalog governance gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Specialist Governance & Boundary Standard is a documentation-, governance-, meta
 ## Unreleased
 
 ### Added
+- Added Phase 4C-B deterministic, read-only Pattern Catalog synchronization validation, canonical Catalog projection, strict governance integration, and behavior coverage without automatic Catalog writes or promotion authority.
 - Added Phase 4C-A deterministic, read-only Markdown rendering for validated Artificer audit reports, with stdout-only CLI output, canonical ordering, Markdown safety, governance integration, and behavior coverage.
 - Added Phase 4A Artificer governance contracts, including native JSON schemas for Individual Source Audits (`AUDIT_REPORT_SCHEMA.json`), Orchestra Evolution Proposals (`EVOLUTION_PROPOSAL_SCHEMA.json`), Governance Decisions (`GOVERNANCE_DECISION_SCHEMA.json`), and Pattern Catalog Promotion Records (`PROMOTION_RECORD_SCHEMA.json`).
 - Established isolated read-only registries for Phase 4A records (`reviews/`, `decisions/`, `proposals/`, and `promotions/`).

--- a/DECISION_LOG.md
+++ b/DECISION_LOG.md
@@ -286,3 +286,35 @@ create no Catalog, governance, source, or runtime writes.
 - docs/internal/ARTIFICER_PHASE4_GOVERNANCE_CONTRACT.md
 - docs/internal/ARTIFICER_WORKFLOW.md
 - internal/artificer/reviews/README.md
+
+---
+
+## Date: 2026-07-12
+
+**Decision:**
+Implement Phase 4C-B as a deterministic, read-only gate that treats validated
+promotion JSON as canonical and `docs/internal/PATTERN_CATALOG.md` as a manual,
+human-readable projection that must match those records exactly.
+
+**Reason:**
+The Catalog must remain manually synchronized, fully traceable, and unable to
+invent implementation or approval authority in Markdown. Exact whole-file
+comparison keeps stale rows, stale entries, reordered content, and formatting
+drift visible at the first deterministic line mismatch.
+
+**Rejected Alternatives:**
+- Automatic Catalog rewrites (rejected; Phase 4C-B is read-only).
+- Catalog-derived authority (rejected; validated JSON promotion records remain canonical).
+- Advisory-only mismatch reporting (rejected; the Catalog gate is a strict validator).
+
+**Affected Components:**
+- scripts/validate_artificer_pattern_catalog.py
+- tests/behavior/test_artificer_pattern_catalog.py
+- scripts/governance_check.py
+- scripts/test_governance_check.py
+- tests/behavior/run_tests.py
+- docs/internal/PATTERN_CATALOG.md
+- docs/internal/ARTIFICER_PHASE4_GOVERNANCE_CONTRACT.md
+- docs/internal/ARTIFICER_WORKFLOW.md
+- internal/artificer/promotions/README.md
+- internal/artificer/CHECKLIST.md

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -6,11 +6,11 @@
 * **Base Branch:** `main`
 * **Current Release:** `v1.1.1`
 * **Target Patch:** `v1.1.2`
-* **Current Stable State:** Artificer Phase 4B completed through PR #164
-* **Current Task:** Artificer Phase 4C-A deterministic audit rendering
-* **Mode:** Phase 4C-A implementation and audit
-* **Latest Validation:** Phase 4B post-merge hardening passes strict governance checks.
-* **Pending Next Steps:** Audit Phase 4C-A implementation before staging or publication.
+* **Current Stable State:** Artificer Phase 4C-A completed through PR #165
+* **Current Task:** Artificer Phase 4C-B Pattern Catalog synchronization gate
+* **Mode:** Phase 4C-B implementation and audit
+* **Latest Validation:** PR #165 passed Validate, Governance Check, and cross-platform validation
+* **Pending Next Steps:** Audit Phase 4C-B before staging or publication
 * **Most Recent Checkpoint:** 2026-07-12 - Phase 4B post-merge hardening implemented and validated.
 * **Related but Forbidden Repo for this task:** `C:\+AA`
 * **Active Governance Gates:**

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,18 +1,18 @@
 # Session Handoff
 
-- **Current Stable State:** Artificer Phase 4B completed through PR #164
-- **Current Task:** Artificer Phase 4C-A deterministic audit rendering
+- **Current Stable State:** Artificer Phase 4C-A completed through PR #165
+- **Current Task:** Artificer Phase 4C-B Pattern Catalog synchronization gate
 - **Current Repo:** `C:\+conductor`
 - **Canonical Branch:** `main`
 - **Base Branch:** `main`
 - **Current Release:** `v1.1.1`
 - **Target Patch:** `v1.1.2`
-- **Mode:** Phase 4C-A implementation and audit
-- **Allowed Files:** Phase 4C-A renderer, behavior tests, governance integration, and named documentation/state files only.
+- **Mode:** Phase 4C-B implementation and audit
+- **Allowed Files:** Exact Phase 4C-B scope from the task brief only.
 - **Forbidden Repo:** `C:\+AA`
-- **Last Validation:** Phase 4B post-merge hardening passes strict governance checks.
+- **Last Validation:** PR #165 passed Validate, Governance Check, and cross-platform validation
 - **Known Risks:** Prompt-load thresholds remain advisory and current observed Groups A, B, C, and Grand Total exceed documented soft limits; no replacement baseline has been approved.
-- **Next Step:** Audit Phase 4C-A implementation before staging, commit, push, or PR creation.
+- **Next Step:** Audit Phase 4C-B before staging, commit, push, or PR creation.
 - **Fresh-Session Warning:** If the current conversation has long prior history from another repository, enter safe mode and request user confirmation before proceeding with implementation.
 
 ## Token Control Note

--- a/docs/internal/ARTIFICER_PHASE4_GOVERNANCE_CONTRACT.md
+++ b/docs/internal/ARTIFICER_PHASE4_GOVERNANCE_CONTRACT.md
@@ -68,8 +68,13 @@ updates governance JSON, source evidence, or `PATTERN_CATALOG.md`. Rendered
 Markdown is not governance authority; validated JSON records remain canonical.
 
 Phase 4C-B separately owns Pattern Catalog synchronization and its governance
-gate. Phase 4C-A grants no approval, implementation, promotion, or Catalog
-authority.
+gate. Promotion remains manual. Promotion JSON remains canonical. The Catalog
+is only a deterministic human-readable projection and the validator never edits
+the Catalog. Every validated promotion requires exactly one Catalog index row
+and exactly one Catalog entry. No ungoverned Catalog row or entry is allowed.
+Catalog lifecycle status mirrors the promotion record exactly. `--print-expected`
+is preview-only and writes only to standard output. Artificer receives no
+approval, implementation, or Catalog authority.
 
 ## 14. Phase 4.5 Pilot Sources
 The canonical Phase 4.5 pilot repositories are strictly defined as:

--- a/docs/internal/ARTIFICER_WORKFLOW.md
+++ b/docs/internal/ARTIFICER_WORKFLOW.md
@@ -14,7 +14,10 @@ graph TD
     D --> E[Stage 4: Specialist Mapping & Evidence Recording]
     E --> F[Stage 5: Individual Audit & Proposal Generation]
     F --> G[Stage 6: Governance Review & Approval]
-    G --> H[Stage 7: Specialist-Owned Implementation]
+    G --> H[Stage 7: Manual Promotion Record]
+    H --> I[Stage 8: Manual Pattern Catalog Synchronization]
+    I --> J[Stage 9: Phase 4C-B Catalog Gate]
+    J --> K[Stage 10: Specialist-Owned Implementation]
 ```
 
 ---
@@ -51,6 +54,21 @@ graph TD
 3. **The Steward**: Reviews business alignment and scope.
 4. **Maintainer**: Gives final approval.
 
-### Stage 7: Specialist-Owned Implementation
-1. Once approved, the pattern is implemented on a separate branch.
+### Governed Promotion Sequence
+Approved Decision -> Approved Proposal -> Manual Promotion Record -> Manual Pattern Catalog Synchronization -> Phase 4C-B Catalog Gate -> Specialist-Owned Implementation
+
+### Stage 7: Manual Promotion Record
+1. Once governance approval exists, a maintainer manually creates the promotion record.
+2. Promotion remains manual and the JSON promotion record is canonical.
+
+### Stage 8: Manual Pattern Catalog Synchronization
+1. A maintainer manually synchronizes `docs/internal/PATTERN_CATALOG.md` with the validated promotion registry.
+2. The Catalog is a human-readable projection only and must never be updated automatically by Artificer.
+
+### Stage 9: Phase 4C-B Catalog Gate
+1. Run `python scripts/validate_artificer_pattern_catalog.py`.
+2. `IMPLEMENTING`, `IMPLEMENTED`, and `RETIRED` remain specialist- or maintainer-controlled lifecycle states mirrored from the promotion record.
+
+### Stage 10: Specialist-Owned Implementation
+1. Once the Catalog gate passes, the pattern is implemented on a separate branch.
 2. The implementation is owned by the designated Orchestra specialist (e.g. Cloak for frontend, Clockwork for backend structure), not by Artificer.

--- a/docs/internal/PATTERN_CATALOG.md
+++ b/docs/internal/PATTERN_CATALOG.md
@@ -1,38 +1,20 @@
 # Orchestra Pattern Catalog
 
-This document is the registry for all external design patterns that have been successfully audited, approved by governance, and adapted into Orchestra.
+This document is the governed human-readable projection of validated Artificer promotion records.
 
-> [!NOTE]
-> All candidate patterns begin as raw `PATTERN_SCHEMA.json` instances located within bundle directories in `internal/artificer/records/`. Only governance-approved patterns are manually promoted to this catalog. Rejected, deferred, blocked, and revision-required candidates remain strictly in the decision registry. Automatic catalog editing remains prohibited in Phase 4A.
+> [!IMPORTANT]
+> Canonical authority remains with the validated Artificer JSON records. This Markdown file is manually synchronized and is never updated automatically by Artificer.
 >
-> The catalog uses the following promotion lifecycle statuses: `APPROVED`, `IMPLEMENTING`, `IMPLEMENTED`, `RETIRED`. Approval does not mean implementation is complete. Each entry must explicitly trace to a promotion record, decision record, source bundle, commit SHA, file, and line range.
+> Use `python scripts/validate_artificer_pattern_catalog.py --print-expected` to preview the canonical Catalog representation. The command writes only to standard output.
 
 ## Catalog Index
 
 | ID | Pattern Name | Source Repository | Approval Date | Status | Assigned Specialist |
-|---|---|---|---|---|---|
+| --- | --- | --- | --- | --- | --- |
 | | | | | | |
 
 ---
 
 ## Catalog Entries
 
-*(No patterns have been approved or implemented yet. Future entries will follow the template below.)*
-
-### Template
-
-```markdown
-### [Pattern ID]: [Pattern Name]
-- **Status**: [APPROVED | IMPLEMENTING | IMPLEMENTED | RETIRED]
-- **Source**: [Source URL]
-- **Source Bundle**: [Bundle ID]
-- **Audited Commit**: [Commit SHA]
-- **Source File**: [File Path]
-- **Line Range**: [Line Range]
-- **Decision Record**: [Decision ID]
-- **Promotion Record**: [Promotion ID]
-- **Original License**: [License]
-- **Orchestra Specialist Owner**: [Specialist]
-- **Adaptation Branch**: [Branch Name]
-- **Summary**: [Brief description of how the pattern was adapted and where it is used in Orchestra.]
-```
+*(No patterns have been manually promoted.)*

--- a/internal/artificer/CHECKLIST.md
+++ b/internal/artificer/CHECKLIST.md
@@ -36,3 +36,15 @@ Use this checklist during every repository audit to evaluate design patterns for
 - [ ] Run `scripts/validate_artificer_governance_records.py` before governance review; empty governance registries are valid.
 - [ ] Confirm validation only reads committed records, performs no external execution, and grants Artificer no approval or implementation authority.
 - [ ] Leave Pattern Catalog rendering and catalog-gate work to Phase 4C; leave OpenHero and Strix pilot audits to Phase 4.5.
+
+## Phase 4C-B: Pattern Catalog Synchronization Gate
+- [ ] Confirm Phase 4B records are valid before loading the Catalog projection.
+- [ ] Confirm the promotion record was manually reviewed.
+- [ ] Confirm the Catalog row is present exactly once.
+- [ ] Confirm the Catalog entry is present exactly once.
+- [ ] Confirm lifecycle status is synchronized.
+- [ ] Confirm source traceability is synchronized.
+- [ ] Confirm license and attribution are synchronized.
+- [ ] Confirm specialist ownership is synchronized.
+- [ ] Confirm no extra Catalog entry exists.
+- [ ] Run `scripts/validate_artificer_pattern_catalog.py` and confirm the Catalog gate passes.

--- a/internal/artificer/promotions/README.md
+++ b/internal/artificer/promotions/README.md
@@ -10,7 +10,9 @@ Files must be named using their catalog pattern ID:
 ## Requirements
 *   **Traceability**: Every promotion record must trace to a proposal ID, decision ID, source bundle, commit SHA, file, and line range.
 *   **Manual Creation**: Records are manually created and reviewed.
-*   **Validation**: Phase 4B deterministically validates this registry and does not mutate the Pattern Catalog; Phase 4C owns catalog rendering and gating.
+*   **Catalog Projection**: Every validated promotion record must project to exactly one Catalog index row and exactly one Catalog entry in `docs/internal/PATTERN_CATALOG.md`.
+*   **Manual Synchronization**: The Pattern Catalog is synchronized manually; automatic Catalog writes are prohibited.
+*   **Validation**: Run `python scripts/validate_artificer_pattern_catalog.py` to enforce synchronization, or `python scripts/validate_artificer_pattern_catalog.py --print-expected` to preview the canonical projection without writing files.
 *   **No Approval Authority**: No record in this registry grants Artificer approval or implementation authority.
 *   **No External Modifications**: No registry may modify an external repository.
 *   **Empty State**: An empty registry is valid.

--- a/scripts/governance_check.py
+++ b/scripts/governance_check.py
@@ -37,6 +37,7 @@ REQUIRED_VALIDATION_SCRIPTS = [
     "scripts/validate_artificer_internal.py",
     "scripts/validate_artificer_records.py",
     "scripts/validate_artificer_governance_records.py",
+    "scripts/validate_artificer_pattern_catalog.py",
     "scripts/render_artificer_audit_report.py",
 ]
 
@@ -53,6 +54,7 @@ STRICT_VALIDATOR_SCRIPTS = [
     "scripts/validate_artificer_internal.py",
     "scripts/validate_artificer_records.py",
     "scripts/validate_artificer_governance_records.py",
+    "scripts/validate_artificer_pattern_catalog.py",
 ]
 
 SIGNIFICANT_CHANGE_PATTERNS = [

--- a/scripts/test_governance_check.py
+++ b/scripts/test_governance_check.py
@@ -43,6 +43,12 @@ def test_artificer_audit_renderer_is_registered_read_only():
     assert_equal("renderer is not a strict validator", script in gc.STRICT_VALIDATOR_SCRIPTS, False)
 
 
+def test_artificer_pattern_catalog_validator_is_registered():
+    script = "scripts/validate_artificer_pattern_catalog.py"
+    assert_equal("required catalog validator", script in gc.REQUIRED_VALIDATION_SCRIPTS, True)
+    assert_equal("strict catalog validator", script in gc.STRICT_VALIDATOR_SCRIPTS, True)
+
+
 def test_repo_memory_path_check():
     with tempfile.TemporaryDirectory(prefix="governance-memory-test-") as temp_dir:
         repo_root = Path(temp_dir)
@@ -195,6 +201,7 @@ def main():
     test_tracked_repo_files_only()
     test_artificer_governance_validator_is_registered()
     test_artificer_audit_renderer_is_registered_read_only()
+    test_artificer_pattern_catalog_validator_is_registered()
     test_repo_memory_path_check()
     test_startup_state_claim_check()
     print("Governance check helper tests passed.")

--- a/scripts/validate_artificer_pattern_catalog.py
+++ b/scripts/validate_artificer_pattern_catalog.py
@@ -1,0 +1,604 @@
+#!/usr/bin/env python3
+"""Deterministic validator for the governed Artificer Pattern Catalog."""
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import validate_artificer_governance_records
+from validate_artificer_records import (
+    ValidationFailure,
+    ValidatorConfigurationError,
+    load_json_without_duplicate_keys,
+)
+
+
+ARTIFICER_DIR = "internal/artificer"
+CATALOG_PATH = "docs/internal/PATTERN_CATALOG.md"
+PROMOTIONS_DIR = f"{ARTIFICER_DIR}/promotions"
+MAX_CATALOG_BYTES = 1_048_576
+MARKDOWN_RE = re.compile(r"([\\`*_{}\[\]()#+.!|<>-])")
+
+
+@dataclass(frozen=True)
+class CatalogFailure:
+    target: str
+    reason: str
+    remediation: str
+
+
+class CatalogProjectionError(Exception):
+    """Raised when the canonical Catalog projection cannot be produced."""
+
+
+@dataclass(frozen=True)
+class PromotionProjection:
+    catalog_pattern_id: str
+    pattern_name: str
+    source_repository: str
+    source_url: str
+    source_bundle_id: str
+    audited_commit: str
+    source_file: str
+    line_range: str
+    pattern_record_path: str
+    decision_id: str
+    proposal_id: str
+    promotion_id: str
+    promotion_record_path: str
+    approval_date: str
+    status: str
+    assigned_specialist: str
+    original_license: str
+    attribution_required: bool
+    attribution_summary: str
+    pattern_classification: str
+    pattern_description: str
+
+
+def _rel(repo_root: Path, path: Path) -> str:
+    return path.relative_to(repo_root).as_posix()
+
+
+def _failure(target: str, reason: str, remediation: str) -> CatalogFailure:
+    return CatalogFailure(target, reason, remediation)
+
+
+def _relative_detail(repo_root: Path, value: object) -> str:
+    detail = str(value)
+    variants = {
+        str(repo_root),
+        str(repo_root.resolve()),
+        repo_root.as_posix(),
+        repo_root.resolve().as_posix(),
+    }
+    for variant in sorted(variants, key=len, reverse=True):
+        detail = detail.replace(f"{variant}/", "").replace(f"{variant}\\", "")
+        detail = detail.replace(variant, ".")
+    return detail
+
+
+def _clean_text(value: object) -> str:
+    text = str(value)
+    text = text.replace("\r\n", " ")
+    text = text.replace("\r", " ")
+    text = text.replace("\n", " ")
+    text = text.replace("::", "&colon;&colon;")
+    return text
+
+
+def _escape_markdown(value: object) -> str:
+    return MARKDOWN_RE.sub(r"\\\1", _clean_text(value))
+
+
+def _table_value(value: object) -> str:
+    return _escape_markdown(value)
+
+
+def _heading_value(value: object) -> str:
+    return _escape_markdown(value)
+
+
+def _inline_value(value: object) -> str:
+    return _escape_markdown(value)
+
+
+def _load_projection_record(
+    repo_root: Path, promotion_path: Path
+) -> PromotionProjection:
+    target = _rel(repo_root, promotion_path)
+    try:
+        promotion = load_json_without_duplicate_keys(promotion_path)
+        intake_path = repo_root / ARTIFICER_DIR / "records" / promotion["source_bundle_id"] / "source-intake.json"
+        pattern_path = repo_root / Path(promotion["pattern_record_path"])
+        intake = load_json_without_duplicate_keys(intake_path)
+        pattern = load_json_without_duplicate_keys(pattern_path)
+    except (KeyError, ValueError, ValidatorConfigurationError) as exc:
+        detail = _relative_detail(repo_root, exc)
+        raise CatalogProjectionError(
+            f"{target}: canonical projection could not be produced: {detail}"
+        ) from exc
+
+    return PromotionProjection(
+        catalog_pattern_id=promotion["catalog_pattern_id"],
+        pattern_name=pattern["name"],
+        source_repository=intake["repository"],
+        source_url=intake["canonical_url"],
+        source_bundle_id=promotion["source_bundle_id"],
+        audited_commit=intake["reviewed_commit_sha"],
+        source_file=pattern["source_file"],
+        line_range=pattern["line_range"],
+        pattern_record_path=promotion["pattern_record_path"],
+        decision_id=promotion["decision_id"],
+        proposal_id=promotion["proposal_id"],
+        promotion_id=promotion["promotion_id"],
+        promotion_record_path=f"{PROMOTIONS_DIR}/{promotion['catalog_pattern_id']}.json",
+        approval_date=promotion["approval_date"],
+        status=promotion["promotion_status"],
+        assigned_specialist=promotion["assigned_specialist"],
+        original_license=promotion["license_and_attribution"]["original_license"],
+        attribution_required=promotion["license_and_attribution"]["attribution_required"],
+        attribution_summary=promotion["license_and_attribution"]["summary"],
+        pattern_classification=pattern["classification"],
+        pattern_description=pattern["description"],
+    )
+
+
+def _load_promotions(repo_root: Path) -> list[PromotionProjection]:
+    promotions_root = repo_root / PROMOTIONS_DIR
+    if not promotions_root.is_dir():
+        return []
+    projections = [
+        _load_projection_record(repo_root, path)
+        for path in sorted(
+            promotions_root.glob("*.json"),
+            key=lambda item: (item.name.casefold(), item.name),
+        )
+    ]
+    return sorted(
+        projections,
+        key=lambda item: (
+            item.catalog_pattern_id.casefold(),
+            item.catalog_pattern_id,
+        ),
+    )
+
+
+def _validate_unique_source_pattern_pairs(
+    promotions: list[PromotionProjection],
+) -> list[CatalogFailure]:
+    failures: list[CatalogFailure] = []
+    seen: dict[tuple[str, str], str] = {}
+    for promotion in promotions:
+        pair = (promotion.source_bundle_id, promotion.pattern_record_path)
+        current_target = promotion.promotion_record_path
+        first_target = seen.get(pair)
+        if first_target is not None:
+            reason = (
+                "Two promotion records project the same "
+                "(source_bundle_id, pattern_record_path) pair"
+            )
+            remediation = (
+                "Keep exactly one promotion record for the source bundle and "
+                "pattern pair."
+            )
+            failures.append(_failure(first_target, reason, remediation))
+            failures.append(_failure(current_target, reason, remediation))
+        else:
+            seen[pair] = current_target
+    return failures
+
+
+def _render_index_row(promotion: PromotionProjection) -> str:
+    return (
+        f"| {_table_value(promotion.catalog_pattern_id)} | "
+        f"{_table_value(promotion.pattern_name)} | "
+        f"{_table_value(promotion.source_repository)} | "
+        f"{_table_value(promotion.approval_date)} | "
+        f"{_table_value(promotion.status)} | "
+        f"{_table_value(promotion.assigned_specialist)} |"
+    )
+
+
+def _render_entry(promotion: PromotionProjection) -> list[str]:
+    return [
+        (
+            f"### {_heading_value(promotion.catalog_pattern_id)}: "
+            f"{_heading_value(promotion.pattern_name)}"
+        ),
+        "",
+        f"- **Status**: {_inline_value(promotion.status)}",
+        f"- **Source Repository**: {_inline_value(promotion.source_repository)}",
+        f"- **Source URL**: {_inline_value(promotion.source_url)}",
+        f"- **Source Bundle**: {_inline_value(promotion.source_bundle_id)}",
+        f"- **Audited Commit**: {_inline_value(promotion.audited_commit)}",
+        f"- **Source File**: {_inline_value(promotion.source_file)}",
+        f"- **Line Range**: {_inline_value(promotion.line_range)}",
+        f"- **Pattern Record**: {_inline_value(promotion.pattern_record_path)}",
+        f"- **Decision Record**: {_inline_value(promotion.decision_id)}",
+        f"- **Proposal Record**: {_inline_value(promotion.proposal_id)}",
+        f"- **Promotion Record**: {_inline_value(promotion.promotion_id)}",
+        (
+            "- **Promotion Record Path**: "
+            f"{_inline_value(promotion.promotion_record_path)}"
+        ),
+        f"- **Approval Date**: {_inline_value(promotion.approval_date)}",
+        f"- **Original License**: {_inline_value(promotion.original_license)}",
+        (
+            "- **Attribution Required**: "
+            f"{_inline_value(str(promotion.attribution_required).lower())}"
+        ),
+        (
+            "- **Attribution Summary**: "
+            f"{_inline_value(promotion.attribution_summary)}"
+        ),
+        (
+            "- **Orchestra Specialist Owner**: "
+            f"{_inline_value(promotion.assigned_specialist)}"
+        ),
+        (
+            "- **Pattern Classification**: "
+            f"{_inline_value(promotion.pattern_classification)}"
+        ),
+        (
+            "- **Pattern Description**: "
+            f"{_inline_value(promotion.pattern_description)}"
+        ),
+    ]
+
+
+def _map_governance_failures(
+    failures: list[ValidationFailure],
+) -> list[CatalogFailure]:
+    return [
+        CatalogFailure(
+            failure.target,
+            failure.reason,
+            failure.remediation,
+        )
+        for failure in failures
+    ]
+
+
+def render_expected_catalog(repo_root: Path) -> str:
+    """Return the deterministic canonical Pattern Catalog Markdown."""
+    root = Path(repo_root).resolve()
+    governance_failures = validate_artificer_governance_records.validate_repository(root)
+    if governance_failures:
+        failure = governance_failures[0]
+        raise CatalogProjectionError(
+            f"{failure.target}: {failure.reason} Remediation: {failure.remediation}"
+        )
+
+    promotions = _load_promotions(root)
+    duplicate_failures = _validate_unique_source_pattern_pairs(promotions)
+    if duplicate_failures:
+        failure = sorted(
+            duplicate_failures,
+            key=lambda item: (
+                item.target.casefold(),
+                item.target,
+                item.reason.casefold(),
+                item.reason,
+                item.remediation.casefold(),
+                item.remediation,
+            ),
+        )[0]
+        raise CatalogProjectionError(
+            f"{failure.target}: {failure.reason} Remediation: {failure.remediation}"
+        )
+
+    lines = [
+        "# Orchestra Pattern Catalog",
+        "",
+        (
+            "This document is the governed human-readable projection of "
+            "validated Artificer promotion records."
+        ),
+        "",
+        "> [!IMPORTANT]",
+        (
+            "> Canonical authority remains with the validated Artificer JSON "
+            "records. This Markdown file is manually synchronized and is never "
+            "updated automatically by Artificer."
+        ),
+        ">",
+        (
+            "> Use `python scripts/validate_artificer_pattern_catalog.py "
+            "--print-expected` to preview the canonical Catalog "
+            "representation. The command writes only to standard output."
+        ),
+        "",
+        "## Catalog Index",
+        "",
+        (
+            "| ID | Pattern Name | Source Repository | Approval Date | "
+            "Status | Assigned Specialist |"
+        ),
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    if promotions:
+        lines.extend(_render_index_row(promotion) for promotion in promotions)
+    else:
+        lines.append("| | | | | | |")
+
+    lines.extend(["", "---", "", "## Catalog Entries", ""])
+    if promotions:
+        for index, promotion in enumerate(promotions):
+            if index:
+                lines.append("")
+            lines.extend(_render_entry(promotion))
+    else:
+        lines.append("*(No patterns have been manually promoted.)*")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _validate_catalog_file(repo_root: Path) -> tuple[Path | None, list[CatalogFailure]]:
+    root = Path(repo_root).resolve()
+    catalog_path = root / CATALOG_PATH
+    docs_path = root / "docs"
+    internal_path = docs_path / "internal"
+
+    for rel_target, path in (("docs", docs_path), ("docs/internal", internal_path)):
+        if path.is_symlink():
+            return None, [
+                _failure(
+                    rel_target,
+                    "Catalog ancestor directory must not be a symbolic link",
+                    "Replace the symbolic link with a regular repository directory.",
+                )
+            ]
+    if catalog_path.is_symlink():
+        return None, [
+            _failure(
+                CATALOG_PATH,
+                "Catalog file must not be a symbolic link",
+                "Replace the symbolic link with a regular UTF-8 Markdown file.",
+            )
+        ]
+    if not catalog_path.exists():
+        return None, [
+            _failure(
+                CATALOG_PATH,
+                "Catalog file is missing",
+                "Restore docs/internal/PATTERN_CATALOG.md as a regular UTF-8 Markdown file.",
+            )
+        ]
+    if not catalog_path.is_file():
+        return None, [
+            _failure(
+                CATALOG_PATH,
+                "Catalog path is not a regular file",
+                "Replace docs/internal/PATTERN_CATALOG.md with a regular UTF-8 Markdown file.",
+            )
+        ]
+    size = catalog_path.stat().st_size
+    if size > MAX_CATALOG_BYTES:
+        return None, [
+            _failure(
+                CATALOG_PATH,
+                (
+                    "Catalog file exceeds the maximum size of "
+                    f"{MAX_CATALOG_BYTES} bytes ({size} bytes)"
+                ),
+                "Reduce docs/internal/PATTERN_CATALOG.md to the canonical Catalog content.",
+            )
+        ]
+    return catalog_path, []
+
+
+def _read_catalog_text(repo_root: Path, catalog_path: Path) -> tuple[str | None, list[CatalogFailure]]:
+    try:
+        raw = catalog_path.read_bytes()
+    except OSError as exc:
+        return None, [
+            _failure(
+                CATALOG_PATH,
+                f"Catalog file cannot be read: {_relative_detail(repo_root, exc)}",
+                "Restore a readable UTF-8 Markdown file at docs/internal/PATTERN_CATALOG.md.",
+            )
+        ]
+    if raw.startswith(b"\xef\xbb\xbf"):
+        return None, [
+            _failure(
+                CATALOG_PATH,
+                "Catalog file must not use a UTF-8 byte order mark",
+                "Save docs/internal/PATTERN_CATALOG.md as UTF-8 without BOM.",
+            )
+        ]
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        return None, [
+            _failure(
+                CATALOG_PATH,
+                f"Catalog file is not valid UTF-8: {_relative_detail(repo_root, exc)}",
+                "Save docs/internal/PATTERN_CATALOG.md as valid UTF-8 without BOM.",
+            )
+        ]
+    return text.replace("\r\n", "\n").replace("\r", "\n"), []
+
+
+def _compare_catalog(
+    actual: str, expected: str
+) -> CatalogFailure | None:
+    if actual == expected:
+        return None
+
+    actual_lines = actual.split("\n")
+    expected_lines = expected.split("\n")
+    common = min(len(actual_lines), len(expected_lines))
+    for index in range(common):
+        if actual_lines[index] != expected_lines[index]:
+            return _failure(
+                f"{CATALOG_PATH}:{index + 1}",
+                "Catalog line differs from the canonical promotion projection",
+                (
+                    "Replace the line with the canonical expected content or "
+                    "inspect --print-expected."
+                ),
+            )
+    if len(actual_lines) < len(expected_lines):
+        line_number = common + 1
+        return _failure(
+            f"{CATALOG_PATH}:{line_number}",
+            f"Catalog is missing canonical content beginning at line {line_number}",
+            (
+                "Add the canonical expected content beginning at that line or "
+                "inspect --print-expected."
+            ),
+        )
+    line_number = common + 1
+    return _failure(
+        f"{CATALOG_PATH}:{line_number}",
+        f"Catalog contains non-canonical content beginning at line {line_number}",
+        (
+            "Remove the extra content beginning at that line or inspect "
+            "--print-expected."
+        ),
+    )
+
+
+def validate_repository(repo_root: Path) -> list[CatalogFailure]:
+    """Return deterministic Catalog synchronization failures."""
+    root = Path(repo_root).resolve()
+    try:
+        governance_failures = validate_artificer_governance_records.validate_repository(root)
+    except ValidatorConfigurationError:
+        raise
+    failures = _map_governance_failures(governance_failures)
+    if failures:
+        return sorted(
+            failures,
+            key=lambda item: (
+                item.target.casefold(),
+                item.target,
+                item.reason.casefold(),
+                item.reason,
+                item.remediation.casefold(),
+                item.remediation,
+            ),
+        )
+
+    promotions = _load_promotions(root)
+    failures.extend(_validate_unique_source_pattern_pairs(promotions))
+    catalog_path, catalog_failures = _validate_catalog_file(root)
+    failures.extend(catalog_failures)
+    if failures:
+        return sorted(
+            failures,
+            key=lambda item: (
+                item.target.casefold(),
+                item.target,
+                item.reason.casefold(),
+                item.reason,
+                item.remediation.casefold(),
+                item.remediation,
+            ),
+        )
+    if catalog_path is None:
+        return []
+
+    actual_text, text_failures = _read_catalog_text(root, catalog_path)
+    failures.extend(text_failures)
+    if actual_text is None or failures:
+        return sorted(
+            failures,
+            key=lambda item: (
+                item.target.casefold(),
+                item.target,
+                item.reason.casefold(),
+                item.reason,
+                item.remediation.casefold(),
+                item.remediation,
+            ),
+        )
+
+    try:
+        expected_text = render_expected_catalog(root)
+    except ValidatorConfigurationError:
+        raise
+    except CatalogProjectionError as exc:
+        failures.append(
+            _failure(
+                CATALOG_PATH,
+                _relative_detail(root, exc),
+                "Fix the promotion projection inputs and re-run validation.",
+            )
+        )
+        return sorted(
+            failures,
+            key=lambda item: (
+                item.target.casefold(),
+                item.target,
+                item.reason.casefold(),
+                item.reason,
+                item.remediation.casefold(),
+                item.remediation,
+            ),
+        )
+
+    mismatch = _compare_catalog(actual_text, expected_text)
+    if mismatch is not None:
+        failures.append(mismatch)
+    return sorted(
+        failures,
+        key=lambda item: (
+            item.target.casefold(),
+            item.target,
+            item.reason.casefold(),
+            item.reason,
+            item.remediation.casefold(),
+            item.remediation,
+        ),
+    )
+
+
+def _print_failure(failure: CatalogFailure) -> None:
+    print(f"[FAIL] {failure.target}: {failure.reason}")
+    print(f"       Remediation: {failure.remediation}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run Catalog validation or print the expected projection."""
+    parser = argparse.ArgumentParser(
+        description="Artificer Pattern Catalog synchronization validator."
+    )
+    parser.add_argument("--repo-root", default=None)
+    parser.add_argument("--print-expected", action="store_true")
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        return 0 if exc.code == 0 else 2
+
+    repo_root = (
+        Path(args.repo_root).resolve()
+        if args.repo_root
+        else Path(__file__).resolve().parent.parent
+    )
+    try:
+        if args.print_expected:
+            sys.stdout.write(render_expected_catalog(repo_root))
+            return 0
+        failures = validate_repository(repo_root)
+    except ValidatorConfigurationError as exc:
+        print(f"[FAIL] Configuration error: {_relative_detail(repo_root, exc)}")
+        print("       Remediation: Restore valid Phase 3 and Phase 4 schema contracts.")
+        return 2
+    except CatalogProjectionError as exc:
+        print(f"[FAIL] {CATALOG_PATH}: {_relative_detail(repo_root, exc)}")
+        print("       Remediation: Fix the promotion projection inputs and re-run validation.")
+        return 1
+
+    if failures:
+        for failure in failures:
+            _print_failure(failure)
+        return 1
+    print("[PASS] docs/internal/PATTERN_CATALOG.md is synchronized with validated promotion records.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/behavior/run_tests.py
+++ b/tests/behavior/run_tests.py
@@ -26,6 +26,8 @@ def main():
         {"Name": "validate_artificer_governance_records.py", "Path": "scripts/validate_artificer_governance_records.py"},
         {"Name": "test_artificer_governance_records.py", "Path": "tests/behavior/test_artificer_governance_records.py"},
         {"Name": "test_artificer_audit_report_renderer.py", "Path": "tests/behavior/test_artificer_audit_report_renderer.py"}
+        ,{"Name": "validate_artificer_pattern_catalog.py", "Path": "scripts/validate_artificer_pattern_catalog.py"}
+        ,{"Name": "test_artificer_pattern_catalog.py", "Path": "tests/behavior/test_artificer_pattern_catalog.py"}
     ]
     
     failed = False

--- a/tests/behavior/test_artificer_pattern_catalog.py
+++ b/tests/behavior/test_artificer_pattern_catalog.py
@@ -1,0 +1,926 @@
+#!/usr/bin/env python3
+"""Behavior coverage for Artificer Phase 4C-B Pattern Catalog validation."""
+
+import contextlib
+import io
+import json
+import os
+import re
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+import sys
+
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+import validate_artificer_pattern_catalog as validator  # noqa: E402
+
+from test_artificer_governance_records import (  # noqa: E402
+    BUNDLE,
+    OTHER_BUNDLE,
+    OTHER_PATTERN_PATH,
+    PATTERN_PATH,
+    SHA,
+    add_source_bundle,
+    fixture_repo,
+    read_json,
+    update_json,
+    write_json,
+)
+
+
+PASSING_SCENARIOS = (
+    "empty promotion registry and canonical empty Catalog",
+    "one approved promotion",
+    "APPROVED lifecycle",
+    "IMPLEMENTING lifecycle",
+    "IMPLEMENTED lifecycle",
+    "RETIRED lifecycle",
+    "multiple promotion projections in canonical order",
+    "repeated rendering produces identical output",
+    "opposite promotion-file creation orders",
+    "opposite JSON key insertion orders",
+    "Markdown-special characters",
+    "repeated spaces and tabs preserved",
+    "CRLF Catalog accepted after logical normalization",
+    "exactly one final newline",
+    "--print-expected produces canonical stdout only",
+    "--print-expected does not mutate repository state",
+)
+
+INDEX_ROW = "| catalog\\-pattern | Reference Pattern | owner/repository | 2026\\-07\\-04 | APPROVED | ponytail |"
+HEADING_LINE = "### catalog\\-pattern: Reference Pattern"
+
+NEGATIVE_SCENARIOS = (
+    "missing Catalog",
+    "symlinked Catalog",
+    "symlinked docs ancestor",
+    "symlinked docs/internal ancestor",
+    "non-regular Catalog path",
+    "oversized Catalog",
+    "invalid UTF-8",
+    "UTF-8 BOM",
+    "missing final newline",
+    "extra final newline",
+    "trailing whitespace",
+    "missing index row",
+    "extra index row",
+    "duplicate index row",
+    "missing Catalog entry",
+    "extra Catalog entry",
+    "duplicate Catalog entry",
+    "incorrect index order",
+    "incorrect entry order",
+    "stale Catalog ID",
+    "stale pattern name",
+    "stale source repository",
+    "stale approval date",
+    "stale lifecycle status",
+    "stale assigned specialist",
+    "stale source URL",
+    "stale source bundle",
+    "stale audited commit",
+    "stale source file",
+    "stale line range",
+    "stale pattern-record path",
+    "stale decision ID",
+    "stale proposal ID",
+    "stale promotion ID",
+    "stale promotion-record path",
+    "stale license",
+    "stale attribution flag",
+    "stale attribution summary",
+    "stale pattern classification",
+    "stale pattern description",
+    "promotion exists while Catalog remains empty",
+    "Catalog entry exists without a promotion",
+    "two promotions target the same source pattern pair",
+    "Phase 4B governance precondition failure",
+    "missing schema configuration",
+    "malformed schema configuration",
+    "unsupported schema configuration",
+    "invalid CLI arguments",
+)
+
+
+def snapshot_tree(root: Path) -> dict[str, bytes]:
+    snapshot: dict[str, bytes] = {}
+    for path in sorted(root.rglob("*"), key=lambda item: item.as_posix()):
+        if path.is_file() and not path.is_symlink():
+            snapshot[path.relative_to(root).as_posix()] = path.read_bytes()
+    return snapshot
+
+
+def empty_catalog_text() -> str:
+    return (
+        "# Orchestra Pattern Catalog\n\n"
+        "This document is the governed human-readable projection of validated Artificer promotion records.\n\n"
+        "> [!IMPORTANT]\n"
+        "> Canonical authority remains with the validated Artificer JSON records. This Markdown file is manually synchronized and is never updated automatically by Artificer.\n"
+        ">\n"
+        "> Use `python scripts/validate_artificer_pattern_catalog.py --print-expected` to preview the canonical Catalog representation. The command writes only to standard output.\n\n"
+        "## Catalog Index\n\n"
+        "| ID | Pattern Name | Source Repository | Approval Date | Status | Assigned Specialist |\n"
+        "| --- | --- | --- | --- | --- | --- |\n"
+        "| | | | | | |\n\n"
+        "---\n\n"
+        "## Catalog Entries\n\n"
+        "*(No patterns have been manually promoted.)*\n"
+    )
+
+
+def add_complete_chain(
+    root: Path,
+    *,
+    bundle_id: str,
+    catalog_id: str,
+    promotion_id: str,
+    decision_id: str,
+    proposal_id: str,
+    audit_id: str,
+    pattern_slug: str,
+    pattern_name: str,
+    status: str = "APPROVED",
+    repository: str = "owner/repository-two",
+    source_file: str = "src/other.py",
+    line_range: str = "30-40",
+    classification: str = "ADAPTED_PATTERN",
+    description: str = "Second source-backed pattern.",
+) -> dict[str, Path]:
+    add_source_bundle(root, bundle_id, repository=repository)
+    source = root / "internal/artificer/records" / bundle_id
+    pattern_rel = f"internal/artificer/records/{bundle_id}/patterns/{pattern_slug}.json"
+    update_json(
+        source / "patterns/reference-pattern.json",
+        lambda data: data.update(
+            {
+                "name": pattern_name,
+                "description": description,
+                "source_file": source_file,
+                "line_range": line_range,
+                "classification": classification,
+            }
+        ),
+    )
+    update_json(
+        source / "source-intake.json",
+        lambda data: data.__setitem__(
+            "files_examined", [{"file_path": source_file, "line_ranges": [line_range]}]
+        ),
+    )
+    pattern_path = source / "patterns" / f"{pattern_slug}.json"
+    (source / "patterns/reference-pattern.json").rename(pattern_path)
+    paths = {
+        "audit": root / f"internal/artificer/reviews/{bundle_id}/audit-report.json",
+        "decision": root / f"internal/artificer/decisions/{bundle_id}/{pattern_slug}.json",
+        "proposal": root / f"internal/artificer/proposals/{proposal_id}.json",
+        "promotion": root / f"internal/artificer/promotions/{catalog_id}.json",
+        "pattern": pattern_path,
+    }
+    audit = {
+        "schema_version": "1.0",
+        "audit_report_id": audit_id,
+        "source_bundle_id": bundle_id,
+        "source_intake_path": f"internal/artificer/records/{bundle_id}/source-intake.json",
+        "source_repository": repository,
+        "reviewed_commit_sha": SHA,
+        "audit_date": "2026-07-02",
+        "executive_summary": "Audit summary.",
+        "findings": [
+            {
+                "finding_id": f"finding-{catalog_id}",
+                "pattern_record_path": pattern_rel,
+                "title": "Finding",
+                "finding": "Observed behavior.",
+                "recommendation": "Use concept only.",
+                "assigned_specialist": "ponytail",
+                "risk_level": "LOW",
+                "evidence": [
+                    {
+                        "bucket": "SOURCE_CONFIRMED",
+                        "source_file": source_file,
+                        "line_range": line_range,
+                        "summary": "Observed.",
+                    }
+                ],
+            }
+        ],
+        "license_analysis": {
+            "detected_license": "MIT",
+            "compatibility_assessment": "COMPATIBLE",
+            "governor_review_required": False,
+            "summary": "Recorded only.",
+        },
+        "security_review": {
+            "external_execution_performed": False,
+            "summary": "No external execution.",
+        },
+        "limitations": ["Static source evidence only."],
+    }
+    decision = {
+        "schema_version": "1.0",
+        "decision_id": decision_id,
+        "source_bundle_id": bundle_id,
+        "pattern_record_path": pattern_rel,
+        "audit_report_id": audit_id,
+        "decision_status": "APPROVED",
+        "assigned_specialist": "ponytail",
+        "reviews": {
+            reviewer: {
+                "status": status_value,
+                "rationale": "Reviewed.",
+                "review_date": "2026-07-03",
+            }
+            for reviewer, status_value in {
+                "arbiter": "APPROVED",
+                "governor": "NOT_REQUIRED",
+                "steward": "APPROVED",
+            }.items()
+        },
+        "maintainer_decision": {
+            "status": "APPROVED",
+            "rationale": "Approved.",
+            "decision_date": "2026-07-03",
+        },
+        "implementation_restriction": "CONCEPT_ONLY",
+        "decision_date": "2026-07-03",
+    }
+    proposal = {
+        "schema_version": "1.0",
+        "proposal_id": proposal_id,
+        "title": "Proposal",
+        "objective": "Adapt concept.",
+        "source_audit_ids": [audit_id],
+        "selected_patterns": [
+            {
+                "decision_id": decision_id,
+                "pattern_record_path": pattern_rel,
+                "target_component": "validator",
+                "evolution_mechanism": "CONCEPTUAL_ADAPTATION",
+                "owner_specialist": "ponytail",
+                "rationale": "Approved concept.",
+            }
+        ],
+        "verification_plan": "Run tests.",
+        "governance_handoff": "Maintainer review.",
+        "proposal_status": "APPROVED",
+    }
+    promotion = {
+        "schema_version": "1.0",
+        "promotion_id": promotion_id,
+        "catalog_pattern_id": catalog_id,
+        "decision_id": decision_id,
+        "proposal_id": proposal_id,
+        "source_bundle_id": bundle_id,
+        "pattern_record_path": pattern_rel,
+        "approval_date": "2026-07-04",
+        "promotion_status": status,
+        "assigned_specialist": "ponytail",
+        "source_traceability": {
+            "repository": repository,
+            "reviewed_commit_sha": SHA,
+            "source_file": source_file,
+            "line_range": line_range,
+        },
+        "license_and_attribution": {
+            "original_license": "MIT",
+            "attribution_required": True,
+            "summary": "Retain attribution.",
+        },
+        "automatic_promotion": False,
+    }
+    write_json(paths["audit"], audit)
+    write_json(paths["decision"], decision)
+    write_json(paths["proposal"], proposal)
+    write_json(paths["promotion"], promotion)
+    return paths
+
+
+class PatternCatalogTests(unittest.TestCase):
+    def with_repo(self, chain: str = "complete") -> tuple[Path, dict[str, Path]]:
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        root = Path(temp.name)
+        paths = fixture_repo(root, chain)
+        catalog_path = root / "docs/internal/PATTERN_CATALOG.md"
+        catalog_path.parent.mkdir(parents=True, exist_ok=True)
+        catalog_path.write_text(validator.render_expected_catalog(root), encoding="utf-8")
+        return root, paths
+
+    def assert_no_absolute_path_leak(self, root: Path, *values: object) -> None:
+        leak = str(root)
+        for value in values:
+            self.assertNotIn(leak, str(value))
+
+    def assert_failure(
+        self,
+        root: Path,
+        failures: list[validator.CatalogFailure],
+        *,
+        target_contains: str,
+        reason_contains: str,
+        remediation_contains: str,
+    ) -> None:
+        self.assertTrue(failures, "Expected validation to fail")
+        matching = [
+            failure
+            for failure in failures
+            if target_contains in failure.target and reason_contains in failure.reason
+        ]
+        self.assertTrue(
+            matching,
+            f"Expected failure target={target_contains!r} reason={reason_contains!r}, got {failures!r}",
+        )
+        self.assertIn(remediation_contains, matching[0].remediation)
+        self.assert_no_absolute_path_leak(
+            root,
+            matching[0].target,
+            matching[0].reason,
+            matching[0].remediation,
+        )
+
+    def run_main(self, root: Path, *argv: str) -> tuple[int, str, str]:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            code = validator.main(["--repo-root", str(root), *argv])
+        self.assert_no_absolute_path_leak(root, stdout.getvalue(), stderr.getvalue())
+        return code, stdout.getvalue(), stderr.getvalue()
+
+    def test_passing_render_and_validation_scenarios(self) -> None:
+        scenarios = [
+            ("empty promotion registry and canonical empty Catalog", "empty", None, None),
+            ("one approved promotion", "complete", None, None),
+            ("APPROVED lifecycle", "complete", lambda root, paths: None, "APPROVED"),
+            (
+                "IMPLEMENTING lifecycle",
+                "complete",
+                lambda root, paths: update_json(paths["promotion"], lambda data: data.__setitem__("promotion_status", "IMPLEMENTING")),
+                "IMPLEMENTING",
+            ),
+            (
+                "IMPLEMENTED lifecycle",
+                "complete",
+                lambda root, paths: update_json(paths["promotion"], lambda data: data.__setitem__("promotion_status", "IMPLEMENTED")),
+                "IMPLEMENTED",
+            ),
+            (
+                "RETIRED lifecycle",
+                "complete",
+                lambda root, paths: update_json(paths["promotion"], lambda data: data.__setitem__("promotion_status", "RETIRED")),
+                "RETIRED",
+            ),
+            (
+                "multiple promotion projections in canonical order",
+                "complete",
+                lambda root, paths: add_complete_chain(
+                    root,
+                    bundle_id=OTHER_BUNDLE,
+                    catalog_id="a-catalog-pattern",
+                    promotion_id="promotion-2",
+                    decision_id="decision-2",
+                    proposal_id="proposal-2",
+                    audit_id="audit-2",
+                    pattern_slug="another-pattern",
+                    pattern_name="Another Pattern",
+                ),
+                None,
+            ),
+        ]
+        for name, chain, mutate, expected_status in scenarios:
+            with self.subTest(name=name):
+                root, paths = self.with_repo(chain)
+                if mutate is not None:
+                    mutate(root, paths)
+                expected = validator.render_expected_catalog(root)
+                (root / "docs/internal/PATTERN_CATALOG.md").write_text(expected, encoding="utf-8")
+                failures = validator.validate_repository(root)
+                self.assertEqual(failures, [])
+                code, stdout, stderr = self.run_main(root)
+                self.assertEqual(code, 0)
+                self.assertEqual(stderr, "")
+                self.assertEqual(
+                    stdout,
+                    "[PASS] docs/internal/PATTERN_CATALOG.md is synchronized with validated promotion records.\n",
+                )
+                if expected_status is not None:
+                    self.assertIn(f"- **Status**: {expected_status}", expected)
+
+    def test_projection_stability_and_markdown_scenarios(self) -> None:
+        scenarios = [
+            (
+                "repeated rendering produces identical output",
+                lambda root, paths: (
+                    self.assertEqual(
+                        validator.render_expected_catalog(root),
+                        validator.render_expected_catalog(root),
+                    )
+                ),
+            ),
+            (
+                "opposite promotion-file creation orders",
+                lambda root, paths: (
+                    add_complete_chain(
+                        root,
+                        bundle_id=OTHER_BUNDLE,
+                        catalog_id="z-catalog-pattern",
+                        promotion_id="promotion-2",
+                        decision_id="decision-2",
+                        proposal_id="proposal-2",
+                        audit_id="audit-2",
+                        pattern_slug="late-pattern",
+                        pattern_name="Late Pattern",
+                    ),
+                    add_complete_chain(
+                        root,
+                        bundle_id="owner__repository__cccccccccccc",
+                        catalog_id="a-catalog-pattern",
+                        promotion_id="promotion-3",
+                        decision_id="decision-3",
+                        proposal_id="proposal-3",
+                        audit_id="audit-3",
+                        pattern_slug="early-pattern",
+                        pattern_name="Early Pattern",
+                        repository="owner/repository-three",
+                    ),
+                ),
+            ),
+            (
+                "opposite JSON key insertion orders",
+                lambda root, paths: paths["promotion"].write_text(
+                    json.dumps(
+                        {
+                            "automatic_promotion": False,
+                            "license_and_attribution": {
+                                "summary": "Retain attribution.",
+                                "attribution_required": True,
+                                "original_license": "MIT",
+                            },
+                            "source_traceability": {
+                                "line_range": "10-20",
+                                "source_file": "src/example.py",
+                                "reviewed_commit_sha": SHA,
+                                "repository": "owner/repository",
+                            },
+                            "assigned_specialist": "ponytail",
+                            "promotion_status": "APPROVED",
+                            "approval_date": "2026-07-04",
+                            "pattern_record_path": PATTERN_PATH,
+                            "source_bundle_id": BUNDLE,
+                            "proposal_id": "proposal-1",
+                            "decision_id": "decision-1",
+                            "catalog_pattern_id": "catalog-pattern",
+                            "promotion_id": "promotion-1",
+                            "schema_version": "1.0",
+                        },
+                        indent=2,
+                    ),
+                    encoding="utf-8",
+                ),
+            ),
+            (
+                "Markdown-special characters",
+                lambda root, paths: (
+                    update_json(
+                        paths["promotion"],
+                        lambda data: data["license_and_attribution"].__setitem__(
+                            "summary", 'Uses :: [link](x) <html> *stars* | pipes'
+                        ),
+                    ),
+                    update_json(
+                        root / PATTERN_PATH,
+                        lambda data: data.update(
+                            {
+                                "name": "# Heading *Name*",
+                                "description": "Text with | pipe and > quote",
+                            }
+                        ),
+                    ),
+                ),
+            ),
+            (
+                "repeated spaces and tabs preserved",
+                lambda root, paths: update_json(
+                    root / PATTERN_PATH,
+                    lambda data: data.__setitem__(
+                        "description", "Tabs\tstay and  repeated  spaces stay"
+                    ),
+                ),
+            ),
+            (
+                "CRLF Catalog accepted after logical normalization",
+                lambda root, paths: (
+                    (root / "docs/internal/PATTERN_CATALOG.md").write_bytes(
+                        validator.render_expected_catalog(root).replace("\n", "\r\n").encode("utf-8")
+                    )
+                ),
+            ),
+            (
+                "exactly one final newline",
+                lambda root, paths: (
+                    self.assertTrue(validator.render_expected_catalog(root).endswith("\n")),
+                    self.assertFalse(validator.render_expected_catalog(root).endswith("\n\n")),
+                ),
+            ),
+        ]
+        for name, mutate in scenarios:
+            with self.subTest(name=name):
+                root, paths = self.with_repo("complete")
+                mutate(root, paths)
+                if name != "CRLF Catalog accepted after logical normalization":
+                    expected = validator.render_expected_catalog(root)
+                    (root / "docs/internal/PATTERN_CATALOG.md").write_text(expected, encoding="utf-8")
+                failures = validator.validate_repository(root)
+                self.assertEqual(failures, [])
+
+    def test_print_expected_scenarios(self) -> None:
+        scenarios = [
+            "--print-expected produces canonical stdout only",
+            "--print-expected does not mutate repository state",
+        ]
+        for name in scenarios:
+            with self.subTest(name=name):
+                root, paths = self.with_repo("complete")
+                before = snapshot_tree(root)
+                code, stdout, stderr = self.run_main(root, "--print-expected")
+                after = snapshot_tree(root)
+                self.assertEqual(code, 0)
+                self.assertEqual(stderr, "")
+                self.assertEqual(stdout, validator.render_expected_catalog(root))
+                self.assertEqual(before, after)
+
+    def test_catalog_file_safety_failures(self) -> None:
+        scenarios = [
+            {
+                "name": "missing Catalog",
+                "mutate": lambda root, paths: (root / "docs/internal/PATTERN_CATALOG.md").unlink(),
+                "target": "docs/internal/PATTERN_CATALOG.md",
+                "reason": "Catalog file is missing",
+                "remediation": "Restore docs/internal/PATTERN_CATALOG.md",
+            },
+            {
+                "name": "symlinked Catalog",
+                "mutate": self.make_symlink_catalog,
+                "target": "docs/internal/PATTERN_CATALOG.md",
+                "reason": "symbolic link",
+                "remediation": "regular UTF-8 Markdown file",
+            },
+            {
+                "name": "symlinked docs ancestor",
+                "mutate": self.make_symlink_docs,
+                "target": "docs",
+                "reason": "ancestor directory",
+                "remediation": "regular repository directory",
+            },
+            {
+                "name": "symlinked docs/internal ancestor",
+                "mutate": self.make_symlink_docs_internal,
+                "target": "docs/internal",
+                "reason": "ancestor directory",
+                "remediation": "regular repository directory",
+            },
+            {
+                "name": "non-regular Catalog path",
+                "mutate": lambda root, paths: (
+                    (root / "docs/internal/PATTERN_CATALOG.md").unlink(),
+                    (root / "docs/internal/PATTERN_CATALOG.md").mkdir(),
+                ),
+                "target": "docs/internal/PATTERN_CATALOG.md",
+                "reason": "not a regular file",
+                "remediation": "regular UTF-8 Markdown file",
+            },
+            {
+                "name": "oversized Catalog",
+                "mutate": lambda root, paths: (
+                    root / "docs/internal/PATTERN_CATALOG.md"
+                ).write_bytes(b"x" * (validator.MAX_CATALOG_BYTES + 1)),
+                "target": "docs/internal/PATTERN_CATALOG.md",
+                "reason": "exceeds the maximum size",
+                "remediation": "canonical Catalog content",
+            },
+            {
+                "name": "invalid UTF-8",
+                "mutate": lambda root, paths: (
+                    root / "docs/internal/PATTERN_CATALOG.md"
+                ).write_bytes(b"\xff"),
+                "target": "docs/internal/PATTERN_CATALOG.md",
+                "reason": "not valid UTF-8",
+                "remediation": "valid UTF-8 without BOM",
+            },
+            {
+                "name": "UTF-8 BOM",
+                "mutate": lambda root, paths: (
+                    root / "docs/internal/PATTERN_CATALOG.md"
+                ).write_bytes(b"\xef\xbb\xbf" + validator.render_expected_catalog(root).encode("utf-8")),
+                "target": "docs/internal/PATTERN_CATALOG.md",
+                "reason": "byte order mark",
+                "remediation": "without BOM",
+            },
+            {
+                "name": "missing final newline",
+                "mutate": lambda root, paths: (
+                    root / "docs/internal/PATTERN_CATALOG.md"
+                ).write_text(validator.render_expected_catalog(root).removesuffix("\n"), encoding="utf-8"),
+                "target": "docs/internal/PATTERN_CATALOG.md",
+                "reason": "missing canonical content",
+                "remediation": "canonical expected content",
+            },
+            {
+                "name": "extra final newline",
+                "mutate": lambda root, paths: (
+                    root / "docs/internal/PATTERN_CATALOG.md"
+                ).write_text(validator.render_expected_catalog(root) + "\n", encoding="utf-8"),
+                "target": "docs/internal/PATTERN_CATALOG.md",
+                "reason": "non-canonical content",
+                "remediation": "Remove the extra content",
+            },
+            {
+                "name": "trailing whitespace",
+                "mutate": lambda root, paths: self.replace_line(
+                    root,
+                    INDEX_ROW,
+                    f"{INDEX_ROW} ",
+                ),
+                "target": "docs/internal/PATTERN_CATALOG.md",
+                "reason": "line differs",
+                "remediation": "canonical expected content",
+            },
+        ]
+        for case in scenarios:
+            with self.subTest(name=case["name"]):
+                root, paths = self.with_repo("complete")
+                case["mutate"](root, paths)
+                failures = validator.validate_repository(root)
+                self.assert_failure(
+                    root,
+                    failures,
+                    target_contains=case["target"],
+                    reason_contains=case["reason"],
+                    remediation_contains=case["remediation"],
+                )
+
+    def test_catalog_sync_mismatch_failures(self) -> None:
+        scenarios = [
+            {
+                "name": "missing index row",
+                "mutate": lambda root, paths: self.replace_line(
+                    root,
+                    INDEX_ROW,
+                    "",
+                ),
+            },
+            {
+                "name": "extra index row",
+                "mutate": lambda root, paths: self.insert_after(
+                    root,
+                    INDEX_ROW,
+                    "| extra | Extra | owner/repository | 2026-07-04 | APPROVED | ponytail |",
+                ),
+            },
+            {
+                "name": "duplicate index row",
+                "mutate": lambda root, paths: self.insert_after(
+                    root,
+                    INDEX_ROW,
+                    INDEX_ROW,
+                ),
+            },
+            {
+                "name": "missing Catalog entry",
+                "mutate": lambda root, paths: self.remove_block(
+                    root, re.escape(HEADING_LINE)
+                ),
+            },
+            {
+                "name": "extra Catalog entry",
+                "mutate": lambda root, paths: self.append_text(
+                    root,
+                    "\n### extra: Extra\n\n- **Status**: APPROVED\n",
+                ),
+            },
+            {
+                "name": "duplicate Catalog entry",
+                "mutate": lambda root, paths: self.append_text(
+                    root,
+                    "\n### catalog\\-pattern: Reference Pattern\n\n- **Status**: APPROVED\n",
+                ),
+            },
+            {
+                "name": "incorrect index order",
+                "mutate": lambda root, paths: self.make_two_promotions_out_of_order(root),
+            },
+            {
+                "name": "incorrect entry order",
+                "mutate": lambda root, paths: self.make_two_entries_out_of_order(root),
+            },
+            {"name": "stale Catalog ID", "mutate": lambda root, paths: self.replace_text(root, "catalog\\-pattern", "stale-id", 1)},
+            {"name": "stale pattern name", "mutate": lambda root, paths: self.replace_text(root, "Reference Pattern", "Stale Pattern", 1)},
+            {"name": "stale source repository", "mutate": lambda root, paths: self.replace_text(root, "owner/repository", "other/repo", 1)},
+            {"name": "stale approval date", "mutate": lambda root, paths: self.replace_text(root, "2026\\-07\\-04", "2026-07-09", 1)},
+            {"name": "stale lifecycle status", "mutate": lambda root, paths: self.replace_text(root, "APPROVED", "IMPLEMENTED", 1)},
+            {"name": "stale assigned specialist", "mutate": lambda root, paths: self.replace_text(root, "ponytail", "cloak", 1)},
+            {"name": "stale source URL", "mutate": lambda root, paths: self.replace_text(root, "https://example\\.test/owner/repository", "https://example.test/other/repo", 1)},
+            {"name": "stale source bundle", "mutate": lambda root, paths: self.replace_text(root, "owner\\_\\_repository\\_\\_aaaaaaaaaaaa", "owner__repository__bbbbbbbbbbbb", 1)},
+            {"name": "stale audited commit", "mutate": lambda root, paths: self.replace_text(root, SHA, "b" * 40, 1)},
+            {"name": "stale source file", "mutate": lambda root, paths: self.replace_text(root, "src/example\\.py", "src/other.py", 1)},
+            {"name": "stale line range", "mutate": lambda root, paths: self.replace_text(root, "10\\-20", "1-2", 1)},
+            {"name": "stale pattern-record path", "mutate": lambda root, paths: self.replace_text(root, "internal/artificer/records/owner\\_\\_repository\\_\\_aaaaaaaaaaaa/patterns/reference\\-pattern\\.json", "wrong.json", 1)},
+            {"name": "stale decision ID", "mutate": lambda root, paths: self.replace_text(root, "decision\\-1", "decision-9", 1)},
+            {"name": "stale proposal ID", "mutate": lambda root, paths: self.replace_text(root, "proposal\\-1", "proposal-9", 1)},
+            {"name": "stale promotion ID", "mutate": lambda root, paths: self.replace_text(root, "promotion\\-1", "promotion-9", 1)},
+            {"name": "stale promotion-record path", "mutate": lambda root, paths: self.replace_text(root, "internal/artificer/promotions/catalog\\-pattern\\.json", "internal/artificer/promotions/other.json", 1)},
+            {"name": "stale license", "mutate": lambda root, paths: self.replace_text(root, "MIT", "Apache-2.0", 1)},
+            {"name": "stale attribution flag", "mutate": lambda root, paths: self.replace_text(root, "true", "false", 1)},
+            {"name": "stale attribution summary", "mutate": lambda root, paths: self.replace_text(root, "Retain attribution\\.", "Different summary.", 1)},
+            {"name": "stale pattern classification", "mutate": lambda root, paths: self.replace_text(root, "REFERENCE\\_ONLY", "ADAPTED_PATTERN", 1)},
+            {"name": "stale pattern description", "mutate": lambda root, paths: self.replace_text(root, "Source\\-backed pattern\\.", "Stale description.", 1)},
+            {
+                "name": "promotion exists while Catalog remains empty",
+                "mutate": lambda root, paths: (root / "docs/internal/PATTERN_CATALOG.md").write_text(empty_catalog_text(), encoding="utf-8"),
+            },
+            {
+                "name": "Catalog entry exists without a promotion",
+                "mutate": lambda root, paths: self.append_text(
+                    root,
+                    "\n### stale: Stale Entry\n\n- **Status**: APPROVED\n",
+                ),
+            },
+        ]
+        for case in scenarios:
+            with self.subTest(name=case["name"]):
+                root, paths = self.with_repo("complete")
+                case["mutate"](root, paths)
+                failures = validator.validate_repository(root)
+                self.assert_failure(
+                    root,
+                    failures,
+                    target_contains="docs/internal/PATTERN_CATALOG.md",
+                    reason_contains="Catalog",
+                    remediation_contains="print-expected",
+                )
+
+    def test_governance_and_cli_failures(self) -> None:
+        scenarios = [
+            {
+                "name": "two promotions target the same source pattern pair",
+                "mutate": self.make_duplicate_source_pair,
+                "exit_code": 1,
+                "target": "internal/artificer/promotions",
+                "reason": "same (source_bundle_id, pattern_record_path) pair",
+            },
+            {
+                "name": "Phase 4B governance precondition failure",
+                "mutate": lambda root, paths: update_json(
+                    paths["promotion"],
+                    lambda data: data.__setitem__("decision_id", "missing"),
+                ),
+                "exit_code": 1,
+                "target": "internal/artificer/promotions/catalog-pattern.json",
+                "reason": "approved decision",
+            },
+            {
+                "name": "missing schema configuration",
+                "mutate": lambda root, paths: (root / "internal/artificer/PROMOTION_RECORD_SCHEMA.json").unlink(),
+                "exit_code": 2,
+                "target": "Configuration error",
+                "reason": "Schema file missing",
+            },
+            {
+                "name": "malformed schema configuration",
+                "mutate": lambda root, paths: (root / "internal/artificer/PROMOTION_RECORD_SCHEMA.json").write_text("{", encoding="utf-8"),
+                "exit_code": 2,
+                "target": "Configuration error",
+                "reason": "Schema file invalid",
+            },
+            {
+                "name": "unsupported schema configuration",
+                "mutate": lambda root, paths: update_json(
+                    root / "internal/artificer/PROMOTION_RECORD_SCHEMA.json",
+                    lambda data: data.__setitem__("minLength", 1),
+                ),
+                "exit_code": 2,
+                "target": "Configuration error",
+                "reason": "unsupported keyword",
+            },
+        ]
+        for case in scenarios:
+            with self.subTest(name=case["name"]):
+                root, paths = self.with_repo("complete")
+                case["mutate"](root, paths)
+                code, stdout, stderr = self.run_main(root)
+                self.assertEqual(code, case["exit_code"])
+                self.assertEqual(stderr, "")
+                self.assertIn(case["target"], stdout)
+                self.assertIn(case["reason"], stdout)
+
+        root, paths = self.with_repo("complete")
+        code, stdout, stderr = self.run_main(root, "--write")
+        self.assertEqual(code, 2)
+        self.assertEqual(stdout, "")
+        self.assertIn("usage:", stderr)
+
+    def make_symlink_catalog(self, root: Path, paths: dict[str, Path]) -> None:
+        actual = root / "docs/internal/real-catalog.md"
+        actual.write_text(validator.render_expected_catalog(root), encoding="utf-8")
+        catalog = root / "docs/internal/PATTERN_CATALOG.md"
+        catalog.unlink()
+        os.symlink(actual, catalog)
+
+    def make_symlink_docs(self, root: Path, paths: dict[str, Path]) -> None:
+        original = root / "docs"
+        target = root / "real-docs"
+        shutil.move(str(original), str(target))
+        os.symlink(target, original)
+
+    def make_symlink_docs_internal(self, root: Path, paths: dict[str, Path]) -> None:
+        original = root / "docs/internal"
+        target = root / "docs/real-internal"
+        shutil.move(str(original), str(target))
+        os.symlink(target, original)
+
+    def replace_text(self, root: Path, pattern: str, replacement: str, count: int) -> None:
+        path = root / "docs/internal/PATTERN_CATALOG.md"
+        text = path.read_text(encoding="utf-8")
+        updated = text.replace(pattern, replacement, count)
+        path.write_text(updated, encoding="utf-8")
+
+    def replace_line(self, root: Path, old: str, new: str) -> None:
+        path = root / "docs/internal/PATTERN_CATALOG.md"
+        text = path.read_text(encoding="utf-8")
+        path.write_text(text.replace(old, new, 1), encoding="utf-8")
+
+    def insert_after(self, root: Path, needle: str, addition: str) -> None:
+        path = root / "docs/internal/PATTERN_CATALOG.md"
+        text = path.read_text(encoding="utf-8")
+        path.write_text(text.replace(needle, f"{needle}\n{addition}", 1), encoding="utf-8")
+
+    def append_text(self, root: Path, text: str) -> None:
+        path = root / "docs/internal/PATTERN_CATALOG.md"
+        path.write_text(path.read_text(encoding="utf-8") + text, encoding="utf-8")
+
+    def remove_block(self, root: Path, heading_pattern: str) -> None:
+        path = root / "docs/internal/PATTERN_CATALOG.md"
+        lines = path.read_text(encoding="utf-8").splitlines()
+        start = next(i for i, line in enumerate(lines) if re.search(heading_pattern, line))
+        end = len(lines)
+        for index in range(start + 1, len(lines)):
+            if lines[index].startswith("### "):
+                end = index
+                break
+        remaining = lines[:start] + lines[end:]
+        path.write_text("\n".join(remaining).rstrip() + "\n", encoding="utf-8")
+
+    def make_two_promotions_out_of_order(self, root: Path) -> None:
+        add_complete_chain(
+            root,
+            bundle_id=OTHER_BUNDLE,
+            catalog_id="a-catalog-pattern",
+            promotion_id="promotion-2",
+            decision_id="decision-2",
+            proposal_id="proposal-2",
+            audit_id="audit-2",
+            pattern_slug="another-pattern",
+            pattern_name="Another Pattern",
+        )
+        expected = validator.render_expected_catalog(root)
+        first = "| a\\-catalog\\-pattern | Another Pattern | owner/repository-two | 2026\\-07\\-04 | APPROVED | ponytail |"
+        second = INDEX_ROW
+        text = expected.replace(first, "__A__").replace(second, first).replace("__A__", second)
+        (root / "docs/internal/PATTERN_CATALOG.md").write_text(text, encoding="utf-8")
+
+    def make_two_entries_out_of_order(self, root: Path) -> None:
+        add_complete_chain(
+            root,
+            bundle_id=OTHER_BUNDLE,
+            catalog_id="a-catalog-pattern",
+            promotion_id="promotion-2",
+            decision_id="decision-2",
+            proposal_id="proposal-2",
+            audit_id="audit-2",
+            pattern_slug="another-pattern",
+            pattern_name="Another Pattern",
+        )
+        expected = validator.render_expected_catalog(root)
+        entry_a = (
+            "### a\\-catalog\\-pattern: Another Pattern\n\n"
+            "- **Status**: APPROVED\n"
+        )
+        entry_b = (
+            "### catalog\\-pattern: Reference Pattern\n\n"
+            "- **Status**: APPROVED\n"
+        )
+        text = expected.replace(entry_a, "__A__").replace(entry_b, entry_a).replace("__A__", entry_b)
+        (root / "docs/internal/PATTERN_CATALOG.md").write_text(text, encoding="utf-8")
+
+    def make_duplicate_source_pair(self, root: Path, paths: dict[str, Path]) -> None:
+        data = read_json(paths["promotion"])
+        data["promotion_id"] = "promotion-2"
+        data["catalog_pattern_id"] = "dup-catalog"
+        write_json(root / "internal/artificer/promotions/dup-catalog.json", data)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Implements Artificer Phase 4C-B by adding a deterministic, read-only governance gate for the Orchestra Pattern Catalog.

The new validator verifies that:

```text
docs/internal/PATTERN_CATALOG.md
```

is an exact human-readable projection of the validated promotion records stored in:

```text
internal/artificer/promotions/*.json
```

Promotion remains entirely manual. Validated JSON records remain canonical, and Artificer does not automatically modify the Pattern Catalog or gain approval, promotion, or implementation authority.

## What Changed

### Pattern Catalog governance gate

Added:

* `scripts/validate_artificer_pattern_catalog.py`

The validator:

* runs the existing Phase 4B governance-record validator as a prerequisite;
* fails closed when governance records or cross-record relationships are invalid;
* derives the expected Pattern Catalog from validated promotion, source-intake, and pattern records;
* compares the committed Catalog against the canonical projection;
* reports deterministic, line-specific synchronization failures;
* performs no file writes;
* performs no network access;
* invokes no subprocesses;
* installs no dependencies;
* executes no external code.

### Canonical Catalog projection

The Catalog now uses a fixed deterministic structure containing:

* a Catalog index;
* one detailed entry per validated promotion record;
* canonical lifecycle status;
* complete source traceability;
* governance decision and proposal references;
* licensing and attribution information;
* assigned specialist ownership;
* source pattern classification and description.

Each Catalog entry includes:

* Status
* Source Repository
* Source URL
* Source Bundle
* Audited Commit
* Source File
* Line Range
* Pattern Record
* Decision Record
* Proposal Record
* Promotion Record
* Promotion Record Path
* Approval Date
* Original License
* Attribution Required
* Attribution Summary
* Orchestra Specialist Owner
* Pattern Classification
* Pattern Description

The validator does not infer or maintain Markdown-only fields such as adaptation branches, implementation locations, or implementation summaries.

### One-to-one synchronization controls

The gate enforces that:

* every validated promotion record appears exactly once in the Catalog index;
* every validated promotion record appears exactly once in the Catalog entries;
* no Catalog row or entry exists without a corresponding promotion record;
* lifecycle status exactly matches the promotion record;
* index rows and detailed entries use identical canonical ordering;
* duplicate source-pattern promotions are rejected;
* an empty promotion registry requires the canonical empty Catalog state.

The current repository has no promotion records, so the committed Catalog remains in the canonical empty state.

### Deterministic ordering

Promotion projections are sorted using:

```python
(
    catalog_pattern_id.casefold(),
    catalog_pattern_id,
)
```

The output remains stable across:

* operating systems;
* filesystem enumeration order;
* promotion-file creation order;
* JSON key insertion order;
* repeated executions.

### Markdown and path safety

The validator:

* escapes Markdown control characters;
* prevents injected headings, links, block quotes, HTML, lists, and directives;
* preserves repeated spaces and tabs;
* converts CR and LF record newlines to spaces;
* normalizes Catalog CRLF and CR line endings for cross-platform comparison;
* rejects UTF-8 BOMs and invalid UTF-8;
* rejects symbolic-link Catalog files and ancestor directories;
* rejects non-regular and oversized Catalog files;
* prevents absolute local paths from appearing in validation output.

Catalog synchronization remains strict for:

* trailing whitespace;
* missing final newline;
* extra final newlines;
* reordered content;
* stale field values;
* missing or extra rows and entries.

### CLI contract

Default validation:

```powershell
python scripts/validate_artificer_pattern_catalog.py
```

Optional repository root:

```powershell
python scripts/validate_artificer_pattern_catalog.py `
  --repo-root <path>
```

Preview the canonical expected Catalog:

```powershell
python scripts/validate_artificer_pattern_catalog.py `
  --print-expected
```

`--print-expected` writes only to standard output and does not modify the repository.

Exit codes:

```text
0 — validation passed or expected projection printed
1 — governance, Catalog safety, projection, or synchronization failure
2 — invalid CLI arguments or validator configuration failure
```

No automatic write, update, fix, or apply option is provided.

### Behavior coverage

Added:

* `tests/behavior/test_artificer_pattern_catalog.py`

Coverage includes:

* 6 test methods;
* 16 named passing scenarios;
* 48 named negative scenarios.

Passing scenarios include:

* canonical empty Catalog;
* one approved promotion;
* `APPROVED`, `IMPLEMENTING`, `IMPLEMENTED`, and `RETIRED` lifecycles;
* multiple promotions in canonical order;
* repeated-render determinism;
* opposite promotion-file creation orders;
* opposite JSON key insertion orders;
* Markdown-special characters;
* repeated spaces and tabs;
* CRLF Catalog normalization;
* exact final newline;
* canonical stdout preview;
* preview non-mutation.

Negative scenarios include:

* missing, symlinked, non-regular, oversized, BOM, and invalid UTF-8 Catalog files;
* missing or extra final newlines;
* trailing whitespace;
* missing, extra, or duplicate index rows;
* missing, extra, or duplicate entries;
* incorrect index and entry ordering;
* stale Catalog IDs and metadata fields;
* stale source traceability;
* stale governance references;
* stale licensing and attribution data;
* stale classification and description;
* promotion records absent from the Catalog;
* Catalog entries without promotion records;
* duplicate source-pattern promotions;
* Phase 4B governance failures;
* missing, malformed, and unsupported schema configuration;
* invalid CLI arguments.

### Governance integration

Updated:

* `scripts/governance_check.py`
* `scripts/test_governance_check.py`
* `tests/behavior/run_tests.py`

The Pattern Catalog validator is registered in both:

```text
REQUIRED_VALIDATION_SCRIPTS
STRICT_VALIDATOR_SCRIPTS
```

It therefore runs as part of strict governance validation without requiring GitHub Actions workflow changes.

### Documentation and repository state

Updated:

* `CHANGELOG.md`
* `DECISION_LOG.md`
* `PROJECT_STATE.md`
* `SESSION_HANDOFF.md`
* `docs/internal/ARTIFICER_PHASE4_GOVERNANCE_CONTRACT.md`
* `docs/internal/ARTIFICER_WORKFLOW.md`
* `docs/internal/PATTERN_CATALOG.md`
* `internal/artificer/CHECKLIST.md`
* `internal/artificer/promotions/README.md`

The documentation now establishes the governed sequence:

```text
Approved Decision
→ Approved Proposal
→ Manual Promotion Record
→ Manual Pattern Catalog Synchronization
→ Phase 4C-B Catalog Gate
→ Specialist-Owned Implementation
```

It also clarifies that:

* promotion records are created manually;
* the Catalog is synchronized manually;
* JSON governance records remain authoritative;
* the validator never edits the Catalog;
* lifecycle status remains specialist- and maintainer-controlled;
* Artificer receives no approval or implementation authority.

## Validation

The complete validation matrix passed:

* Python compilation checks: passed
* Artificer internal validator: passed
* Artificer source-record validator: passed
* Artificer governance-record validator: passed
* Pattern Catalog validator: passed
* Artificer internal tests: `52 passed`
* Artificer source-record tests: `62 passed`
* Artificer governance-record tests: `17 passed`, `1 platform-dependent skip`
* Audit renderer tests: `10 passed`
* Pattern Catalog tests: `6 passed`
* Pattern Catalog passing scenarios: `16`
* Pattern Catalog negative scenarios: `48`
* Governance helper tests: passed
* Integrated behavior suite: passed
* Strict governance: `0 errors, 0 warnings`
* Runtime tests: `43 passed`
* Runtime coverage: `95.51%`
* Preview non-mutation check: passed
* `git diff --check`: passed
* Working tree after commit: clean

## Scope Boundaries

This pull request does not:

* automatically modify the Pattern Catalog;
* automatically create promotion records;
* alter Artificer JSON schemas;
* modify the Phase 4B governance-record validator;
* modify the Phase 4C-A audit renderer;
* grant Artificer approval, promotion, or implementation authority;
* audit OpenHero or Strix;
* create Phase 4.5 pilot records;
* clone, fetch, install, compile, or execute external repositories;
* modify runtime behavior;
* modify adapters;
* modify public routing or manifests;
* modify GitHub Actions workflows.

## Relationship to Previous Phases

This work builds on:

* Phase 4A governance contracts;
* Phase 4B governance-record validation;
* Phase 4B post-merge hardening;
* Phase 4C-A deterministic audit-report rendering through PR #165.

Phase 4C-B completes the Pattern Catalog synchronization and governance gate required before Phase 4.5 pilot intake can begin.

## Next Phase

After this pull request is merged and `main` is synchronized, Phase 4.5 may begin independent governed pilot audits of:

* `CristianOlivera1/openhero`
* `usestrix/strix`

Those repositories remain unaudited and must not be cloned, installed, compiled, or executed inside the Orchestra workspace.
