### PR TITLE
docs: sync v1.1.2 post-release status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ Specialist Governance & Boundary Standard is a documentation-, governance-, meta
 
 ## v1.1.2 - Trusted Runtime Authority
 
-This patch is prepared for maintainer review. The `v1.1.2` tag and GitHub Release remain pending a separate post-merge publication gate.
+This patch was published on July 14, 2026 as the `v1.1.2` GitHub Release.
 
 ### Added
 - Implemented Issue #182 Phase 6B-D trusted runtime composition and Phase 6C adversarial validation, including explicit finite authority modes, immutable route bindings, authority and capability enforcement before governance, single initialization per root or child run identity, manifest-grant provenance and binding-owner validation, structured lifecycle and terminal-result integration, bounded in-process delegated execution, deterministic audit evidence, and lifecycle source-state enforcement for `ACTIVATE`, `WAIT`, and `RESUME`. Missing capability identifiers retain runtime `CAPABILITY_DENIED` behavior.

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -10,7 +10,7 @@ A governance-first specialist skill framework that routes complex AI-assisted so
 Open-source developer tooling and AI orchestration framework
 
 ## Current Stage
-Public release `v1.1.1`, with target patch `v1.1.2` in release preparation under Issue #184
+Public release `v1.1.2` (Trusted Runtime Authority), with post-release UI engineering and validation governance merged through PR #187
 
 ## Primary Users
 Developers and maintainers who install Orchestra as a plugin, skill set, or runtime package inside a supported or scaffold-only IDE or coding host (Claude Code, Codex, Antigravity, Cursor, Windsurf, JetBrains, Zed, Neovim)

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,16 +1,16 @@
 # Project State
 
 - **Project Name:** Orchestra
-- **Active Repo:** `C:\+conductor`
+- **Active Repo:** `C:\conductor`
 - **Canonical Branch:** `main`
 - **Base Branch:** `main`
-- **Active Worktree:** `C:\+conductor\.tmp\v1.1.2-trusted-runtime-authority`
-- **Active Branch:** `release/v1.1.2-trusted-runtime-authority`
-- **Approved Base:** `96adf09ea898dbc43f55a691f2587cf5ba75084c`
-- **Current Public Release:** `v1.1.1`
-- **Target Prepared Release:** `v1.1.2`
-- **Current Stable State:** Phase 6B-A through Phase 6C merged through PR #183; Issues #178, #180, and #182 closed
-- **Current Task:** Issue #184 combined Phase 6D-A through Phase 6D-C release preparation
+- **Active Worktree:** `C:\conductor`
+- **Active Branch:** `fix/claude-marketplace-version-sync`
+- **Approved Base:** `9b82849179c4ef11382e8835316153ed8d3c9d6e`
+- **Current Public Release:** `v1.1.2`
+- **Release Status:** Published July 14, 2026
+- **Current Stable State:** `v1.1.2` published; README transparency and UI engineering and validation governance merged through PR #187
+- **Current Task:** Post-release maintenance
 - **Phase 6D-A:** Complete locally; four canonical promotions are `IMPLEMENTED`, with traceability, Apache-2.0 attribution, and `automatic_promotion: false` preserved
 - **Phase 6D-B:** Complete locally; Pattern Catalog, README, runtime, setup, compatibility, roadmap, and adapter-maturity documentation synchronized
 - **Phase 6D-C:** Complete locally; release metadata, release notes, changelog, two complete validation passes, and exact-scope audit passed
@@ -18,9 +18,9 @@
 - **Adapter Maturity:** Codex, Claude Code, and Antigravity are supported; Cursor, Windsurf, VS Code/VSCodium, JetBrains, Zed, and Neovim remain scaffold-only
 - **Latest Validation:** Second authoritative Phase 6D pass: 194 runtime tests passed at 97.72% coverage; behavior runner passed with 153 reported unittest cases and one skip; strict governance passed with 0 errors and 0 warnings
 - **Full Validation Baseline:** Two complete Phase 6D passes matched; exact revised scope is 31 files, 30 modified and 1 added, with zero staged files
