### PR TITLE
docs: reconcile delegated Phase D runtime overlap

### DIFF
--- a/docs/project/DELEGATED_PHASE_D_RUNTIME_OVERLAP_ASSESSMENT.md
+++ b/docs/project/DELEGATED_PHASE_D_RUNTIME_OVERLAP_ASSESSMENT.md
@@ -1,0 +1,101 @@
+# Delegated Phase D Runtime Overlap Assessment
+
+## Status
+
+```text
+Assessment: COMPLETE
+Phase: Delegated Phase D overlap reconciliation
+Baseline: current main after Delegated Phase C repository-contract delivery
+Runtime extension verdict: NO_DUPLICATE_RUNTIME_EXTENSION_REQUIRED
+Live host reliability evidence: PENDING_LOCAL_HOST_VALIDATION
+Release target: v1.2.0
+```
+
+## Purpose
+
+The original Delegated Phase D plan predates several runtime and governance implementations that are now canonical in Orchestra. Implementing that older plan literally would duplicate existing contracts, create competing sources of truth, and weaken the framework's ownership boundaries.
+
+This assessment reconciles the original Phase D targets against current repository facts and classifies each target before any additional runtime implementation is permitted.
+
+## Disposition vocabulary
+
+- `SATISFIED_BY_EXISTING_RUNTIME` — the required semantics are already implemented and validated in the canonical runtime.
+- `PARTIALLY_SATISFIED_REQUIRES_BOUNDED_EXTENSION` — a material runtime gap remains and a narrowly scoped extension is justified.
+- `INSTRUCTION_LEVEL_SUFFICIENT_NO_RUNTIME_CHANGE` — the record is intentionally a governance/evidence artifact and making it runtime-authoritative would duplicate or distort current boundaries.
+- `DEFERRED_NOT_RELEASE_BLOCKING` — a valid future capability remains outside the v1.2.0 release requirement.
+
+## Reconciliation matrix
+
+| Original Phase D target | Current canonical implementation | Disposition | Rationale |
+| --- | --- | --- | --- |
+| Delegated execution envelope | Existing runtime envelope, trusted authority/capability composition, delegation resolution, run identity, and lifecycle contracts | `SATISFIED_BY_EXISTING_RUNTIME` | A second delegated envelope would create a competing authority carrier. Existing runtime composition already binds execution identity, authority, capabilities, delegation, lifecycle, and audit evidence. |
+| `ApprovedUnitPlan` typed model | Canonical immutable `ApprovedUnitPlan` plus structural, path, envelope, dependency, governance-reference, and contextual validation | `SATISFIED_BY_EXISTING_RUNTIME` | The Spec Kitty-derived Phase 2 implementation already promoted this target into the runtime and validates it fail-closed. |
+| Execution evidence packet | Overseer output contract, deterministic evidence identity/freshness validators, Tuner continuity validation, retrospective/evidence artifacts | `INSTRUCTION_LEVEL_SUFFICIENT_NO_RUNTIME_CHANGE` | Evidence is validation input, not execution authority. Converting the packet into an independent runtime state model would create a second source of truth for evidence and continuation. |
+| Transition decision record | Arbiter output contract plus trusted lifecycle/terminal transition enforcement and coordination transition validation | `INSTRUCTION_LEVEL_SUFFICIENT_NO_RUNTIME_CHANGE` | Arbiter owns the governance disposition while runtime lifecycle code enforces legal state transitions. A second typed governance-decision runtime object is unnecessary unless a concrete consumer requires one. |
+| Checkpoint record | Arbiter checkpoint output contract plus Phase C portable continuity protocol | `INSTRUCTION_LEVEL_SUFFICIENT_NO_RUNTIME_CHANGE` | Checkpoints are explicit handoff evidence. Persisting them as runtime state would cross the current no-durable-collaboration boundary and is not required for repository or host continuity validation. |
+| Capacity handoff record | Arbiter capacity-handoff output contract plus Phase C `WAIT_FOR_CAPACITY` continuity contract | `INSTRUCTION_LEVEL_SUFFICIENT_NO_RUNTIME_CHANGE` | The record intentionally transports bounded continuation evidence; it does not need to become a new runtime authority or durable store. |
+| Authority/capability enforcement | Trusted root authority loading, immutable authority/capability intersection, manifest provenance, enforcement before governance | `SATISFIED_BY_EXISTING_RUNTIME` | Implemented through the trusted runtime authority progression and adversarial validation. |
+| Bounded delegation | Immutable child authority/capability resolution, parent/run identity validation, depth enforcement, context minimization, deterministic accepted/rejected audit events | `SATISFIED_BY_EXISTING_RUNTIME` | Current delegation contracts already implement the material Phase D trust boundary. |
+| Lifecycle control | Typed lifecycle state, exact transition table, WAIT/RESUME semantics, terminal replay/conflict handling | `SATISFIED_BY_EXISTING_RUNTIME` | Existing runtime lifecycle is the canonical state-transition mechanism. |
+| Structured audit integration | Runtime audit interfaces/events, correlation IDs, retrospective records, coordination audit evidence | `SATISFIED_BY_EXISTING_RUNTIME` | Audit evidence is already deterministic and linked to canonical run/correlation identities. |
+| Cross-specialist evidence continuity | Tuner typed coordination, canonical fingerprints, stale-evidence invalidation, contradiction handling, minimal re-entry recommendations | `SATISFIED_BY_EXISTING_RUNTIME` | Phase 2-4 Tuner work provides the missing continuity semantics that the old Phase D plan assumed did not yet exist. |
+| Context reset / host handoff reliability | Phase C portable host reliability protocol, deterministic repository simulations, live evidence boundary | `DEFERRED_NOT_RELEASE_BLOCKING` for live evidence only | Repository contracts are implementable remotely; actual installed-host evidence remains explicitly pending and must not be fabricated. |
+| Durable checkpoint/evidence persistence | No canonical durable collaboration store | `DEFERRED_NOT_RELEASE_BLOCKING` | SQLite, RPC, daemons, durable collaboration persistence, and host-process orchestration remain explicit non-goals for the current release. |
+
+## Existing runtime foundations that supersede the old Phase D assumptions
+
+The following merged work materially changes the implementation landscape assumed by the original Phase D plan:
+
+1. **Trusted authority and capability runtime** — finite authority modes, immutable route bindings, authority/capability enforcement, manifest grant provenance, and fail-closed capability denial.
+2. **Bounded delegation and lifecycle** — immutable effective child resolutions, depth and parent identity enforcement, context minimization, lifecycle transitions, wait/resume, terminal replay, and deterministic audit events.
+3. **Cross-specialist coordination runtime** — immutable collaboration records, deterministic transitions/rejections, evidence fingerprints, stale-evidence invalidation, contradiction handling, and minimal specialist re-entry.
+4. **Spec Kitty-derived runtime contracts** — runtime envelope serialization, RFC 9562 UUIDv7 correlation identity, phase retrospective records, and canonical `ApprovedUnitPlan` extensions.
+5. **Status and worktree contracts** — read-only status projection and optional path-confined worktree isolation without new authority.
+6. **Cross-layer integrity contracts** — frontend/backend, backend/persistence, and broader cross-module audit evidence without introducing another runtime execution layer.
+7. **Delegated host reliability contract** — repository-verifiable continuity semantics while keeping live installed-host evidence distinct and pending.
+
+## Why no new runtime record classes are authorized by this assessment
+
+### Evidence is not authority
+
+`ExecutionEvidencePacket`, `CheckpointRecord`, and `CapacityHandoffRecord` exist to carry review and continuation evidence. They should not become independent runtime state authorities unless a concrete runtime consumer requires typed in-process behavior that cannot be provided by the current envelope, lifecycle, delegation, evidence identity, and coordination contracts.
+
+No such unmet consumer requirement is established by the current repository.
+
+### Arbiter decisions are governance outputs
+
+`TransitionDecisionRecord` represents Arbiter's decision and evidence. The runtime already owns legal lifecycle transition enforcement. Duplicating the decision into another authoritative runtime state model would blur the separation between governance disposition and runtime mechanics.
+
+### Durable storage remains intentionally excluded
+
+The current architecture explicitly excludes persistent collaboration state, SQLite/RPC coordination, background daemons, and host-process orchestration. Adding typed persistent checkpoint or evidence models merely to satisfy an outdated plan would create architecture drift rather than close a validated gap.
+
+## Gap decision
+
+```text
+PARTIALLY_SATISFIED_REQUIRES_BOUNDED_EXTENSION count: 0
+SATISFIED_BY_EXISTING_RUNTIME: authority, capability, delegation, lifecycle, envelope, ApprovedUnitPlan, audit, coordination
+INSTRUCTION_LEVEL_SUFFICIENT_NO_RUNTIME_CHANGE: evidence packet, transition decision, checkpoint, capacity handoff
+DEFERRED_NOT_RELEASE_BLOCKING: live installed-host evidence and durable collaboration persistence
+```
+
+Therefore **no additional Phase D runtime implementation is justified for v1.2.0**.
+
+Any future proposal to add a typed runtime record for an instruction-level artifact must first demonstrate all of the following:
+
+1. a concrete runtime consumer that cannot use existing canonical contracts;
+2. no duplicate source of truth or authority;
+3. explicit serialization and compatibility requirements;
+4. fail-closed authority and lifecycle behavior;
+5. migration and backward-compatibility impact;
+6. focused and adversarial tests proving the new type is necessary.
+
+## Release implication
+
+Phase D overlap reconciliation is complete for release-planning purposes. Orchestra may proceed to v1.2.0 release preparation without adding duplicate runtime models.
+
+The remaining Phase C live-host evidence debt must stay visible in release documentation as `PENDING_LOCAL_HOST_VALIDATION` until actual installed-host evidence is produced. It must not be converted into a release claim by repository CI alone.
+
+## Preserved boundaries
+
+This assessment authorizes no new runtime model, database, migration, persistence layer, RPC service, daemon, deployment behavior, marketplace publication, installed-host mutation, policy activation, destructive cleanup, force push, or history rewrite.


