### PR TITLE
feat: complete cross-layer audit integrity profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 This changelog tracks the repository history using git tags, merge history, and the prior documented milestone log that lived under `docs/meta/CHANGELOG.md`.
 
+## Unreleased - Cross-Layer Integrity Phase F2
+
+### Backend-to-Persistence Integrity
+
+- Extended the shared cross-module audit protocol with a deterministic backend-to-persistence profile covering service input, domain validation, transaction ownership, repository operations, ORM/query mapping, schema constraints, persistence execution, commit/rollback, readback/projection, and service-result propagation.
+- Added a dedicated backend-to-persistence checklist plus executable happy-path and rollback/failure traces with deterministic finding ownership across Clockwork, Chronicler, The Tuner, and Overseer.
+- Added fail-closed evidence for mapping/constraint drift, missing ownership, specialist contradiction, missing executable evidence, stale contract identity, transaction atomicity, and retry/idempotency risk.
+
+### Cross-Module Logical-Flow Integrity
+
+- Added a language-neutral cross-module profile covering entrypoints, input contracts, module decisions, handoff payloads, shared state or side effects, result propagation, error propagation, and final observable outcomes.
+- Added executable happy/failure traces and deterministic findings for handoff drift, missing owners, contradictory module contracts, stale evidence, swallowed/error-path drift, and duplicate side effects.
+- Added `scripts/validate_cross_layer_integrity_contract.py` and extended the existing focused cross-layer behavior suite so normal behavior validation exercises the frontend/backend, backend/persistence, and broader cross-module profiles together.
+
+### Preserved Boundaries
+
+- Reused the existing Conductor -> The Tuner -> domain specialist -> Overseer -> Arbiter authority model; no new specialist, command, plugin, runtime model, persistence implementation, or policy authority was added.
+- Rebound the original frontend/backend fixture identity to the expanded canonical protocol without changing its workflow semantics.
+- The capability remains unreleased. No deployment, installed-integration mutation, force push, history rewrite, or policy activation is part of Phase F2.
+
 ## Unreleased - Spec Kitty-Derived Governed Phase Execution Contracts
 
 ### Frontend-to-Backend Synchronicity Contract
@@ -215,7 +235,7 @@ Portable Runtime is the first Orchestra release that normalizes the repository a
 
 ### Release Highlights
 - Added `orchestra_runtime/` as the shared runtime core for routing, manifest parsing, skill loading, governance validation, execution flow, and audit logging.
-- Added `PRAP v1` as the stable Portable Runtime Adapter Protocol for host metadata, capabilities, compatibility, and validation.
+- Added `PRAP v1` as the stable Portable Runtime Adapter Protocol for host metadata, capabilities, compatibility records, and protocol validation.
 - Added thin adapter support for Codex, Claude Code, Antigravity, Cursor, Windsurf, VS Code, VSCodium compatibility, JetBrains, Zed, and Neovim.
 - Added scaffold-only packaging surfaces for Cursor, Windsurf, VS Code, JetBrains, Zed, and Neovim.
 - Normalized release-facing documentation, compatibility guidance, and manifest metadata for the `v1.0.0 Portable Runtime` baseline.
@@ -429,7 +449,7 @@ This patch was published on July 14, 2026 as the `v1.1.2` GitHub Release.
 
 - Added structured automated router benchmark runner (`scripts/router_benchmark_runner.py`) to validate test case definitions without triggering live LLM behavior.
 
-- Reduced `skills/conductor/SKILL.md` prompt payload by consolidating duplicate execution mode rules into canonical pointers, while preserving strict behavior conformance.
+- Reduced `skills/conductor/SKILL.md` prompt payload by consolidating duplicate execution mode rules into canonical pointers, while preserving governance behavior and test fixtures.
 
 - Created `docs/performance/CONDUCTOR_LOAD_REDUCTION_PLAN.md` outlining a strategy to safely reduce `skills/conductor/SKILL.md` prompt load while preserving governance behavior and test fixtures.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -336,7 +336,7 @@ This patch was published on July 14, 2026 as the `v1.1.2` GitHub Release.
 ### Changed
 - Added Windows coverage and runtime test execution to cross-platform CI validation.
 - Integrated Release Mode governance docs so The Governor now treats app release compliance artifacts as required when applicable and returns `REVISION_REQUIRED` or `BLOCKED` when release-gate documentation is missing.
-- Clarified optional project governance rulesets so `PROJECT_CONTEXT.md` enforcement depends on project type and risk level.
+- Clarified optional project governance rulesets so `PROJECT_CONTEXT.md` enforcement depends on project type, risk level, and declared governance level.
 - Wired `tests/runtime` into CI, enforced portable runtime coverage with `pytest-cov --cov-fail-under=90`, switched `validate.yml` to `python tests/behavior/run_tests.py`, and added runtime tests for alias loading, default-command fallback, and unresolved command-to-skill handling.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,7 +151,7 @@ Phase 2 is merged through PR #197 at merge commit `7423d3e7db7fb8e32dfe91454f5c2
 - Extended Overseer evidence packets and Tuner handoffs with current contract and change identity.
 - Enforced Arbiter blocking on stale or mismatched evidence and Conductor-only minimal re-entry routing.
 - Preserved pre-existing artifacts, single-owner bypass, Dagger gating, and default-deny external actions.
-- Removed implicit current-HEAD, workflow-dispatch, `origin/main`, and local `main` evidence-baseline fallbacks. Local and workflow-dispatch validation now require `ORCHESTRA_APPROVED_BASE_SHA`; verified pull-request base and push-before event SHAs remain supported.
+- Removed implicit current-HEAD, workflow-dispatch, `origin/main`, and local `main` evidence-baseline fallbacks. Local and workflow-dispatch validation now require `ORCHESTRA_APPROVED_BASE_SHA`; verified pull-request base and push-before GitHub event reference remain supported.
 
 ## Unreleased - Issue #195 Cross-Specialist Coordination Phase 1
 
@@ -235,7 +235,7 @@ Portable Runtime is the first Orchestra release that normalizes the repository a
 
 ### Release Highlights
 - Added `orchestra_runtime/` as the shared runtime core for routing, manifest parsing, skill loading, governance validation, execution flow, and audit logging.
-- Added `PRAP v1` as the stable Portable Runtime Adapter Protocol for host metadata, capabilities, compatibility records, and protocol validation.
+- Added `PRAP v1` as the stable Portable Runtime Adapter Protocol for host metadata, capabilities, compatibility, and validation.
 - Added thin adapter support for Codex, Claude Code, Antigravity, Cursor, Windsurf, VS Code, VSCodium compatibility, JetBrains, Zed, and Neovim.
 - Added scaffold-only packaging surfaces for Cursor, Windsurf, VS Code, JetBrains, Zed, and Neovim.
 - Normalized release-facing documentation, compatibility guidance, and manifest metadata for the `v1.0.0 Portable Runtime` baseline.
@@ -431,7 +431,7 @@ This patch was published on July 14, 2026 as the `v1.1.2` GitHub Release.
 
 - Added Phase 8A router-first integration hardening audit documentation.
 
-- Documented the `tests/fixtures/router_benchmarks.json` schema in `ROUTER_BENCHMARK_FIXTURE_SCHEMA.md` and updated the benchmark validation runner to enforce the root shape and `schema_version`.
+- Documented `tests/fixtures/router_benchmarks.json` schema in `ROUTER_BENCHMARK_FIXTURE_SCHEMA.md` and updated the benchmark validation runner to enforce the root shape and `schema_version`.
 
 - Refactored `scripts/router_benchmark_runner.py` to extract hardcoded definitions into a machine-readable fixture at `tests/fixtures/router_benchmarks.json`, preserving existing validation capabilities.
 
@@ -449,7 +449,7 @@ This patch was published on July 14, 2026 as the `v1.1.2` GitHub Release.
 
 - Added structured automated router benchmark runner (`scripts/router_benchmark_runner.py`) to validate test case definitions without triggering live LLM behavior.
 
-- Reduced `skills/conductor/SKILL.md` prompt payload by consolidating duplicate execution mode rules into canonical pointers, while preserving governance behavior and test fixtures.
+- Reduced `skills/conductor/SKILL.md` prompt payload by consolidating duplicate execution mode rules into canonical pointers, while preserving strict behavior conformance.
 
 - Created `docs/performance/CONDUCTOR_LOAD_REDUCTION_PLAN.md` outlining a strategy to safely reduce `skills/conductor/SKILL.md` prompt load while preserving governance behavior and test fixtures.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,7 +256,7 @@ Specialist Governance & Boundary Standard is a documentation-, governance-, meta
 
 ### Changed
 - Clarified governance authority boundaries for Arbiter status vocabulary, Steward hygiene wording, and Governor/Cipher release-security ownership without changing governance semantics.
-- Clarified Governance Strictness Levels as a derived scale over existing project context. The two ladders should not be treated as interchangeable.
+- Clarified Governance Strictness Levels as a derived scale over existing project type, operating mode, release stage, and risk classifications without changing governance semantics.
 - Strengthened Cloak's documentation-only frontend review contract with artifact-evidence requirements, clearer form and validation messaging review, explicit loading/empty/error/success/retry/permission-state review, sharper frontend handoff blueprint guidance, and matching tracked Codex export parity for the updated Cloak docs.
 - Normalized Conductor's skill documentation against the shared specialist authoring standard by clarifying activation conditions, supported work, scope enforcement, validation expectations, local-only safety, and direct-route versus orchestration versus reroute guidance, with matching tracked Codex export parity.
 - Normalized Ponytail specialist documentation with explicit activation conditions, supported work, scope enforcement, validation expectations, local-only safety, and direct handoff boundaries for implementation-owned code changes, with matching tracked Codex export parity.
@@ -300,7 +300,7 @@ This patch was published on July 14, 2026 as the `v1.1.2` GitHub Release.
 ### Added
 - Added layered UI engineering and validation ownership across Cloak static risk analysis, Clockwork engineering integrity, renewed Cloak review, Overseer current-commit evidence validation, and explicit human approval boundaries.
 - Recorded unanimous Phase 5C-B Arbiter, Governor, and Steward approval plus conditional Butler disposition for the design-only authority/capability proposal, without runtime implementation or source-expression reuse authority.
-- Added four manual Phase 5D `APPROVED` promotion records with pinned Strix provenance, Apache-2.0 attribution boundaries, conceptual-adaptation limits, and `automatic_promotion: false`.
+- Added four manual Phase 5D `APPROVED` promotion records with pinned Strix provenance, Apache-2.0 attribution boundaries, and `automatic_promotion: false`.
 - Manually synchronized the Phase 5E Pattern Catalog with the four canonical promotion records; Catalog projection remains separate from implementation authority.
 - Added the Phase 5C-A Evolution Proposal schema `1.1`, deterministic proposal lifecycle validation, focused behavior coverage, and one design-only Orchestra authority/capability proposal in `UNDER_REVIEW`, without promotion, Pattern Catalog, source-reuse, prompt-reuse, or implementation authority.
 - Added Phase 4.5-A OpenHero pilot source-intake, pattern, and audit records through a pinned static read-only GitHub inspection with no decisions, proposals, promotions, or Pattern Catalog changes.
@@ -336,7 +336,7 @@ This patch was published on July 14, 2026 as the `v1.1.2` GitHub Release.
 ### Changed
 - Added Windows coverage and runtime test execution to cross-platform CI validation.
 - Integrated Release Mode governance docs so The Governor now treats app release compliance artifacts as required when applicable and returns `REVISION_REQUIRED` or `BLOCKED` when release-gate documentation is missing.
-- Clarified optional project governance rulesets so `PROJECT_CONTEXT.md` enforcement depends on project type, risk level, and declared governance level.
+- Clarified optional project governance rulesets so `PROJECT_CONTEXT.md` enforcement depends on project type and risk level.
 - Wired `tests/runtime` into CI, enforced portable runtime coverage with `pytest-cov --cov-fail-under=90`, switched `validate.yml` to `python tests/behavior/run_tests.py`, and added runtime tests for alias loading, default-command fallback, and unresolved command-to-skill handling.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,7 +151,7 @@ Phase 2 is merged through PR #197 at merge commit `7423d3e7db7fb8e32dfe91454f5c2
 - Extended Overseer evidence packets and Tuner handoffs with current contract and change identity.
 - Enforced Arbiter blocking on stale or mismatched evidence and Conductor-only minimal re-entry routing.
 - Preserved pre-existing artifacts, single-owner bypass, Dagger gating, and default-deny external actions.
-- Removed implicit current-HEAD, workflow-dispatch, `origin/main`, and local `main` evidence-baseline fallbacks. Local and workflow-dispatch validation now require `ORCHESTRA_APPROVED_BASE_SHA`; verified pull-request base and push-before GitHub event reference remain supported.
+- Removed implicit current-HEAD, workflow-dispatch, `origin/main`, and local `main` evidence-baseline fallbacks. Local and workflow-dispatch validation now require `ORCHESTRA_APPROVED_BASE_SHA`; verified pull-request base and push-before event SHAs remain supported.
 
 ## Unreleased - Issue #195 Cross-Specialist Coordination Phase 1
 
@@ -256,7 +256,7 @@ Specialist Governance & Boundary Standard is a documentation-, governance-, meta
 
 ### Changed
 - Clarified governance authority boundaries for Arbiter status vocabulary, Steward hygiene wording, and Governor/Cipher release-security ownership without changing governance semantics.
-- Clarified Governance Strictness Levels as a derived scale over existing project type, operating mode, release stage, and risk classifications without changing governance semantics.
+- Clarified Governance Strictness Levels as a derived scale over existing project context. The two ladders should not be treated as interchangeable.
 - Strengthened Cloak's documentation-only frontend review contract with artifact-evidence requirements, clearer form and validation messaging review, explicit loading/empty/error/success/retry/permission-state review, sharper frontend handoff blueprint guidance, and matching tracked Codex export parity for the updated Cloak docs.
 - Normalized Conductor's skill documentation against the shared specialist authoring standard by clarifying activation conditions, supported work, scope enforcement, validation expectations, local-only safety, and direct-route versus orchestration versus reroute guidance, with matching tracked Codex export parity.
 - Normalized Ponytail specialist documentation with explicit activation conditions, supported work, scope enforcement, validation expectations, local-only safety, and direct handoff boundaries for implementation-owned code changes, with matching tracked Codex export parity.
@@ -300,7 +300,7 @@ This patch was published on July 14, 2026 as the `v1.1.2` GitHub Release.
 ### Added
 - Added layered UI engineering and validation ownership across Cloak static risk analysis, Clockwork engineering integrity, renewed Cloak review, Overseer current-commit evidence validation, and explicit human approval boundaries.
 - Recorded unanimous Phase 5C-B Arbiter, Governor, and Steward approval plus conditional Butler disposition for the design-only authority/capability proposal, without runtime implementation or source-expression reuse authority.
-- Added four manual Phase 5D `APPROVED` promotion records with pinned Strix provenance, Apache-2.0 attribution boundaries, and `automatic_promotion: false`.
+- Added four manual Phase 5D `APPROVED` promotion records with pinned Strix provenance, Apache-2.0 attribution boundaries, conceptual-adaptation limits, and `automatic_promotion: false`.
 - Manually synchronized the Phase 5E Pattern Catalog with the four canonical promotion records; Catalog projection remains separate from implementation authority.
 - Added the Phase 5C-A Evolution Proposal schema `1.1`, deterministic proposal lifecycle validation, focused behavior coverage, and one design-only Orchestra authority/capability proposal in `UNDER_REVIEW`, without promotion, Pattern Catalog, source-reuse, prompt-reuse, or implementation authority.
 - Added Phase 4.5-A OpenHero pilot source-intake, pattern, and audit records through a pinned static read-only GitHub inspection with no decisions, proposals, promotions, or Pattern Catalog changes.
@@ -431,7 +431,7 @@ This patch was published on July 14, 2026 as the `v1.1.2` GitHub Release.
 
 - Added Phase 8A router-first integration hardening audit documentation.
 
-- Documented `tests/fixtures/router_benchmarks.json` schema in `ROUTER_BENCHMARK_FIXTURE_SCHEMA.md` and updated the benchmark validation runner to enforce the root shape and `schema_version`.
+- Documented the `tests/fixtures/router_benchmarks.json` schema in `ROUTER_BENCHMARK_FIXTURE_SCHEMA.md` and updated the benchmark validation runner to enforce the root shape and `schema_version`.
 
 - Refactored `scripts/router_benchmark_runner.py` to extract hardcoded definitions into a machine-readable fixture at `tests/fixtures/router_benchmarks.json`, preserving existing validation capabilities.
 

--- a/docs/setup/VALIDATION.md
+++ b/docs/setup/VALIDATION.md
@@ -47,14 +47,18 @@ The Python behavior runner executes the following checks sequentially:
 7. **Governance Evaluation (`evaluate_governance.py`)**: Validates source-level governance behavior expectations.
 8. **Runtime Guardrail and Dagger Simulations**: Runs the runtime guardrail scan, Dagger guardrail tests, and isolated regression checks for guardrails, project-context validation, and lock acquisition behavior.
 9. **Runtime Coverage Gate (`pytest-cov`)**: The CI workflow separately runs `tests/runtime` with `--cov=orchestra_runtime --cov-report=term-missing --cov-fail-under=90`.
-10. **Cross-Layer Synchronicity Contract**: Runs `scripts/validate_cross_layer_synchronicity_contract.py` and `tests/behavior/test_cross_layer_synchronicity_contract.py` to enforce the canonical workflow stages, deterministic statuses, single-owner findings, executable evidence, and fail-closed re-entry behavior.
+10. **Cross-Layer Synchronicity Contract**: Runs `scripts/validate_cross_layer_synchronicity_contract.py` and `tests/behavior/test_cross_layer_synchronicity_contract.py` to enforce the frontend-to-backend workflow stages, deterministic statuses, single-owner findings, executable evidence, and fail-closed re-entry behavior.
+11. **Cross-Layer Integrity Profiles**: The same focused behavior test loads `scripts/validate_cross_layer_integrity_contract.py` and validates the backend-to-persistence and language-neutral cross-module logical-flow profiles, including ordered traces, contract identity, transaction/constraint parity, handoff/error propagation, deterministic statuses, singular finding ownership, and fail-closed re-entry.
 
 Run the focused cross-layer checks directly:
 
 ```powershell
 python .\scripts\validate_cross_layer_synchronicity_contract.py
+python .\scripts\validate_cross_layer_integrity_contract.py
 python .\tests\behavior\test_cross_layer_synchronicity_contract.py
 ```
+
+The three implemented audit profiles reuse `docs/validation/CROSS_MODULE_LOGIC_AUDIT_PROTOCOL.md` and its common evidence, invalidation, ownership, and continuation rules. The focused integrity validator does not grant persistence, implementation, Git, merge, release, deployment, or policy authority.
 
 ---
 
