### PR TITLE
docs: document and close out Phase B

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Phase B instruction-level delegated governance was merged into `main` through PR
 - Updated `scripts/validate_governance_protocol_consistency.py` and `tests/behavior/test_governance_protocol_consistency.py` to enforce exact record schemas and reject unqualified stale Phase B status claims while preserving clearly qualified Phase A history.
 - Updated `tests/behavior/test_router_contracts.py` with reference-integrity cases plus the contract-driven trace evaluator and 11 required negative mutations.
 - Corrected current Phase A-D and deployment status across the delegated execution policy, governance layer, governance review flow, and implementation plan. PR #190 has been merged.
+- Updated `README.md` with the merged delegated phase progression loop, all six transition dispositions, checkpoint behavior, owner-relay reduction, and the preserved external-action boundary.
+- Stabilized `PROJECT_STATE.md` and `SESSION_HANDOFF.md` after the PR #191 post-merge synchronization.
 
 ## Unreleased - Phase A Delegated Autonomous Governance Contract Design
 

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -4,26 +4,20 @@
 - **Active Repo:** `C:\conductor`
 - **Canonical Branch:** `main`
 - **Base Branch:** `main`
-- **Active Branch:** `docs/phase-b-post-merge-state-sync`
+- **Stable Continuation Branch:** `main`
 - **Current Public Release:** `v1.1.2`
 - **Release Status:** Published July 14, 2026
-- **Current Task:** Phase B post-merge canonical state synchronization
 - **Phase A:** Merged / Canonical (`docs/governance/DELEGATED_EXECUTION_POLICY.md`)
 - **Phase B:** Merged / Canonical through PR #190
 - **Phase B Merge Commit:** `d37a2f7b31543efacf7a5e81c3f4d08c12da017d`
-- **Former Feature Head:** `861e70b6f06aa823e0a52f017bc0a39faf76c2e7`
 - **PR #190:** Merged and closed (`2026-07-21T23:44:55Z`)
-- **Implementation Commit:** `777eca8a1dc3a2a6b281f6ebcf16c7cfcde9b4d8` (`777eca8`)
-- **State-Sync Commit:** `702ef005946cab69725267d0e4e89abd0c67ae99` (`702ef00`)
-- **Codex Mirror Correction Commit:** `44350ece2989b5dcae9acae9c5658e3cefcb75d5` (`44350ec`)
-- **Maintainer Correction Commit:** `b2d54461c8b37e4e1bc5d3d3df00da3cf2cb9806` (`b2d5446`)
-- **Decision-Log Correction Commit:** `017b79a2cd0893990721a3c8391ca4e743666cac` (`017b79a`)
-- **Latest Validated Content-Correction Head:** `017b79a2cd0893990721a3c8391ca4e743666cac`
-- **Prior Immutable State-Sync Head:** `c3ce31cc37b1f70bcb6e0aa4b3786cdb6c420b0f` (`c3ce31c`)
-- **Decision-Log Correction:** Unsupported Phase B file claims removed; delegated-phase-trace fixture recorded accurately.
+- **Post-Merge State Synchronization:** Merged through PR #191
+- **Post-Merge Synchronization Commit:** `93cf3904fd593eaf267a76598a0d2ccc1514da99`
+- **PR #191:** Merged and closed (`2026-07-22T00:06:15Z`)
+- **Phase B Release / Deployment:** Not performed
+- **Active Phase B Implementation Task:** None
 - **Phase C:** Not started
-- **Phase D:** Not started; requires separate authorization
-- **Release / Deployment:** Not performed
+- **Phase D:** Not started
 - **Latest Validation:**
   - Governance protocol consistency: PASS (`scripts/validate_governance_protocol_consistency.py`, `tests/behavior/test_governance_protocol_consistency.py`)
   - Routing contract: PASS (`scripts/validate_routing_contract.py`, `tests/behavior/test_router_contracts.py`)
@@ -32,9 +26,13 @@
   - Codex export validation: PASS (`adapters/codex/validate_codex_export.py`)
   - Structure, Manifest, IDE packaging, Governance check, Stale references: PASS
   - Runtime tests & coverage: PASS (194 tests passed; 97.72% coverage)
