### PR TITLE
feat: add cross-layer integrity audit profiles

### DIFF
--- a/docs/validation/CROSS_LAYER_INTEGRITY_PROFILE_PROTOCOL.md
+++ b/docs/validation/CROSS_LAYER_INTEGRITY_PROFILE_PROTOCOL.md
@@ -1,0 +1,181 @@
+# Cross-Layer Integrity Profile Protocol
+
+## Status and relationship to the shared audit protocol
+
+This protocol extends the canonical [Cross-Module Logic Audit Protocol](CROSS_MODULE_LOGIC_AUDIT_PROTOCOL.md) with two additional audit profiles. It does not replace or mutate the frontend-to-backend profile, its evidence identity, or its Codex portable reference bundle.
+
+```text
+Profile protocol status: IMPLEMENTED_PHASE_F2
+Baseline: 2bc63308415221c54babba578e812ec95bc65f4c
+Parent protocol: docs/validation/CROSS_MODULE_LOGIC_AUDIT_PROTOCOL.md
+Decision owner per finding: exactly one specialist
+Coordination owner: The Tuner
+Routing owner: Conductor
+Validation owner: Overseer
+Transition owner: Arbiter
+Implementation authority: external and separately granted
+Git and release authority: not created by this protocol
+```
+
+All common finding fields, deterministic statuses, evidence-identity rules, contradiction handling, invalidation behavior, specialist re-entry rules, stop conditions, and authority boundaries are inherited from the parent protocol.
+
+## Backend-to-persistence integrity profile
+
+Trace every applicable backend-to-persistence workflow in this order:
+
+1. `SERVICE_INPUT`
+2. `DOMAIN_VALIDATION`
+3. `TRANSACTION_BOUNDARY`
+4. `REPOSITORY_OPERATION`
+5. `MAPPING_OR_QUERY`
+6. `SCHEMA_CONSTRAINT`
+7. `PERSISTENCE_EXECUTION`
+8. `COMMIT_OR_ROLLBACK`
+9. `READBACK_OR_PROJECTION`
+10. `SERVICE_RESULT`
+
+### Ownership
+
+- Clockwork owns service, repository-interface, and architectural-flow decisions.
+- Chronicler owns schema, query, migration, transaction-semantics, durability, and stored-record decisions.
+- Cipher owns technical security findings only when the persistence path crosses a trust boundary.
+- The Tuner coordinates references, contradictions, and re-entry but does not select a winning persistence rule.
+- Overseer owns evidence sufficiency.
+- Arbiter owns continuation disposition.
+
+### Required evidence
+
+The profile requires:
+
+- `contract_mapping`
+- `validation_and_constraint_parity`
+- `transaction_semantics`
+- `query_mapping`
+- `error_mapping`
+- `concurrency_and_idempotency`
+- `executable_workflow`
+
+Reads must explicitly mark non-applicable commit behavior rather than silently omit `COMMIT_OR_ROLLBACK`. Writes must prove either commit or rollback behavior and observable error propagation.
+
+### Fail-closed conditions
+
+Return the parent protocol's deterministic blocking or re-entry status when any of the following is found:
+
+- service and schema validation rules disagree;
+- mapping silently drops, renames, coerces, or defaults a required field;
+- transaction ownership is absent or permits partial commit;
+- retry or duplicate execution can create unintended duplicate writes;
+- repository/query behavior disagrees with the accepted service contract;
+- migration or schema assumptions are stale or unsupported by current evidence;
+- persistence errors are swallowed or mapped to false success;
+- executable happy-path or failure-path evidence is missing.
+
+## Cross-module logical-flow integrity profile
+
+This profile is language-neutral. A module may be a class, package, function, service, job, handler, adapter, or equivalent architectural unit.
+
+Trace every applicable cross-module workflow in this order:
+
+1. `ENTRYPOINT`
+2. `INPUT_CONTRACT`
+3. `MODULE_A_DECISION`
+4. `HANDOFF_PAYLOAD`
+5. `MODULE_B_DECISION`
+6. `SHARED_STATE_OR_SIDE_EFFECT`
+7. `RESULT_PROPAGATION`
+8. `ERROR_PROPAGATION`
+9. `FINAL_OBSERVABLE_OUTCOME`
+
+### Ownership
+
+Clockwork is the canonical owner for cross-module control flow, dependency direction, interface compatibility, handoff shape, state-mutation ordering, and error propagation. Other specialists retain decision ownership when a traced decision enters their canonical domain. The Tuner coordinates but does not rewrite or resolve specialist-owned decisions.
+
+### Required evidence
+
+The profile requires:
+
+- `input_contract`
+- `handoff_contract`
+- `control_flow`
+- `state_and_side_effects`
+- `error_propagation`
+- `dependency_direction`
+- `executable_workflow`
+
+### Fail-closed conditions
+
+Return the parent protocol's deterministic blocking or re-entry status when any of the following is found:
+
+- required handoff fields are silently dropped, renamed, coerced, or defaulted;
+- branch conditions are contradictory across module boundaries;
+- dependency direction introduces an accidental cycle;
+- a retry or re-entry path can duplicate a side effect;
+- an exception or rejected result is swallowed or converted to false success;
+- shared mutable state lacks a clear owner or invalidation behavior;
+- async, queued, callback, or event-driven handoffs lose required ordering or correlation;
+- executable happy-path or failure-path evidence is missing.
+
+## Deterministic status inheritance
+
+Both profiles use the parent protocol's exact status set:
+
+```text
+CROSS_LAYER_ALIGNMENT_CONFIRMED
+CROSS_LAYER_ALIGNMENT_GAPS_FOUND
+CROSS_LAYER_CONTRACT_INCOMPLETE
+CROSS_LAYER_CONTRADICTION_REVIEW_REQUIRED
+CROSS_LAYER_EVIDENCE_INSUFFICIENT
+CROSS_LAYER_CONTRACT_STALE
+SPECIALIST_REENTRY_REQUIRED
+```
+
+No additional status is introduced by Phase F2.
+
+## Finding and evidence rules
+
+Every non-confirmed case must contain the parent protocol's complete finding contract:
+
+```yaml
+finding_id: stable identifier
+severity: CRITICAL | MAJOR | MINOR | CLEANUP
+owner: exactly one specialist slug
+affected_stages: non-empty profile-stage list
+evidence: source, executable, or explicit missing-evidence references
+impact: observable cross-layer consequence
+minimal_remediation: smallest contract-aligned correction
+required_validation: evidence needed to close the finding
+```
+
+At least one executable happy-path and one executable failure-path trace must exist for each profile. Passing unit tests alone is insufficient evidence for `CROSS_LAYER_ALIGNMENT_CONFIRMED`.
+
+## Invalidation and re-entry additions
+
+| Change | Minimal re-entry | Invalidated evidence |
+| --- | --- | --- |
+| Repository interface or service contract | Clockwork; Chronicler when persistence semantics change | Affected backend, persistence, and integration evidence |
+| Schema, migration, query, transaction, or durability rule | Chronicler; Clockwork when service or repository behavior changes | Persistence and dependent service evidence |
+| Cross-module handoff or control-flow condition | Clockwork plus only affected domain owners | Affected module-flow and downstream evidence |
+| Profile protocol identity or executable fixture identity | The Tuner, Overseer, Arbiter | All mismatched F2 profile evidence |
+
+An open invalidation blocks alignment confirmation until affected contracts and downstream evidence are refreshed.
+
+## Checklists and executable evidence
+
+- [Backend-to-Persistence Integrity Checklist](checklists/BACKEND_PERSISTENCE_INTEGRITY_CHECKLIST.md)
+- [Cross-Module Logical-Flow Integrity Checklist](checklists/CROSS_MODULE_LOGIC_INTEGRITY_CHECKLIST.md)
+- `tests/behavior/cross-layer-integrity-fixtures.json`
+- `scripts/validate_cross_layer_integrity_contract.py`
+
+## Preserved boundaries
+
+Phase F2 adds audit evidence only. It does not create or widen:
+
+- implementation authority;
+- database or migration authority;
+- destructive cleanup authority;
+- Git staging, commit, push, merge, or force-push authority;
+- release, deployment, publication, or installed-host mutation authority;
+- policy activation authority;
+- specialist, plugin, command, or runtime-model registration.
+
+Material architecture, persistence, security, governance, or residual-risk decisions remain owned by the existing Orchestra specialist and governance paths.