@@ -100,7 +104,7 @@ Runtime lock files and session state are local-only and are written under `.amal
 
 ### How State Locking Works
 1. **Lock File**: When an agent begins a workflow task (e.g. implementation or audit), it checks for the existence of `.amalgam/lock.json`.
-2. **Process Liveness Verification**: If a lock file exists, `manage-state-lock.ps1` parses the PID and verifies if that process is still running on the system.
+2. **Process Liveness Verification**: If a lock file exists, `manage-state-lock.ps1` parses the PID and verifies if that process is still running.
    - If the process is dead or the lock is older than 1 hour, the lock is treated as **stale** and automatically ignored.
    - If the process is alive, it blocks the current run and raises a **lock collision** error.
 3. **Acquisition & Release**: The active session writes its unique Session ID, PID, and timestamp to the lock. Upon task completion or test suite termination, the lock is released.

--- a/docs/validation/CROSS_MODULE_LOGIC_AUDIT_PROTOCOL.md
+++ b/docs/validation/CROSS_MODULE_LOGIC_AUDIT_PROTOCOL.md
@@ -5,8 +5,8 @@
 This protocol defines deterministic cross-layer audit evidence for Orchestra. It extends, but does not replace, the canonical [Cross-Specialist Coordination Protocol](../routing/CROSS_SPECIALIST_COORDINATION_PROTOCOL.md).
 
 ```text
-Protocol status: IMPLEMENTED_FOR_FRONTEND_BACKEND_SYNCHRONICITY
-Baseline: 6bce297c7469f9c08ce41308cbb993cc863ac540
+Protocol status: IMPLEMENTED_FOR_FRONTEND_BACKEND_BACKEND_PERSISTENCE_AND_CROSS_MODULE_LOGIC
+Baseline for Phase F2: 2bc63308415221c54babba578e812ec95bc65f4c
 Decision owner per finding: exactly one specialist
 Coordination owner: The Tuner
 Routing owner: Conductor
@@ -47,7 +47,44 @@ Every applicable workflow is traced in this order:
 10. `CLIENT_CACHE_OR_STATE_UPDATE`
 11. `FINAL_RENDERED_STATE`
 
-The trace records source references, owners, field mappings, validation rules, authorization behavior, state transitions, side effects, retries, idempotency, accessibility behavior, and executable evidence. `REPOSITORY_AND_PERSISTENCE` is traced only at an existing contract boundary in this slice. New persistence design is deferred to Chronicler and separate authorization.
+The trace records source references, owners, field mappings, validation rules, authorization behavior, state transitions, side effects, retries, idempotency, accessibility behavior, and executable evidence. `REPOSITORY_AND_PERSISTENCE` may reference an existing persistence contract; when persistence semantics themselves are in scope, use the backend-to-persistence profile below.
+
+## Backend-to-persistence workflow
+
+Backend-to-persistence integrity is traced in this order:
+
+1. `SERVICE_INPUT`
+2. `DOMAIN_VALIDATION`
+3. `TRANSACTION_BOUNDARY`
+4. `REPOSITORY_OPERATION`
+5. `MAPPING_OR_QUERY`
+6. `SCHEMA_CONSTRAINT`
+7. `PERSISTENCE_EXECUTION`
+8. `COMMIT_OR_ROLLBACK`
+9. `READBACK_OR_PROJECTION`
+10. `SERVICE_RESULT`
+
+Clockwork owns service, repository-interface, and architectural-flow decisions. Chronicler owns schema, query, migration, transaction-semantics, durability, and stored-record decisions. Cipher owns security findings only when the persistence path crosses a technical trust boundary. The Tuner coordinates references and contradictions but never selects the winning persistence rule.
+
+Required evidence covers contract mapping, validation-versus-constraint parity, transaction semantics, ORM/query mapping, error mapping, concurrency/idempotency, and executable happy/failure paths. Reads must explicitly mark non-applicable commit behavior rather than silently omitting a stage. Writes must prove commit or rollback behavior and observable error propagation.
+
+## Cross-module logical-flow workflow
+
+Language-neutral cross-module integrity is traced in this order:
+
+1. `ENTRYPOINT`
+2. `INPUT_CONTRACT`
+3. `MODULE_A_DECISION`
+4. `HANDOFF_PAYLOAD`
+5. `MODULE_B_DECISION`
+6. `SHARED_STATE_OR_SIDE_EFFECT`
+7. `RESULT_PROPAGATION`
+8. `ERROR_PROPAGATION`
+9. `FINAL_OBSERVABLE_OUTCOME`
+
+Clockwork is the canonical decision owner for cross-module control flow, dependency direction, interface compatibility, handoff shape, state mutation ordering, and error propagation. Other domain specialists retain ownership when a traced decision enters their domain. This profile is language-neutral: modules may be classes, packages, services, functions, jobs, handlers, adapters, or equivalent architectural units.
+
+Required evidence covers the input contract, handoff contract, control-flow conditions, state and side effects, error propagation, dependency direction, and executable happy/failure paths. Cycles, swallowed errors, duplicated side effects, incompatible handoffs, and contradictory branch conditions fail closed.
 
 ## Finding contract
 
@@ -73,16 +110,18 @@ Evidence must bind to the approved baseline, frozen contract revision and hash, 
 Required workflow evidence includes:
 
 - stage references and owners;
-- request and response field mappings;
-- client and server validation parity;
-- authentication and authorization parity;
+- boundary field and type mappings;
+- validation and constraint parity;
+- authentication and authorization parity when applicable;
+- transaction, side-effect, retry, concurrency, and idempotency semantics when applicable;
+- dependency direction and handoff compatibility;
+- result and error propagation;
 - applicable loading, queued, processing, cancellation, timeout, success, error, empty, deleted, and stale states;
-- side effects, retries, and idempotency;
-- keyboard, focus, semantic, status, and error accessibility behavior;
+- keyboard, focus, semantic, status, and error accessibility behavior for user-visible flows;
 - executable happy-path and failure-path evidence;
 - explicit missing evidence and invalidation events.
 
-Passing unit tests alone is insufficient. At least one executable end-to-end workflow representation must prove the stage transitions and expected result.
+Passing unit tests alone is insufficient. At least one executable end-to-end workflow representation must prove the applicable stage transitions and expected result for each active audit profile.
 
 ## Deterministic statuses
 
@@ -111,17 +150,23 @@ SPECIALIST_REENTRY_REQUIRED
 | UI contract | Cloak; Clockwork or Cipher only when API or authorization changes | Affected UI and Overseer evidence |
 | API shape or backend validation | Clockwork; Cipher when a trust boundary changes | Affected frontend and integration evidence |
 | Authorization | Cipher, Cloak, Overseer | Persona, route, content, and visible-state evidence |
-| Persistence beyond declared trace | Chronicler plus human scope authorization | Packet and all dependent workflow evidence |
+| Repository interface or service contract | Clockwork; Chronicler when persistence semantics change | Affected backend, persistence, and integration evidence |
+| Schema, migration, query, transaction, or durability rule | Chronicler; Clockwork when service/repository behavior changes | Persistence and dependent service evidence |
+| Cross-module handoff or control-flow condition | Clockwork plus only affected domain owners | Affected module-flow and downstream evidence |
 | Baseline, contract hash, or evidence fingerprint | The Tuner, Overseer, Arbiter | All mismatched evidence |
 
 An open invalidation event blocks readiness. Re-entry revises only affected specialist contracts and then refreshes downstream evidence.
 
 ## Contradictions and stop conditions
 
-The Tuner records conflicting clauses, owners, severity, participants, and whether human review is required. Conductor routes correction. Human review is mandatory for scope, architecture, security, privacy, persistence, policy, authority, or residual-risk tradeoffs not already frozen.
+The Tuner records conflicting clauses, owners, severity, participants, and whether human review is required. Conductor routes correction. Material scope, architecture, security, privacy, persistence, policy, authority, or residual-risk tradeoffs require the applicable existing governance decision path.
 
 Stop on baseline drift, protected-path mutation, undeclared generated artifacts, scope growth, secret exposure, destructive behavior, failed parity, or exhausted bounded remediation. No audit result authorizes stage, commit, push, pull request, merge, release, deployment, policy activation, force push, or history rewrite.
 
-## First implemented checklist
+## Implemented checklists
 
-The normative first-slice checklist is [Frontend-to-Backend Synchronicity Checklist](checklists/FRONTEND_BACKEND_SYNCHRONICITY_CHECKLIST.md). Backend-persistence and broader cross-module checklists remain deferred.
+- [Frontend-to-Backend Synchronicity Checklist](checklists/FRONTEND_BACKEND_SYNCHRONICITY_CHECKLIST.md)
+- [Backend-to-Persistence Integrity Checklist](checklists/BACKEND_PERSISTENCE_INTEGRITY_CHECKLIST.md)
+- [Cross-Module Logical-Flow Integrity Checklist](checklists/CROSS_MODULE_LOGIC_INTEGRITY_CHECKLIST.md)
+
+All profiles reuse the same Tuner packet, finding contract, deterministic statuses, identity binding, invalidation model, Overseer evidence ownership, and Arbiter continuation boundary.

--- a/docs/validation/checklists/BACKEND_PERSISTENCE_INTEGRITY_CHECKLIST.md
+++ b/docs/validation/checklists/BACKEND_PERSISTENCE_INTEGRITY_CHECKLIST.md
@@ -1,0 +1,51 @@
+# Backend-to-Persistence Integrity Checklist
+
+Use this checklist with the [Cross-Module Logic Audit Protocol](../CROSS_MODULE_LOGIC_AUDIT_PROTOCOL.md) and a frozen `CrossLayerContractPacket`.
+
+## Identity and scope
+
+- [ ] Repository, branch, approved baseline, current commit, packet revision, and protocol hash match.
+- [ ] Service, repository, mapping/query, schema, migration, and transaction boundaries in scope are explicitly identified.
+- [ ] Every changed path is allowlisted and protected persistence paths remain unchanged unless explicitly in scope.
+- [ ] Existing data, migration, rollback, backup, and destructive-operation boundaries remain separately governed.
+
+## Workflow trace
+
+- [ ] `SERVICE_INPUT` identifies the accepted domain/service input and caller assumptions.
+- [ ] `DOMAIN_VALIDATION` maps required, optional, null, range, format, normalization, and invariant rules.
+- [ ] `TRANSACTION_BOUNDARY` identifies transaction ownership, isolation expectations, and read-only/non-applicable behavior.
+- [ ] `REPOSITORY_OPERATION` maps the service request to one repository/interface operation.
+- [ ] `MAPPING_OR_QUERY` maps domain fields to ORM/query parameters and result fields without silent loss or coercion.
+- [ ] `SCHEMA_CONSTRAINT` proves database constraints agree with domain and repository expectations.
+- [ ] `PERSISTENCE_EXECUTION` identifies the actual read/write behavior and expected affected rows/records.
+- [ ] `COMMIT_OR_ROLLBACK` proves success commit or failure rollback behavior; read-only flows explicitly mark this stage non-applicable.
+- [ ] `READBACK_OR_PROJECTION` proves persisted or selected data is reconstructed without drift.
+- [ ] `SERVICE_RESULT` proves storage results and failures are mapped back to the service contract deterministically.
+
+## Integrity and failure coverage
+
+- [ ] Validation and schema constraints agree; neither layer silently accepts values rejected by the other.
+- [ ] Repository mapping preserves names, types, nullability, defaults, identifiers, and ownership fields.
+- [ ] Transaction scope does not partially commit multi-step operations.
+- [ ] Constraint, connectivity, timeout, serialization, deadlock/conflict, and zero-row outcomes map to explicit service behavior.
+- [ ] Retry and duplicate execution cannot create unintended duplicate writes.
+- [ ] Optimistic/pessimistic concurrency behavior is explicit when applicable.
+- [ ] Migration or schema-version assumptions are current and source-backed.
+- [ ] Secrets, credentials, and sensitive persisted values are not exposed in evidence.
+
+## Findings and evidence
+
+- [ ] Each finding has one owner, severity, affected stages, evidence, impact, minimal remediation, and required validation.
+- [ ] Clockwork owns service/repository architecture findings; Chronicler owns schema, query, transaction, and persistence semantics; Cipher owns technical trust-boundary findings.
+- [ ] Contradictions are recorded by The Tuner and routed rather than silently resolved.
+- [ ] Executable happy-path and failure-path evidence is current and bound to the protocol identity.
+- [ ] Missing evidence produces `CROSS_LAYER_EVIDENCE_INSUFFICIENT`.
+- [ ] Changed identity produces `CROSS_LAYER_CONTRACT_STALE` or `SPECIALIST_REENTRY_REQUIRED`.
+- [ ] No open invalidation remains before `CROSS_LAYER_ALIGNMENT_CONFIRMED`.
+
+## Closeout
+
+- [ ] Focused integrity validator and behavior tests pass.
+- [ ] Full behavior, runtime regression, packaging, prompt-budget, governance, scope, secret, and diff checks pass.
+- [ ] Overseer records current evidence and Arbiter records continuation state.
+- [ ] Release, deployment, destructive migration, and installed-integration actions remain separately governed.

--- a/docs/validation/checklists/CROSS_MODULE_LOGIC_INTEGRITY_CHECKLIST.md
+++ b/docs/validation/checklists/CROSS_MODULE_LOGIC_INTEGRITY_CHECKLIST.md
@@ -1,0 +1,50 @@
+# Cross-Module Logical-Flow Integrity Checklist
+
+Use this checklist with the [Cross-Module Logic Audit Protocol](../CROSS_MODULE_LOGIC_AUDIT_PROTOCOL.md) and a frozen `CrossLayerContractPacket`.
+
+## Identity and scope
+
+- [ ] Repository, branch, approved baseline, current commit, packet revision, and protocol hash match.
+- [ ] The entrypoint, participating modules, dependency direction, shared state, and observable outcome are identified.
+- [ ] Every changed path is allowlisted and unrelated modules remain outside the frozen slice.
+- [ ] The audit remains language-neutral: a module may be a class, package, function, service, job, handler, adapter, or equivalent unit.
+
+## Workflow trace
+
+- [ ] `ENTRYPOINT` identifies the invocation and its externally observable intent.
+- [ ] `INPUT_CONTRACT` maps accepted input names, types, optionality, invariants, and caller assumptions.
+- [ ] `MODULE_A_DECISION` identifies the first module's branch conditions, transformation, and owned decision.
+- [ ] `HANDOFF_PAYLOAD` maps every value crossing the module boundary, including omitted/default behavior.
+- [ ] `MODULE_B_DECISION` proves the receiving module interprets the handoff under the same contract.
+- [ ] `SHARED_STATE_OR_SIDE_EFFECT` identifies state mutation, I/O, event publication, caching, or an explicit no-side-effect result.
+- [ ] `RESULT_PROPAGATION` proves success values propagate without semantic drift.
+- [ ] `ERROR_PROPAGATION` proves errors are preserved, transformed intentionally, or handled explicitly rather than swallowed.
+- [ ] `FINAL_OBSERVABLE_OUTCOME` proves the caller-visible result matches the original intent.
+
+## Logical-flow integrity
+
+- [ ] Branch conditions are mutually compatible across modules.
+- [ ] Required handoff fields cannot be silently dropped, renamed, coerced, or defaulted.
+- [ ] Dependency direction follows the accepted architecture and introduces no accidental cycle.
+- [ ] State mutation and side effects occur exactly once and in the required order.
+- [ ] Retry/re-entry behavior cannot duplicate side effects.
+- [ ] Exceptions, error objects, sentinel values, and rejected results retain deterministic meaning across boundaries.
+- [ ] Async, queued, callback, or event-driven handoffs preserve correlation and ordering when applicable.
+- [ ] Shared mutable state has an explicit owner and invalidation/update behavior.
+
+## Findings and evidence
+
+- [ ] Clockwork owns cross-module control-flow, handoff, dependency, and error-propagation decisions unless the traced decision enters another specialist's domain.
+- [ ] Each finding has one owner, severity, affected stages, evidence, impact, minimal remediation, and required validation.
+- [ ] Contradictions are recorded by The Tuner and routed rather than silently resolved.
+- [ ] Executable happy-path and failure-path traces are current and bound to the protocol identity.
+- [ ] Missing evidence produces `CROSS_LAYER_EVIDENCE_INSUFFICIENT`.
+- [ ] Changed identity produces `CROSS_LAYER_CONTRACT_STALE` or `SPECIALIST_REENTRY_REQUIRED`.
+- [ ] No open invalidation remains before `CROSS_LAYER_ALIGNMENT_CONFIRMED`.
+
+## Closeout
+
+- [ ] Focused integrity validator and behavior tests pass.
+- [ ] Full behavior, runtime regression, packaging, prompt-budget, governance, scope, secret, and diff checks pass.
+- [ ] Overseer records current evidence and Arbiter records continuation state.
+- [ ] No audit result creates implementation, Git, merge, release, deployment, or policy authority.