-  - GitHub Actions CI: PASS (9/9 checks pass on mark-ready authorization head `c3ce31c` for PR #190)
-- **Maintainer Findings:** All prior findings resolved; none pending before the next immutable review.
-- **Publication / Action Flags:** Standing external-action flags set to false (no merge, tag, release, deploy, or destructive operations executed).
-- **Next Gate:** Maintainer review of the post-merge synchronization PR
+- **Startup Verification Rule:** Resolve current `main` rather than recording a self-referential closeout SHA:
+  ```powershell
+  git switch main
+  git fetch origin
+  git rev-parse origin/main
+  python scripts\preflight_sync_check.py
+  ```
+- **Next Ecosystem Priority:** Resume Pathway Batch 7A under a separately verified and updated project prompt; do not infer Pathway repository authority from this record.
 
-This file records current verified state only. Historical decisions remain in `DECISION_LOG.md` and `CHANGELOG.md`.
+This file records stable current state only. Historical decisions remain in `DECISION_LOG.md` and `CHANGELOG.md`.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,56 @@ The sequence is deliberate:
 8. Structured lifecycle signals record waiting or a distinct terminal result.
 9. Run-linked audit events record what happened without granting permission.
 
+## Delegated Phase Progression
+
+For an approved delegated phase, a human or maintainer authorizes the phase and its execution envelope once. Conductor may then route only the internal units already approved by that envelope. Specialists execute inside those bounds, while Overseer and repository validators produce current evidence. Arbiter evaluates that evidence and emits the next transition disposition.
+
+Accepted units create checkpoints. Unchanged approved units can continue without repeated owner relay, but Orchestra still escalates missing intent, contradictions, scope expansion, policy decisions, protected actions, and unauthorized external actions.
+
+~~~mermaid
+flowchart TD
+    Authorized["Authorized Phase + Execution Envelope"]
+    Unit["Approved Unit Execution"]
+    Evidence["Current Evidence"]
+    Arbiter{"Arbiter Disposition"}
+    Checkpoint["Checkpoint Accepted Unit"]
+    Next{"Another Approved Unit?"}
+    Remediate["Deterministic In-Scope Remediation"]
+    WaitEvidence["Wait for Evidence"]
+    WaitCapacity["Capacity Checkpoint + Resume Later"]
+    Human["Human Decision or Authority"]
+    Stop["Preserve State + Halt"]
+    PhaseValidation["Phase Validation"]
+    HumanReview["Human Review"]
+
+    Authorized --> Unit --> Evidence --> Arbiter
+    Arbiter -- AUTO_CONTINUE --> Checkpoint --> Next
+    Next -- Yes --> Unit
+    Next -- No --> PhaseValidation --> HumanReview
+    Arbiter -- AUTO_REMEDIATE_AND_REVALIDATE --> Remediate --> Unit
+    Arbiter -- WAIT_FOR_EVIDENCE --> WaitEvidence --> Evidence
+    Arbiter -- WAIT_FOR_CAPACITY --> WaitCapacity --> Unit
+    Arbiter -- ESCALATE_HUMAN --> Human --> Authorized
+    Arbiter -- STOP --> Stop
+~~~
+
+Accessible summary: an authorized phase executes one approved unit, produces evidence, and asks Arbiter for the next disposition. Accepted units checkpoint before the next approved unit. Other dispositions remediate and revalidate, wait for evidence or capacity, escalate for human authority, or stop. After the final accepted unit, phase validation leads to human review.
+
+| Transition disposition | Meaning |
+|---|---|
+| `AUTO_CONTINUE` | Begin the next approved unit. |
+| `AUTO_REMEDIATE_AND_REVALIDATE` | Correct a deterministic in-scope defect and rerun the required checks. |
+| `WAIT_FOR_EVIDENCE` | Pause until required evidence is produced. |
+| `WAIT_FOR_CAPACITY` | Checkpoint safely and resume later without treating capacity as a new owner decision. |
+| `ESCALATE_HUMAN` | Request missing intent, policy, scope, or external-action authority. |
+| `STOP` | Preserve a prohibited, unsafe, or invalid state and halt. |
+
+Validation proves conformance to the authorized envelope; it cannot create authority. Stage, commit, push, pull-request, merge, release, deployment, production, infrastructure, secret, and destructive actions remain separately governed.
+
+Phase B instruction-level delegated progression is merged and canonical on `main` through PR #190. The current public release remains `v1.1.2`; Phase B has not yet been included in a new tagged release or deployment.
+
+See the [Delegated Execution Policy](docs/governance/DELEGATED_EXECUTION_POLICY.md) for the canonical contract and the [Governance Review Flow](docs/governance/GOVERNANCE_REVIEW_FLOW.md) for the review sequence.
+
 ## One Request, Coordinated Responsibilities
 
 Consider one request:

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,41 +1,29 @@
 # Session Handoff
 
-- **Current Stable State:** `v1.1.2` published; Phase A canonical delegated governance contracts merged; Phase B instruction-level delegated governance merged and canonical through PR #190.
-- **Current Task:** Phase B post-merge canonical state synchronization.
+- **Current Stable State:** `v1.1.2` published; Phase A and Phase B delegated governance are merged and canonical on `main`.
 - **Current Repo:** `C:\conductor`
 - **Canonical Branch:** `main`
 - **Base Branch:** `main`
-- **Starting Point:** `main` at `d37a2f7b31543efacf7a5e81c3f4d08c12da017d`
+- **Stable Continuation Branch:** `main`
 - **Exact Worktree:** `C:\conductor`
-- **Active Branch:** `docs/phase-b-post-merge-state-sync`
 - **Current Public Release:** `v1.1.2`
-- **Completed Phase B Units:** B0 through B7 completed.
-- **Phase B Implementation Commit:** `777eca8a1dc3a2a6b281f6ebcf16c7cfcde9b4d8` (`777eca8`)
-- **Phase B State-Sync Commit:** `702ef005946cab69725267d0e4e89abd0c67ae99` (`702ef00`)
-- **Codex Mirror Correction Commit:** `44350ece2989b5dcae9acae9c5658e3cefcb75d5` (`44350ec`)
-- **Maintainer Correction Commit:** `b2d54461c8b37e4e1bc5d3d3df00da3cf2cb9806` (`b2d5446`)
-- **Decision-Log Correction Commit:** `017b79a2cd0893990721a3c8391ca4e743666cac` (`017b79a`)
-- **Former Feature Head:** `861e70b6f06aa823e0a52f017bc0a39faf76c2e7`
-- **Canonical Merge Commit:** `d37a2f7b31543efacf7a5e81c3f4d08c12da017d`
-- **PR #190:** Merged and closed (`2026-07-21T23:44:55Z`)
-- **Phase B Status:** Merged and canonical on `main` through PR #190.
+- **Phase B Status:** Resolved, merged, and canonical through PR #190.
+- **Phase B Merge Commit:** `d37a2f7b31543efacf7a5e81c3f4d08c12da017d`
+- **PR #190:** Merged the Phase B implementation and is closed.
+- **Post-Merge State Synchronization:** PR #191 merged the canonical post-merge status synchronization.
+- **Post-Merge Synchronization Commit:** `93cf3904fd593eaf267a76598a0d2ccc1514da99`
+- **README Closeout:** `README.md` now documents delegated phase progression, all six transition dispositions, checkpoints, reduced owner relay, and preserved external-action authority boundaries.
+- **Active Phase B Implementation or Correction Task:** None
 - **Later Phases:** Phase C and Phase D have not started.
-- **Startup Verification Rule:** Resolve current branch tips at session start using:
+- **Release / Deployment:** Not performed; Phase B is not included in a new tagged release.
+- **Former Phase B Branches:** Historical only; do not resume them for future work.
+- **Default Continuation Point:**
   ```powershell
-  git branch --show-current
-  git rev-parse HEAD
+  git switch main
+  git fetch origin
   git rev-parse origin/main
-  git status --short
+  python scripts\preflight_sync_check.py
   ```
-- **Validation Summary:**
-  - Governance protocol consistency: PASS (`scripts/validate_governance_protocol_consistency.py`, `tests/behavior/test_governance_protocol_consistency.py`)
-  - Routing contract: PASS (`scripts/validate_routing_contract.py`, `tests/behavior/test_router_contracts.py`)
-  - Static behavioral expectations: PASS (`tests/behavior/evaluate_governance.py` - 26/26 checks)
-  - Prompt load budget: PASS (`scripts/validate_prompt_load_budget.py` - 7/7 packages pass)
-  - Codex export validation: PASS (`adapters/codex/validate_codex_export.py`)
-  - Structure, Manifest, IDE packaging, Governance check, Stale references: PASS
-  - Runtime tests & coverage: PASS (194 tests passed; 97.72% coverage)
-  - CI: PASS (9/9 checks on PR #190 before merge).
-- **Standing Action Flags:** All false (no tag, release, deploy, or destructive operations performed).
-- **Release / Deployment:** Not performed.
-- **Next Step:** Maintainer review of the post-merge synchronization PR.
+- **Next Ecosystem Work:** Resume Pathway Batch 7A only after verifying its repository baseline and obtaining explicit authority through a separately updated project prompt.
+
+This handoff grants no authority over the Pathway repository, Phase C, Phase D, release, or deployment.


### PR DESCRIPTION
## Summary

- Adds the README delegated phase progression section and Mermaid flow.
- Documents all six transition dispositions and their bounded meanings.
- Records Phase B as merged and canonical through PR #190.
- Stabilizes PROJECT_STATE.md and SESSION_HANDOFF.md after PR #191.
- Keeps v1.1.2 as the current public release.
- Confirms Phase C, Phase D, release, and deployment remain unstarted.
- Makes no implementation or runtime changes.

## Validation

- Preflight sync check: PASS
- Strict governance: PASS, 0 errors and 0 warnings
- Full behavior suite: PASS
- Runtime: 194 passed
- Coverage: 97.72%