--- a/docs/validation/checklists/BACKEND_PERSISTENCE_INTEGRITY_CHECKLIST.md
+++ b/docs/validation/checklists/BACKEND_PERSISTENCE_INTEGRITY_CHECKLIST.md
@@ -1,0 +1,51 @@
+# Backend-to-Persistence Integrity Checklist
+
+Use this checklist with the [Cross-Layer Integrity Profile Protocol](../CROSS_LAYER_INTEGRITY_PROFILE_PROTOCOL.md) and the shared [Cross-Module Logic Audit Protocol](../CROSS_MODULE_LOGIC_AUDIT_PROTOCOL.md).
+
+## Identity and scope
+
+- [ ] Repository, branch, approved baseline, current commit, packet revision, and profile-protocol hash match.
+- [ ] Service, repository, mapping/query, schema, migration, and transaction boundaries in scope are explicitly identified.
+- [ ] Every changed path is allowlisted and protected persistence paths remain unchanged unless explicitly in scope.
+- [ ] Existing data, migration, rollback, backup, and destructive-operation boundaries remain separately governed.
+
+## Workflow trace
+
+- [ ] `SERVICE_INPUT` identifies the accepted domain/service input and caller assumptions.
+- [ ] `DOMAIN_VALIDATION` maps required, optional, null, range, format, normalization, and invariant rules.
+- [ ] `TRANSACTION_BOUNDARY` identifies transaction ownership, isolation expectations, and read-only/non-applicable behavior.
+- [ ] `REPOSITORY_OPERATION` maps the service request to one repository/interface operation.
+- [ ] `MAPPING_OR_QUERY` maps domain fields to ORM/query parameters and result fields without silent loss or coercion.
+- [ ] `SCHEMA_CONSTRAINT` proves database constraints agree with domain and repository expectations.
+- [ ] `PERSISTENCE_EXECUTION` identifies the actual read/write behavior and expected affected rows/records.
+- [ ] `COMMIT_OR_ROLLBACK` proves success commit or failure rollback behavior; read-only flows explicitly mark this stage non-applicable.
+- [ ] `READBACK_OR_PROJECTION` proves persisted or selected data is reconstructed without drift.
+- [ ] `SERVICE_RESULT` proves storage results and failures are mapped back to the service contract deterministically.
+
+## Integrity and failure coverage
+
+- [ ] Validation and schema constraints agree; neither layer silently accepts values rejected by the other.
+- [ ] Repository mapping preserves names, types, nullability, defaults, identifiers, and ownership fields.
+- [ ] Transaction scope does not partially commit multi-step operations.
+- [ ] Constraint, connectivity, timeout, serialization, deadlock/conflict, and zero-row outcomes map to explicit service behavior.
+- [ ] Retry and duplicate execution cannot create unintended duplicate writes.
+- [ ] Optimistic/pessimistic concurrency behavior is explicit when applicable.
+- [ ] Migration or schema-version assumptions are current and source-backed.
+- [ ] Secrets, credentials, and sensitive persisted values are not exposed in evidence.
+
+## Findings and evidence
+
+- [ ] Each finding has one owner, severity, affected stages, evidence, impact, minimal remediation, and required validation.
+- [ ] Clockwork owns service/repository architecture findings; Chronicler owns schema, query, transaction, and persistence semantics; Cipher owns technical trust-boundary findings.
+- [ ] Contradictions are recorded by The Tuner and routed rather than silently resolved.
+- [ ] Executable happy-path and failure-path evidence is current and bound to the profile-protocol identity.
+- [ ] Missing evidence produces `CROSS_LAYER_EVIDENCE_INSUFFICIENT`.
+- [ ] Changed identity produces `CROSS_LAYER_CONTRACT_STALE` or `SPECIALIST_REENTRY_REQUIRED`.
+- [ ] No open invalidation remains before `CROSS_LAYER_ALIGNMENT_CONFIRMED`.
+
+## Closeout
+
+- [ ] Focused integrity validator and behavior tests pass.
+- [ ] Full behavior, runtime regression, packaging, prompt-budget, governance, scope, secret, and diff checks pass.
+- [ ] Overseer records current evidence and Arbiter records continuation state.
+- [ ] Release, deployment, destructive migration, and installed-integration actions remain separately governed.

--- a/docs/validation/checklists/CROSS_MODULE_LOGIC_INTEGRITY_CHECKLIST.md
+++ b/docs/validation/checklists/CROSS_MODULE_LOGIC_INTEGRITY_CHECKLIST.md
@@ -1,0 +1,50 @@
+# Cross-Module Logical-Flow Integrity Checklist
+
+Use this checklist with the [Cross-Layer Integrity Profile Protocol](../CROSS_LAYER_INTEGRITY_PROFILE_PROTOCOL.md) and the shared [Cross-Module Logic Audit Protocol](../CROSS_MODULE_LOGIC_AUDIT_PROTOCOL.md).
+
+## Identity and scope
+
+- [ ] Repository, branch, approved baseline, current commit, packet revision, and profile-protocol hash match.
+- [ ] The entrypoint, participating modules, dependency direction, shared state, and observable outcome are identified.
+- [ ] Every changed path is allowlisted and unrelated modules remain outside the frozen slice.
+- [ ] The audit remains language-neutral: a module may be a class, package, function, service, job, handler, adapter, or equivalent unit.
+
+## Workflow trace
+
+- [ ] `ENTRYPOINT` identifies the invocation and its externally observable intent.
+- [ ] `INPUT_CONTRACT` maps accepted input names, types, optionality, invariants, and caller assumptions.
+- [ ] `MODULE_A_DECISION` identifies the first module's branch conditions, transformation, and owned decision.
+- [ ] `HANDOFF_PAYLOAD` maps every value crossing the module boundary, including omitted/default behavior.
+- [ ] `MODULE_B_DECISION` proves the receiving module interprets the handoff under the same contract.
+- [ ] `SHARED_STATE_OR_SIDE_EFFECT` identifies state mutation, I/O, event publication, caching, or an explicit no-side-effect result.
+- [ ] `RESULT_PROPAGATION` proves success values propagate without semantic drift.
+- [ ] `ERROR_PROPAGATION` proves errors are preserved, transformed intentionally, or handled explicitly rather than swallowed.
+- [ ] `FINAL_OBSERVABLE_OUTCOME` proves the caller-visible result matches the original intent.
+
+## Logical-flow integrity
+
+- [ ] Branch conditions are mutually compatible across modules.
+- [ ] Required handoff fields cannot be silently dropped, renamed, coerced, or defaulted.
+- [ ] Dependency direction follows the accepted architecture and introduces no accidental cycle.
+- [ ] State mutation and side effects occur exactly once and in the required order.
+- [ ] Retry/re-entry behavior cannot duplicate side effects.
+- [ ] Exceptions, error objects, sentinel values, and rejected results retain deterministic meaning across boundaries.
+- [ ] Async, queued, callback, or event-driven handoffs preserve correlation and ordering when applicable.
+- [ ] Shared mutable state has an explicit owner and invalidation/update behavior.
+
+## Findings and evidence
+
+- [ ] Clockwork owns cross-module control-flow, handoff, dependency, and error-propagation decisions unless the traced decision enters another specialist's domain.
+- [ ] Each finding has one owner, severity, affected stages, evidence, impact, minimal remediation, and required validation.
+- [ ] Contradictions are recorded by The Tuner and routed rather than silently resolved.
+- [ ] Executable happy-path and failure-path traces are current and bound to the profile-protocol identity.
+- [ ] Missing evidence produces `CROSS_LAYER_EVIDENCE_INSUFFICIENT`.
+- [ ] Changed identity produces `CROSS_LAYER_CONTRACT_STALE` or `SPECIALIST_REENTRY_REQUIRED`.
+- [ ] No open invalidation remains before `CROSS_LAYER_ALIGNMENT_CONFIRMED`.
+
+## Closeout
+
+- [ ] Focused integrity validator and behavior tests pass.
+- [ ] Full behavior, runtime regression, packaging, prompt-budget, governance, scope, secret, and diff checks pass.
+- [ ] Overseer records current evidence and Arbiter records continuation state.
+- [ ] No audit result creates implementation, Git, merge, release, deployment, or policy authority.