--- a/scripts/validate_cross_layer_integrity_contract.py
+++ b/scripts/validate_cross_layer_integrity_contract.py
@@ -1,0 +1,342 @@
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+REQUIRED_STATUSES = {
+    "CROSS_LAYER_ALIGNMENT_CONFIRMED",
+    "CROSS_LAYER_ALIGNMENT_GAPS_FOUND",
+    "CROSS_LAYER_CONTRACT_INCOMPLETE",
+    "CROSS_LAYER_CONTRADICTION_REVIEW_REQUIRED",
+    "CROSS_LAYER_EVIDENCE_INSUFFICIENT",
+    "CROSS_LAYER_CONTRACT_STALE",
+    "SPECIALIST_REENTRY_REQUIRED",
+}
+OWNERS = {"clockwork", "chronicler", "cloak", "cipher", "overseer", "the-tuner"}
+VALID_REENTRY = OWNERS | {"conductor", "arbiter"}
+SEVERITIES = {"CRITICAL", "MAJOR", "MINOR", "CLEANUP"}
+FINDING_FIELDS = {
+    "finding_id", "severity", "owner", "affected_stages", "evidence",
+    "impact", "minimal_remediation", "required_validation",
+}
+WORKFLOW_KINDS = {"HAPPY_PATH", "FAILURE_PATH"}
+PROFILE_SPECS = {
+    "backend_persistence": {
+        "stages": (
+            "SERVICE_INPUT", "DOMAIN_VALIDATION", "TRANSACTION_BOUNDARY",
+            "REPOSITORY_OPERATION", "MAPPING_OR_QUERY", "SCHEMA_CONSTRAINT",
+            "PERSISTENCE_EXECUTION", "COMMIT_OR_ROLLBACK",
+            "READBACK_OR_PROJECTION", "SERVICE_RESULT",
+        ),
+        "evidence": {
+            "contract_mapping", "validation_and_constraint_parity",
+            "transaction_semantics", "query_mapping", "error_mapping",
+            "concurrency_and_idempotency", "executable_workflow",
+        },
+        "required_cases": {
+            "backend-persistence-happy-path", "backend-contract-mapping-gap",
+            "backend-owner-contract-missing", "backend-persistence-contradiction",
+            "backend-evidence-missing", "backend-contract-stale",
+            "backend-transaction-reentry",
+        },
+    },
+    "cross_module_logic": {
+        "stages": (
+            "ENTRYPOINT", "INPUT_CONTRACT", "MODULE_A_DECISION",
+            "HANDOFF_PAYLOAD", "MODULE_B_DECISION",
+            "SHARED_STATE_OR_SIDE_EFFECT", "RESULT_PROPAGATION",
+            "ERROR_PROPAGATION", "FINAL_OBSERVABLE_OUTCOME",
+        ),
+        "evidence": {
+            "input_contract", "handoff_contract", "control_flow",
+            "state_and_side_effects", "error_propagation",
+            "dependency_direction", "executable_workflow",
+        },
+        "required_cases": {
+            "cross-module-happy-path", "cross-module-flow-gap",
+            "cross-module-owner-contract-missing", "cross-module-contradiction",
+            "cross-module-evidence-missing", "cross-module-contract-stale",
+            "cross-module-side-effect-reentry",
+        },
+    },
+}
+
+
+def load_json(path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _nonempty(value):
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _canonical_text_bytes(path):
+    text = path.read_text(encoding="utf-8")
+    return text.replace("\r\n", "\n").replace("\r", "\n").encode("utf-8")
+
+
+def _validate_contract_identity(identity, protocol_bytes):
+    errors = []
+    if not isinstance(identity, dict):
+        return ["fixtures: contract_identity must be an object"]
+    required = {"approved_baseline", "contract_revision", "protocol_sha256", "source_branch"}
+    if set(identity) != required:
+        return ["fixtures: contract_identity must contain exactly the required fields"]
+    if not re.fullmatch(r"[0-9a-f]{40}", str(identity["approved_baseline"])):
+        errors.append("fixtures: approved_baseline must be a 40-character lowercase commit SHA")
+    if not _nonempty(identity["contract_revision"]):
+        errors.append("fixtures: contract_revision must be non-empty")
+    if not _nonempty(identity["source_branch"]):
+        errors.append("fixtures: source_branch must be non-empty")
+    expected_hash = hashlib.sha256(protocol_bytes).hexdigest()
+    if identity["protocol_sha256"] != expected_hash:
+        errors.append("fixtures: protocol_sha256 does not match the canonical cross-module audit protocol")
+    return errors
+
+
+def _validate_finding(profile_name, case_id, finding, finding_owner, stages):
+    if not isinstance(finding, dict) or set(finding) != FINDING_FIELDS:
+        return [f"{profile_name}/{case_id}: non-confirmed result requires a complete finding object"]
+    errors = []
+    if finding.get("owner") != finding_owner or finding_owner not in OWNERS:
+        errors.append(f"{profile_name}/{case_id}: finding owner must be one valid singular owner")
+    if not _nonempty(finding.get("finding_id")):
+        errors.append(f"{profile_name}/{case_id}: finding_id must be non-empty")
+    if finding.get("severity") not in SEVERITIES:
+        errors.append(f"{profile_name}/{case_id}: finding severity is invalid")
+    affected = finding.get("affected_stages")
+    if (
+        not isinstance(affected, list)
+        or not affected
+        or len(affected) != len(set(affected))
+        or any(stage not in stages for stage in affected)
+    ):
+        errors.append(f"{profile_name}/{case_id}: affected_stages must be a unique non-empty profile stage list")
+    refs = finding.get("evidence")
+    if not isinstance(refs, list) or not refs or any(not _nonempty(ref) for ref in refs):
+        errors.append(f"{profile_name}/{case_id}: finding evidence must contain non-empty references")
+    for field in ("impact", "minimal_remediation", "required_validation"):
+        if not _nonempty(finding.get(field)):
+            errors.append(f"{profile_name}/{case_id}: finding {field} must be non-empty")
+    return errors
+
+
+def _validate_workflows(profile_name, profile, stages):
+    errors = []
+    workflows = profile.get("executable_workflows")
+    workflow_map = {}
+    if not isinstance(workflows, list) or not workflows:
+        return [f"{profile_name}: executable_workflows must be a non-empty list"], workflow_map
+    for workflow in workflows:
+        if not isinstance(workflow, dict):
+            errors.append(f"{profile_name}: every executable workflow must be an object")
+            continue
+        workflow_id = workflow.get("id")
+        if not _nonempty(workflow_id) or workflow_id in workflow_map:
+            errors.append(f"{profile_name}: missing or duplicate workflow id {workflow_id!r}")
+            continue
+        workflow_map[workflow_id] = workflow
+        if workflow.get("kind") not in WORKFLOW_KINDS:
+            errors.append(f"{profile_name}/{workflow_id}: unknown workflow kind")
+        if not _nonempty(workflow.get("case_id")):
+            errors.append(f"{profile_name}/{workflow_id}: case_id must be non-empty")
+        if not _nonempty(workflow.get("expected_final_state")):
+            errors.append(f"{profile_name}/{workflow_id}: expected_final_state must be non-empty")
+        trace = workflow.get("trace")
+        if not isinstance(trace, list):
+            errors.append(f"{profile_name}/{workflow_id}: trace must be a list")
+            continue
+        seen_stages = [entry.get("stage") if isinstance(entry, dict) else None for entry in trace]
+        if tuple(seen_stages) != stages:
+            errors.append(f"{profile_name}/{workflow_id}: trace must contain profile stages in exact order")
+            continue
+        for entry in trace:
+            stage = entry["stage"]
+            if set(entry) != {"stage", "owner", "source_ref", "evidence_ref", "result"}:
+                errors.append(f"{profile_name}/{workflow_id}/{stage}: trace entry fields are incomplete or unknown")
+                continue
+            if entry["owner"] not in OWNERS:
+                errors.append(f"{profile_name}/{workflow_id}/{stage}: invalid stage owner")
+            for field in ("source_ref", "evidence_ref", "result"):
+                if not _nonempty(entry[field]):
+                    errors.append(f"{profile_name}/{workflow_id}/{stage}: {field} must be non-empty")
+    return errors, workflow_map
+
+
+def _validate_profile(profile_name, profile, spec):
+    errors = []
+    stages = spec["stages"]
+    evidence_fields = spec["evidence"]
+    if tuple(profile.get("stages", ())) != stages:
+        errors.append(f"{profile_name}: stages must match the canonical profile order")
+    if set(profile.get("required_evidence", ())) != evidence_fields:
+        errors.append(f"{profile_name}: required_evidence is incomplete or unknown")
+
+    workflow_errors, workflow_map = _validate_workflows(profile_name, profile, stages)
+    errors.extend(workflow_errors)
+
+    seen_cases = set()
+    covered_statuses = set()
+    referenced_workflows = set()
+    cases = profile.get("cases")
+    if not isinstance(cases, list) or not cases:
+        return errors + [f"{profile_name}: cases must be a non-empty list"]
+
+    for case in cases:
+        if not isinstance(case, dict):
+            errors.append(f"{profile_name}: every case must be an object")
+            continue
+        case_id = case.get("id")
+        if not _nonempty(case_id) or case_id in seen_cases:
+            errors.append(f"{profile_name}: missing or duplicate case id {case_id!r}")
+            continue
+        seen_cases.add(case_id)
+
+        status = case.get("expected_status")
+        owner = case.get("finding_owner")
+        finding = case.get("finding")
+        evidence = case.get("evidence")
+        reentry = case.get("expected_reentry")
+        workflow_id = case.get("workflow_id")
+
+        if status not in REQUIRED_STATUSES:
+            errors.append(f"{profile_name}/{case_id}: unknown status")
+        else:
+            covered_statuses.add(status)
+
+        if (
+            not isinstance(evidence, dict)
+            or set(evidence) != evidence_fields
+            or not all(isinstance(value, bool) for value in evidence.values())
+        ):
+            errors.append(f"{profile_name}/{case_id}: evidence must contain exactly the profile boolean fields")
+            continue
+
+        if (
+            not isinstance(reentry, list)
+            or len(reentry) != len(set(reentry))
+            or any(item not in VALID_REENTRY for item in reentry)
+        ):
+            errors.append(f"{profile_name}/{case_id}: expected_reentry must be a unique valid specialist list")
+
+        if workflow_id is not None:
+            if workflow_id not in workflow_map:
+                errors.append(f"{profile_name}/{case_id}: workflow_id does not reference an executable workflow")
+            else:
+                referenced_workflows.add(workflow_id)
+
+        if evidence["executable_workflow"] and not workflow_id:
+            errors.append(f"{profile_name}/{case_id}: executable evidence requires workflow_id")
+        if not evidence["executable_workflow"] and workflow_id is not None:
+            errors.append(f"{profile_name}/{case_id}: missing executable evidence cannot reference a workflow")
+
+        if status == "CROSS_LAYER_ALIGNMENT_CONFIRMED":
+            if owner is not None or finding is not None or not all(evidence.values()) or reentry:
+                errors.append(f"{profile_name}/{case_id}: confirmed alignment requires complete evidence and no finding or re-entry")
+        else:
+            errors.extend(_validate_finding(profile_name, case_id, finding, owner, stages))
+
+        if status == "CROSS_LAYER_EVIDENCE_INSUFFICIENT" and all(evidence.values()):
+            errors.append(f"{profile_name}/{case_id}: insufficient evidence must identify a missing evidence field")
+        if status == "CROSS_LAYER_CONTRACT_STALE" and reentry != ["the-tuner", "overseer", "arbiter"]:
+            errors.append(f"{profile_name}/{case_id}: stale identity must re-enter Tuner, Overseer, and Arbiter")
+        if status == "CROSS_LAYER_CONTRADICTION_REVIEW_REQUIRED" and "conductor" not in reentry:
+            errors.append(f"{profile_name}/{case_id}: contradiction must route back through Conductor")
+        if status == "SPECIALIST_REENTRY_REQUIRED" and not reentry:
+            errors.append(f"{profile_name}/{case_id}: re-entry status requires an explicit specialist set")
+
+    missing_cases = spec["required_cases"] - seen_cases
+    if missing_cases:
+        errors.append(f"{profile_name}: missing required cases {sorted(missing_cases)}")
+    missing_statuses = REQUIRED_STATUSES - covered_statuses
+    if missing_statuses:
+        errors.append(f"{profile_name}: statuses lack cases {sorted(missing_statuses)}")
+
+    present_kinds = {workflow.get("kind") for workflow in workflow_map.values()}
+    if not WORKFLOW_KINDS <= present_kinds:
+        errors.append(f"{profile_name}: both happy-path and failure-path workflows are required")
+    unreferenced = set(workflow_map) - referenced_workflows
+    if unreferenced:
+        errors.append(f"{profile_name}: unreferenced executable workflows {sorted(unreferenced)}")
+    return errors
+
+
+def validate_fixtures(data, protocol_bytes=None):
+    errors = []
+    if data.get("schema_version") != "orchestra-cross-layer-integrity-v1":
+        errors.append("fixtures: invalid schema_version")
+    if set(data.get("statuses", ())) != REQUIRED_STATUSES:
+        errors.append("fixtures: deterministic status set is incomplete or unknown")
+    if protocol_bytes is not None:
+        errors.extend(_validate_contract_identity(data.get("contract_identity"), protocol_bytes))
+
+    profiles = data.get("profiles")
+    if not isinstance(profiles, dict) or set(profiles) != set(PROFILE_SPECS):
+        errors.append("fixtures: profiles must contain exactly backend_persistence and cross_module_logic")
+        return errors
+
+    for name, spec in PROFILE_SPECS.items():
+        errors.extend(_validate_profile(name, profiles[name], spec))
+    return errors
+
+
+def validate(repo_root):
+    errors = []
+    paths = {
+        "protocol": repo_root / "docs/validation/CROSS_MODULE_LOGIC_AUDIT_PROTOCOL.md",
+        "backend_checklist": repo_root / "docs/validation/checklists/BACKEND_PERSISTENCE_INTEGRITY_CHECKLIST.md",
+        "module_checklist": repo_root / "docs/validation/checklists/CROSS_MODULE_LOGIC_INTEGRITY_CHECKLIST.md",
+        "fixtures": repo_root / "tests/behavior/cross-layer-integrity-fixtures.json",
+    }
+    for label, path in paths.items():
+        if not path.is_file():
+            errors.append(f"missing required {label}: {path.relative_to(repo_root).as_posix()}")
+    if errors:
+        return errors
+
+    protocol_bytes = _canonical_text_bytes(paths["protocol"])
+    protocol = protocol_bytes.decode("utf-8")
+    backend_checklist = paths["backend_checklist"].read_text(encoding="utf-8")
+    module_checklist = paths["module_checklist"].read_text(encoding="utf-8")
+
+    required_protocol_tokens = [
+        "Backend-to-persistence workflow",
+        "Cross-module logical-flow workflow",
+        "Passing unit tests alone is insufficient",
+        "exactly one specialist",
+        *REQUIRED_STATUSES,
+        *PROFILE_SPECS["backend_persistence"]["stages"],
+        *PROFILE_SPECS["cross_module_logic"]["stages"],
+    ]
+    for token in required_protocol_tokens:
+        if token not in protocol:
+            errors.append(f"protocol: missing {token!r}")
+
+    for token in ("`COMMIT_OR_ROLLBACK`", "Clockwork owns service", "Chronicler owns schema"):
+        if token not in backend_checklist:
+            errors.append(f"backend checklist: missing {token!r}")
+    for token in ("`HANDOFF_PAYLOAD`", "dependency direction", "Clockwork owns cross-module"):
+        if token not in module_checklist:
+            errors.append(f"cross-module checklist: missing {token!r}")
+
+    errors.extend(validate_fixtures(load_json(paths["fixtures"]), protocol_bytes))
+    return errors
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Validate backend-persistence and cross-module integrity audit contracts.")
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[1])
+    args = parser.parse_args(argv)
+    errors = validate(args.repo_root.resolve())
+    if errors:
+        for error in errors:
+            print(f"[FAIL] {error}")
+        return 1
+    print("[PASS] Cross-layer backend-persistence and cross-module integrity contracts are deterministic and complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/behavior/cross-layer-integrity-fixtures.json
+++ b/tests/behavior/cross-layer-integrity-fixtures.json
@@ -1,0 +1,135 @@
+{
+  "schema_version": "orchestra-cross-layer-integrity-v1",
+  "contract_identity": {
+    "approved_baseline": "2bc63308415221c54babba578e812ec95bc65f4c",
+    "contract_revision": "cross-layer-integrity-f2-v1",
+    "protocol_sha256": "ae8cbdba111fe071de4afd34d34a78ad8af152ac80336ac73eeb36b2fbc5b74b",
+    "source_branch": "feat/cross-layer-integrity-f2"
+  },
+  "statuses": [
+    "CROSS_LAYER_ALIGNMENT_CONFIRMED",
+    "CROSS_LAYER_ALIGNMENT_GAPS_FOUND",
+    "CROSS_LAYER_CONTRACT_INCOMPLETE",
+    "CROSS_LAYER_CONTRADICTION_REVIEW_REQUIRED",
+    "CROSS_LAYER_EVIDENCE_INSUFFICIENT",
+    "CROSS_LAYER_CONTRACT_STALE",
+    "SPECIALIST_REENTRY_REQUIRED"
+  ],
+  "profiles": {
+    "backend_persistence": {
+      "stages": [
+        "SERVICE_INPUT",
+        "DOMAIN_VALIDATION",
+        "TRANSACTION_BOUNDARY",
+        "REPOSITORY_OPERATION",
+        "MAPPING_OR_QUERY",
+        "SCHEMA_CONSTRAINT",
+        "PERSISTENCE_EXECUTION",
+        "COMMIT_OR_ROLLBACK",
+        "READBACK_OR_PROJECTION",
+        "SERVICE_RESULT"
+      ],
+      "required_evidence": [
+        "contract_mapping",
+        "validation_and_constraint_parity",
+        "transaction_semantics",
+        "query_mapping",
+        "error_mapping",
+        "concurrency_and_idempotency",
+        "executable_workflow"
+      ],
+      "executable_workflows": [
+        {
+          "id": "account-write-happy",
+          "case_id": "backend-persistence-happy-path",
+          "kind": "HAPPY_PATH",
+          "trace": [
+            {"stage":"SERVICE_INPUT","owner":"clockwork","source_ref":"fixture://bp-happy/source/service_input","evidence_ref":"fixture://bp-happy/evidence/service_input","result":"service_input proves expected success semantics"},
+            {"stage":"DOMAIN_VALIDATION","owner":"clockwork","source_ref":"fixture://bp-happy/source/domain_validation","evidence_ref":"fixture://bp-happy/evidence/domain_validation","result":"domain_validation proves expected success semantics"},
+            {"stage":"TRANSACTION_BOUNDARY","owner":"clockwork","source_ref":"fixture://bp-happy/source/transaction_boundary","evidence_ref":"fixture://bp-happy/evidence/transaction_boundary","result":"transaction_boundary proves expected success semantics"},
+            {"stage":"REPOSITORY_OPERATION","owner":"clockwork","source_ref":"fixture://bp-happy/source/repository_operation","evidence_ref":"fixture://bp-happy/evidence/repository_operation","result":"repository_operation proves expected success semantics"},
+            {"stage":"MAPPING_OR_QUERY","owner":"chronicler","source_ref":"fixture://bp-happy/source/mapping_or_query","evidence_ref":"fixture://bp-happy/evidence/mapping_or_query","result":"mapping_or_query proves expected success semantics"},
+            {"stage":"SCHEMA_CONSTRAINT","owner":"chronicler","source_ref":"fixture://bp-happy/source/schema_constraint","evidence_ref":"fixture://bp-happy/evidence/schema_constraint","result":"schema_constraint proves expected success semantics"},
+            {"stage":"PERSISTENCE_EXECUTION","owner":"chronicler","source_ref":"fixture://bp-happy/source/persistence_execution","evidence_ref":"fixture://bp-happy/evidence/persistence_execution","result":"persistence_execution proves expected success semantics"},
+            {"stage":"COMMIT_OR_ROLLBACK","owner":"chronicler","source_ref":"fixture://bp-happy/source/commit_or_rollback","evidence_ref":"fixture://bp-happy/evidence/commit_or_rollback","result":"commit_or_rollback proves expected success semantics"},
+            {"stage":"READBACK_OR_PROJECTION","owner":"chronicler","source_ref":"fixture://bp-happy/source/readback_or_projection","evidence_ref":"fixture://bp-happy/evidence/readback_or_projection","result":"readback_or_projection proves expected success semantics"},
+            {"stage":"SERVICE_RESULT","owner":"clockwork","source_ref":"fixture://bp-happy/source/service_result","evidence_ref":"fixture://bp-happy/evidence/service_result","result":"service_result proves expected success semantics"}
+          ],
+          "expected_final_state": "validated write commits once, reads back, and returns the saved record"
+        },
+        {
+          "id": "account-write-failure",
+          "case_id": "backend-transaction-reentry",
+          "kind": "FAILURE_PATH",
+          "trace": [
+            {"stage":"SERVICE_INPUT","owner":"clockwork","source_ref":"fixture://bp-fail/source/service_input","evidence_ref":"fixture://bp-fail/evidence/service_input","result":"service_input proves expected failure semantics"},
+            {"stage":"DOMAIN_VALIDATION","owner":"clockwork","source_ref":"fixture://bp-fail/source/domain_validation","evidence_ref":"fixture://bp-fail/evidence/domain_validation","result":"domain_validation proves expected failure semantics"},
+            {"stage":"TRANSACTION_BOUNDARY","owner":"clockwork","source_ref":"fixture://bp-fail/source/transaction_boundary","evidence_ref":"fixture://bp-fail/evidence/transaction_boundary","result":"transaction_boundary proves expected failure semantics"},
+            {"stage":"REPOSITORY_OPERATION","owner":"clockwork","source_ref":"fixture://bp-fail/source/repository_operation","evidence_ref":"fixture://bp-fail/evidence/repository_operation","result":"repository_operation proves expected failure semantics"},
+            {"stage":"MAPPING_OR_QUERY","owner":"chronicler","source_ref":"fixture://bp-fail/source/mapping_or_query","evidence_ref":"fixture://bp-fail/evidence/mapping_or_query","result":"mapping_or_query proves expected failure semantics"},
+            {"stage":"SCHEMA_CONSTRAINT","owner":"chronicler","source_ref":"fixture://bp-fail/source/schema_constraint","evidence_ref":"fixture://bp-fail/evidence/schema_constraint","result":"schema_constraint proves expected failure semantics"},
+            {"stage":"PERSISTENCE_EXECUTION","owner":"chronicler","source_ref":"fixture://bp-fail/source/persistence_execution","evidence_ref":"fixture://bp-fail/evidence/persistence_execution","result":"persistence_execution proves expected failure semantics"},
+            {"stage":"COMMIT_OR_ROLLBACK","owner":"chronicler","source_ref":"fixture://bp-fail/source/commit_or_rollback","evidence_ref":"fixture://bp-fail/evidence/commit_or_rollback","result":"commit_or_rollback proves expected failure semantics"},
+            {"stage":"READBACK_OR_PROJECTION","owner":"chronicler","source_ref":"fixture://bp-fail/source/readback_or_projection","evidence_ref":"fixture://bp-fail/evidence/readback_or_projection","result":"readback_or_projection proves expected failure semantics"},
+            {"stage":"SERVICE_RESULT","owner":"clockwork","source_ref":"fixture://bp-fail/source/service_result","evidence_ref":"fixture://bp-fail/evidence/service_result","result":"service_result proves expected failure semantics"}
+          ],
+          "expected_final_state": "storage failure rolls back and propagates as a deterministic service failure"
+        }
+      ],
+      "cases": [
+        {"id":"backend-persistence-happy-path","expected_status":"CROSS_LAYER_ALIGNMENT_CONFIRMED","finding_owner":null,"finding":null,"evidence":{"contract_mapping":true,"validation_and_constraint_parity":true,"transaction_semantics":true,"query_mapping":true,"error_mapping":true,"concurrency_and_idempotency":true,"executable_workflow":true},"workflow_id":"account-write-happy","expected_reentry":[]},
+        {"id":"backend-contract-mapping-gap","expected_status":"CROSS_LAYER_ALIGNMENT_GAPS_FOUND","finding_owner":"chronicler","finding":{"finding_id":"F-BP-MAP-001","severity":"MAJOR","owner":"chronicler","affected_stages":["DOMAIN_VALIDATION","MAPPING_OR_QUERY","SCHEMA_CONSTRAINT"],"evidence":["fixture://finding/f-bp-map-001"],"impact":"service and persistence field or constraint semantics disagree","minimal_remediation":"align repository/query mapping and schema rules with the accepted service contract","required_validation":"mapping and constraint tests prove exact parity"},"evidence":{"contract_mapping":false,"validation_and_constraint_parity":false,"transaction_semantics":true,"query_mapping":true,"error_mapping":true,"concurrency_and_idempotency":true,"executable_workflow":true},"workflow_id":"account-write-happy","expected_reentry":["chronicler","clockwork","overseer"]},
+        {"id":"backend-owner-contract-missing","expected_status":"CROSS_LAYER_CONTRACT_INCOMPLETE","finding_owner":"the-tuner","finding":{"finding_id":"F-BP-CONTRACT-001","severity":"MAJOR","owner":"the-tuner","affected_stages":["REPOSITORY_OPERATION","SCHEMA_CONSTRAINT"],"evidence":["fixture://finding/f-bp-contract-001"],"impact":"a persistence decision lacks singular ownership or acceptance criteria","minimal_remediation":"route the incomplete contract through Conductor","required_validation":"complete ownership and acceptance criteria are present"},"evidence":{"contract_mapping":true,"validation_and_constraint_parity":true,"transaction_semantics":true,"query_mapping":true,"error_mapping":true,"concurrency_and_idempotency":true,"executable_workflow":true},"workflow_id":"account-write-happy","expected_reentry":["conductor","chronicler"]},
+        {"id":"backend-persistence-contradiction","expected_status":"CROSS_LAYER_CONTRADICTION_REVIEW_REQUIRED","finding_owner":"the-tuner","finding":{"finding_id":"F-BP-CONTRA-001","severity":"CRITICAL","owner":"the-tuner","affected_stages":["DOMAIN_VALIDATION","TRANSACTION_BOUNDARY","SCHEMA_CONSTRAINT"],"evidence":["fixture://finding/f-bp-contra-001"],"impact":"Clockwork and Chronicler contracts require incompatible behavior","minimal_remediation":"route conflicting clauses without choosing a winner","required_validation":"revised contracts remove the contradiction"},"evidence":{"contract_mapping":true,"validation_and_constraint_parity":true,"transaction_semantics":true,"query_mapping":true,"error_mapping":true,"concurrency_and_idempotency":true,"executable_workflow":true},"workflow_id":"account-write-happy","expected_reentry":["conductor","clockwork","chronicler"]},
+        {"id":"backend-evidence-missing","expected_status":"CROSS_LAYER_EVIDENCE_INSUFFICIENT","finding_owner":"overseer","finding":{"finding_id":"F-BP-EVIDENCE-001","severity":"MAJOR","owner":"overseer","affected_stages":["SERVICE_INPUT","DOMAIN_VALIDATION","TRANSACTION_BOUNDARY","REPOSITORY_OPERATION","MAPPING_OR_QUERY","SCHEMA_CONSTRAINT","PERSISTENCE_EXECUTION","COMMIT_OR_ROLLBACK","READBACK_OR_PROJECTION","SERVICE_RESULT"],"evidence":["fixture://finding/f-bp-evidence-001"],"impact":"backend-to-persistence alignment cannot be demonstrated","minimal_remediation":"produce current executable happy and failure traces","required_validation":"Overseer verifies both traces against current identity"},"evidence":{"contract_mapping":true,"validation_and_constraint_parity":true,"transaction_semantics":true,"query_mapping":true,"error_mapping":true,"concurrency_and_idempotency":true,"executable_workflow":false},"workflow_id":null,"expected_reentry":["overseer"]},
+        {"id":"backend-contract-stale","expected_status":"CROSS_LAYER_CONTRACT_STALE","finding_owner":"the-tuner","finding":{"finding_id":"F-BP-STALE-001","severity":"MAJOR","owner":"the-tuner","affected_stages":["SERVICE_INPUT","DOMAIN_VALIDATION","TRANSACTION_BOUNDARY","REPOSITORY_OPERATION","MAPPING_OR_QUERY","SCHEMA_CONSTRAINT","PERSISTENCE_EXECUTION","COMMIT_OR_ROLLBACK","READBACK_OR_PROJECTION","SERVICE_RESULT"],"evidence":["fixture://finding/f-bp-stale-001"],"impact":"evidence is bound to a superseded contract revision","minimal_remediation":"refresh packet and dependent evidence","required_validation":"Tuner, Overseer, and Arbiter verify current identity"},"evidence":{"contract_mapping":true,"validation_and_constraint_parity":true,"transaction_semantics":true,"query_mapping":true,"error_mapping":true,"concurrency_and_idempotency":true,"executable_workflow":true},"workflow_id":"account-write-happy","expected_reentry":["the-tuner","overseer","arbiter"]},
+        {"id":"backend-transaction-reentry","expected_status":"SPECIALIST_REENTRY_REQUIRED","finding_owner":"chronicler","finding":{"finding_id":"F-BP-TX-001","severity":"CRITICAL","owner":"chronicler","affected_stages":["TRANSACTION_BOUNDARY","PERSISTENCE_EXECUTION","COMMIT_OR_ROLLBACK"],"evidence":["fixture://finding/f-bp-tx-001"],"impact":"write can partially commit or duplicate under retry","minimal_remediation":"define atomic transaction and idempotency semantics","required_validation":"failure and duplicate-execution evidence proves rollback and one logical write"},"evidence":{"contract_mapping":true,"validation_and_constraint_parity":true,"transaction_semantics":false,"query_mapping":true,"error_mapping":true,"concurrency_and_idempotency":false,"executable_workflow":true},"workflow_id":"account-write-failure","expected_reentry":["chronicler","clockwork","overseer"]}
+      ]
+    },
+    "cross_module_logic": {
+      "stages": ["ENTRYPOINT","INPUT_CONTRACT","MODULE_A_DECISION","HANDOFF_PAYLOAD","MODULE_B_DECISION","SHARED_STATE_OR_SIDE_EFFECT","RESULT_PROPAGATION","ERROR_PROPAGATION","FINAL_OBSERVABLE_OUTCOME"],
+      "required_evidence": ["input_contract","handoff_contract","control_flow","state_and_side_effects","error_propagation","dependency_direction","executable_workflow"],
+      "executable_workflows": [
+        {
+          "id":"module-flow-happy","case_id":"cross-module-happy-path","kind":"HAPPY_PATH",
+          "trace":[
+            {"stage":"ENTRYPOINT","owner":"clockwork","source_ref":"fixture://cm-happy/source/entrypoint","evidence_ref":"fixture://cm-happy/evidence/entrypoint","result":"entrypoint proves expected success semantics"},
+            {"stage":"INPUT_CONTRACT","owner":"clockwork","source_ref":"fixture://cm-happy/source/input_contract","evidence_ref":"fixture://cm-happy/evidence/input_contract","result":"input_contract proves expected success semantics"},
+            {"stage":"MODULE_A_DECISION","owner":"clockwork","source_ref":"fixture://cm-happy/source/module_a_decision","evidence_ref":"fixture://cm-happy/evidence/module_a_decision","result":"module_a_decision proves expected success semantics"},
+            {"stage":"HANDOFF_PAYLOAD","owner":"clockwork","source_ref":"fixture://cm-happy/source/handoff_payload","evidence_ref":"fixture://cm-happy/evidence/handoff_payload","result":"handoff_payload proves expected success semantics"},
+            {"stage":"MODULE_B_DECISION","owner":"clockwork","source_ref":"fixture://cm-happy/source/module_b_decision","evidence_ref":"fixture://cm-happy/evidence/module_b_decision","result":"module_b_decision proves expected success semantics"},
+            {"stage":"SHARED_STATE_OR_SIDE_EFFECT","owner":"clockwork","source_ref":"fixture://cm-happy/source/shared_state_or_side_effect","evidence_ref":"fixture://cm-happy/evidence/shared_state_or_side_effect","result":"shared_state_or_side_effect proves expected success semantics"},
+            {"stage":"RESULT_PROPAGATION","owner":"clockwork","source_ref":"fixture://cm-happy/source/result_propagation","evidence_ref":"fixture://cm-happy/evidence/result_propagation","result":"result_propagation proves expected success semantics"},
+            {"stage":"ERROR_PROPAGATION","owner":"clockwork","source_ref":"fixture://cm-happy/source/error_propagation","evidence_ref":"fixture://cm-happy/evidence/error_propagation","result":"error_propagation proves expected success semantics"},
+            {"stage":"FINAL_OBSERVABLE_OUTCOME","owner":"clockwork","source_ref":"fixture://cm-happy/source/final_observable_outcome","evidence_ref":"fixture://cm-happy/evidence/final_observable_outcome","result":"final_observable_outcome proves expected success semantics"}
+          ],
+          "expected_final_state":"input crosses module boundaries once and returns the intended result"
+        },
+        {
+          "id":"module-flow-failure","case_id":"cross-module-side-effect-reentry","kind":"FAILURE_PATH",
+          "trace":[
+            {"stage":"ENTRYPOINT","owner":"clockwork","source_ref":"fixture://cm-fail/source/entrypoint","evidence_ref":"fixture://cm-fail/evidence/entrypoint","result":"entrypoint proves expected failure semantics"},
+            {"stage":"INPUT_CONTRACT","owner":"clockwork","source_ref":"fixture://cm-fail/source/input_contract","evidence_ref":"fixture://cm-fail/evidence/input_contract","result":"input_contract proves expected failure semantics"},
+            {"stage":"MODULE_A_DECISION","owner":"clockwork","source_ref":"fixture://cm-fail/source/module_a_decision","evidence_ref":"fixture://cm-fail/evidence/module_a_decision","result":"module_a_decision proves expected failure semantics"},
+            {"stage":"HANDOFF_PAYLOAD","owner":"clockwork","source_ref":"fixture://cm-fail/source/handoff_payload","evidence_ref":"fixture://cm-fail/evidence/handoff_payload","result":"handoff_payload proves expected failure semantics"},
+            {"stage":"MODULE_B_DECISION","owner":"clockwork","source_ref":"fixture://cm-fail/source/module_b_decision","evidence_ref":"fixture://cm-fail/evidence/module_b_decision","result":"module_b_decision proves expected failure semantics"},
+            {"stage":"SHARED_STATE_OR_SIDE_EFFECT","owner":"clockwork","source_ref":"fixture://cm-fail/source/shared_state_or_side_effect","evidence_ref":"fixture://cm-fail/evidence/shared_state_or_side_effect","result":"shared_state_or_side_effect proves expected failure semantics"},
+            {"stage":"RESULT_PROPAGATION","owner":"clockwork","source_ref":"fixture://cm-fail/source/result_propagation","evidence_ref":"fixture://cm-fail/evidence/result_propagation","result":"result_propagation proves expected failure semantics"},
+            {"stage":"ERROR_PROPAGATION","owner":"clockwork","source_ref":"fixture://cm-fail/source/error_propagation","evidence_ref":"fixture://cm-fail/evidence/error_propagation","result":"error_propagation proves expected failure semantics"},
+            {"stage":"FINAL_OBSERVABLE_OUTCOME","owner":"clockwork","source_ref":"fixture://cm-fail/source/final_observable_outcome","evidence_ref":"fixture://cm-fail/evidence/final_observable_outcome","result":"final_observable_outcome proves expected failure semantics"}
+          ],
+          "expected_final_state":"failure propagates without false success or duplicate side effect"
+        }
+      ],
+      "cases":[
+        {"id":"cross-module-happy-path","expected_status":"CROSS_LAYER_ALIGNMENT_CONFIRMED","finding_owner":null,"finding":null,"evidence":{"input_contract":true,"handoff_contract":true,"control_flow":true,"state_and_side_effects":true,"error_propagation":true,"dependency_direction":true,"executable_workflow":true},"workflow_id":"module-flow-happy","expected_reentry":[]},
+        {"id":"cross-module-flow-gap","expected_status":"CROSS_LAYER_ALIGNMENT_GAPS_FOUND","finding_owner":"clockwork","finding":{"finding_id":"F-CM-FLOW-001","severity":"MAJOR","owner":"clockwork","affected_stages":["INPUT_CONTRACT","HANDOFF_PAYLOAD","MODULE_B_DECISION","ERROR_PROPAGATION"],"evidence":["fixture://finding/f-cm-flow-001"],"impact":"handoff or branch semantics drift across modules","minimal_remediation":"align handoff, branch, and error semantics under the accepted module contract","required_validation":"boundary tests prove exact handoff and error propagation"},"evidence":{"input_contract":true,"handoff_contract":false,"control_flow":false,"state_and_side_effects":true,"error_propagation":false,"dependency_direction":true,"executable_workflow":true},"workflow_id":"module-flow-happy","expected_reentry":["clockwork","overseer"]},
+        {"id":"cross-module-owner-contract-missing","expected_status":"CROSS_LAYER_CONTRACT_INCOMPLETE","finding_owner":"the-tuner","finding":{"finding_id":"F-CM-CONTRACT-001","severity":"MAJOR","owner":"the-tuner","affected_stages":["MODULE_A_DECISION","MODULE_B_DECISION"],"evidence":["fixture://finding/f-cm-contract-001"],"impact":"a module decision lacks singular ownership or acceptance criteria","minimal_remediation":"route the incomplete contract through Conductor","required_validation":"complete ownership and criteria are present"},"evidence":{"input_contract":true,"handoff_contract":true,"control_flow":true,"state_and_side_effects":true,"error_propagation":true,"dependency_direction":true,"executable_workflow":true},"workflow_id":"module-flow-happy","expected_reentry":["conductor","clockwork"]},
+        {"id":"cross-module-contradiction","expected_status":"CROSS_LAYER_CONTRADICTION_REVIEW_REQUIRED","finding_owner":"the-tuner","finding":{"finding_id":"F-CM-CONTRA-001","severity":"CRITICAL","owner":"the-tuner","affected_stages":["MODULE_A_DECISION","HANDOFF_PAYLOAD","MODULE_B_DECISION"],"evidence":["fixture://finding/f-cm-contra-001"],"impact":"module contracts prescribe incompatible handoff behavior","minimal_remediation":"route conflicting clauses without choosing a winner","required_validation":"revised owner contracts agree on one handoff"},"evidence":{"input_contract":true,"handoff_contract":true,"control_flow":true,"state_and_side_effects":true,"error_propagation":true,"dependency_direction":true,"executable_workflow":true},"workflow_id":"module-flow-happy","expected_reentry":["conductor","clockwork"]},
+        {"id":"cross-module-evidence-missing","expected_status":"CROSS_LAYER_EVIDENCE_INSUFFICIENT","finding_owner":"overseer","finding":{"finding_id":"F-CM-EVIDENCE-001","severity":"MAJOR","owner":"overseer","affected_stages":["ENTRYPOINT","INPUT_CONTRACT","MODULE_A_DECISION","HANDOFF_PAYLOAD","MODULE_B_DECISION","SHARED_STATE_OR_SIDE_EFFECT","RESULT_PROPAGATION","ERROR_PROPAGATION","FINAL_OBSERVABLE_OUTCOME"],"evidence":["fixture://finding/f-cm-evidence-001"],"impact":"cross-module flow cannot be demonstrated","minimal_remediation":"produce current happy and failure traces","required_validation":"Overseer verifies both traces against current identity"},"evidence":{"input_contract":true,"handoff_contract":true,"control_flow":true,"state_and_side_effects":true,"error_propagation":true,"dependency_direction":true,"executable_workflow":false},"workflow_id":null,"expected_reentry":["overseer"]},
+        {"id":"cross-module-contract-stale","expected_status":"CROSS_LAYER_CONTRACT_STALE","finding_owner":"the-tuner","finding":{"finding_id":"F-CM-STALE-001","severity":"MAJOR","owner":"the-tuner","affected_stages":["ENTRYPOINT","INPUT_CONTRACT","MODULE_A_DECISION","HANDOFF_PAYLOAD","MODULE_B_DECISION","SHARED_STATE_OR_SIDE_EFFECT","RESULT_PROPAGATION","ERROR_PROPAGATION","FINAL_OBSERVABLE_OUTCOME"],"evidence":["fixture://finding/f-cm-stale-001"],"impact":"module-flow evidence is bound to a superseded revision","minimal_remediation":"refresh packet and dependent evidence","required_validation":"Tuner, Overseer, and Arbiter verify current identity"},"evidence":{"input_contract":true,"handoff_contract":true,"control_flow":true,"state_and_side_effects":true,"error_propagation":true,"dependency_direction":true,"executable_workflow":true},"workflow_id":"module-flow-happy","expected_reentry":["the-tuner","overseer","arbiter"]},
+        {"id":"cross-module-side-effect-reentry","expected_status":"SPECIALIST_REENTRY_REQUIRED","finding_owner":"clockwork","finding":{"finding_id":"F-CM-SIDEFX-001","severity":"CRITICAL","owner":"clockwork","affected_stages":["SHARED_STATE_OR_SIDE_EFFECT","RESULT_PROPAGATION","ERROR_PROPAGATION"],"evidence":["fixture://finding/f-cm-sidefx-001"],"impact":"retry or error flow can duplicate a side effect or report false success","minimal_remediation":"make side-effect ordering and idempotency explicit","required_validation":"failure and duplicate-invocation evidence proves one side effect and correct error propagation"},"evidence":{"input_contract":true,"handoff_contract":true,"control_flow":true,"state_and_side_effects":false,"error_propagation":true,"dependency_direction":true,"executable_workflow":true},"workflow_id":"module-flow-failure","expected_reentry":["clockwork","overseer"]}
+      ]
+    }
+  }
+}

--- a/tests/behavior/cross-layer-synchronicity-fixtures.json
+++ b/tests/behavior/cross-layer-synchronicity-fixtures.json
@@ -42,17 +42,83 @@
       "case_id": "happy-path-aligned",
       "kind": "HAPPY_PATH",
       "trace": [
-        {"stage":"UI_CONTROL","owner":"cloak","source_ref":"fixture://ui/save-button","evidence_ref":"fixture://evidence/ui-control","result":"enabled control exposes accessible name"},
-        {"stage":"CLIENT_EVENT","owner":"cloak","source_ref":"fixture://client/save-click","evidence_ref":"fixture://evidence/client-event","result":"single click produces one submit intent"},
-        {"stage":"CLIENT_STATE_OR_FORM_MODEL","owner":"clockwork","source_ref":"fixture://client/profile-form","evidence_ref":"fixture://evidence/client-model","result":"normalized model passes client validation"},
-        {"stage":"SERIALIZED_REQUEST","owner":"clockwork","source_ref":"fixture://http/profile-request","evidence_ref":"fixture://evidence/request","result":"request contains canonical fields and types"},
-        {"stage":"API_ROUTE","owner":"cipher","source_ref":"fixture://api/profile-route","evidence_ref":"fixture://evidence/route","result":"authenticated authorized request reaches handler"},
-        {"stage":"BACKEND_HANDLER","owner":"clockwork","source_ref":"fixture://backend/profile-handler","evidence_ref":"fixture://evidence/handler","result":"handler parses and validates canonical request"},
-        {"stage":"SERVICE_OPERATION","owner":"clockwork","source_ref":"fixture://service/update-profile","evidence_ref":"fixture://evidence/service","result":"operation applies one idempotent update"},
-        {"stage":"REPOSITORY_AND_PERSISTENCE","owner":"chronicler","source_ref":"fixture://repository/profile-store","evidence_ref":"fixture://evidence/repository","result":"existing repository contract records update"},
-        {"stage":"API_RESPONSE","owner":"clockwork","source_ref":"fixture://http/profile-response","evidence_ref":"fixture://evidence/response","result":"response maps canonical saved profile"},
-        {"stage":"CLIENT_CACHE_OR_STATE_UPDATE","owner":"clockwork","source_ref":"fixture://client/profile-cache","evidence_ref":"fixture://evidence/cache","result":"cache reconciles server response without stale overwrite"},
-        {"stage":"FINAL_RENDERED_STATE","owner":"cloak","source_ref":"fixture://ui/profile-success","evidence_ref":"fixture://evidence/render","result":"success state is visible and announced"}
+        {
+          "stage": "UI_CONTROL",
+          "owner": "cloak",
+          "source_ref": "fixture://ui/save-button",
+          "evidence_ref": "fixture://evidence/ui-control",
+          "result": "enabled control exposes accessible name"
+        },
+        {
+          "stage": "CLIENT_EVENT",
+          "owner": "cloak",
+          "source_ref": "fixture://client/save-click",
+          "evidence_ref": "fixture://evidence/client-event",
+          "result": "single click produces one submit intent"
+        },
+        {
+          "stage": "CLIENT_STATE_OR_FORM_MODEL",
+          "owner": "clockwork",
+          "source_ref": "fixture://client/profile-form",
+          "evidence_ref": "fixture://evidence/client-model",
+          "result": "normalized model passes client validation"
+        },
+        {
+          "stage": "SERIALIZED_REQUEST",
+          "owner": "clockwork",
+          "source_ref": "fixture://http/profile-request",
+          "evidence_ref": "fixture://evidence/request",
+          "result": "request contains canonical fields and types"
+        },
+        {
+          "stage": "API_ROUTE",
+          "owner": "cipher",
+          "source_ref": "fixture://api/profile-route",
+          "evidence_ref": "fixture://evidence/route",
+          "result": "authenticated authorized request reaches handler"
+        },
+        {
+          "stage": "BACKEND_HANDLER",
+          "owner": "clockwork",
+          "source_ref": "fixture://backend/profile-handler",
+          "evidence_ref": "fixture://evidence/handler",
+          "result": "handler parses and validates canonical request"
+        },
+        {
+          "stage": "SERVICE_OPERATION",
+          "owner": "clockwork",
+          "source_ref": "fixture://service/update-profile",
+          "evidence_ref": "fixture://evidence/service",
+          "result": "operation applies one idempotent update"
+        },
+        {
+          "stage": "REPOSITORY_AND_PERSISTENCE",
+          "owner": "chronicler",
+          "source_ref": "fixture://repository/profile-store",
+          "evidence_ref": "fixture://evidence/repository",
+          "result": "existing repository contract records update"
+        },
+        {
+          "stage": "API_RESPONSE",
+          "owner": "clockwork",
+          "source_ref": "fixture://http/profile-response",
+          "evidence_ref": "fixture://evidence/response",
+          "result": "response maps canonical saved profile"
+        },
+        {
+          "stage": "CLIENT_CACHE_OR_STATE_UPDATE",
+          "owner": "clockwork",
+          "source_ref": "fixture://client/profile-cache",
+          "evidence_ref": "fixture://evidence/cache",
+          "result": "cache reconciles server response without stale overwrite"
+        },
+        {
+          "stage": "FINAL_RENDERED_STATE",
+          "owner": "cloak",
+          "source_ref": "fixture://ui/profile-success",
+          "evidence_ref": "fixture://evidence/render",
+          "result": "success state is visible and announced"
+        }
       ],
       "expected_final_state": "profile update is persisted, reconciled, visible, and announced"
     },
