### PR TITLE
docs: add external repository attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,9 @@ Orchestra may inspect selected external open-source repositories through source-
 |---|---|---|
 | [`usestrix/strix`](https://github.com/usestrix/strix) | Reference source for lifecycle-gated completion, declared authority scope, run-scoped capabilities, and validated specialist delegation | Four governed reference-only patterns were independently implemented as Orchestra-native runtime contracts and released in `v1.1.2` |
 | [`CristianOlivera1/openhero`](https://github.com/CristianOlivera1/openhero) | Static review covering UI orchestration, resilience, archive validation, and defensive-security observations | Audit findings were retained for reference; no OpenHero pattern has been promoted or implemented in Orchestra |
+| [`bryllim/bryl-minimal-design`](https://github.com/bryllim/bryl-minimal-design) | MIT-licensed design-language source for Cloak's `bryl-minimal` template | Orchestra includes an attributed framework-native design profile based on Bryl Lim's repository; the source repository remains separately owned and maintained |
+| [`DietrichGebert/ponytail`](https://github.com/DietrichGebert/ponytail) | Historical external implementation companion and reference for minimal, focused code changes | The upstream repository remains separately owned and maintained by Dietrich Gebert; Orchestra's current Ponytail specialist is an independently maintained Orchestra component, not a vendored copy or required dependency |
+| [`JuliusBrussee/caveman`](https://github.com/JuliusBrussee/caveman) | Historical external communication companion for concise, token-efficient output | The upstream repository remains separately owned and maintained by Julius Brussee; Caveman is not bundled, vendored, or required by Orchestra |
 
 ### External-source incorporation boundary
 


### PR DESCRIPTION
## Scope

- add `bryllim/bryl-minimal-design` to the existing external repository attribution table
- attribute the upstream Ponytail repository to `DietrichGebert/ponytail`
- attribute the upstream Caveman repository to `JuliusBrussee/caveman`
- distinguish external upstream ownership from Orchestra-native components and synchronized forks

## Exact-scope confirmation

- only `README.md` changed
- three lines added
- no existing README content, formatting, or structure changed
- no runtime, adapter, governance, release, or deployment files changed

## Validation

- baseline: `0804c4914289c885af3fd65a1cab0107c6ba2ff4`
- implementation commit: `3dfac6ea10ecb1d5eb33a1686dbcb0243ad5cdb2`
- compare result: one file modified, three additions, zero deletions
- external repository ownership and MIT licenses verified against the upstream repositories

No merge, release, deployment, or destructive action is authorized by this pull request.