-- **Publication Boundary:** No commit, push, pull request, tag, or GitHub Release is authorized in this batch
-- **Next Gate:** Maintainer review of the unstaged Phase 6D diff; merge and publication remain separately gated
-- **Issue:** #184 - release: finalize authority promotions and prepare v1.1.2
-- **Do-Not-Touch:** Runtime, tests, scripts, workflows, skills, commands, schemas, validators, adapter implementation, and `C:\+AA`
+- **Publication Status:** Issue #184 closed; PR #185 merged; `v1.1.2` tag and GitHub Release published
+- **Next Gate:** Normal post-release maintenance through reviewed pull requests
+- **Issue:** #184 closed after `v1.1.2` publication
+- **Maintenance Boundary:** Keep unrelated runtime, tests, scripts, workflows, skills, commands, schemas, validators, and adapter implementation out of documentation-only release syncs
 
 This file records current verified state only. Historical decisions remain in `DECISION_LOG.md` and `CHANGELOG.md`.

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,20 +1,20 @@
 # Session Handoff
 
-- **Current Stable State:** Phase 6B-A through Phase 6C merged through PR #183; Issues #178, #180, and #182 closed
-- **Current Task:** Issue #184 combined Phase 6D-A through Phase 6D-C release preparation
-- **Current Repo:** `C:\+conductor`
+- **Current Stable State:** `v1.1.2` published; post-release README transparency and UI engineering and validation governance merged through PR #187
+- **Current Task:** Synchronize stale post-release documentation references
+- **Current Repo:** `C:\conductor`
 - **Canonical Branch:** `main`
 - **Base Branch:** `main`
-- **Exact Worktree:** `C:\+conductor\.tmp\v1.1.2-trusted-runtime-authority`
-- **Exact Branch:** `release/v1.1.2-trusted-runtime-authority`
-- **Approved Base:** `96adf09ea898dbc43f55a691f2587cf5ba75084c`
-- **Current Public Release:** `v1.1.1`
-- **Target Prepared Release:** `v1.1.2`
-- **Completed This Batch:** Phase 6D-A promotion finalization; Phase 6D-B Catalog and documentation synchronization; Phase 6D-C version normalization, release notes, and changelog preparation
-- **Current Checkpoint:** Phase 6D-C complete locally and ready for maintainer review
+- **Exact Worktree:** `C:\conductor`
+- **Exact Branch:** `fix/claude-marketplace-version-sync`
+- **Approved Base:** `9b82849179c4ef11382e8835316153ed8d3c9d6e`
+- **Current Public Release:** `v1.1.2`
+- **Release Status:** Published July 14, 2026
+- **Completed Release:** Issue #184 closed; PR #185 merged; `v1.1.2` tag and GitHub Release published
+- **Current Checkpoint:** Current-facing release documentation aligned with published `v1.1.2`
 - **Last Validation:** Second authoritative Phase 6D pass: 194 runtime tests passed at 97.72% coverage; behavior runner passed with 153 reported unittest cases and one skip; strict governance passed with 0 errors and 0 warnings
 - **Validation State:** Two complete validation passes matched after the evidence update; exact revised scope is 31 files, 30 modified and 1 added, with zero staged files
-- **Allowed Scope:** Issue #184 revised 31-file scope, 30 modified and 1 added, including the authorized Claude marketplace version-only change
-- **Boundary Rules:** Do not modify runtime, tests, validators, schemas, scripts, workflows, skills, commands, adapter implementation, or external-source records. Do not stage, commit, push, open a pull request, merge, tag, publish, or close Issue #184
-- **Publication Boundary:** The `v1.1.2` tag and GitHub Release require a separate post-merge human-authorized gate
-- **Next Step:** Maintainer reviews the unstaged Phase 6D diff. Commit, push, pull request, merge, Issue #184 closure, tag, and GitHub Release actions require separate authorization
+- **Allowed Scope:** Current-facing post-release documentation only; Claude manifests remain unchanged because both already use `1.1.2`
+- **Boundary Rules:** Do not modify runtime, tests, validators, schemas, scripts, workflows, skills, commands, adapter implementation, or external-source records
+- **Publication Status:** `v1.1.2` is published and marked Latest on GitHub
+- **Next Step:** Review and merge the focused post-release documentation sync

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -1,6 +1,6 @@
 # Codex Adapter for Orchestra
 
-This adapter provides a Codex-compatible export of the current Orchestra skills. The repository is preparing `v1.1.2`; the public release remains `v1.1.1` until the separate post-merge publication gate succeeds.
+This adapter provides a Codex-compatible export of the current Orchestra skills for the published `v1.1.2` release.
 
 ## Purpose
 

--- a/docs/project/V1_READINESS_CHECKLIST.md
+++ b/docs/project/V1_READINESS_CHECKLIST.md
@@ -1,6 +1,6 @@
 # v1.1.2 Trusted Runtime Authority Readiness Checklist
 