@@ -61,30 +127,390 @@
       "case_id": "authorization-mismatch",
       "kind": "FAILURE_PATH",
       "trace": [
-        {"stage":"UI_CONTROL","owner":"cloak","source_ref":"fixture://ui/admin-save-button","evidence_ref":"fixture://evidence/auth-ui-control","result":"control is visible only to authorized persona"},
-        {"stage":"CLIENT_EVENT","owner":"cloak","source_ref":"fixture://client/admin-save-click","evidence_ref":"fixture://evidence/auth-client-event","result":"event produces one protected request"},
-        {"stage":"CLIENT_STATE_OR_FORM_MODEL","owner":"clockwork","source_ref":"fixture://client/admin-form","evidence_ref":"fixture://evidence/auth-client-model","result":"model passes client validation"},
-        {"stage":"SERIALIZED_REQUEST","owner":"clockwork","source_ref":"fixture://http/admin-request","evidence_ref":"fixture://evidence/auth-request","result":"request shape is canonical"},
-        {"stage":"API_ROUTE","owner":"cipher","source_ref":"fixture://api/admin-route","evidence_ref":"fixture://evidence/auth-route","result":"backend rejects unauthorized persona"},
-        {"stage":"BACKEND_HANDLER","owner":"clockwork","source_ref":"fixture://backend/admin-handler","evidence_ref":"fixture://evidence/auth-handler","result":"handler returns deterministic forbidden response"},
-        {"stage":"SERVICE_OPERATION","owner":"clockwork","source_ref":"fixture://service/admin-update","evidence_ref":"fixture://evidence/auth-service","result":"service is not invoked"},
-        {"stage":"REPOSITORY_AND_PERSISTENCE","owner":"chronicler","source_ref":"fixture://repository/admin-store","evidence_ref":"fixture://evidence/auth-repository","result":"repository is not invoked"},
-        {"stage":"API_RESPONSE","owner":"clockwork","source_ref":"fixture://http/admin-forbidden","evidence_ref":"fixture://evidence/auth-response","result":"response is 403 with canonical error"},
-        {"stage":"CLIENT_CACHE_OR_STATE_UPDATE","owner":"clockwork","source_ref":"fixture://client/admin-cache","evidence_ref":"fixture://evidence/auth-cache","result":"cache remains unchanged"},
-        {"stage":"FINAL_RENDERED_STATE","owner":"cloak","source_ref":"fixture://ui/admin-forbidden","evidence_ref":"fixture://evidence/auth-render","result":"forbidden state is visible and announced"}
+        {
+          "stage": "UI_CONTROL",
+          "owner": "cloak",
+          "source_ref": "fixture://ui/admin-save-button",
+          "evidence_ref": "fixture://evidence/auth-ui-control",
+          "result": "control is visible only to authorized persona"
+        },
+        {
+          "stage": "CLIENT_EVENT",
+          "owner": "cloak",
+          "source_ref": "fixture://client/admin-save-click",
+          "evidence_ref": "fixture://evidence/auth-client-event",
+          "result": "event produces one protected request"
+        },
+        {
+          "stage": "CLIENT_STATE_OR_FORM_MODEL",
+          "owner": "clockwork",
+          "source_ref": "fixture://client/admin-form",
+          "evidence_ref": "fixture://evidence/auth-client-model",
+          "result": "model passes client validation"
+        },
+        {
+          "stage": "SERIALIZED_REQUEST",
+          "owner": "clockwork",
+          "source_ref": "fixture://http/admin-request",
+          "evidence_ref": "fixture://evidence/auth-request",
+          "result": "request shape is canonical"
+        },
+        {
+          "stage": "API_ROUTE",
+          "owner": "cipher",
+          "source_ref": "fixture://api/admin-route",
+          "evidence_ref": "fixture://evidence/auth-route",
+          "result": "backend rejects unauthorized persona"
+        },
+        {
+          "stage": "BACKEND_HANDLER",
+          "owner": "clockwork",
+          "source_ref": "fixture://backend/admin-handler",
+          "evidence_ref": "fixture://evidence/auth-handler",
+          "result": "handler returns deterministic forbidden response"
+        },
+        {
+          "stage": "SERVICE_OPERATION",
+          "owner": "clockwork",
+          "source_ref": "fixture://service/admin-update",
+          "evidence_ref": "fixture://evidence/auth-service",
+          "result": "service is not invoked"
+        },
+        {
+          "stage": "REPOSITORY_AND_PERSISTENCE",
+          "owner": "chronicler",
+          "source_ref": "fixture://repository/admin-store",
+          "evidence_ref": "fixture://evidence/auth-repository",
+          "result": "repository is not invoked"
+        },
+        {
+          "stage": "API_RESPONSE",
+          "owner": "clockwork",
+          "source_ref": "fixture://http/admin-forbidden",
+          "evidence_ref": "fixture://evidence/auth-response",
+          "result": "response is 403 with canonical error"
+        },
+        {
+          "stage": "CLIENT_CACHE_OR_STATE_UPDATE",
+          "owner": "clockwork",
+          "source_ref": "fixture://client/admin-cache",
+          "evidence_ref": "fixture://evidence/auth-cache",
+          "result": "cache remains unchanged"
+        },
+        {
+          "stage": "FINAL_RENDERED_STATE",
+          "owner": "cloak",
+          "source_ref": "fixture://ui/admin-forbidden",
+          "evidence_ref": "fixture://evidence/auth-render",
+          "result": "forbidden state is visible and announced"
+        }
       ],
       "expected_final_state": "unauthorized request is rejected, no side effect occurs, and the denial is visible"
     }
   ],
   "cases": [
-    {"id":"happy-path-aligned","expected_status":"CROSS_LAYER_ALIGNMENT_CONFIRMED","finding_owner":null,"finding":null,"evidence":{"field_mapping":true,"validation_parity":true,"authorization_parity":true,"state_coverage":true,"accessibility":true,"executable_workflow":true},"workflow_id":"profile-update-happy-path","expected_reentry":[]},
-    {"id":"request-field-mismatch","expected_status":"CROSS_LAYER_ALIGNMENT_GAPS_FOUND","finding_owner":"clockwork","finding":{"finding_id":"F-REQUEST-001","severity":"MAJOR","owner":"clockwork","affected_stages":["CLIENT_STATE_OR_FORM_MODEL","SERIALIZED_REQUEST","BACKEND_HANDLER"],"evidence":["fixture://evidence/request-field-mismatch"],"impact":"client field is omitted and backend applies an unintended default","minimal_remediation":"align the request mapping with the accepted API contract","required_validation":"request serialization and handler tests prove the canonical field mapping"},"evidence":{"field_mapping":false,"validation_parity":true,"authorization_parity":true,"state_coverage":true,"accessibility":true,"executable_workflow":true},"workflow_id":"profile-update-happy-path","expected_reentry":["clockwork","overseer"]},
-    {"id":"missing-executable-evidence","expected_status":"CROSS_LAYER_EVIDENCE_INSUFFICIENT","finding_owner":"overseer","finding":{"finding_id":"F-EVIDENCE-001","severity":"MAJOR","owner":"overseer","affected_stages":["UI_CONTROL","CLIENT_EVENT","CLIENT_STATE_OR_FORM_MODEL","SERIALIZED_REQUEST","API_ROUTE","BACKEND_HANDLER","SERVICE_OPERATION","REPOSITORY_AND_PERSISTENCE","API_RESPONSE","CLIENT_CACHE_OR_STATE_UPDATE","FINAL_RENDERED_STATE"],"evidence":["missing://executable-workflow"],"impact":"alignment cannot be demonstrated across the complete user-visible workflow","minimal_remediation":"produce current happy-path and failure-path executable traces","required_validation":"Overseer verifies traces against the frozen packet identity"},"evidence":{"field_mapping":true,"validation_parity":true,"authorization_parity":true,"state_coverage":true,"accessibility":true,"executable_workflow":false},"workflow_id":null,"expected_reentry":["overseer"]},
-    {"id":"authorization-mismatch","expected_status":"CROSS_LAYER_ALIGNMENT_GAPS_FOUND","finding_owner":"cipher","finding":{"finding_id":"F-AUTH-001","severity":"CRITICAL","owner":"cipher","affected_stages":["UI_CONTROL","API_ROUTE","BACKEND_HANDLER","FINAL_RENDERED_STATE"],"evidence":["fixture://evidence/authorization-mismatch"],"impact":"frontend visibility and backend authorization disagree","minimal_remediation":"align persona visibility and backend authorization under the accepted policy","required_validation":"authorized and unauthorized persona traces prove consistent UI and backend enforcement"},"evidence":{"field_mapping":true,"validation_parity":true,"authorization_parity":false,"state_coverage":true,"accessibility":true,"executable_workflow":true},"workflow_id":"admin-update-authorization-failure","expected_reentry":["cipher","cloak","overseer"]},
-    {"id":"stale-contract-identity","expected_status":"CROSS_LAYER_CONTRACT_STALE","finding_owner":"the-tuner","finding":{"finding_id":"F-IDENTITY-001","severity":"MAJOR","owner":"the-tuner","affected_stages":["UI_CONTROL","CLIENT_EVENT","CLIENT_STATE_OR_FORM_MODEL","SERIALIZED_REQUEST","API_ROUTE","BACKEND_HANDLER","SERVICE_OPERATION","REPOSITORY_AND_PERSISTENCE","API_RESPONSE","CLIENT_CACHE_OR_STATE_UPDATE","FINAL_RENDERED_STATE"],"evidence":["fixture://evidence/stale-contract-hash"],"impact":"evidence is bound to a superseded contract revision","minimal_remediation":"reconcile the packet and refresh all dependent evidence","required_validation":"Tuner, Overseer, and Arbiter verify the current identity chain"},"evidence":{"field_mapping":true,"validation_parity":true,"authorization_parity":true,"state_coverage":true,"accessibility":true,"executable_workflow":true},"workflow_id":"profile-update-happy-path","expected_reentry":["the-tuner","overseer","arbiter"]},
-    {"id":"inaccessible-backend-state","expected_status":"CROSS_LAYER_ALIGNMENT_GAPS_FOUND","finding_owner":"cloak","finding":{"finding_id":"F-STATE-001","severity":"MAJOR","owner":"cloak","affected_stages":["API_RESPONSE","CLIENT_CACHE_OR_STATE_UPDATE","FINAL_RENDERED_STATE"],"evidence":["fixture://evidence/inaccessible-backend-state"],"impact":"backend failure is not exposed as an actionable accessible UI state","minimal_remediation":"render and announce the backend failure without reporting success","required_validation":"failure-path UI test proves focus, status announcement, and recovery action"},"evidence":{"field_mapping":true,"validation_parity":true,"authorization_parity":true,"state_coverage":false,"accessibility":false,"executable_workflow":true},"workflow_id":"profile-update-happy-path","expected_reentry":["cloak","overseer"]},
-    {"id":"persistence-scope-expansion","expected_status":"SPECIALIST_REENTRY_REQUIRED","finding_owner":"chronicler","finding":{"finding_id":"F-PERSISTENCE-001","severity":"MAJOR","owner":"chronicler","affected_stages":["REPOSITORY_AND_PERSISTENCE"],"evidence":["fixture://evidence/new-persistence-requirement"],"impact":"the requested behavior exceeds the existing persistence contract and frozen scope","minimal_remediation":"return to Chronicler and Conductor for a separately authorized persistence contract","required_validation":"new scope, migration, and persistence evidence are reviewed before implementation"},"evidence":{"field_mapping":true,"validation_parity":true,"authorization_parity":true,"state_coverage":true,"accessibility":true,"executable_workflow":true},"workflow_id":"profile-update-happy-path","expected_reentry":["chronicler","conductor"]},
-    {"id":"missing-owner-contract","expected_status":"CROSS_LAYER_CONTRACT_INCOMPLETE","finding_owner":"the-tuner","finding":{"finding_id":"F-OWNER-001","severity":"MAJOR","owner":"the-tuner","affected_stages":["SERVICE_OPERATION"],"evidence":["missing://service-operation-owner"],"impact":"the packet cannot assign decision accountability for the service operation","minimal_remediation":"Conductor routes the missing domain contract and the packet is re-frozen","required_validation":"Tuner and Overseer verify complete ownership and current evidence"},"evidence":{"field_mapping":true,"validation_parity":true,"authorization_parity":true,"state_coverage":true,"accessibility":true,"executable_workflow":true},"workflow_id":"profile-update-happy-path","expected_reentry":["conductor","the-tuner"]},
-    {"id":"contradictory-api-requirement","expected_status":"CROSS_LAYER_CONTRADICTION_REVIEW_REQUIRED","finding_owner":"the-tuner","finding":{"finding_id":"F-CONTRADICTION-001","severity":"CRITICAL","owner":"the-tuner","affected_stages":["API_ROUTE","BACKEND_HANDLER"],"evidence":["fixture://evidence/clockwork-api-contract","fixture://evidence/cipher-authorization-contract"],"impact":"accepted specialist contracts prescribe incompatible route behavior","minimal_remediation":"Conductor routes specialist revision or human resolution without Tuner choosing a winner","required_validation":"revised specialist contracts remove the contradiction and dependent evidence is refreshed"},"evidence":{"field_mapping":true,"validation_parity":true,"authorization_parity":true,"state_coverage":true,"accessibility":true,"executable_workflow":true},"workflow_id":"admin-update-authorization-failure","expected_reentry":["conductor","clockwork","cipher"]}
+    {
+      "id": "happy-path-aligned",
+      "expected_status": "CROSS_LAYER_ALIGNMENT_CONFIRMED",
+      "finding_owner": null,
+      "finding": null,
+      "evidence": {
+        "field_mapping": true,
+        "validation_parity": true,
+        "authorization_parity": true,
+        "state_coverage": true,
+        "accessibility": true,
+        "executable_workflow": true
+      },
+      "workflow_id": "profile-update-happy-path",
+      "expected_reentry": []
+    },
+    {
+      "id": "request-field-mismatch",
+      "expected_status": "CROSS_LAYER_ALIGNMENT_GAPS_FOUND",
+      "finding_owner": "clockwork",
+      "finding": {
+        "finding_id": "F-REQUEST-001",
+        "severity": "MAJOR",
+        "owner": "clockwork",
+        "affected_stages": [
+          "CLIENT_STATE_OR_FORM_MODEL",
+          "SERIALIZED_REQUEST",
+          "BACKEND_HANDLER"
+        ],
+        "evidence": [
+          "fixture://evidence/request-field-mismatch"
+        ],
+        "impact": "client field is omitted and backend applies an unintended default",
+        "minimal_remediation": "align the request mapping with the accepted API contract",
+        "required_validation": "request serialization and handler tests prove the canonical field mapping"
+      },
+      "evidence": {
+        "field_mapping": false,
+        "validation_parity": true,
+        "authorization_parity": true,
+        "state_coverage": true,
+        "accessibility": true,
+        "executable_workflow": true
+      },
+      "workflow_id": "profile-update-happy-path",
+      "expected_reentry": [
+        "clockwork",
+        "overseer"
+      ]
+    },
+    {
+      "id": "missing-executable-evidence",
+      "expected_status": "CROSS_LAYER_EVIDENCE_INSUFFICIENT",
+      "finding_owner": "overseer",
+      "finding": {
+        "finding_id": "F-EVIDENCE-001",
+        "severity": "MAJOR",
+        "owner": "overseer",
+        "affected_stages": [
+          "UI_CONTROL",
+          "CLIENT_EVENT",
+          "CLIENT_STATE_OR_FORM_MODEL",
+          "SERIALIZED_REQUEST",
+          "API_ROUTE",
+          "BACKEND_HANDLER",
+          "SERVICE_OPERATION",
+          "REPOSITORY_AND_PERSISTENCE",
+          "API_RESPONSE",
+          "CLIENT_CACHE_OR_STATE_UPDATE",
+          "FINAL_RENDERED_STATE"
+        ],
+        "evidence": [
+          "missing://executable-workflow"
+        ],
+        "impact": "alignment cannot be demonstrated across the complete user-visible workflow",
+        "minimal_remediation": "produce current happy-path and failure-path executable traces",
+        "required_validation": "Overseer verifies traces against the frozen packet identity"
+      },
+      "evidence": {
+        "field_mapping": true,
+        "validation_parity": true,
+        "authorization_parity": true,
+        "state_coverage": true,
+        "accessibility": true,
+        "executable_workflow": false
+      },
+      "workflow_id": null,
+      "expected_reentry": [
+        "overseer"
+      ]
+    },
+    {
+      "id": "authorization-mismatch",
+      "expected_status": "CROSS_LAYER_ALIGNMENT_GAPS_FOUND",
+      "finding_owner": "cipher",
+      "finding": {
+        "finding_id": "F-AUTH-001",
+        "severity": "CRITICAL",
+        "owner": "cipher",
+        "affected_stages": [
+          "UI_CONTROL",
+          "API_ROUTE",
+          "BACKEND_HANDLER",
+          "FINAL_RENDERED_STATE"
+        ],
+        "evidence": [
+          "fixture://evidence/authorization-mismatch"
+        ],
+        "impact": "frontend visibility and backend authorization disagree",
+        "minimal_remediation": "align persona visibility and backend authorization under the accepted policy",
+        "required_validation": "authorized and unauthorized persona traces prove consistent UI and backend enforcement"
+      },
+      "evidence": {
+        "field_mapping": true,
+        "validation_parity": true,
+        "authorization_parity": false,
+        "state_coverage": true,
+        "accessibility": true,
+        "executable_workflow": true
+      },
+      "workflow_id": "admin-update-authorization-failure",
+      "expected_reentry": [
+        "cipher",
+        "cloak",
+        "overseer"
+      ]
+    },
+    {
+      "id": "stale-contract-identity",
+      "expected_status": "CROSS_LAYER_CONTRACT_STALE",
+      "finding_owner": "the-tuner",
+      "finding": {
+        "finding_id": "F-IDENTITY-001",
+        "severity": "MAJOR",
+        "owner": "the-tuner",
+        "affected_stages": [
+          "UI_CONTROL",
+          "CLIENT_EVENT",
+          "CLIENT_STATE_OR_FORM_MODEL",
+          "SERIALIZED_REQUEST",
+          "API_ROUTE",
+          "BACKEND_HANDLER",
+          "SERVICE_OPERATION",
+          "REPOSITORY_AND_PERSISTENCE",
+          "API_RESPONSE",
+          "CLIENT_CACHE_OR_STATE_UPDATE",
+          "FINAL_RENDERED_STATE"
+        ],
+        "evidence": [
+          "fixture://evidence/stale-contract-hash"
+        ],
+        "impact": "evidence is bound to a superseded contract revision",
+        "minimal_remediation": "reconcile the packet and refresh all dependent evidence",
+        "required_validation": "Tuner, Overseer, and Arbiter verify the current identity chain"
+      },
+      "evidence": {
+        "field_mapping": true,
+        "validation_parity": true,
+        "authorization_parity": true,
+        "state_coverage": true,
+        "accessibility": true,
+        "executable_workflow": true
+      },
+      "workflow_id": "profile-update-happy-path",
+      "expected_reentry": [
+        "the-tuner",
+        "overseer",
+        "arbiter"
+      ]
+    },
+    {
+      "id": "inaccessible-backend-state",
+      "expected_status": "CROSS_LAYER_ALIGNMENT_GAPS_FOUND",
+      "finding_owner": "cloak",
+      "finding": {
+        "finding_id": "F-STATE-001",
+        "severity": "MAJOR",
+        "owner": "cloak",
+        "affected_stages": [
+          "API_RESPONSE",
+          "CLIENT_CACHE_OR_STATE_UPDATE",
+          "FINAL_RENDERED_STATE"
+        ],
+        "evidence": [
+          "fixture://evidence/inaccessible-backend-state"
+        ],
+        "impact": "backend failure is not exposed as an actionable accessible UI state",
+        "minimal_remediation": "render and announce the backend failure without reporting success",
+        "required_validation": "failure-path UI test proves focus, status announcement, and recovery action"
+      },
+      "evidence": {
+        "field_mapping": true,
+        "validation_parity": true,
+        "authorization_parity": true,
+        "state_coverage": false,
+        "accessibility": false,
+        "executable_workflow": true
+      },
+      "workflow_id": "profile-update-happy-path",
+      "expected_reentry": [
+        "cloak",
+        "overseer"
+      ]
+    },
+    {
+      "id": "persistence-scope-expansion",
+      "expected_status": "SPECIALIST_REENTRY_REQUIRED",
+      "finding_owner": "chronicler",
+      "finding": {
+        "finding_id": "F-PERSISTENCE-001",
+        "severity": "MAJOR",
+        "owner": "chronicler",
+        "affected_stages": [
+          "REPOSITORY_AND_PERSISTENCE"
+        ],
+        "evidence": [
+          "fixture://evidence/new-persistence-requirement"
+        ],
+        "impact": "the requested behavior exceeds the existing persistence contract and frozen scope",
+        "minimal_remediation": "return to Chronicler and Conductor for a separately authorized persistence contract",
+        "required_validation": "new scope, migration, and persistence evidence are reviewed before implementation"
+      },
+      "evidence": {
+        "field_mapping": true,
+        "validation_parity": true,
+        "authorization_parity": true,
+        "state_coverage": true,
+        "accessibility": true,
+        "executable_workflow": true
+      },
+      "workflow_id": "profile-update-happy-path",
+      "expected_reentry": [
+        "chronicler",
+        "conductor"
+      ]
+    },
+    {
+      "id": "missing-owner-contract",
+      "expected_status": "CROSS_LAYER_CONTRACT_INCOMPLETE",
+      "finding_owner": "the-tuner",
+      "finding": {
+        "finding_id": "F-OWNER-001",
+        "severity": "MAJOR",
+        "owner": "the-tuner",
+        "affected_stages": [
+          "SERVICE_OPERATION"
+        ],
+        "evidence": [
+          "missing://service-operation-owner"
+        ],
+        "impact": "the packet cannot assign decision accountability for the service operation",
+        "minimal_remediation": "Conductor routes the missing domain contract and the packet is re-frozen",
+        "required_validation": "Tuner and Overseer verify complete ownership and current evidence"
+      },
+      "evidence": {
+        "field_mapping": true,
+        "validation_parity": true,
+        "authorization_parity": true,
+        "state_coverage": true,
+        "accessibility": true,
+        "executable_workflow": true
+      },
+      "workflow_id": "profile-update-happy-path",
+      "expected_reentry": [
+        "conductor",
+        "the-tuner"
+      ]
+    },
+    {
+      "id": "contradictory-api-requirement",
+      "expected_status": "CROSS_LAYER_CONTRADICTION_REVIEW_REQUIRED",
+      "finding_owner": "the-tuner",
+      "finding": {
+        "finding_id": "F-CONTRADICTION-001",
+        "severity": "CRITICAL",
+        "owner": "the-tuner",
+        "affected_stages": [
+          "API_ROUTE",
+          "BACKEND_HANDLER"
+        ],
+        "evidence": [
+          "fixture://evidence/clockwork-api-contract",
+          "fixture://evidence/cipher-authorization-contract"
+        ],
+        "impact": "accepted specialist contracts prescribe incompatible route behavior",
+        "minimal_remediation": "Conductor routes specialist revision or human resolution without Tuner choosing a winner",
+        "required_validation": "revised specialist contracts remove the contradiction and dependent evidence is refreshed"
+      },
+      "evidence": {
+        "field_mapping": true,
+        "validation_parity": true,
+        "authorization_parity": true,
+        "state_coverage": true,
+        "accessibility": true,
+        "executable_workflow": true
+      },
+      "workflow_id": "admin-update-authorization-failure",
+      "expected_reentry": [
+        "conductor",
+        "clockwork",
+        "cipher"
+      ]
+    }
   ]
 }