### PR DESCRIPTION
## Summary

Completes Issue #215 Phase F4 by reconciling the original Delegated Phase D runtime plan against the capabilities that have since become canonical in Orchestra.

## Result

No additional Phase D runtime model is justified for v1.2.0.

The assessment classifies the old targets as:

- `SATISFIED_BY_EXISTING_RUNTIME`
- `INSTRUCTION_LEVEL_SUFFICIENT_NO_RUNTIME_CHANGE`
- `DEFERRED_NOT_RELEASE_BLOCKING`

There are zero `PARTIALLY_SATISFIED_REQUIRES_BOUNDED_EXTENSION` findings.

## Existing runtime coverage

The current repository already provides trusted authority/capability enforcement, bounded delegation, lifecycle control, runtime envelopes, correlation identity, `ApprovedUnitPlan`, retrospective/audit evidence, Tuner coordination and evidence continuity, status/worktree contracts, cross-layer integrity contracts, and the repository-verifiable Phase C host reliability contract.

## No-duplication decision

The old `ExecutionEvidencePacket`, `TransitionDecisionRecord`, `CheckpointRecord`, and `CapacityHandoffRecord` targets remain governance/evidence artifacts. Promoting them into new independent runtime-authoritative models without a concrete missing consumer would duplicate current sources of truth and blur the separation between evidence, Arbiter governance disposition, and runtime lifecycle enforcement.

## Deferred boundary

Actual installed-host Phase C evidence remains `PENDING_LOCAL_HOST_VALIDATION`. Durable collaboration persistence, SQLite/RPC coordination, daemons, and host-process orchestration remain outside the v1.2.0 release requirement.

## Boundaries

Documentation-only. No runtime, adapter, manifest/version, persistence, policy, release, deployment, installed-host, destructive cleanup, force-push, or history-rewrite changes.

Refs #215