-Public release remains `v1.1.1`. Target patch `v1.1.2` is prepared only when every Phase 6D check passes; tag creation and GitHub Release publication require a separate post-merge gate.
+`v1.1.2` completed every Phase 6D gate and was published on July 14, 2026.
 
 - [x] **Trusted runtime merged**: Phase 6B-A through Phase 6C merged through PR #183.
 - [x] **Authority and capability ordering**: Exact authority and runtime capability evaluation precede governance.
@@ -13,5 +13,5 @@ Public release remains `v1.1.1`. Target patch `v1.1.2` is prepared only when eve
 - [x] **Release notes and changelog prepared**: `v1.1.2` release notes exist and changelog entries are synchronized.
 - [x] **Complete final validation passed twice**: Final evidence update is followed by a second authoritative full validation run.
 - [x] **Exact scope verified**: Only Issue #184 authorized files are changed, with zero staged files.
-- [ ] **Maintainer review completed**: Unstaged Phase 6D diff is accepted before any commit or publication action.
-- [ ] **Post-merge publication authorized**: Annotated tag and GitHub Release remain uncreated until separate approval.
+- [x] **Maintainer review completed**: Phase 6D changes merged through PR #185.
+- [x] **Post-merge publication completed**: Annotated `v1.1.2` tag and GitHub Release were published.

--- a/docs/releases/v1.1.2-trusted-runtime-authority.md
+++ b/docs/releases/v1.1.2-trusted-runtime-authority.md
@@ -1,6 +1,6 @@
 # Orchestra v1.1.2: Trusted Runtime Authority
 
-`v1.1.2` is prepared for maintainer review. The current public release remains `v1.1.1`; no `v1.1.2` tag or GitHub Release is created by this release-preparation branch.
+`v1.1.2` was published on July 14, 2026 after the release-preparation changes merged through PR #185.
 
 ## Release Theme
 

--- a/docs/setup/COMPATIBILITY.md
+++ b/docs/setup/COMPATIBILITY.md
@@ -1,6 +1,6 @@
 # Compatibility
 
-The public release remains Orchestra `v1.1.1` while `v1.1.2` is prepared. The prepared patch keeps the Markdown-first, runtime-core-first baseline and adds trusted runtime authority, capabilities, delegation, lifecycle control, and audit evidence without changing host maturity claims.
+The current public release is Orchestra `v1.1.2`. It keeps the Markdown-first, runtime-core-first baseline and adds trusted runtime authority, capabilities, delegation, lifecycle control, and audit evidence without changing host maturity claims.
 
 Scaffold-only hosts are not yet full support claims. Promotion requirements and graduation order live in `docs/project/SCAFFOLD_ADAPTER_GRADUATION_CRITERIA.md`.
 

--- a/docs/setup/INSTALLATION.md
+++ b/docs/setup/INSTALLATION.md
@@ -4,7 +4,7 @@ Orchestra can be installed in several ways depending on your AI host or IDE:
 
 ## Release Status
 
-The current public release is `v1.1.1`. Target patch `v1.1.2` is in release preparation and is not published until the Phase 6D branch merges and the separate publication gate succeeds.
+The current public release is `v1.1.2`, published July 14, 2026 after the Phase 6D release gate completed.
 
 | Host | Install Surface | Current Status |
 |---|---|---|


### PR DESCRIPTION
## Summary

Synchronizes current-facing release and project-state documentation with the published `v1.1.2` release.

## Changes

- Updated release, setup, compatibility, adapter, project-context, project-state, and handoff references from pre-publication wording to the published `v1.1.2` state.
- Marked the Phase 6D maintainer-review and publication gates complete.
- Recorded Issue #184 closure, PR #185 merge, and the July 14, 2026 GitHub Release publication.
- Left `.claude-plugin/marketplace.json` unchanged because it and `.claude-plugin/plugin.json` already use version `1.1.2`.
- No runtime, validator, manifest, skill, command, schema, workflow, or test files were modified.

## Reason

The requested `1.1.0` to `1.1.1` marketplace change was based on stale state. Current manifests already match at `1.1.2`, and GitHub marks `v1.1.2` as the latest release. The remaining mismatch was in current-facing documentation that still described `v1.1.2` as unpublished.

The Claude plugin validator now reports:

```text
PASS: Manifest version and marketplace plugin version match
All checks passed.
```

## Validation

```text
python scripts/validate_claude_plugin.py
python scripts/check_for_updates.py
python scripts/validate_manifest.py
python scripts/governance_check.py --strict
git diff --check
git diff -- .claude-plugin/marketplace.json
git status --short
```