--- a/tests/behavior/cross-layer-synchronicity-fixtures.json
+++ b/tests/behavior/cross-layer-synchronicity-fixtures.json
@@ -3,7 +3,7 @@
   "contract_identity": {
     "approved_baseline": "6bce297c7469f9c08ce41308cbb993cc863ac540",
     "contract_revision": "frontend-backend-synchronicity-v1",
-    "protocol_sha256": "a866820fcfd4901d128db3e5f3568f0d9067277693e9e68d2f9b49371336fbb9",
+    "protocol_sha256": "ae8cbdba111fe071de4afd34d34a78ad8af152ac80336ac73eeb36b2fbc5b74b",
     "source_branch": "codex/frontend-backend-synchronicity-v1"
   },
   "workflow_stages": [
@@ -42,83 +42,17 @@
       "case_id": "happy-path-aligned",
       "kind": "HAPPY_PATH",
       "trace": [
-        {
-          "stage": "UI_CONTROL",
-          "owner": "cloak",
-          "source_ref": "fixture://ui/save-button",
-          "evidence_ref": "fixture://evidence/ui-control",
-          "result": "enabled control exposes accessible name"
-        },
-        {
-          "stage": "CLIENT_EVENT",
-          "owner": "cloak",
-          "source_ref": "fixture://client/save-click",
-          "evidence_ref": "fixture://evidence/client-event",
-          "result": "single click produces one submit intent"
-        },
-        {
-          "stage": "CLIENT_STATE_OR_FORM_MODEL",
-          "owner": "clockwork",
-          "source_ref": "fixture://client/profile-form",
-          "evidence_ref": "fixture://evidence/client-model",
-          "result": "normalized model passes client validation"
-        },
-        {
-          "stage": "SERIALIZED_REQUEST",
-          "owner": "clockwork",
-          "source_ref": "fixture://http/profile-request",
-          "evidence_ref": "fixture://evidence/request",
-          "result": "request contains canonical fields and types"
-        },
-        {
-          "stage": "API_ROUTE",
-          "owner": "cipher",
-          "source_ref": "fixture://api/profile-route",
-          "evidence_ref": "fixture://evidence/route",
-          "result": "authenticated authorized request reaches handler"
-        },
-        {
-          "stage": "BACKEND_HANDLER",
-          "owner": "clockwork",
-          "source_ref": "fixture://backend/profile-handler",
-          "evidence_ref": "fixture://evidence/handler",
-          "result": "handler parses and validates canonical request"
-        },
-        {
-          "stage": "SERVICE_OPERATION",
-          "owner": "clockwork",
-          "source_ref": "fixture://service/update-profile",
-          "evidence_ref": "fixture://evidence/service",
-          "result": "operation applies one idempotent update"
-        },
-        {
-          "stage": "REPOSITORY_AND_PERSISTENCE",
-          "owner": "chronicler",
-          "source_ref": "fixture://repository/profile-store",
-          "evidence_ref": "fixture://evidence/repository",
-          "result": "existing repository contract records update"
-        },
-        {
-          "stage": "API_RESPONSE",
-          "owner": "clockwork",
-          "source_ref": "fixture://http/profile-response",
-          "evidence_ref": "fixture://evidence/response",
-          "result": "response maps canonical saved profile"
-        },
-        {
-          "stage": "CLIENT_CACHE_OR_STATE_UPDATE",
-          "owner": "clockwork",
-          "source_ref": "fixture://client/profile-cache",
-          "evidence_ref": "fixture://evidence/cache",
-          "result": "cache reconciles server response without stale overwrite"
-        },
-        {
-          "stage": "FINAL_RENDERED_STATE",
-          "owner": "cloak",
-          "source_ref": "fixture://ui/profile-success",
-          "evidence_ref": "fixture://evidence/render",
-          "result": "success state is visible and announced"
-        }
+        {"stage":"UI_CONTROL","owner":"cloak","source_ref":"fixture://ui/save-button","evidence_ref":"fixture://evidence/ui-control","result":"enabled control exposes accessible name"},
+        {"stage":"CLIENT_EVENT","owner":"cloak","source_ref":"fixture://client/save-click","evidence_ref":"fixture://evidence/client-event","result":"single click produces one submit intent"},
+        {"stage":"CLIENT_STATE_OR_FORM_MODEL","owner":"clockwork","source_ref":"fixture://client/profile-form","evidence_ref":"fixture://evidence/client-model","result":"normalized model passes client validation"},
+        {"stage":"SERIALIZED_REQUEST","owner":"clockwork","source_ref":"fixture://http/profile-request","evidence_ref":"fixture://evidence/request","result":"request contains canonical fields and types"},
+        {"stage":"API_ROUTE","owner":"cipher","source_ref":"fixture://api/profile-route","evidence_ref":"fixture://evidence/route","result":"authenticated authorized request reaches handler"},
+        {"stage":"BACKEND_HANDLER","owner":"clockwork","source_ref":"fixture://backend/profile-handler","evidence_ref":"fixture://evidence/handler","result":"handler parses and validates canonical request"},
+        {"stage":"SERVICE_OPERATION","owner":"clockwork","source_ref":"fixture://service/update-profile","evidence_ref":"fixture://evidence/service","result":"operation applies one idempotent update"},
+        {"stage":"REPOSITORY_AND_PERSISTENCE","owner":"chronicler","source_ref":"fixture://repository/profile-store","evidence_ref":"fixture://evidence/repository","result":"existing repository contract records update"},
+        {"stage":"API_RESPONSE","owner":"clockwork","source_ref":"fixture://http/profile-response","evidence_ref":"fixture://evidence/response","result":"response maps canonical saved profile"},
+        {"stage":"CLIENT_CACHE_OR_STATE_UPDATE","owner":"clockwork","source_ref":"fixture://client/profile-cache","evidence_ref":"fixture://evidence/cache","result":"cache reconciles server response without stale overwrite"},
+        {"stage":"FINAL_RENDERED_STATE","owner":"cloak","source_ref":"fixture://ui/profile-success","evidence_ref":"fixture://evidence/render","result":"success state is visible and announced"}
       ],
       "expected_final_state": "profile update is persisted, reconciled, visible, and announced"
     },