--- a/scripts/validate_cross_layer_integrity_contract.py
+++ b/scripts/validate_cross_layer_integrity_contract.py
@@ -1,0 +1,313 @@
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+STATUSES = {
+    "CROSS_LAYER_ALIGNMENT_CONFIRMED",
+    "CROSS_LAYER_ALIGNMENT_GAPS_FOUND",
+    "CROSS_LAYER_CONTRACT_INCOMPLETE",
+    "CROSS_LAYER_CONTRADICTION_REVIEW_REQUIRED",
+    "CROSS_LAYER_EVIDENCE_INSUFFICIENT",
+    "CROSS_LAYER_CONTRACT_STALE",
+    "SPECIALIST_REENTRY_REQUIRED",
+}
+OWNERS = {"clockwork", "chronicler", "cloak", "cipher", "overseer", "the-tuner"}
+REENTRY_OWNERS = OWNERS | {"conductor", "arbiter"}
+SEVERITIES = {"CRITICAL", "MAJOR", "MINOR", "CLEANUP"}
+FINDING_FIELDS = {
+    "finding_id", "severity", "owner", "affected_stages", "evidence",
+    "impact", "minimal_remediation", "required_validation",
+}
+PROFILE_SPECS = {
+    "backend_persistence": {
+        "stages": (
+            "SERVICE_INPUT", "DOMAIN_VALIDATION", "TRANSACTION_BOUNDARY",
+            "REPOSITORY_OPERATION", "MAPPING_OR_QUERY", "SCHEMA_CONSTRAINT",
+            "PERSISTENCE_EXECUTION", "COMMIT_OR_ROLLBACK",
+            "READBACK_OR_PROJECTION", "SERVICE_RESULT",
+        ),
+        "evidence": {
+            "contract_mapping", "validation_and_constraint_parity",
+            "transaction_semantics", "query_mapping", "error_mapping",
+            "concurrency_and_idempotency", "executable_workflow",
+        },
+    },
+    "cross_module_logic": {
+        "stages": (
+            "ENTRYPOINT", "INPUT_CONTRACT", "MODULE_A_DECISION",
+            "HANDOFF_PAYLOAD", "MODULE_B_DECISION",
+            "SHARED_STATE_OR_SIDE_EFFECT", "RESULT_PROPAGATION",
+            "ERROR_PROPAGATION", "FINAL_OBSERVABLE_OUTCOME",
+        ),
+        "evidence": {
+            "input_contract", "handoff_contract", "control_flow",
+            "state_and_side_effects", "error_propagation",
+            "dependency_direction", "executable_workflow",
+        },
+    },
+}
+
+
+def _nonempty(value):
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _canonical_bytes(path):
+    text = path.read_text(encoding="utf-8")
+    return text.replace("\r\n", "\n").replace("\r", "\n").encode("utf-8")
+
+
+def _load_json(path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _validate_identity(identity, protocol_bytes):
+    errors = []
+    required = {"approved_baseline", "contract_revision", "protocol_sha256", "source_branch"}
+    if not isinstance(identity, dict) or set(identity) != required:
+        return ["fixtures: contract_identity must contain exactly the required fields"]
+    if not re.fullmatch(r"[0-9a-f]{40}", str(identity["approved_baseline"])):
+        errors.append("fixtures: approved_baseline must be a lowercase 40-character SHA")
+    if not _nonempty(identity["contract_revision"]):
+        errors.append("fixtures: contract_revision must be non-empty")
+    if not _nonempty(identity["source_branch"]):
+        errors.append("fixtures: source_branch must be non-empty")
+    expected = hashlib.sha256(protocol_bytes).hexdigest()
+    if identity["protocol_sha256"] != expected:
+        errors.append("fixtures: protocol_sha256 does not match the F2 integrity profile protocol")
+    return errors
+
+
+def _validate_workflows(profile_name, profile, stages):
+    errors = []
+    workflow_map = {}
+    workflows = profile.get("executable_workflows")
+    if not isinstance(workflows, list) or not workflows:
+        return [f"{profile_name}: executable_workflows must be non-empty"], workflow_map
+    kinds = set()
+    for workflow in workflows:
+        if not isinstance(workflow, dict):
+            errors.append(f"{profile_name}: workflow must be an object")
+            continue
+        workflow_id = workflow.get("id")
+        if not _nonempty(workflow_id) or workflow_id in workflow_map:
+            errors.append(f"{profile_name}: missing or duplicate workflow id")
+            continue
+        workflow_map[workflow_id] = workflow
+        kind = workflow.get("kind")
+        if kind not in {"HAPPY_PATH", "FAILURE_PATH"}:
+            errors.append(f"{profile_name}/{workflow_id}: invalid workflow kind")
+        else:
+            kinds.add(kind)
+        if not _nonempty(workflow.get("expected_final_state")):
+            errors.append(f"{profile_name}/{workflow_id}: expected_final_state must be non-empty")
+        trace = workflow.get("trace")
+        if not isinstance(trace, list):
+            errors.append(f"{profile_name}/{workflow_id}: trace must be a list")
+            continue
+        seen = [entry.get("stage") if isinstance(entry, dict) else None for entry in trace]
+        if tuple(seen) != stages:
+            errors.append(f"{profile_name}/{workflow_id}: trace must contain profile stages in exact order")
+            continue
+        for entry in trace:
+            if set(entry) != {"stage", "owner", "source_ref", "evidence_ref", "result"}:
+                errors.append(f"{profile_name}/{workflow_id}: trace entry fields are incomplete or unknown")
+                continue
+            if entry["owner"] not in OWNERS:
+                errors.append(f"{profile_name}/{workflow_id}/{entry['stage']}: invalid owner")
+            for field in ("source_ref", "evidence_ref", "result"):
+                if not _nonempty(entry[field]):
+                    errors.append(f"{profile_name}/{workflow_id}/{entry['stage']}: {field} must be non-empty")
+    if kinds != {"HAPPY_PATH", "FAILURE_PATH"}:
+        errors.append(f"{profile_name}: both happy-path and failure-path workflows are required")
+    return errors, workflow_map
+
+
+def _validate_finding(profile_name, case_id, finding, owner, stages):
+    if not isinstance(finding, dict) or set(finding) != FINDING_FIELDS:
+        return [f"{profile_name}/{case_id}: non-confirmed result requires a complete finding object"]
+    errors = []
+    if owner not in OWNERS or finding.get("owner") != owner:
+        errors.append(f"{profile_name}/{case_id}: finding must have one valid singular owner")
+    if finding.get("severity") not in SEVERITIES:
+        errors.append(f"{profile_name}/{case_id}: invalid severity")
+    if not _nonempty(finding.get("finding_id")):
+        errors.append(f"{profile_name}/{case_id}: finding_id must be non-empty")
+    affected = finding.get("affected_stages")
+    if (
+        not isinstance(affected, list) or not affected
+        or len(affected) != len(set(affected))
+        or any(stage not in stages for stage in affected)
+    ):
+        errors.append(f"{profile_name}/{case_id}: affected_stages must be a unique non-empty profile-stage list")
+    refs = finding.get("evidence")
+    if not isinstance(refs, list) or not refs or any(not _nonempty(ref) for ref in refs):
+        errors.append(f"{profile_name}/{case_id}: finding evidence must be non-empty")
+    for field in ("impact", "minimal_remediation", "required_validation"):
+        if not _nonempty(finding.get(field)):
+            errors.append(f"{profile_name}/{case_id}: {field} must be non-empty")
+    return errors
+
+
+def _validate_profile(name, profile, spec):
+    errors = []
+    stages = spec["stages"]
+    evidence_fields = spec["evidence"]
+    if tuple(profile.get("stages", ())) != stages:
+        errors.append(f"{name}: stages must match canonical order")
+    if set(profile.get("required_evidence", ())) != evidence_fields:
+        errors.append(f"{name}: required_evidence is incomplete or unknown")
+
+    workflow_errors, workflow_map = _validate_workflows(name, profile, stages)
+    errors.extend(workflow_errors)
+
+    cases = profile.get("cases")
+    if not isinstance(cases, list) or not cases:
+        return errors + [f"{name}: cases must be non-empty"]
+    seen_ids = set()
+    covered_statuses = set()
+    referenced_workflows = set()
+    for case in cases:
+        if not isinstance(case, dict):
+            errors.append(f"{name}: case must be an object")
+            continue
+        case_id = case.get("id")
+        if not _nonempty(case_id) or case_id in seen_ids:
+            errors.append(f"{name}: missing or duplicate case id")
+            continue
+        seen_ids.add(case_id)
+        status = case.get("expected_status")
+        if status not in STATUSES:
+            errors.append(f"{name}/{case_id}: unknown status")
+        else:
+            covered_statuses.add(status)
+
+        evidence = case.get("evidence")
+        if (
+            not isinstance(evidence, dict)
+            or set(evidence) != evidence_fields
+            or not all(isinstance(value, bool) for value in evidence.values())
+        ):
+            errors.append(f"{name}/{case_id}: evidence must contain exactly the profile boolean fields")
+            continue
+
+        reentry = case.get("expected_reentry")
+        if (
+            not isinstance(reentry, list)
+            or len(reentry) != len(set(reentry))
+            or any(owner not in REENTRY_OWNERS for owner in reentry)
+        ):
+            errors.append(f"{name}/{case_id}: expected_reentry must be a unique valid specialist list")
+            reentry = []
+
+        workflow_id = case.get("workflow_id")
+        if workflow_id is not None:
+            if workflow_id not in workflow_map:
+                errors.append(f"{name}/{case_id}: workflow_id does not reference an executable workflow")
+            else:
+                referenced_workflows.add(workflow_id)
+        if evidence["executable_workflow"] and not workflow_id:
+            errors.append(f"{name}/{case_id}: executable evidence requires workflow_id")
+        if not evidence["executable_workflow"] and workflow_id is not None:
+            errors.append(f"{name}/{case_id}: missing executable evidence cannot reference a workflow")
+
+        owner = case.get("finding_owner")
+        finding = case.get("finding")
+        if status == "CROSS_LAYER_ALIGNMENT_CONFIRMED":
+            if owner is not None or finding is not None or reentry or not all(evidence.values()):
+                errors.append(f"{name}/{case_id}: confirmed alignment requires complete evidence and no finding or re-entry")
+        else:
+            errors.extend(_validate_finding(name, case_id, finding, owner, stages))
+
+        if status == "CROSS_LAYER_EVIDENCE_INSUFFICIENT" and all(evidence.values()):
+            errors.append(f"{name}/{case_id}: insufficient evidence must identify a missing evidence field")
+        if status == "CROSS_LAYER_CONTRACT_STALE" and reentry != ["the-tuner", "overseer", "arbiter"]:
+            errors.append(f"{name}/{case_id}: stale identity must re-enter Tuner, Overseer, and Arbiter")
+        if status == "CROSS_LAYER_CONTRADICTION_REVIEW_REQUIRED" and "conductor" not in reentry:
+            errors.append(f"{name}/{case_id}: contradiction must route back through Conductor")
+        if status == "SPECIALIST_REENTRY_REQUIRED" and not reentry:
+            errors.append(f"{name}/{case_id}: re-entry status requires an explicit specialist set")
+
+    if covered_statuses != STATUSES:
+        errors.append(f"{name}: every deterministic status must have a fixture case")
+    if set(workflow_map) != referenced_workflows:
+        errors.append(f"{name}: every executable workflow must be referenced by at least one case")
+    return errors
+
+
+def validate_fixtures(data, protocol_bytes):
+    errors = []
+    if data.get("schema_version") != "orchestra-cross-layer-integrity-v1":
+        errors.append("fixtures: invalid schema_version")
+    if set(data.get("statuses", ())) != STATUSES:
+        errors.append("fixtures: deterministic status set is incomplete or unknown")
+    errors.extend(_validate_identity(data.get("contract_identity"), protocol_bytes))
+    profiles = data.get("profiles")
+    if not isinstance(profiles, dict) or set(profiles) != set(PROFILE_SPECS):
+        return errors + ["fixtures: profiles must contain exactly backend_persistence and cross_module_logic"]
+    for name, spec in PROFILE_SPECS.items():
+        errors.extend(_validate_profile(name, profiles[name], spec))
+    return errors
+
+
+def validate(repo_root):
+    parent = repo_root / "docs/validation/CROSS_MODULE_LOGIC_AUDIT_PROTOCOL.md"
+    protocol = repo_root / "docs/validation/CROSS_LAYER_INTEGRITY_PROFILE_PROTOCOL.md"
+    backend = repo_root / "docs/validation/checklists/BACKEND_PERSISTENCE_INTEGRITY_CHECKLIST.md"
+    cross_module = repo_root / "docs/validation/checklists/CROSS_MODULE_LOGIC_INTEGRITY_CHECKLIST.md"
+    fixtures = repo_root / "tests/behavior/cross-layer-integrity-fixtures.json"
+    required = (parent, protocol, backend, cross_module, fixtures)
+    missing = [path.relative_to(repo_root).as_posix() for path in required if not path.is_file()]
+    if missing:
+        return [f"missing required F2 artifact: {path}" for path in missing]
+
+    errors = []
+    parent_text = parent.read_text(encoding="utf-8")
+    protocol_bytes = _canonical_bytes(protocol)
+    protocol_text = protocol_bytes.decode("utf-8")
+    backend_text = backend.read_text(encoding="utf-8")
+    module_text = cross_module.read_text(encoding="utf-8")
+
+    for status in STATUSES:
+        if status not in parent_text or status not in protocol_text:
+            errors.append(f"protocol inheritance: missing deterministic status {status}")
+    for spec in PROFILE_SPECS.values():
+        for stage in spec["stages"]:
+            if stage not in protocol_text:
+                errors.append(f"profile protocol: missing stage {stage}")
+    for token in (
+        "Cross-Module Logic Audit Protocol",
+        "Passing unit tests alone is insufficient",
+        "exactly one specialist",
+    ):
+        if token not in protocol_text:
+            errors.append(f"profile protocol: missing {token!r}")
+    for token in ("`COMMIT_OR_ROLLBACK`", "Clockwork owns service/repository architecture findings", "Chronicler owns schema"):
+        if token not in backend_text:
+            errors.append(f"backend checklist: missing {token!r}")
+    for token in ("`HANDOFF_PAYLOAD`", "Dependency direction", "Clockwork owns cross-module"):
+        if token not in module_text:
+            errors.append(f"cross-module checklist: missing {token!r}")
+
+    errors.extend(validate_fixtures(_load_json(fixtures), protocol_bytes))
+    return errors
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Validate F2 backend-persistence and cross-module integrity profiles.")
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[1])
+    args = parser.parse_args(argv)
+    errors = validate(args.repo_root.resolve())
+    if errors:
+        for error in errors:
+            print(f"[FAIL] {error}")
+        return 1
+    print("[PASS] Cross-layer backend-persistence and cross-module integrity profiles are deterministic and complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/behavior/cross-layer-integrity-fixtures.json
+++ b/tests/behavior/cross-layer-integrity-fixtures.json
@@ -1,0 +1,114 @@
+{
+  "schema_version": "orchestra-cross-layer-integrity-v1",
+  "contract_identity": {
+    "approved_baseline": "2bc63308415221c54babba578e812ec95bc65f4c",
+    "contract_revision": "cross-layer-integrity-f2-v3",
+    "protocol_sha256": "9402ffe1d44f0ba19c04c1f255f3746a68e1f4a19877041acbcd421d5ef30736",
+    "source_branch": "feat/cross-layer-integrity-f2-v3"
+  },
+  "statuses": [
+    "CROSS_LAYER_ALIGNMENT_CONFIRMED",
+    "CROSS_LAYER_ALIGNMENT_GAPS_FOUND",
+    "CROSS_LAYER_CONTRACT_INCOMPLETE",
+    "CROSS_LAYER_CONTRADICTION_REVIEW_REQUIRED",
+    "CROSS_LAYER_EVIDENCE_INSUFFICIENT",
+    "CROSS_LAYER_CONTRACT_STALE",
+    "SPECIALIST_REENTRY_REQUIRED"
+  ],
+  "profiles": {
+    "backend_persistence": {
+      "stages": ["SERVICE_INPUT","DOMAIN_VALIDATION","TRANSACTION_BOUNDARY","REPOSITORY_OPERATION","MAPPING_OR_QUERY","SCHEMA_CONSTRAINT","PERSISTENCE_EXECUTION","COMMIT_OR_ROLLBACK","READBACK_OR_PROJECTION","SERVICE_RESULT"],
+      "required_evidence": ["contract_mapping","validation_and_constraint_parity","transaction_semantics","query_mapping","error_mapping","concurrency_and_idempotency","executable_workflow"],
+      "executable_workflows": [
+        {
+          "id": "bp-happy",
+          "kind": "HAPPY_PATH",
+          "trace": [
+            {"stage":"SERVICE_INPUT","owner":"clockwork","source_ref":"fixture://bp/service-input","evidence_ref":"fixture://bp/evidence/service-input","result":"accepted service input"},
+            {"stage":"DOMAIN_VALIDATION","owner":"clockwork","source_ref":"fixture://bp/domain-validation","evidence_ref":"fixture://bp/evidence/domain-validation","result":"domain validation passes"},
+            {"stage":"TRANSACTION_BOUNDARY","owner":"clockwork","source_ref":"fixture://bp/transaction","evidence_ref":"fixture://bp/evidence/transaction","result":"one transaction owns the write"},
+            {"stage":"REPOSITORY_OPERATION","owner":"clockwork","source_ref":"fixture://bp/repository","evidence_ref":"fixture://bp/evidence/repository","result":"repository operation matches service intent"},
+            {"stage":"MAPPING_OR_QUERY","owner":"chronicler","source_ref":"fixture://bp/mapping","evidence_ref":"fixture://bp/evidence/mapping","result":"mapping preserves fields and types"},
+            {"stage":"SCHEMA_CONSTRAINT","owner":"chronicler","source_ref":"fixture://bp/schema","evidence_ref":"fixture://bp/evidence/schema","result":"schema constraints match validation"},
+            {"stage":"PERSISTENCE_EXECUTION","owner":"chronicler","source_ref":"fixture://bp/persist","evidence_ref":"fixture://bp/evidence/persist","result":"exactly one write executes"},
+            {"stage":"COMMIT_OR_ROLLBACK","owner":"chronicler","source_ref":"fixture://bp/commit","evidence_ref":"fixture://bp/evidence/commit","result":"transaction commits once"},
+            {"stage":"READBACK_OR_PROJECTION","owner":"chronicler","source_ref":"fixture://bp/readback","evidence_ref":"fixture://bp/evidence/readback","result":"stored data projects without drift"},
+            {"stage":"SERVICE_RESULT","owner":"clockwork","source_ref":"fixture://bp/result","evidence_ref":"fixture://bp/evidence/result","result":"service returns canonical saved result"}
+          ],
+          "expected_final_state": "one validated write commits and returns the saved result"
+        },
+        {
+          "id": "bp-failure",
+          "kind": "FAILURE_PATH",
+          "trace": [
+            {"stage":"SERVICE_INPUT","owner":"clockwork","source_ref":"fixture://bp-fail/service-input","evidence_ref":"fixture://bp-fail/evidence/service-input","result":"accepted service input"},
+            {"stage":"DOMAIN_VALIDATION","owner":"clockwork","source_ref":"fixture://bp-fail/domain-validation","evidence_ref":"fixture://bp-fail/evidence/domain-validation","result":"domain validation passes"},
+            {"stage":"TRANSACTION_BOUNDARY","owner":"clockwork","source_ref":"fixture://bp-fail/transaction","evidence_ref":"fixture://bp-fail/evidence/transaction","result":"transaction begins"},
+            {"stage":"REPOSITORY_OPERATION","owner":"clockwork","source_ref":"fixture://bp-fail/repository","evidence_ref":"fixture://bp-fail/evidence/repository","result":"repository operation starts"},
+            {"stage":"MAPPING_OR_QUERY","owner":"chronicler","source_ref":"fixture://bp-fail/mapping","evidence_ref":"fixture://bp-fail/evidence/mapping","result":"query mapping is canonical"},
+            {"stage":"SCHEMA_CONSTRAINT","owner":"chronicler","source_ref":"fixture://bp-fail/schema","evidence_ref":"fixture://bp-fail/evidence/schema","result":"constraint rejects invalid persistence state"},
+            {"stage":"PERSISTENCE_EXECUTION","owner":"chronicler","source_ref":"fixture://bp-fail/persist","evidence_ref":"fixture://bp-fail/evidence/persist","result":"write fails deterministically"},
+            {"stage":"COMMIT_OR_ROLLBACK","owner":"chronicler","source_ref":"fixture://bp-fail/rollback","evidence_ref":"fixture://bp-fail/evidence/rollback","result":"transaction rolls back"},
+            {"stage":"READBACK_OR_PROJECTION","owner":"chronicler","source_ref":"fixture://bp-fail/readback","evidence_ref":"fixture://bp-fail/evidence/readback","result":"no partial write is visible"},
+            {"stage":"SERVICE_RESULT","owner":"clockwork","source_ref":"fixture://bp-fail/result","evidence_ref":"fixture://bp-fail/evidence/result","result":"service returns deterministic failure"}
+          ],
+          "expected_final_state": "failure rolls back with no duplicate or partial write"
+        }
+      ],
+      "cases": [
+        {"id":"backend-persistence-happy-path","expected_status":"CROSS_LAYER_ALIGNMENT_CONFIRMED","finding_owner":null,"finding":null,"evidence":{"contract_mapping":true,"validation_and_constraint_parity":true,"transaction_semantics":true,"query_mapping":true,"error_mapping":true,"concurrency_and_idempotency":true,"executable_workflow":true},"workflow_id":"bp-happy","expected_reentry":[]},
+        {"id":"backend-contract-mapping-gap","expected_status":"CROSS_LAYER_ALIGNMENT_GAPS_FOUND","finding_owner":"chronicler","finding":{"finding_id":"F-BP-MAP-001","severity":"MAJOR","owner":"chronicler","affected_stages":["MAPPING_OR_QUERY","SCHEMA_CONSTRAINT"],"evidence":["fixture://finding/bp-map"],"impact":"service and persistence semantics disagree","minimal_remediation":"align mapping and constraints with the accepted service contract","required_validation":"mapping and constraint evidence proves parity"},"evidence":{"contract_mapping":false,"validation_and_constraint_parity":false,"transaction_semantics":true,"query_mapping":true,"error_mapping":true,"concurrency_and_idempotency":true,"executable_workflow":true},"workflow_id":"bp-happy","expected_reentry":["chronicler","clockwork","overseer"]},
+        {"id":"backend-owner-contract-missing","expected_status":"CROSS_LAYER_CONTRACT_INCOMPLETE","finding_owner":"the-tuner","finding":{"finding_id":"F-BP-CONTRACT-001","severity":"MAJOR","owner":"the-tuner","affected_stages":["REPOSITORY_OPERATION"],"evidence":["missing://bp-owner"],"impact":"a persistence decision lacks singular ownership","minimal_remediation":"route the incomplete contract through Conductor","required_validation":"complete ownership and criteria are present"},"evidence":{"contract_mapping":true,"validation_and_constraint_parity":true,"transaction_semantics":true,"query_mapping":true,"error_mapping":true,"concurrency_and_idempotency":true,"executable_workflow":true},"workflow_id":"bp-happy","expected_reentry":["conductor","chronicler"]},
+        {"id":"backend-persistence-contradiction","expected_status":"CROSS_LAYER_CONTRADICTION_REVIEW_REQUIRED","finding_owner":"the-tuner","finding":{"finding_id":"F-BP-CONTRA-001","severity":"CRITICAL","owner":"the-tuner","affected_stages":["DOMAIN_VALIDATION","SCHEMA_CONSTRAINT"],"evidence":["fixture://finding/bp-contradiction"],"impact":"specialist contracts require incompatible behavior","minimal_remediation":"route conflicting clauses without choosing a winner","required_validation":"revised contracts remove the contradiction"},"evidence":{"contract_mapping":true,"validation_and_constraint_parity":true,"transaction_semantics":true,"query_mapping":true,"error_mapping":true,"concurrency_and_idempotency":true,"executable_workflow":true},"workflow_id":"bp-happy","expected_reentry":["conductor","clockwork","chronicler"]},
+        {"id":"backend-evidence-missing","expected_status":"CROSS_LAYER_EVIDENCE_INSUFFICIENT","finding_owner":"overseer","finding":{"finding_id":"F-BP-EVIDENCE-001","severity":"MAJOR","owner":"overseer","affected_stages":["SERVICE_INPUT","SERVICE_RESULT"],"evidence":["missing://bp-executable"],"impact":"backend-to-persistence alignment cannot be demonstrated","minimal_remediation":"produce current executable happy and failure traces","required_validation":"Overseer verifies both traces against current identity"},"evidence":{"contract_mapping":true,"validation_and_constraint_parity":true,"transaction_semantics":true,"query_mapping":true,"error_mapping":true,"concurrency_and_idempotency":true,"executable_workflow":false},"workflow_id":null,"expected_reentry":["overseer"]},
+        {"id":"backend-contract-stale","expected_status":"CROSS_LAYER_CONTRACT_STALE","finding_owner":"the-tuner","finding":{"finding_id":"F-BP-STALE-001","severity":"MAJOR","owner":"the-tuner","affected_stages":["SERVICE_INPUT","SERVICE_RESULT"],"evidence":["fixture://finding/bp-stale"],"impact":"evidence is bound to a superseded profile revision","minimal_remediation":"refresh packet and dependent evidence","required_validation":"Tuner, Overseer, and Arbiter verify current identity"},"evidence":{"contract_mapping":true,"validation_and_constraint_parity":true,"transaction_semantics":true,"query_mapping":true,"error_mapping":true,"concurrency_and_idempotency":true,"executable_workflow":true},"workflow_id":"bp-happy","expected_reentry":["the-tuner","overseer","arbiter"]},
+        {"id":"backend-transaction-reentry","expected_status":"SPECIALIST_REENTRY_REQUIRED","finding_owner":"chronicler","finding":{"finding_id":"F-BP-TX-001","severity":"CRITICAL","owner":"chronicler","affected_stages":["TRANSACTION_BOUNDARY","COMMIT_OR_ROLLBACK"],"evidence":["fixture://finding/bp-transaction"],"impact":"write can partially commit or duplicate under retry","minimal_remediation":"define atomic transaction and idempotency semantics","required_validation":"failure and duplicate-execution evidence proves one logical write"},"evidence":{"contract_mapping":true,"validation_and_constraint_parity":true,"transaction_semantics":false,"query_mapping":true,"error_mapping":true,"concurrency_and_idempotency":false,"executable_workflow":true},"workflow_id":"bp-failure","expected_reentry":["chronicler","clockwork","overseer"]}
+      ]
+    },
+    "cross_module_logic": {
+      "stages": ["ENTRYPOINT","INPUT_CONTRACT","MODULE_A_DECISION","HANDOFF_PAYLOAD","MODULE_B_DECISION","SHARED_STATE_OR_SIDE_EFFECT","RESULT_PROPAGATION","ERROR_PROPAGATION","FINAL_OBSERVABLE_OUTCOME"],
+      "required_evidence": ["input_contract","handoff_contract","control_flow","state_and_side_effects","error_propagation","dependency_direction","executable_workflow"],
+      "executable_workflows": [
+        {
+          "id":"cm-happy","kind":"HAPPY_PATH",
+          "trace":[
+            {"stage":"ENTRYPOINT","owner":"clockwork","source_ref":"fixture://cm/entry","evidence_ref":"fixture://cm/evidence/entry","result":"entrypoint receives intended input"},
+            {"stage":"INPUT_CONTRACT","owner":"clockwork","source_ref":"fixture://cm/input","evidence_ref":"fixture://cm/evidence/input","result":"input contract is valid"},
+            {"stage":"MODULE_A_DECISION","owner":"clockwork","source_ref":"fixture://cm/a","evidence_ref":"fixture://cm/evidence/a","result":"module A chooses expected branch"},
+            {"stage":"HANDOFF_PAYLOAD","owner":"clockwork","source_ref":"fixture://cm/handoff","evidence_ref":"fixture://cm/evidence/handoff","result":"handoff preserves contract"},
+            {"stage":"MODULE_B_DECISION","owner":"clockwork","source_ref":"fixture://cm/b","evidence_ref":"fixture://cm/evidence/b","result":"module B interprets handoff consistently"},
+            {"stage":"SHARED_STATE_OR_SIDE_EFFECT","owner":"clockwork","source_ref":"fixture://cm/side-effect","evidence_ref":"fixture://cm/evidence/side-effect","result":"side effect occurs once"},
+            {"stage":"RESULT_PROPAGATION","owner":"clockwork","source_ref":"fixture://cm/result","evidence_ref":"fixture://cm/evidence/result","result":"success propagates without drift"},
+            {"stage":"ERROR_PROPAGATION","owner":"clockwork","source_ref":"fixture://cm/error","evidence_ref":"fixture://cm/evidence/error","result":"no hidden error path"},
+            {"stage":"FINAL_OBSERVABLE_OUTCOME","owner":"clockwork","source_ref":"fixture://cm/outcome","evidence_ref":"fixture://cm/evidence/outcome","result":"caller observes intended result"}
+          ],
+          "expected_final_state":"one coherent module flow returns the intended result"
+        },
+        {
+          "id":"cm-failure","kind":"FAILURE_PATH",
+          "trace":[
+            {"stage":"ENTRYPOINT","owner":"clockwork","source_ref":"fixture://cm-fail/entry","evidence_ref":"fixture://cm-fail/evidence/entry","result":"entrypoint receives intended input"},
+            {"stage":"INPUT_CONTRACT","owner":"clockwork","source_ref":"fixture://cm-fail/input","evidence_ref":"fixture://cm-fail/evidence/input","result":"input contract is valid"},
+            {"stage":"MODULE_A_DECISION","owner":"clockwork","source_ref":"fixture://cm-fail/a","evidence_ref":"fixture://cm-fail/evidence/a","result":"module A enters failure branch"},
+            {"stage":"HANDOFF_PAYLOAD","owner":"clockwork","source_ref":"fixture://cm-fail/handoff","evidence_ref":"fixture://cm-fail/evidence/handoff","result":"failure handoff is explicit"},
+            {"stage":"MODULE_B_DECISION","owner":"clockwork","source_ref":"fixture://cm-fail/b","evidence_ref":"fixture://cm-fail/evidence/b","result":"module B preserves failure semantics"},
+            {"stage":"SHARED_STATE_OR_SIDE_EFFECT","owner":"clockwork","source_ref":"fixture://cm-fail/side-effect","evidence_ref":"fixture://cm-fail/evidence/side-effect","result":"no duplicate side effect occurs"},
+            {"stage":"RESULT_PROPAGATION","owner":"clockwork","source_ref":"fixture://cm-fail/result","evidence_ref":"fixture://cm-fail/evidence/result","result":"false success is not emitted"},
+            {"stage":"ERROR_PROPAGATION","owner":"clockwork","source_ref":"fixture://cm-fail/error","evidence_ref":"fixture://cm-fail/evidence/error","result":"error propagates deterministically"},
+            {"stage":"FINAL_OBSERVABLE_OUTCOME","owner":"clockwork","source_ref":"fixture://cm-fail/outcome","evidence_ref":"fixture://cm-fail/evidence/outcome","result":"caller observes failure"}
+          ],
+          "expected_final_state":"failure propagates without false success or duplicate side effect"
+        }
+      ],
+      "cases":[
+        {"id":"cross-module-happy-path","expected_status":"CROSS_LAYER_ALIGNMENT_CONFIRMED","finding_owner":null,"finding":null,"evidence":{"input_contract":true,"handoff_contract":true,"control_flow":true,"state_and_side_effects":true,"error_propagation":true,"dependency_direction":true,"executable_workflow":true},"workflow_id":"cm-happy","expected_reentry":[]},
+        {"id":"cross-module-flow-gap","expected_status":"CROSS_LAYER_ALIGNMENT_GAPS_FOUND","finding_owner":"clockwork","finding":{"finding_id":"F-CM-FLOW-001","severity":"MAJOR","owner":"clockwork","affected_stages":["HANDOFF_PAYLOAD","MODULE_B_DECISION","ERROR_PROPAGATION"],"evidence":["fixture://finding/cm-flow"],"impact":"handoff or branch semantics drift across modules","minimal_remediation":"align handoff and error semantics","required_validation":"boundary tests prove exact handoff and error propagation"},"evidence":{"input_contract":true,"handoff_contract":false,"control_flow":false,"state_and_side_effects":true,"error_propagation":false,"dependency_direction":true,"executable_workflow":true},"workflow_id":"cm-happy","expected_reentry":["clockwork","overseer"]},
+        {"id":"cross-module-owner-contract-missing","expected_status":"CROSS_LAYER_CONTRACT_INCOMPLETE","finding_owner":"the-tuner","finding":{"finding_id":"F-CM-CONTRACT-001","severity":"MAJOR","owner":"the-tuner","affected_stages":["MODULE_A_DECISION"],"evidence":["missing://cm-owner"],"impact":"a module decision lacks singular ownership","minimal_remediation":"route the incomplete contract through Conductor","required_validation":"complete ownership and criteria are present"},"evidence":{"input_contract":true,"handoff_contract":true,"control_flow":true,"state_and_side_effects":true,"error_propagation":true,"dependency_direction":true,"executable_workflow":true},"workflow_id":"cm-happy","expected_reentry":["conductor","clockwork"]},
+        {"id":"cross-module-contradiction","expected_status":"CROSS_LAYER_CONTRADICTION_REVIEW_REQUIRED","finding_owner":"the-tuner","finding":{"finding_id":"F-CM-CONTRA-001","severity":"CRITICAL","owner":"the-tuner","affected_stages":["MODULE_A_DECISION","HANDOFF_PAYLOAD","MODULE_B_DECISION"],"evidence":["fixture://finding/cm-contradiction"],"impact":"module contracts prescribe incompatible handoff behavior","minimal_remediation":"route conflicting clauses without choosing a winner","required_validation":"revised contracts agree on one handoff"},"evidence":{"input_contract":true,"handoff_contract":true,"control_flow":true,"state_and_side_effects":true,"error_propagation":true,"dependency_direction":true,"executable_workflow":true},"workflow_id":"cm-happy","expected_reentry":["conductor","clockwork"]},
+        {"id":"cross-module-evidence-missing","expected_status":"CROSS_LAYER_EVIDENCE_INSUFFICIENT","finding_owner":"overseer","finding":{"finding_id":"F-CM-EVIDENCE-001","severity":"MAJOR","owner":"overseer","affected_stages":["ENTRYPOINT","FINAL_OBSERVABLE_OUTCOME"],"evidence":["missing://cm-executable"],"impact":"cross-module flow cannot be demonstrated","minimal_remediation":"produce current happy and failure traces","required_validation":"Overseer verifies both traces against current identity"},"evidence":{"input_contract":true,"handoff_contract":true,"control_flow":true,"state_and_side_effects":true,"error_propagation":true,"dependency_direction":true,"executable_workflow":false},"workflow_id":null,"expected_reentry":["overseer"]},
+        {"id":"cross-module-contract-stale","expected_status":"CROSS_LAYER_CONTRACT_STALE","finding_owner":"the-tuner","finding":{"finding_id":"F-CM-STALE-001","severity":"MAJOR","owner":"the-tuner","affected_stages":["ENTRYPOINT","FINAL_OBSERVABLE_OUTCOME"],"evidence":["fixture://finding/cm-stale"],"impact":"module-flow evidence is bound to a superseded revision","minimal_remediation":"refresh packet and dependent evidence","required_validation":"Tuner, Overseer, and Arbiter verify current identity"},"evidence":{"input_contract":true,"handoff_contract":true,"control_flow":true,"state_and_side_effects":true,"error_propagation":true,"dependency_direction":true,"executable_workflow":true},"workflow_id":"cm-happy","expected_reentry":["the-tuner","overseer","arbiter"]},
+        {"id":"cross-module-side-effect-reentry","expected_status":"SPECIALIST_REENTRY_REQUIRED","finding_owner":"clockwork","finding":{"finding_id":"F-CM-SIDEFX-001","severity":"CRITICAL","owner":"clockwork","affected_stages":["SHARED_STATE_OR_SIDE_EFFECT","ERROR_PROPAGATION"],"evidence":["fixture://finding/cm-side-effect"],"impact":"retry or error flow can duplicate a side effect or report false success","minimal_remediation":"make side-effect ordering and idempotency explicit","required_validation":"failure evidence proves one side effect and correct error propagation"},"evidence":{"input_contract":true,"handoff_contract":true,"control_flow":true,"state_and_side_effects":false,"error_propagation":true,"dependency_direction":true,"executable_workflow":true},"workflow_id":"cm-failure","expected_reentry":["clockwork","overseer"]}
+      ]
+    }
+  }
+}

--- a/tests/behavior/test_cross_layer_integrity_contract.py
+++ b/tests/behavior/test_cross_layer_integrity_contract.py
@@ -1,0 +1,175 @@
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = ROOT / "tests/behavior/cross-layer-integrity-fixtures.json"
+PROFILE_PROTOCOL = ROOT / "docs/validation/CROSS_LAYER_INTEGRITY_PROFILE_PROTOCOL.md"
+
+
+def load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+validator = load_module(
+    "cross_layer_integrity_validator",
+    ROOT / "scripts/validate_cross_layer_integrity_contract.py",
+)
+synchronicity_validator = load_module(
+    "synchronicity_validator",
+    ROOT / "scripts/validate_cross_layer_synchronicity_contract.py",
+)
+
+
+def fixture_data():
+    return json.loads(FIXTURES.read_text(encoding="utf-8"))
+
+
+def protocol_bytes():
+    text = PROFILE_PROTOCOL.read_text(encoding="utf-8")
+    return text.replace("\r\n", "\n").replace("\r", "\n").encode("utf-8")
+
+
+def test_real_repo_passes():
+    assert not validator.validate(ROOT)
+
+
+def test_original_frontend_backend_contract_still_passes():
+    assert not synchronicity_validator.validate(ROOT)
+
+
+def test_each_profile_covers_exact_status_set():
+    data = fixture_data()
+    assert set(data["profiles"]) == set(validator.PROFILE_SPECS)
+    for name, spec in validator.PROFILE_SPECS.items():
+        profile = data["profiles"][name]
+        assert tuple(profile["stages"]) == spec["stages"]
+        assert set(profile["required_evidence"]) == spec["evidence"]
+        assert {case["expected_status"] for case in profile["cases"]} == validator.STATUSES
+
+
+def test_workflows_cover_exact_profile_stage_order():
+    data = fixture_data()
+    for name, spec in validator.PROFILE_SPECS.items():
+        kinds = set()
+        for workflow in data["profiles"][name]["executable_workflows"]:
+            kinds.add(workflow["kind"])
+            assert [entry["stage"] for entry in workflow["trace"]] == list(spec["stages"])
+            assert all(entry["owner"] in validator.OWNERS for entry in workflow["trace"])
+        assert kinds == {"HAPPY_PATH", "FAILURE_PATH"}
+
+
+def test_backend_persistence_ownership():
+    cases = {case["id"]: case for case in fixture_data()["profiles"]["backend_persistence"]["cases"]}
+    assert cases["backend-contract-mapping-gap"]["finding_owner"] == "chronicler"
+    assert cases["backend-transaction-reentry"]["finding_owner"] == "chronicler"
+    assert cases["backend-evidence-missing"]["finding_owner"] == "overseer"
+    assert cases["backend-persistence-contradiction"]["finding_owner"] == "the-tuner"
+
+
+def test_cross_module_ownership():
+    cases = {case["id"]: case for case in fixture_data()["profiles"]["cross_module_logic"]["cases"]}
+    assert cases["cross-module-flow-gap"]["finding_owner"] == "clockwork"
+    assert cases["cross-module-side-effect-reentry"]["finding_owner"] == "clockwork"
+    assert cases["cross-module-evidence-missing"]["finding_owner"] == "overseer"
+    assert cases["cross-module-contradiction"]["finding_owner"] == "the-tuner"
+
+
+def test_unknown_status_fails_closed():
+    data = fixture_data()
+    data["profiles"]["backend_persistence"]["cases"][0]["expected_status"] = "UNKNOWN"
+    errors = validator.validate_fixtures(data, protocol_bytes())
+    assert any("unknown status" in error for error in errors)
+
+
+def test_unknown_profile_fails_closed():
+    data = fixture_data()
+    data["profiles"]["unknown"] = copy.deepcopy(data["profiles"]["cross_module_logic"])
+    errors = validator.validate_fixtures(data, protocol_bytes())
+    assert any("profiles must contain exactly" in error for error in errors)
+
+
+def test_protocol_hash_mismatch_fails_closed():
+    data = fixture_data()
+    data["contract_identity"]["protocol_sha256"] = "0" * 64
+    errors = validator.validate_fixtures(data, protocol_bytes())
+    assert any("protocol_sha256 does not match" in error for error in errors)
+
+
+def test_missing_executable_evidence_fails_closed():
+    data = fixture_data()
+    case = next(
+        item for item in data["profiles"]["cross_module_logic"]["cases"]
+        if item["id"] == "cross-module-evidence-missing"
+    )
+    case["evidence"]["executable_workflow"] = True
+    errors = validator.validate_fixtures(data, protocol_bytes())
+    assert any("executable evidence requires workflow_id" in error for error in errors)
+
+
+def test_incomplete_trace_fails_closed():
+    data = fixture_data()
+    data["profiles"]["backend_persistence"]["executable_workflows"][0]["trace"].pop()
+    errors = validator.validate_fixtures(data, protocol_bytes())
+    assert any("trace must contain profile stages in exact order" in error for error in errors)
+
+
+def test_incomplete_finding_fails_closed():
+    data = fixture_data()
+    case = next(
+        item for item in data["profiles"]["backend_persistence"]["cases"]
+        if item["id"] == "backend-contract-mapping-gap"
+    )
+    del case["finding"]["required_validation"]
+    errors = validator.validate_fixtures(data, protocol_bytes())
+    assert any("complete finding object" in error for error in errors)
+
+
+def test_stale_identity_requires_full_continuity_chain():
+    data = fixture_data()
+    case = next(
+        item for item in data["profiles"]["cross_module_logic"]["cases"]
+        if item["id"] == "cross-module-contract-stale"
+    )
+    case["expected_reentry"] = ["the-tuner", "overseer"]
+    errors = validator.validate_fixtures(data, protocol_bytes())
+    assert any("must re-enter Tuner, Overseer, and Arbiter" in error for error in errors)
+
+
+def test_contradiction_requires_conductor_reentry():
+    data = fixture_data()
+    case = next(
+        item for item in data["profiles"]["backend_persistence"]["cases"]
+        if item["id"] == "backend-persistence-contradiction"
+    )
+    case["expected_reentry"] = ["clockwork", "chronicler"]
+    errors = validator.validate_fixtures(data, protocol_bytes())
+    assert any("contradiction must route back through Conductor" in error for error in errors)
+
+
+def main():
+    test_real_repo_passes()
+    test_original_frontend_backend_contract_still_passes()
+    test_each_profile_covers_exact_status_set()
+    test_workflows_cover_exact_profile_stage_order()
+    test_backend_persistence_ownership()
+    test_cross_module_ownership()
+    test_unknown_status_fails_closed()
+    test_unknown_profile_fails_closed()
+    test_protocol_hash_mismatch_fails_closed()
+    test_missing_executable_evidence_fails_closed()
+    test_incomplete_trace_fails_closed()
+    test_incomplete_finding_fails_closed()
+    test_stale_identity_requires_full_continuity_chain()
+    test_contradiction_requires_conductor_reentry()
+    print("Cross-layer integrity profile tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/behavior/test_cross_layer_synchronicity_contract.py
+++ b/tests/behavior/test_cross_layer_synchronicity_contract.py
@@ -1,6 +1,7 @@
 import copy
 import importlib.util
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -8,11 +9,9 @@ ROOT = Path(__file__).resolve().parents[2]
 VALIDATOR_PATH = ROOT / "scripts/validate_cross_layer_synchronicity_contract.py"
 FIXTURES_PATH = ROOT / "tests/behavior/cross-layer-synchronicity-fixtures.json"
 PROTOCOL_PATH = ROOT / "docs/validation/CROSS_MODULE_LOGIC_AUDIT_PROTOCOL.md"
+INTEGRITY_TEST_PATH = ROOT / "tests/behavior/test_cross_layer_integrity_contract.py"
 
-spec = importlib.util.spec_from_file_location(
-    "synchronicity_validator",
-    VALIDATOR_PATH,
-)
+spec = importlib.util.spec_from_file_location("synchronicity_validator", VALIDATOR_PATH)
 validator = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(validator)
 
@@ -41,9 +40,7 @@ def test_all_statuses_have_cases():
 
 def test_executable_workflows_trace_all_stages():
     for workflow in fixtures()["executable_workflows"]:
-        assert [entry["stage"] for entry in workflow["trace"]] == list(
-            validator.REQUIRED_STAGES
-        )
+        assert [entry["stage"] for entry in workflow["trace"]] == list(validator.REQUIRED_STAGES)
         assert all(entry["source_ref"] for entry in workflow["trace"])
         assert all(entry["evidence_ref"] for entry in workflow["trace"])
         assert all(entry["result"] for entry in workflow["trace"])
@@ -83,19 +80,12 @@ def test_stale_identity_reenters_continuity_chain():
 def test_unknown_status_fails_closed():
     data = fixtures()
     data["cases"][0]["expected_status"] = "AUTO_CONTINUE_UNKNOWN"
-    assert any(
-        "unknown status" in error
-        for error in validator.validate_fixtures(data, protocol_bytes())
-    )
+    assert any("unknown status" in error for error in validator.validate_fixtures(data, protocol_bytes()))
 
 
 def test_missing_executable_evidence_fails_closed():
     data = copy.deepcopy(fixtures())
-    case = next(
-        item
-        for item in data["cases"]
-        if item["id"] == "missing-executable-evidence"
-    )
+    case = next(item for item in data["cases"] if item["id"] == "missing-executable-evidence")
     case["evidence"]["executable_workflow"] = True
     assert any(
         "executable evidence requires workflow_id" in error
@@ -123,11 +113,7 @@ def test_incomplete_trace_fails_closed():
 
 def test_incomplete_finding_fails_closed():
     data = fixtures()
-    case = next(
-        item
-        for item in data["cases"]
-        if item["id"] == "request-field-mismatch"
-    )
+    case = next(item for item in data["cases"] if item["id"] == "request-field-mismatch")
     del case["finding"]["required_validation"]
     assert any(
         "complete finding object" in error
@@ -137,16 +123,28 @@ def test_incomplete_finding_fails_closed():
 
 def test_unknown_reentry_owner_fails_closed():
     data = fixtures()
-    case = next(
-        item
-        for item in data["cases"]
-        if item["id"] == "persistence-scope-expansion"
-    )
+    case = next(item for item in data["cases"] if item["id"] == "persistence-scope-expansion")
     case["expected_reentry"].append("unknown-specialist")
     assert any(
         "unique valid specialist list" in error
         for error in validator.validate_fixtures(data, protocol_bytes())
     )
+
+
+def test_f2_integrity_profile_suite():
+    result = subprocess.run(
+        [sys.executable, str(INTEGRITY_TEST_PATH)],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            "F2 cross-layer integrity profile suite failed:\n"
+            + result.stdout
+            + result.stderr
+        )
 
 
 def main():
@@ -163,6 +161,7 @@ def main():
     test_incomplete_trace_fails_closed()
     test_incomplete_finding_fails_closed()
     test_unknown_reentry_owner_fails_closed()
+    test_f2_integrity_profile_suite()
     print("Cross-layer synchronicity contract tests passed.")
     return 0
 


### PR DESCRIPTION
## Summary

Completes Issue #215 Phase F2 with an additive extension of Orchestra's existing cross-layer audit system.

This final implementation intentionally leaves the merged frontend-to-backend protocol, its fixture identity, and the tracked Codex portable reference bundle unchanged. Earlier PRs #218 and #219 demonstrated that changing or remotely rewriting broader surfaces created unnecessary parity and historical-drift risk; this branch reduces the change to the smallest CI-exercised implementation set.

## Baseline and scope

- Base: `2bc63308415221c54babba578e812ec95bc65f4c`
- Branch: `feat/cross-layer-integrity-f2-v3`
- Runtime implementation: unchanged
- Adapter/Codex export bundle: unchanged
- Manifest/version metadata: unchanged
- Database/schema/migration implementation: unchanged
- Existing frontend/backend protocol and fixtures: unchanged

## Backend-to-persistence profile

`SERVICE_INPUT -> DOMAIN_VALIDATION -> TRANSACTION_BOUNDARY -> REPOSITORY_OPERATION -> MAPPING_OR_QUERY -> SCHEMA_CONSTRAINT -> PERSISTENCE_EXECUTION -> COMMIT_OR_ROLLBACK -> READBACK_OR_PROJECTION -> SERVICE_RESULT`

Evidence covers mapping, validation/constraint parity, transaction semantics, query mapping, error mapping, concurrency/idempotency, and executable happy/failure paths.

## Cross-module logical-flow profile

`ENTRYPOINT -> INPUT_CONTRACT -> MODULE_A_DECISION -> HANDOFF_PAYLOAD -> MODULE_B_DECISION -> SHARED_STATE_OR_SIDE_EFFECT -> RESULT_PROPAGATION -> ERROR_PROPAGATION -> FINAL_OBSERVABLE_OUTCOME`

Evidence covers handoff contracts, control flow, dependency direction, state/side effects, error propagation, and executable happy/failure paths.

## Validation design

- Adds an F2 profile protocol and two checklists.
- Adds deterministic fixtures covering all seven existing cross-layer statuses for both profiles.
- Adds a fail-closed F2 validator and focused behavior suite.
- Chains the F2 suite from the existing cross-layer behavior test already executed by the canonical validation runner.
- Explicitly re-runs the original frontend/backend validator as a non-regression check.

## Boundaries

No new specialist, command, plugin, runtime model, persistence implementation, migration, Git authority, release authority, deployment authority, installed-host mutation, policy activation, force push, or history rewrite is introduced.

Changelog/release consolidation remains Phase F5 unless repository governance requires a root changelog entry for this implementation PR.

Supersedes #218 and #219.
Refs #215