@@ -127,390 +61,30 @@
       "case_id": "authorization-mismatch",
       "kind": "FAILURE_PATH",
       "trace": [
-        {
-          "stage": "UI_CONTROL",
-          "owner": "cloak",
-          "source_ref": "fixture://ui/admin-save-button",
-          "evidence_ref": "fixture://evidence/auth-ui-control",
-          "result": "control is visible only to authorized persona"
-        },
-        {
-          "stage": "CLIENT_EVENT",
-          "owner": "cloak",
-          "source_ref": "fixture://client/admin-save-click",
-          "evidence_ref": "fixture://evidence/auth-client-event",
-          "result": "event produces one protected request"
-        },
-        {
-          "stage": "CLIENT_STATE_OR_FORM_MODEL",
-          "owner": "clockwork",
-          "source_ref": "fixture://client/admin-form",
-          "evidence_ref": "fixture://evidence/auth-client-model",
-          "result": "model passes client validation"
-        },
-        {
-          "stage": "SERIALIZED_REQUEST",
-          "owner": "clockwork",
-          "source_ref": "fixture://http/admin-request",
-          "evidence_ref": "fixture://evidence/auth-request",
-          "result": "request shape is canonical"
-        },
-        {
-          "stage": "API_ROUTE",
-          "owner": "cipher",
-          "source_ref": "fixture://api/admin-route",
-          "evidence_ref": "fixture://evidence/auth-route",
-          "result": "backend rejects unauthorized persona"
-        },
-        {
-          "stage": "BACKEND_HANDLER",
-          "owner": "clockwork",
-          "source_ref": "fixture://backend/admin-handler",
-          "evidence_ref": "fixture://evidence/auth-handler",
-          "result": "handler returns deterministic forbidden response"
-        },
-        {
-          "stage": "SERVICE_OPERATION",
-          "owner": "clockwork",
-          "source_ref": "fixture://service/admin-update",
-          "evidence_ref": "fixture://evidence/auth-service",
-          "result": "service is not invoked"
-        },
-        {
-          "stage": "REPOSITORY_AND_PERSISTENCE",
-          "owner": "chronicler",
-          "source_ref": "fixture://repository/admin-store",
-          "evidence_ref": "fixture://evidence/auth-repository",
-          "result": "repository is not invoked"
-        },
-        {
-          "stage": "API_RESPONSE",
-          "owner": "clockwork",
-          "source_ref": "fixture://http/admin-forbidden",
-          "evidence_ref": "fixture://evidence/auth-response",
-          "result": "response is 403 with canonical error"
-        },
-        {
-          "stage": "CLIENT_CACHE_OR_STATE_UPDATE",
-          "owner": "clockwork",
-          "source_ref": "fixture://client/admin-cache",
-          "evidence_ref": "fixture://evidence/auth-cache",
-          "result": "cache remains unchanged"
-        },
-        {
-          "stage": "FINAL_RENDERED_STATE",
-          "owner": "cloak",
-          "source_ref": "fixture://ui/admin-forbidden",
-          "evidence_ref": "fixture://evidence/auth-render",
-          "result": "forbidden state is visible and announced"
-        }
+        {"stage":"UI_CONTROL","owner":"cloak","source_ref":"fixture://ui/admin-save-button","evidence_ref":"fixture://evidence/auth-ui-control","result":"control is visible only to authorized persona"},
+        {"stage":"CLIENT_EVENT","owner":"cloak","source_ref":"fixture://client/admin-save-click","evidence_ref":"fixture://evidence/auth-client-event","result":"event produces one protected request"},
+        {"stage":"CLIENT_STATE_OR_FORM_MODEL","owner":"clockwork","source_ref":"fixture://client/admin-form","evidence_ref":"fixture://evidence/auth-client-model","result":"model passes client validation"},
+        {"stage":"SERIALIZED_REQUEST","owner":"clockwork","source_ref":"fixture://http/admin-request","evidence_ref":"fixture://evidence/auth-request","result":"request shape is canonical"},
+        {"stage":"API_ROUTE","owner":"cipher","source_ref":"fixture://api/admin-route","evidence_ref":"fixture://evidence/auth-route","result":"backend rejects unauthorized persona"},
+        {"stage":"BACKEND_HANDLER","owner":"clockwork","source_ref":"fixture://backend/admin-handler","evidence_ref":"fixture://evidence/auth-handler","result":"handler returns deterministic forbidden response"},
+        {"stage":"SERVICE_OPERATION","owner":"clockwork","source_ref":"fixture://service/admin-update","evidence_ref":"fixture://evidence/auth-service","result":"service is not invoked"},
+        {"stage":"REPOSITORY_AND_PERSISTENCE","owner":"chronicler","source_ref":"fixture://repository/admin-store","evidence_ref":"fixture://evidence/auth-repository","result":"repository is not invoked"},
+        {"stage":"API_RESPONSE","owner":"clockwork","source_ref":"fixture://http/admin-forbidden","evidence_ref":"fixture://evidence/auth-response","result":"response is 403 with canonical error"},
+        {"stage":"CLIENT_CACHE_OR_STATE_UPDATE","owner":"clockwork","source_ref":"fixture://client/admin-cache","evidence_ref":"fixture://evidence/auth-cache","result":"cache remains unchanged"},
+        {"stage":"FINAL_RENDERED_STATE","owner":"cloak","source_ref":"fixture://ui/admin-forbidden","evidence_ref":"fixture://evidence/auth-render","result":"forbidden state is visible and announced"}
       ],
       "expected_final_state": "unauthorized request is rejected, no side effect occurs, and the denial is visible"
     }
   ],
   "cases": [
-    {
-      "id": "happy-path-aligned",
-      "expected_status": "CROSS_LAYER_ALIGNMENT_CONFIRMED",
-      "finding_owner": null,
-      "finding": null,
-      "evidence": {
-        "field_mapping": true,
-        "validation_parity": true,
-        "authorization_parity": true,
-        "state_coverage": true,
-        "accessibility": true,
-        "executable_workflow": true
-      },
-      "workflow_id": "profile-update-happy-path",
-      "expected_reentry": []
-    },
-    {
-      "id": "request-field-mismatch",
-      "expected_status": "CROSS_LAYER_ALIGNMENT_GAPS_FOUND",
-      "finding_owner": "clockwork",
-      "finding": {
-        "finding_id": "F-REQUEST-001",
-        "severity": "MAJOR",
-        "owner": "clockwork",
-        "affected_stages": [
-          "CLIENT_STATE_OR_FORM_MODEL",
-          "SERIALIZED_REQUEST",
-          "BACKEND_HANDLER"
-        ],
-        "evidence": [
-          "fixture://evidence/request-field-mismatch"
-        ],
-        "impact": "client field is omitted and backend applies an unintended default",
-        "minimal_remediation": "align the request mapping with the accepted API contract",
-        "required_validation": "request serialization and handler tests prove the canonical field mapping"
-      },
-      "evidence": {
-        "field_mapping": false,
-        "validation_parity": true,
-        "authorization_parity": true,
-        "state_coverage": true,
-        "accessibility": true,
-        "executable_workflow": true
-      },
-      "workflow_id": "profile-update-happy-path",
-      "expected_reentry": [
-        "clockwork",
-        "overseer"
-      ]
-    },
-    {
-      "id": "missing-executable-evidence",
-      "expected_status": "CROSS_LAYER_EVIDENCE_INSUFFICIENT",
-      "finding_owner": "overseer",
-      "finding": {
-        "finding_id": "F-EVIDENCE-001",
-        "severity": "MAJOR",
-        "owner": "overseer",
-        "affected_stages": [
-          "UI_CONTROL",
-          "CLIENT_EVENT",
-          "CLIENT_STATE_OR_FORM_MODEL",
-          "SERIALIZED_REQUEST",
-          "API_ROUTE",
-          "BACKEND_HANDLER",
-          "SERVICE_OPERATION",
-          "REPOSITORY_AND_PERSISTENCE",
-          "API_RESPONSE",
-          "CLIENT_CACHE_OR_STATE_UPDATE",
-          "FINAL_RENDERED_STATE"
-        ],
-        "evidence": [
-          "missing://executable-workflow"
-        ],
-        "impact": "alignment cannot be demonstrated across the complete user-visible workflow",
-        "minimal_remediation": "produce current happy-path and failure-path executable traces",
-        "required_validation": "Overseer verifies traces against the frozen packet identity"
-      },
-      "evidence": {
-        "field_mapping": true,
-        "validation_parity": true,
-        "authorization_parity": true,
-        "state_coverage": true,
-        "accessibility": true,
-        "executable_workflow": false
-      },
-      "workflow_id": null,
-      "expected_reentry": [
-        "overseer"
-      ]
-    },
-    {
-      "id": "authorization-mismatch",
-      "expected_status": "CROSS_LAYER_ALIGNMENT_GAPS_FOUND",
-      "finding_owner": "cipher",
-      "finding": {
-        "finding_id": "F-AUTH-001",
-        "severity": "CRITICAL",
-        "owner": "cipher",
-        "affected_stages": [
-          "UI_CONTROL",
-          "API_ROUTE",
-          "BACKEND_HANDLER",
-          "FINAL_RENDERED_STATE"
-        ],
-        "evidence": [
-          "fixture://evidence/authorization-mismatch"
-        ],
-        "impact": "frontend visibility and backend authorization disagree",
-        "minimal_remediation": "align persona visibility and backend authorization under the accepted policy",
-        "required_validation": "authorized and unauthorized persona traces prove consistent UI and backend enforcement"
-      },
-      "evidence": {
-        "field_mapping": true,
-        "validation_parity": true,
-        "authorization_parity": false,
-        "state_coverage": true,
-        "accessibility": true,
-        "executable_workflow": true
-      },
-      "workflow_id": "admin-update-authorization-failure",
-      "expected_reentry": [
-        "cipher",
-        "cloak",
-        "overseer"
-      ]
-    },
-    {
-      "id": "stale-contract-identity",
-      "expected_status": "CROSS_LAYER_CONTRACT_STALE",
-      "finding_owner": "the-tuner",
-      "finding": {
-        "finding_id": "F-IDENTITY-001",
-        "severity": "MAJOR",
-        "owner": "the-tuner",
-        "affected_stages": [
-          "UI_CONTROL",
-          "CLIENT_EVENT",
-          "CLIENT_STATE_OR_FORM_MODEL",
-          "SERIALIZED_REQUEST",
-          "API_ROUTE",
-          "BACKEND_HANDLER",
-          "SERVICE_OPERATION",
-          "REPOSITORY_AND_PERSISTENCE",
-          "API_RESPONSE",
-          "CLIENT_CACHE_OR_STATE_UPDATE",
-          "FINAL_RENDERED_STATE"
-        ],
-        "evidence": [
-          "fixture://evidence/stale-contract-hash"
-        ],
-        "impact": "evidence is bound to a superseded contract revision",
-        "minimal_remediation": "reconcile the packet and refresh all dependent evidence",
-        "required_validation": "Tuner, Overseer, and Arbiter verify the current identity chain"
-      },
-      "evidence": {
-        "field_mapping": true,
-        "validation_parity": true,
-        "authorization_parity": true,
-        "state_coverage": true,
-        "accessibility": true,
-        "executable_workflow": true
-      },
-      "workflow_id": "profile-update-happy-path",
-      "expected_reentry": [
-        "the-tuner",
-        "overseer",
-        "arbiter"
-      ]
-    },
-    {
-      "id": "inaccessible-backend-state",
-      "expected_status": "CROSS_LAYER_ALIGNMENT_GAPS_FOUND",
-      "finding_owner": "cloak",
-      "finding": {
-        "finding_id": "F-STATE-001",
-        "severity": "MAJOR",
-        "owner": "cloak",
-        "affected_stages": [
-          "API_RESPONSE",
-          "CLIENT_CACHE_OR_STATE_UPDATE",
-          "FINAL_RENDERED_STATE"
-        ],
-        "evidence": [
-          "fixture://evidence/inaccessible-backend-state"
-        ],
-        "impact": "backend failure is not exposed as an actionable accessible UI state",
-        "minimal_remediation": "render and announce the backend failure without reporting success",
-        "required_validation": "failure-path UI test proves focus, status announcement, and recovery action"
-      },
-      "evidence": {
-        "field_mapping": true,
-        "validation_parity": true,
-        "authorization_parity": true,
-        "state_coverage": false,
-        "accessibility": false,
-        "executable_workflow": true
-      },
-      "workflow_id": "profile-update-happy-path",
-      "expected_reentry": [
-        "cloak",
-        "overseer"
-      ]
-    },
-    {
-      "id": "persistence-scope-expansion",
-      "expected_status": "SPECIALIST_REENTRY_REQUIRED",
-      "finding_owner": "chronicler",
-      "finding": {
-        "finding_id": "F-PERSISTENCE-001",
-        "severity": "MAJOR",
-        "owner": "chronicler",
-        "affected_stages": [
-          "REPOSITORY_AND_PERSISTENCE"
-        ],
-        "evidence": [
-          "fixture://evidence/new-persistence-requirement"
-        ],
-        "impact": "the requested behavior exceeds the existing persistence contract and frozen scope",
-        "minimal_remediation": "return to Chronicler and Conductor for a separately authorized persistence contract",
-        "required_validation": "new scope, migration, and persistence evidence are reviewed before implementation"
-      },
-      "evidence": {
-        "field_mapping": true,
-        "validation_parity": true,
-        "authorization_parity": true,
-        "state_coverage": true,
-        "accessibility": true,
-        "executable_workflow": true
-      },
-      "workflow_id": "profile-update-happy-path",
-      "expected_reentry": [
-        "chronicler",
-        "conductor"
-      ]
-    },
-    {
-      "id": "missing-owner-contract",
-      "expected_status": "CROSS_LAYER_CONTRACT_INCOMPLETE",
-      "finding_owner": "the-tuner",
-      "finding": {
-        "finding_id": "F-OWNER-001",
-        "severity": "MAJOR",
-        "owner": "the-tuner",
-        "affected_stages": [
-          "SERVICE_OPERATION"
-        ],
-        "evidence": [
-          "missing://service-operation-owner"
-        ],
-        "impact": "the packet cannot assign decision accountability for the service operation",
-        "minimal_remediation": "Conductor routes the missing domain contract and the packet is re-frozen",
-        "required_validation": "Tuner and Overseer verify complete ownership and current evidence"
-      },
-      "evidence": {
-        "field_mapping": true,
-        "validation_parity": true,
-        "authorization_parity": true,
-        "state_coverage": true,
-        "accessibility": true,
-        "executable_workflow": true
-      },
-      "workflow_id": "profile-update-happy-path",
-      "expected_reentry": [
-        "conductor",
-        "the-tuner"
-      ]
-    },
-    {
-      "id": "contradictory-api-requirement",
-      "expected_status": "CROSS_LAYER_CONTRADICTION_REVIEW_REQUIRED",
-      "finding_owner": "the-tuner",
-      "finding": {
-        "finding_id": "F-CONTRADICTION-001",
-        "severity": "CRITICAL",
-        "owner": "the-tuner",
-        "affected_stages": [
-          "API_ROUTE",
-          "BACKEND_HANDLER"
-        ],
-        "evidence": [
-          "fixture://evidence/clockwork-api-contract",
-          "fixture://evidence/cipher-authorization-contract"
-        ],
-        "impact": "accepted specialist contracts prescribe incompatible route behavior",
-        "minimal_remediation": "Conductor routes specialist revision or human resolution without Tuner choosing a winner",
-        "required_validation": "revised specialist contracts remove the contradiction and dependent evidence is refreshed"
-      },
-      "evidence": {
-        "field_mapping": true,
-        "validation_parity": true,
-        "authorization_parity": true,
-        "state_coverage": true,
-        "accessibility": true,
-        "executable_workflow": true
-      },
-      "workflow_id": "admin-update-authorization-failure",
-      "expected_reentry": [
-        "conductor",
-        "clockwork",
-        "cipher"
-      ]
-    }
+    {"id":"happy-path-aligned","expected_status":"CROSS_LAYER_ALIGNMENT_CONFIRMED","finding_owner":null,"finding":null,"evidence":{"field_mapping":true,"validation_parity":true,"authorization_parity":true,"state_coverage":true,"accessibility":true,"executable_workflow":true},"workflow_id":"profile-update-happy-path","expected_reentry":[]},
+    {"id":"request-field-mismatch","expected_status":"CROSS_LAYER_ALIGNMENT_GAPS_FOUND","finding_owner":"clockwork","finding":{"finding_id":"F-REQUEST-001","severity":"MAJOR","owner":"clockwork","affected_stages":["CLIENT_STATE_OR_FORM_MODEL","SERIALIZED_REQUEST","BACKEND_HANDLER"],"evidence":["fixture://evidence/request-field-mismatch"],"impact":"client field is omitted and backend applies an unintended default","minimal_remediation":"align the request mapping with the accepted API contract","required_validation":"request serialization and handler tests prove the canonical field mapping"},"evidence":{"field_mapping":false,"validation_parity":true,"authorization_parity":true,"state_coverage":true,"accessibility":true,"executable_workflow":true},"workflow_id":"profile-update-happy-path","expected_reentry":["clockwork","overseer"]},
+    {"id":"missing-executable-evidence","expected_status":"CROSS_LAYER_EVIDENCE_INSUFFICIENT","finding_owner":"overseer","finding":{"finding_id":"F-EVIDENCE-001","severity":"MAJOR","owner":"overseer","affected_stages":["UI_CONTROL","CLIENT_EVENT","CLIENT_STATE_OR_FORM_MODEL","SERIALIZED_REQUEST","API_ROUTE","BACKEND_HANDLER","SERVICE_OPERATION","REPOSITORY_AND_PERSISTENCE","API_RESPONSE","CLIENT_CACHE_OR_STATE_UPDATE","FINAL_RENDERED_STATE"],"evidence":["missing://executable-workflow"],"impact":"alignment cannot be demonstrated across the complete user-visible workflow","minimal_remediation":"produce current happy-path and failure-path executable traces","required_validation":"Overseer verifies traces against the frozen packet identity"},"evidence":{"field_mapping":true,"validation_parity":true,"authorization_parity":true,"state_coverage":true,"accessibility":true,"executable_workflow":false},"workflow_id":null,"expected_reentry":["overseer"]},
+    {"id":"authorization-mismatch","expected_status":"CROSS_LAYER_ALIGNMENT_GAPS_FOUND","finding_owner":"cipher","finding":{"finding_id":"F-AUTH-001","severity":"CRITICAL","owner":"cipher","affected_stages":["UI_CONTROL","API_ROUTE","BACKEND_HANDLER","FINAL_RENDERED_STATE"],"evidence":["fixture://evidence/authorization-mismatch"],"impact":"frontend visibility and backend authorization disagree","minimal_remediation":"align persona visibility and backend authorization under the accepted policy","required_validation":"authorized and unauthorized persona traces prove consistent UI and backend enforcement"},"evidence":{"field_mapping":true,"validation_parity":true,"authorization_parity":false,"state_coverage":true,"accessibility":true,"executable_workflow":true},"workflow_id":"admin-update-authorization-failure","expected_reentry":["cipher","cloak","overseer"]},
+    {"id":"stale-contract-identity","expected_status":"CROSS_LAYER_CONTRACT_STALE","finding_owner":"the-tuner","finding":{"finding_id":"F-IDENTITY-001","severity":"MAJOR","owner":"the-tuner","affected_stages":["UI_CONTROL","CLIENT_EVENT","CLIENT_STATE_OR_FORM_MODEL","SERIALIZED_REQUEST","API_ROUTE","BACKEND_HANDLER","SERVICE_OPERATION","REPOSITORY_AND_PERSISTENCE","API_RESPONSE","CLIENT_CACHE_OR_STATE_UPDATE","FINAL_RENDERED_STATE"],"evidence":["fixture://evidence/stale-contract-hash"],"impact":"evidence is bound to a superseded contract revision","minimal_remediation":"reconcile the packet and refresh all dependent evidence","required_validation":"Tuner, Overseer, and Arbiter verify the current identity chain"},"evidence":{"field_mapping":true,"validation_parity":true,"authorization_parity":true,"state_coverage":true,"accessibility":true,"executable_workflow":true},"workflow_id":"profile-update-happy-path","expected_reentry":["the-tuner","overseer","arbiter"]},
+    {"id":"inaccessible-backend-state","expected_status":"CROSS_LAYER_ALIGNMENT_GAPS_FOUND","finding_owner":"cloak","finding":{"finding_id":"F-STATE-001","severity":"MAJOR","owner":"cloak","affected_stages":["API_RESPONSE","CLIENT_CACHE_OR_STATE_UPDATE","FINAL_RENDERED_STATE"],"evidence":["fixture://evidence/inaccessible-backend-state"],"impact":"backend failure is not exposed as an actionable accessible UI state","minimal_remediation":"render and announce the backend failure without reporting success","required_validation":"failure-path UI test proves focus, status announcement, and recovery action"},"evidence":{"field_mapping":true,"validation_parity":true,"authorization_parity":true,"state_coverage":false,"accessibility":false,"executable_workflow":true},"workflow_id":"profile-update-happy-path","expected_reentry":["cloak","overseer"]},
+    {"id":"persistence-scope-expansion","expected_status":"SPECIALIST_REENTRY_REQUIRED","finding_owner":"chronicler","finding":{"finding_id":"F-PERSISTENCE-001","severity":"MAJOR","owner":"chronicler","affected_stages":["REPOSITORY_AND_PERSISTENCE"],"evidence":["fixture://evidence/new-persistence-requirement"],"impact":"the requested behavior exceeds the existing persistence contract and frozen scope","minimal_remediation":"return to Chronicler and Conductor for a separately authorized persistence contract","required_validation":"new scope, migration, and persistence evidence are reviewed before implementation"},"evidence":{"field_mapping":true,"validation_parity":true,"authorization_parity":true,"state_coverage":true,"accessibility":true,"executable_workflow":true},"workflow_id":"profile-update-happy-path","expected_reentry":["chronicler","conductor"]},
+    {"id":"missing-owner-contract","expected_status":"CROSS_LAYER_CONTRACT_INCOMPLETE","finding_owner":"the-tuner","finding":{"finding_id":"F-OWNER-001","severity":"MAJOR","owner":"the-tuner","affected_stages":["SERVICE_OPERATION"],"evidence":["missing://service-operation-owner"],"impact":"the packet cannot assign decision accountability for the service operation","minimal_remediation":"Conductor routes the missing domain contract and the packet is re-frozen","required_validation":"Tuner and Overseer verify complete ownership and current evidence"},"evidence":{"field_mapping":true,"validation_parity":true,"authorization_parity":true,"state_coverage":true,"accessibility":true,"executable_workflow":true},"workflow_id":"profile-update-happy-path","expected_reentry":["conductor","the-tuner"]},
+    {"id":"contradictory-api-requirement","expected_status":"CROSS_LAYER_CONTRADICTION_REVIEW_REQUIRED","finding_owner":"the-tuner","finding":{"finding_id":"F-CONTRADICTION-001","severity":"CRITICAL","owner":"the-tuner","affected_stages":["API_ROUTE","BACKEND_HANDLER"],"evidence":["fixture://evidence/clockwork-api-contract","fixture://evidence/cipher-authorization-contract"],"impact":"accepted specialist contracts prescribe incompatible route behavior","minimal_remediation":"Conductor routes specialist revision or human resolution without Tuner choosing a winner","required_validation":"revised specialist contracts remove the contradiction and dependent evidence is refreshed"},"evidence":{"field_mapping":true,"validation_parity":true,"authorization_parity":true,"state_coverage":true,"accessibility":true,"executable_workflow":true},"workflow_id":"admin-update-authorization-failure","expected_reentry":["conductor","clockwork","cipher"]}
   ]
 }

--- a/tests/behavior/test_cross_layer_synchronicity_contract.py
+++ b/tests/behavior/test_cross_layer_synchronicity_contract.py
@@ -6,19 +6,29 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 VALIDATOR_PATH = ROOT / "scripts/validate_cross_layer_synchronicity_contract.py"
+INTEGRITY_VALIDATOR_PATH = ROOT / "scripts/validate_cross_layer_integrity_contract.py"
 FIXTURES_PATH = ROOT / "tests/behavior/cross-layer-synchronicity-fixtures.json"
+INTEGRITY_FIXTURES_PATH = ROOT / "tests/behavior/cross-layer-integrity-fixtures.json"
 PROTOCOL_PATH = ROOT / "docs/validation/CROSS_MODULE_LOGIC_AUDIT_PROTOCOL.md"
 
-spec = importlib.util.spec_from_file_location(
-    "synchronicity_validator",
-    VALIDATOR_PATH,
-)
+spec = importlib.util.spec_from_file_location("synchronicity_validator", VALIDATOR_PATH)
 validator = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(validator)
+
+integrity_spec = importlib.util.spec_from_file_location(
+    "cross_layer_integrity_validator",
+    INTEGRITY_VALIDATOR_PATH,
+)
+integrity_validator = importlib.util.module_from_spec(integrity_spec)
+integrity_spec.loader.exec_module(integrity_validator)
 
 
 def fixtures():
     return json.loads(FIXTURES_PATH.read_text(encoding="utf-8"))
+
+
+def integrity_fixtures():
+    return json.loads(INTEGRITY_FIXTURES_PATH.read_text(encoding="utf-8"))
 
 
 def protocol_bytes():
@@ -34,19 +44,41 @@ def test_real_repo_passes():
     assert not validator.validate(ROOT)
 
 
+def test_integrity_repo_passes():
+    assert not integrity_validator.validate(ROOT)
+
+
 def test_all_statuses_have_cases():
     statuses = {case["expected_status"] for case in fixtures()["cases"]}
     assert statuses == validator.REQUIRED_STATUSES
 
 
+def test_integrity_profiles_cover_all_statuses():
+    data = integrity_fixtures()
+    assert set(data["profiles"]) == set(integrity_validator.PROFILE_SPECS)
+    for name, profile_spec in integrity_validator.PROFILE_SPECS.items():
+        profile = data["profiles"][name]
+        assert tuple(profile["stages"]) == profile_spec["stages"]
+        assert set(profile["required_evidence"]) == profile_spec["evidence"]
+        assert {case["expected_status"] for case in profile["cases"]} == integrity_validator.REQUIRED_STATUSES
+
+
 def test_executable_workflows_trace_all_stages():
     for workflow in fixtures()["executable_workflows"]:
-        assert [entry["stage"] for entry in workflow["trace"]] == list(
-            validator.REQUIRED_STAGES
-        )
+        assert [entry["stage"] for entry in workflow["trace"]] == list(validator.REQUIRED_STAGES)
         assert all(entry["source_ref"] for entry in workflow["trace"])
         assert all(entry["evidence_ref"] for entry in workflow["trace"])
         assert all(entry["result"] for entry in workflow["trace"])
+
+
+def test_integrity_workflows_trace_profile_stages():
+    data = integrity_fixtures()
+    for name, profile_spec in integrity_validator.PROFILE_SPECS.items():
+        for workflow in data["profiles"][name]["executable_workflows"]:
+            assert [entry["stage"] for entry in workflow["trace"]] == list(profile_spec["stages"])
+            assert all(entry["source_ref"] for entry in workflow["trace"])
+            assert all(entry["evidence_ref"] for entry in workflow["trace"])
+            assert all(entry["result"] for entry in workflow["trace"])
 
 
 def test_happy_path_requires_complete_evidence():
@@ -68,6 +100,37 @@ def test_failure_paths_have_complete_single_owner_findings():
         assert case["finding"]["affected_stages"]
 
 
+def test_integrity_findings_have_single_owners():
+    for profile in integrity_fixtures()["profiles"].values():
+        for case in profile["cases"]:
+            if case["expected_status"] == "CROSS_LAYER_ALIGNMENT_CONFIRMED":
+                assert case["finding_owner"] is None
+                assert case["finding"] is None
+                continue
+            assert case["finding_owner"] in integrity_validator.OWNERS
+            assert case["finding"]["owner"] == case["finding_owner"]
+            assert set(case["finding"]) == integrity_validator.FINDING_FIELDS
+
+
+def test_backend_persistence_owner_boundaries():
+    cases = {
+        case["id"]: case
+        for case in integrity_fixtures()["profiles"]["backend_persistence"]["cases"]
+    }
+    assert cases["backend-contract-mapping-gap"]["finding_owner"] == "chronicler"
+    assert cases["backend-transaction-reentry"]["finding_owner"] == "chronicler"
+    assert cases["backend-evidence-missing"]["finding_owner"] == "overseer"
+
+
+def test_cross_module_logic_owner_boundaries():
+    cases = {
+        case["id"]: case
+        for case in integrity_fixtures()["profiles"]["cross_module_logic"]["cases"]
+    }
+    assert cases["cross-module-flow-gap"]["finding_owner"] == "clockwork"
+    assert cases["cross-module-side-effect-reentry"]["finding_owner"] == "clockwork"
+
+
 def test_authorization_mismatch_routes_to_cipher():
     case = cases_by_id()["authorization-mismatch"]
     assert case["finding_owner"] == "cipher"
@@ -83,23 +146,39 @@ def test_stale_identity_reenters_continuity_chain():
 def test_unknown_status_fails_closed():
     data = fixtures()
     data["cases"][0]["expected_status"] = "AUTO_CONTINUE_UNKNOWN"
+    assert any("unknown status" in error for error in validator.validate_fixtures(data, protocol_bytes()))
+
+
+def test_integrity_unknown_profile_fails_closed():
+    data = integrity_fixtures()
+    data["profiles"]["unknown"] = copy.deepcopy(data["profiles"]["cross_module_logic"])
     assert any(
-        "unknown status" in error
-        for error in validator.validate_fixtures(data, protocol_bytes())
+        "profiles must contain exactly" in error
+        for error in integrity_validator.validate_fixtures(data, protocol_bytes())
     )
 
 
 def test_missing_executable_evidence_fails_closed():
     data = copy.deepcopy(fixtures())
-    case = next(
-        item
-        for item in data["cases"]
-        if item["id"] == "missing-executable-evidence"
-    )
+    case = next(item for item in data["cases"] if item["id"] == "missing-executable-evidence")
     case["evidence"]["executable_workflow"] = True
     assert any(
         "executable evidence requires workflow_id" in error
         for error in validator.validate_fixtures(data, protocol_bytes())
+    )
+
+
+def test_integrity_missing_executable_evidence_fails_closed():
+    data = integrity_fixtures()
+    case = next(
+        item
+        for item in data["profiles"]["cross_module_logic"]["cases"]
+        if item["id"] == "cross-module-evidence-missing"
+    )
+    case["evidence"]["executable_workflow"] = True
+    assert any(
+        "executable evidence requires workflow_id" in error
+        for error in integrity_validator.validate_fixtures(data, protocol_bytes())
     )
 
 
@@ -112,6 +191,15 @@ def test_protocol_hash_mismatch_fails_closed():
     )
 
 
+def test_integrity_protocol_hash_mismatch_fails_closed():
+    data = integrity_fixtures()
+    data["contract_identity"]["protocol_sha256"] = "0" * 64
+    assert any(
+        "protocol_sha256 does not match" in error
+        for error in integrity_validator.validate_fixtures(data, protocol_bytes())
+    )
+
+
 def test_incomplete_trace_fails_closed():
     data = fixtures()
     data["executable_workflows"][0]["trace"].pop()
@@ -121,13 +209,18 @@ def test_incomplete_trace_fails_closed():
     )
 
 
+def test_integrity_incomplete_trace_fails_closed():
+    data = integrity_fixtures()
+    data["profiles"]["backend_persistence"]["executable_workflows"][0]["trace"].pop()
+    assert any(
+        "trace must contain profile stages in exact order" in error
+        for error in integrity_validator.validate_fixtures(data, protocol_bytes())
+    )
+
+
 def test_incomplete_finding_fails_closed():
     data = fixtures()
-    case = next(
-        item
-        for item in data["cases"]
-        if item["id"] == "request-field-mismatch"
-    )
+    case = next(item for item in data["cases"] if item["id"] == "request-field-mismatch")
     del case["finding"]["required_validation"]
     assert any(
         "complete finding object" in error
@@ -135,13 +228,23 @@ def test_incomplete_finding_fails_closed():
     )
 
 
-def test_unknown_reentry_owner_fails_closed():
-    data = fixtures()
+def test_integrity_stale_identity_requires_continuity_chain():
+    data = integrity_fixtures()
     case = next(
         item
-        for item in data["cases"]
-        if item["id"] == "persistence-scope-expansion"
+        for item in data["profiles"]["cross_module_logic"]["cases"]
+        if item["id"] == "cross-module-contract-stale"
     )
+    case["expected_reentry"] = ["the-tuner", "overseer"]
+    assert any(
+        "must re-enter Tuner, Overseer, and Arbiter" in error
+        for error in integrity_validator.validate_fixtures(data, protocol_bytes())
+    )
+
+
+def test_unknown_reentry_owner_fails_closed():
+    data = fixtures()
+    case = next(item for item in data["cases"] if item["id"] == "persistence-scope-expansion")
     case["expected_reentry"].append("unknown-specialist")
     assert any(
         "unique valid specialist list" in error
@@ -151,19 +254,30 @@ def test_unknown_reentry_owner_fails_closed():
 
 def main():
     test_real_repo_passes()
+    test_integrity_repo_passes()
     test_all_statuses_have_cases()
+    test_integrity_profiles_cover_all_statuses()
     test_executable_workflows_trace_all_stages()
+    test_integrity_workflows_trace_profile_stages()
     test_happy_path_requires_complete_evidence()
     test_failure_paths_have_complete_single_owner_findings()
+    test_integrity_findings_have_single_owners()
+    test_backend_persistence_owner_boundaries()
+    test_cross_module_logic_owner_boundaries()
     test_authorization_mismatch_routes_to_cipher()
     test_stale_identity_reenters_continuity_chain()
     test_unknown_status_fails_closed()
+    test_integrity_unknown_profile_fails_closed()
     test_missing_executable_evidence_fails_closed()
+    test_integrity_missing_executable_evidence_fails_closed()
     test_protocol_hash_mismatch_fails_closed()
+    test_integrity_protocol_hash_mismatch_fails_closed()
     test_incomplete_trace_fails_closed()
+    test_integrity_incomplete_trace_fails_closed()
     test_incomplete_finding_fails_closed()
+    test_integrity_stale_identity_requires_continuity_chain()
     test_unknown_reentry_owner_fails_closed()
-    print("Cross-layer synchronicity contract tests passed.")
+    print("Cross-layer synchronicity and integrity contract tests passed.")
     return 0
 
 


### PR DESCRIPTION
## Summary

Completes Issue #215 Phase F2 by extending Orchestra's existing cross-module audit protocol with two additional deterministic, language-neutral integrity profiles:

- backend-to-persistence contract integrity;
- broader cross-module logical-flow integrity.

The implementation reuses the existing Conductor -> The Tuner -> domain specialist -> Overseer -> Arbiter ownership model and does not introduce a new specialist, command, plugin, runtime authority, persistence implementation, or policy surface.

## Baseline and scope

- Base: `2bc63308415221c54babba578e812ec95bc65f4c`
- Branch: `feat/cross-layer-integrity-f2`
- Changed paths: exactly 9
- Runtime changes: none
- Adapter or installed-integration changes: none
- Manifest/version changes: none
- Persistence implementation or migration changes: none

## Backend-to-persistence profile

Canonical ordered trace:

`SERVICE_INPUT -> DOMAIN_VALIDATION -> TRANSACTION_BOUNDARY -> REPOSITORY_OPERATION -> MAPPING_OR_QUERY -> SCHEMA_CONSTRAINT -> PERSISTENCE_EXECUTION -> COMMIT_OR_ROLLBACK -> READBACK_OR_PROJECTION -> SERVICE_RESULT`

Evidence covers contract mapping, validation/constraint parity, transaction semantics, query mapping, error mapping, concurrency/idempotency, and executable happy/failure paths.

## Cross-module logical-flow profile

Canonical ordered trace:

`ENTRYPOINT -> INPUT_CONTRACT -> MODULE_A_DECISION -> HANDOFF_PAYLOAD -> MODULE_B_DECISION -> SHARED_STATE_OR_SIDE_EFFECT -> RESULT_PROPAGATION -> ERROR_PROPAGATION -> FINAL_OBSERVABLE_OUTCOME`

Evidence covers input/handoff contracts, control flow, state/side effects, error propagation, dependency direction, and executable happy/failure paths.

## Validation design

- Adds `scripts/validate_cross_layer_integrity_contract.py`.
- Adds deterministic fixtures covering all seven existing cross-layer statuses for both profiles.
- Extends the existing focused cross-layer behavior test so the normal `validate` workflow executes the original frontend/backend validator and the new F2 validator together.
- Rebinds the original frontend/backend fixture to the expanded shared protocol hash without changing its workflow semantics.
- Documents direct validation commands in `docs/setup/VALIDATION.md`.

## Boundaries

- No automatic database/schema mutation.
- No new execution or Git authority.
- No release, deployment, publication, installed-host refresh, policy activation, force push, or history rewrite.
- Findings remain single-owner; The Tuner coordinates contradictions but does not decide domain content.

Refs #215