### PR TITLE
release: prepare v1.2.0 release candidate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "orchestra",
       "source": "./",
       "description": "Governance-first specialist skill framework for routed, auditable AI coding workflows.",
-      "version": "1.1.2"
+      "version": "1.2.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra",
   "description": "Governance-first specialist skill framework for routed, auditable AI coding workflows.",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "update_check": {
     "update_check_enabled": true,
     "update_check_channel": "stable",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conductor",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "An installable AI workflow plugin that routes complex software tasks through focused specialist skills for architecture, UI/UX, documentation, diagrams, databases, QA, security, and gated resilience review.",
   "author": {
     "name": "Baelfyre",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,539 +1,151 @@
 # Changelog
 
-This changelog tracks the repository history using git tags, merge history, and the prior documented milestone log that lived under `docs/meta/CHANGELOG.md`.
-## Unreleased - Delegated Governance State Reconciliation R5B
+This changelog records release-level Orchestra history. Detailed implementation chronology remains available in Git history, merged pull requests, `DECISION_LOG.md`, `PROJECT_STATE.md`, and immutable handoff records.
 
-### Changed
+## v1.2.0 Release Candidate - NOT RELEASED
 
-- Reconciled canonical delegated-governance Phase C and Phase D status with the verified clean replay state: Phase C repository contract complete through PR #225, live installed-host evidence still `PENDING_LOCAL_HOST_VALIDATION`, and Phase D overlap reconciliation complete through PR #226.
-- Updated governance consistency validation so obsolete current-state claims such as `Phase C and Phase D are not started` are rejected rather than required.
-- Added regressions preventing stale Phase C/D wording and false promotion of pending live-host evidence.
-- Preserved the Phase D `NO_DUPLICATE_RUNTIME_EXTENSION_REQUIRED` conclusion for v1.2.0 and the R7 live installed-host publication gate.
-- No runtime, adapter, manifest/version, workflow, release, deployment, policy activation, installed-host mutation, or history rewrite is part of R5B.
-
-## Unreleased - Autonomous Replay Merge Hardening R5
+`v1.2.0` is prepared as a minor release candidate. Repository manifests are normalized to `1.2.0`, but the latest published GitHub Release remains `v1.1.2` until R7 live installed-host evidence is reconciled and the separately governed R8 publication gate completes.
 
 ### Added
 
-- Added a fail-closed autonomous merge-readiness protocol that requires a green canonical baseline, exact-head validation evidence, complete successful required checks, changelog freshness, an expected-head merge guard where supported, and independent post-merge verification before `MERGED_VERIFIED` can be recorded.
-- Added a deterministic autonomous merge-readiness evaluator, compact machine-readable fixtures, and runtime regressions covering missing or pending checks, governance/runtime/cross-platform failures, stale heads, red baselines, changelog omissions, mergeability misuse, unresolved blockers, and unverified merge API results.
-- Added repository automation guidance requiring the exact-head fail-closed protocol for autonomous or delegated merges.
+- Delegated Phase B instruction-level autonomous progression with approved execution envelopes, six transition dispositions, checkpoints, bounded remediation, capacity handoff, current evidence requirements, and default-deny external-action authority.
+- The Tuner cross-specialist coordination stack through Phases 1-4: contract assembly, missing-owner and contradiction detection, semantic invalidation, evidence continuity, typed in-memory coordination records, deterministic transitions/rejections, minimal specialist re-entry, and bounded Conductor-owned runtime integration.
+- Spec Kitty-derived governed phase execution contracts: `OrchestraRuntimeEnvelope`, `OrchestraCorrelationID`, `OrchestraPhaseRetrospective`, the 15-field `ApprovedUnitPlan` extension, `OrchestraStatusProjection`, and `OrchestraWorktreeContract`.
+- Cross-layer integrity audit profiles for frontend-to-backend synchronicity, backend-to-persistence integrity, and language-neutral cross-module logical flow using the existing Conductor -> Tuner -> specialist -> Overseer -> Arbiter ownership model.
+- Delegated Phase C repository host-reliability contracts and deterministic adversarial fixtures covering reset/resume, active-host handoff, capacity waits, stale identity, incomplete checkpoints, scaffold-only hosts, authority expansion, and duplicate replay.
+- Fail-closed autonomous merge-readiness protocol, machine-readable evaluation fixtures, and runtime regressions requiring green canonical baseline, exact-head evidence, complete successful required checks, changelog freshness, expected-head merge guards where supported, and independent post-merge verification.
+- `docs/releases/v1.2.0-governed-orchestration-release-candidate.md` as the source-backed candidate release note and publication-boundary record.
 
 ### Changed
 
-- Updated required-status-check guidance to treat Governance Check, behavior validation, runtime tests, and native Windows/Ubuntu/macOS validation as the minimum autonomous merge evidence inventory while keeping additional repository-required checks additive.
-- Updated branch-protection guidance to require live settings verification and blocked-merge tests rather than treating documentation or a configured rule name as proof of enforcement.
-- Reconciled current project state, session handoff, and delegated-governance implementation planning through the clean R1-R4 replay while preserving historical handoff evidence.
+- Reconciled Delegated Phase D against the existing trusted runtime. PR #226 concluded `NO_DUPLICATE_RUNTIME_EXTENSION_REQUIRED` for `v1.2.0`; no competing runtime model was added.
+- Reconciled canonical delegated-governance state so stale Phase C/D not-started claims and false live-host promotion are rejected by executable consistency validation.
+- Normalized the root, Claude Code, Codex, and scaffold adapter version surfaces to `1.2.0` without changing adapter maturity or publishing any IDE marketplace package.
+- Updated README, project context/state, session handoff, roadmap, compatibility, installation, and Codex adapter documentation to distinguish release-candidate metadata from the current public release.
+- Consolidated the previously fragmented post-`v1.1.2` unreleased changelog entries into this release-candidate record while preserving detailed implementation evidence in Git and pull-request history.
 
-### Incident Boundary
+### Clean Replay and Governance Hardening
 
-- The first autonomous finalization experiment remains preserved as learning evidence. Its fail-open merges are not treated as successful validation precedent.
-- `mergeable: true` and merge-API acceptance are explicitly non-authorizing signals. Missing or pending evidence maps to `WAIT_FOR_EVIDENCE`; failed required evidence blocks merge; a red canonical baseline must be remediated before the next phase.
-- The capability remains unreleased. Live installed-host continuity remains `PENDING_LOCAL_HOST_VALIDATION` and is not replaced by repository simulation.
+The first autonomous finalization experiment was rolled back to the verified recovery point and preserved as audit evidence. The accepted clean replay and hardening sequence is:
 
-## Unreleased - Delegated Host Reliability Phase C
+- R1 / PR #223 - Spec Kitty Phase 3 and roadmap reconciliation.
+- R2 / PR #224 - backend-to-persistence and cross-module logical-flow integrity.
+- R3 / PR #225 - delegated Phase C repository host-reliability contract after bounded fixture remediation and a fully fresh exact-head matrix.
+- R4 / PR #226 - Phase D runtime-overlap reconciliation with no duplicate runtime extension required.
+- R5 / PR #227 - autonomous merge-readiness hardening.
+- R5B / PR #228 - delegated-governance current-state reconciliation, merged at `fbe4532ba2083feaa7ed9fcda2988843f1237a78` and independently verified on canonical `main`.
+- R6 - `v1.2.0` release-candidate metadata, public documentation, changelog, and release-note preparation.
 
-### Added
+Historical fail-open merge behavior from the first experiment is not successful validation precedent.
 
-- Added a deterministic delegated-host reliability protocol and checklist for repository-verifiable same-host reset/resume, active-host handoff, capacity waits, stale identity, incomplete checkpoints, authority expansion, scaffold-only host routing, and duplicate replay scenarios.
-- Added fail-closed fixtures, validation, and runtime regression coverage for portable checkpoint and handoff evidence without introducing persistence, RPC, daemon, network orchestration, or new runtime authority.
-- Corrected the first-run fixture defects so all SHA-256 evidence identifiers satisfy the validator's lowercase 64-character contract.
+### Capability Merge Map
+
+Key post-`v1.1.2` canonical milestones include:
+
+- PR #190 - Delegated Phase B instruction-level progression.
+- PR #191 - Phase B post-merge synchronization.
+- PR #197 - The Tuner Phase 2 evidence identity and continuity.
+- PR #198 - The Tuner Phase 3 typed in-memory coordination runtime.
+- PR #200 - The Tuner Phase 4 scenario validation and runtime integration.
+- PR #201 - Tuner Phase 4 post-merge continuity state.
+- PR #208 - Spec Kitty-derived Phase 2 governed execution contracts.
+- PR #210 - Spec Kitty-derived Phase 3A design and ownership package.
+- PR #212 - `OrchestraStatusProjection`.
+- PR #214 - `OrchestraWorktreeContract` and Phase 3 completion.
+- PR #216 - frontend-to-backend synchronicity contract.
+- PR #223 - clean replay roadmap/state closeout.
+- PR #224 - backend-to-persistence and cross-module logical-flow profiles.
+- PR #225 - Delegated Phase C repository host-reliability contract.
+- PR #226 - Delegated Phase D overlap reconciliation.
+- PR #227 - autonomous merge-readiness hardening.
+- PR #228 - delegated-governance current-state reconciliation.
+
+### Compatibility and Authority Boundaries
+
+- Codex, Claude Code, and Antigravity retain supported integration surfaces; version normalization does not by itself prove live installed-host continuity.
+- Cursor, Windsurf, VS Code/VSCodium, JetBrains, Zed, and Neovim remain scaffold-only. No scaffold is graduated or marketplace-published by R6.
+- Existing authority, immutable run-scoped capabilities, bounded delegation, lifecycle, coordination ownership, evidence identity, and default-deny external-action controls remain unchanged.
+- No persistent collaboration storage, SQLite, migrations, RPC, network daemon, remote worker, background agent, production deployment, or automatic policy activation is added by the release candidate.
 
 ### Evidence Boundary
 
-- Repository CI proves only deterministic repository contract behavior. Actual installed Codex, Antigravity, and cross-host reset/resume evidence remains `PENDING_LOCAL_HOST_VALIDATION`.
-- Claude Code remains `SCAFFOLD_ONLY` for Phase C runtime-continuity purposes and cannot produce `AUTO_CONTINUE` as an active receiving host.
-- The capability remains unreleased; no deployment, installed-host mutation, policy activation, or history rewrite is part of Phase C.
+Repository CI proves deterministic repository behavior for the exact candidate revision. It does not prove an installed Codex reset/resume, installed Antigravity reset/resume, real live cross-host continuation, or active Claude Code runtime continuity.
 
-## Unreleased - Cross-Layer Integrity Phase F2
+```text
+REPOSITORY_SIMULATION != LIVE_HOST_EVIDENCE
+LIVE_INSTALLED_HOST_VALIDATION=PENDING_LOCAL_HOST_VALIDATION
+```
 
-### Added
+R7 host-derived evidence remains a publication gate.
 
-- Added an additive backend-to-persistence integrity profile covering service input, domain validation, transaction ownership, repository operations, mapping or query behavior, schema constraints, persistence execution, commit or rollback, readback or projection, and service-result propagation.
-- Added a language-neutral cross-module logical-flow integrity profile covering entrypoints, input contracts, module decisions, handoff payloads, shared state or side effects, result propagation, error propagation, and final observable outcomes.
-- Added dedicated backend-persistence and cross-module checklists, deterministic executable happy/failure traces, a fail-closed validator, and focused behavior coverage.
+### Publication Boundary
 
-### Preserved Boundaries
+R6 does **not** create or publish `v1.2.0`. It performs no tag creation, GitHub Release publication, deployment, marketplace graduation, installed-host mutation, policy activation, force push, or history rewrite.
 
-- Reused the existing Conductor -> The Tuner -> domain specialist -> Overseer -> Arbiter authority model; no new specialist, command, plugin, runtime model, persistence implementation, migration, or policy authority was added.
-- Kept the existing frontend/backend protocol, fixture identity, and Codex portable reference bundle unchanged; the new profiles are additive extensions.
-- The capability remains unreleased. No deployment, installed-integration mutation, policy activation, or history rewrite is part of F2.
+Publication requires a separately authorized R8 gate after R6 is merged and independently verified and R7 live-host evidence is reconciled.
 
-## Unreleased - Spec Kitty-Derived Governed Phase Execution Contracts
+---
 
-### Frontend-to-Backend Synchronicity Contract
+## v1.1.2 - Trusted Runtime Authority
 
-- Added the shared cross-module logic audit protocol and first frontend-to-backend synchronicity checklist without changing runtime or persistence behavior.
-- Added deterministic executable workflow traces, complete finding records, a focused validator, behavior tests, routing integration, strict-governance wiring, portable Codex export parity, and cross-platform canonical evidence hashing.
-- Merged through PR #216 at reviewed head `52d47c2b10770cb5a85dab2eab9e81ce8851adb1` and merge commit `3a2f8b7e65cdab0f7e6a3113d1096ec9dccc23d3`. The capability remains unreleased; no deployment or policy activation occurred.
-
-### Phase 3C WorktreeContract Post-Merge Closeout
-
-- Implemented the typed `OrchestraWorktreeContract` model (`orchestra_runtime/worktree.py`), strict path confinement, exact-base validation, deterministic identity and serialization, lifecycle enforcement, and adapter capability integration.
-- Added focused WorktreeContract and compatibility regressions covering locked and nested repositories, submodules, creation and cleanup races, case collisions, symlink and junction escapes, inspection failure, branch preservation, unrelated-worktree preservation, and post-release verification.
-- Completed consolidated behavior, runtime, coverage, governance, packaging, security, and cross-platform validation on the final reviewed revision.
-- Merged through PR #214 at reviewed head `646111325e6de7c5d31915789fdc22a644125b7b` and merge commit `6bce297c7469f9c08ce41308cbb993cc863ac540`. Phase 3A through Phase 3E are complete and merged, but not released; policy remains inactive.
-
-### Phase 3B Post-Merge State Synchronization
-
-- Merged PR #212 (`fa1e052d82301e70a5869258c3fc6af765163353`): Phase 3B `OrchestraStatusProjection` implementation. One commit (`2a6c7ea8db16ce73d66fae566672f3681094b0f7`), 8 changed paths, 1617 insertions, 51 deletions.
-- All 9 required CI checks passed before merge: Analyze (actions), Analyze (python), CodeQL, governance-check, native-macos-latest, native-ubuntu-latest, native-windows-latest, runtime-tests, validate.
-- No release, no policy activation.
-- Governance deviation: PR #212 was merged by the maintainer after all required technical checks passed. No independent APPROVED review was recorded before merge. The Copilot review state was COMMENTED only due to exhausted quota. This is documented as a governance process deviation and does not retroactively convert the technical self-review into an independent approval.
-
-### Implemented Candidate Phase 3B Status Projection
-
-- Implemented `OrchestraStatusProjection` as a read-only, deterministic, non-authorizing runtime and CLI surface.
-- Added immutable typed status records with strict runtime validation, explicit unknown and conflict diagnostics, revision-matched validation evidence, and deterministic JSON serialization.
-- Added local Git fact collection without fetch, network access, repository mutation, persistence, or cache writes.
-- Added NUL-delimited Git porcelain parsing for paths containing spaces, tabs, newlines, quotes, and non-ASCII characters.
-- Added warning-clean module and script CLI surfaces through `python -m orchestra_runtime.status` and `python scripts/orchestra_status.py`.
-- Added 28 focused StatusProjection tests with 91% statement and branch coverage for `orchestra_runtime/status.py`.
-- Passed 418 runtime tests with 93.80% overall runtime-package coverage, the full behavior suite, strict governance validation, direct validators, CLI checks, and read-only before-and-after evidence.
-- At the Phase 3B merge boundary, Phase 3C was not included. `OrchestraWorktreeContract` was subsequently implemented and merged through PR #214.
-
-### Phase 3A Post-Merge State Synchronization
-
-- Merged PR #210 (`1629eaf3cd3f156f8913f84c9229666257a3145a`): Phase 3A deferred-capability design package. One commit, 11 documentation paths, 635 insertions, 18 deletions.
-- All 9 required CI checks passed before merge: Analyze (actions), Analyze (python), CodeQL, governance-check, native-macos-latest, native-ubuntu-latest, native-windows-latest, runtime-tests, validate.
-- No runtime implementation, no release, no policy activation.
-- Governance deviation: PR #210 was merged by the maintainer after all required technical checks passed. No independent APPROVED review was recorded before merge. The Copilot review state was COMMENTED only due to exhausted quota. This is documented as a governance process deviation and does not retroactively convert the technical self-review into an independent approval.
-- Review findings integrated into Phase 3B and Phase 3C implementation requirements: see `DECISION_LOG.md` for details.
-
-### Added Candidate Phase 3 Design Specifications (Phase 3A)
-
-- Promoted and specified `OrchestraStatusProjection` (`docs/project/ORCHESTRA_STATUS_PROJECTION.md`), a read-only, deterministic status summary and JSON schema owned canonically by Scribe. Priority 1 target for Candidate Phase 3B.
-- Promoted and specified `OrchestraWorktreeContract` (`docs/project/ORCHESTRA_WORKTREE_CONTRACT.md`), an optional host worktree negotiation and path confinement contract owned canonically by Ponytail. Priority 2 target for Candidate Phase 3C.
-- Produced Phase 3 Capability Assessment (`docs/project/SPEC_KITTY_DERIVED_PHASE_3_CAPABILITY_ASSESSMENT.md`), Implementation Plan (`docs/project/SPEC_KITTY_DERIVED_PHASE_3_IMPLEMENTATION_PLAN.md`), and Compatibility and Security Matrix (`docs/project/SPEC_KITTY_DERIVED_PHASE_3_COMPATIBILITY_AND_SECURITY_MATRIX.md`).
-- Reconciled contract ownership matrix (`docs/project/SPEC_KITTY_DERIVED_CONTRACT_OWNERSHIP.md`) to record merged Phase 2 contracts and Candidate Phase 3 specialist ownership assignments (Scribe & Ponytail).
-- Updated project roadmap (`docs/project/ROADMAP.md`) and upgrade roadmap (`docs/project/SPEC_KITTY_DERIVED_UPGRADE_ROADMAP.md`) to record Phase 3A completion.
-
-### Added Implemented Contracts (PR #208)
-
-- Implemented `OrchestraRuntimeEnvelope` (`orchestra_runtime/models.py`, `serialization.py`): Typed variants (`execution_result`, `transition_decision`, `audit_event`) with strict UTF-8 JSON serialization/deserialization and bounded support for Codex and Antigravity runtime adapters (`orchestra_runtime/adapters.py`). Non-authorizing transport metadata.
-- Implemented `OrchestraCorrelationID` (`orchestra_runtime/correlation.py`): Project-owned zero-dependency RFC 9562 UUIDv7 correlation generator with trusted root generation and child propagation (`orchestra_runtime/models.py`). Non-authorizing observational identifier.
-- Implemented `OrchestraPhaseRetrospective` (`orchestra_runtime/retrospective.py`): Typed model and deterministic builder deriving metrics from canonical records. Supplementary audit record.
-- Implemented `ApprovedUnitPlan` extension (`orchestra_runtime/models.py`): 15-field frozen dataclass extension with structural, path, and contextual validation (`validate_approved_unit_plan_context`). Governance decision references do not replace envelope authority; dependency completion is not equivalent to accepted predecessor evidence.
-- Added comprehensive test coverage (`tests/runtime/`): 390 runtime tests (93.72% coverage), 20 cross-contract integration scenarios (`test_spec_kitty_contract_integration.py`), and behavior test suite (exit 0).
-
-### Validation and Quality Assurance
-
-- Merged PR #208 (`1e2992b94abe67a76c1e6ec0b98f8b712ae256e4`) following Phase 2A through Phase 2G lifecycle.
-- Resolved PR #208 cross-platform whitespace check by removing trailing EOF blank line in `tests/runtime/test_runtime_envelope.py` (`1a57c489445a9a333e929cae8f857312bb126a62`).
-- Passed all 9 GitHub Actions status checks: Cross-platform Validation (Windows, Ubuntu, macOS), CodeQL (actions, python), Governance Check, runtime-tests, validate.
-
-### Preserved Boundaries & Explicit Deferrals
-
-- Retained explicit deferral of cross-session correlation restoration, durable correlation persistence, retry/wait/resume state machines, automatic retrospective closeout generation, durable retrospective retention, automatic Steward planning/dispatch integration, revision-history ordering, and automatic policy activation.
-- `docs/governance/DELEGATED_EXECUTION_POLICY.md` remains unamended.
-- No third-party dependencies added; no database, durable storage, or policy changes made.
-- No public release, git tag, or version bump performed (remains unreleased on `main` after `v1.1.2`).
-
-### Historical Design Specifications (Phase 1)
-
-- Added design specification for `OrchestraRuntimeEnvelope` (`docs/project/ORCHESTRA_RUNTIME_ENVELOPE.md`), a derived non-authorizing JSON serialization profile for LLM machine adapters (`json:orchestra-envelope`).
-- Added protocol specification for `OrchestraCorrelationID` (`docs/governance/CORRELATION_ID_PROTOCOL.md`), an optional RFC 9562 UUIDv7 correlation header linking root task lineage across sessions without external PyPI dependencies.
-- Added protocol specification for `OrchestraPhaseRetrospective` (`docs/governance/PHASE_RETROSPECTIVE_PROTOCOL.md`), a source-backed closeout evidence artifact (`replacement_effect: none`) with `MIXED_RETENTION_MODEL`.
-- Added schema extension specification for `OrchestraUnitRecord` (`docs/project/ORCHESTRA_UNIT_RECORD_EXTENSION.md`), an immutable JSON schema extension embedded inside `ApprovedUnitPlan`.
-- Documented selective Spec Kitty-derived design review (v3.2.6, commit `8466727ebbbc01fcaf43575657c9b1b9553784d9`), contract ownership placement (`docs/project/SPEC_KITTY_DERIVED_CONTRACT_OWNERSHIP.md`), and upgrade roadmap (`docs/project/SPEC_KITTY_DERIVED_UPGRADE_ROADMAP.md`).
-
-## Unreleased - Issue #204 Codex Tuner Portable Export
-
-### Fixed
-
-- Added The Tuner's canonical coordination protocol to the PowerShell Codex exporter's portable-reference map.
-- Fresh staged Codex exports now rewrite The Tuner's repository-relative protocol link to a package-local `REFERENCE_CONTEXT.md` anchor and generate the required portable reference bundle.
-- Added cross-language map-parity and real fresh-export regression coverage so the PowerShell exporter and Python validator cannot silently diverge.
-
-### Preserved boundaries
-
-- No routing, runtime authority, specialist ownership, release, deployment, marketplace publication, production, force-push, ruleset, or branch-deletion behavior changed.
-
-## Unreleased - Issue #195 Cross-Specialist Coordination Phase 4
-
-Phase 3 is merged through pull request #198 at merge commit `1b73e232930c9289601474a5cddb282e98378261`. The authorized Phase 4 scenario validation and Conductor-owned runtime integration have been implemented and locally validated on the feature branch. Persistence, SQLite, migrations, RPC, host orchestration, staging, commit, push, pull request, merge, release, deployment, consumer-repository mutation, and expanded external-action authority are not authorized by this implementation record and remain separately governed.
-
-### Implemented and locally validated
-
-- Required a real non-null `ICoordinationController` in trusted runtime composition and preserved exact controller and audit-logger identity across delegated child composition.
-- Added the public stateless `CoordinationRuntimeService` as the explicit validation, signal-application, and coordination-audit boundary.
-- Added optional validation-only runtime preflight for explicitly supplied collaboration sessions while preserving zero-call direct single-owner bypass.
-- Added deterministic transition, rejection, idempotent replay, audit-failure, malformed-result, delegation-identity, and authority-preservation coverage.
-- Added executable consumer-neutral SCN-01 through SCN-06 behavioral proofs for invalidation and minimal re-entry, direct bypass, idempotency ownership, rollback, independent UI/API ownership, compatibility windows, stale evidence, and blocked closeout.
-- Preserved the exact 12-path implementation ceiling without granting commit, push, pull-request, merge, release, deployment, Dagger, or external-action authority.
-
-## Unreleased - Issue #195 Cross-Specialist Coordination Phase 3
-
-The Phase 3 typed runtime foundation was merged through pull request #198 at reviewed head `ca7c37f33fe20376193a4aff752bbe0795cb6ee9` and merge commit `1b73e232930c9289601474a5cddb282e98378261`. The four-commit, 13-path change added immutable in-memory coordination records, deterministic canonical serialization and fingerprints, a stateless coordination controller, fail-closed transition enforcement, audit-event contracts, public runtime exports, and focused contract, lifecycle, and adversarial tests. Governance Check, validate, and Cross-platform Validation passed at the reviewed head. Persistence, SQLite, migrations, RPC, host orchestration, release, deployment, and expanded external-action authority were not added.
+Published July 14, 2026.
 
 ### Added
-- Added typed collaboration graph, contract packet, handoff delta, invalidation, contradiction, artifact lifecycle, signal, session, validation, and audit contracts.
-- Added a stateless coordination controller with deterministic freeze, stale, contradiction, supersede, closeout, and idempotent signal handling.
-- Added focused contract, lifecycle, and adversarial runtime coverage.
+
+- Trusted runtime composition with explicit finite `ACTIVE` and `COMPATIBILITY` authority modes.
+- Immutable run-scoped runtime capability manifests and fail-closed authority/capability enforcement before governance.
+- Bounded in-process specialist delegation with authority and capability subset enforcement, depth limits, specialist identity checks, and explicit context minimization.
+- Structured lifecycle control with deterministic terminal replay, conflict rejection, and exact state transitions.
+- `RuntimeExecutor` integration with authority and capability checks before governance and adapter execution.
+- Adversarial validation for initialization, escalation, provenance, binding ownership, delegation, lifecycle, execution ordering, replay, and audit-sink failure paths.
+- Deterministic non-authorizing audit events.
+- Four governed Artificer promotions finalized as `IMPLEMENTED` with synchronized Pattern Catalog records and preserved provenance/attribution boundaries.
 
 ### Changed
-- Normalized Phase 1 and Phase 2 merge status before beginning the typed runtime foundation.
-- Preserved Conductor-only routing, Tuner non-authority, Ponytail implementation ownership, Overseer evidence ownership, Arbiter continuity authority, single-owner bypass, Dagger gating, and default-deny external actions.
 
-## Unreleased - Issue #195 Cross-Specialist Coordination Phase 2
+- Normalized approved plugin and scaffold-package metadata to `1.1.2` without changing scaffold maturity.
+- Refreshed release, setup, compatibility, runtime, project-state, Codex, roadmap, architecture, and handoff documentation for the trusted runtime authority baseline.
 
-Phase 2 is merged through PR #197 at merge commit `7423d3e7db7fb8e32dfe91454f5c2c5d10aba9bb`. It added deterministic evidence identity and continuity enforcement only. No persistence, SQLite, RPC, release, deployment, or external-action authority was introduced.
+See [v1.1.2 release notes](docs/releases/v1.1.2-trusted-runtime-authority.md).
 
-### Added
-- Added the canonical evidence identity and freshness protocol.
-- Added read-only tracked, staged, untracked, added-file, artifact, and working-tree identity validators.
-- Added invalidation, artifact-lifecycle, manual re-entry, delegated-boundary, and fail-closed behavior fixtures.
-
-### Changed
-- Extended Overseer evidence packets and Tuner handoffs with current contract and change identity.
-- Enforced Arbiter blocking on stale or mismatched evidence and Conductor-only minimal re-entry routing.
-- Preserved pre-existing artifacts, single-owner bypass, Dagger gating, and default-deny external actions.
-- Removed implicit current-HEAD, workflow-dispatch, `origin/main`, and local `main` evidence-baseline fallbacks. Local and workflow-dispatch validation now require `ORCHESTRA_APPROVED_BASE_SHA`; verified pull-request base and push-before event SHAs remain supported.
-
-## Unreleased - Issue #195 Cross-Specialist Coordination Phase 1
-
-Phase 1 is implemented for review on `design/issue-195-tuner-protocol`. It adds instruction-level coordination only. No release, deployment, marketplace publication, typed runtime, SQLite, RPC, or external-action authority is included.
-
-### Added
-- Added `the-tuner` as a Conductor-dependent coordination specialist with canonical collaboration, contract, contradiction, and re-entry outputs.
-- Added `docs/routing/CROSS_SPECIALIST_COORDINATION_PROTOCOL.md`, deterministic Tuner fixtures, focused tests, and a collaboration-contract validator.
-
-### Changed
-- Updated routing, Conductor, Arbiter, Overseer, Ponytail, delegated-governance extension points, minimal prompt metadata, and Codex exports to preserve specialist ownership while detecting incomplete, contradictory, or stale cross-layer contracts.
-- Preserved direct single-owner bypass, Arbiter transition authority, Overseer evidence ownership, Dagger gating, and default-deny external actions.
-
-## Unreleased - Phase B Instruction-Level Delegated Autonomous Loop
-
-Phase B instruction-level delegated governance was merged into `main` through PR #190 at merge commit `d37a2f7b31543efacf7a5e81c3f4d08c12da017d`. Phase C and Phase D remain unstarted. No Phase B release or deployment has been performed.
-
-### Added
-- Added `Delegated Governance Review` output format to Steward and Governor roles (`skills/the-steward/OUTPUT_FORMATS.md`, `skills/the-governor/OUTPUT_FORMATS.md`).
-- Added complete, separate `TransitionDecisionRecord`, `CheckpointRecord`, and `CapacityHandoffRecord` templates to Arbiter (`skills/arbiter/OUTPUT_FORMATS.md`).
-- Added the complete canonical `ExecutionEvidencePacket` template and delegated evidence role to Overseer (`skills/overseer/OUTPUT_FORMATS.md`, `skills/overseer/SKILL.md`, `plugin.json`, `SKILL_INDEX.md`).
-- Added `Delegated Phase Autonomous Loop` to Conductor (`skills/conductor/SKILL.md`).
-- Added 6-tier strict precedence transition evaluation to Arbiter (`skills/arbiter/SKILL.md`).
-- Added `Risk Mode vs Progression Mode` section to Execution Modes Policy (`docs/routing/EXECUTION_MODES_POLICY.md`).
-- Added `Delegated Phase Progression Routing` to Routing Map (`ROUTING_MAP.md`).
-- Added `Progression Modes` section to `SKILL_INDEX.md` and Delegated Phase Progression Rule #8 to `AGENTS.md`.
-- Added four delegated-governance conformance fixtures to `tests/behavior/governance-conformance-fixtures.json`.
-- Added `tests/behavior/delegated-phase-trace-fixtures.json`, a contract-driven three-unit trace covering complete evidence, transition, and checkpoint records; derived phase validation; the exact lifecycle event sequence; zero owner relay; one Steward review; one Governor review; and the canonical default-deny external-action map.
-
-### Changed
-- Updated Steward (`skills/the-steward/SKILL.md`) with delegated phase behavior (skip re-reviews of unchanged approved units).
-- Updated Governor (`skills/the-governor/SKILL.md`) to eliminate domain-membership-only escalations without material uncertainty.
-- Updated `adapters/codex/export-codex-skills.ps1` and `adapters/codex/validate_codex_export.py` to package external reference context inside exported skills, rewrite references to package-local targets, reject missing or escaping Markdown/JSON targets, and preserve tracked source-to-export parity at arbitrary installation depth.
-- Updated `scripts/validate_governance_protocol_consistency.py` and `tests/behavior/test_governance_protocol_consistency.py` to enforce exact record schemas and reject unqualified stale Phase B status claims while preserving clearly qualified Phase A history.
-- Updated `tests/behavior/test_router_contracts.py` with reference-integrity cases plus the contract-driven trace evaluator and 11 required negative mutations.
-- Corrected current Phase A-D and deployment status across the delegated execution policy, governance layer, governance review flow, and implementation plan. PR #190 has been merged.
-- Updated `README.md` with the merged delegated phase progression loop, all six transition dispositions, checkpoint behavior, owner-relay reduction, and the preserved external-action boundary.
-- Stabilized `PROJECT_STATE.md` and `SESSION_HANDOFF.md` after the PR #191 post-merge synchronization.
-
-## Unreleased - Phase A Delegated Autonomous Governance Contract Design
-
-
-Phase A implementation commit: `176da20100dce99e26748c53b9c14e7033c119dd`.
-Initial remote push: Completed to `origin/docs/delegated-autonomous-governance-phase-a`.
-Pull request: Not created. Merge: Not performed. Tag: Not created. Release: Not performed. Deployment: Not performed.
-Next gate: Maintainer review and separate pull-request authorization.
-
-### Added
-- Added `docs/governance/DELEGATED_EXECUTION_POLICY.md` as the single canonical source for
-  delegated phase envelopes, approved unit plans, execution evidence packets, transition
-  decision records, six transition dispositions (`AUTO_CONTINUE`, `AUTO_REMEDIATE_AND_REVALIDATE`,
-  `WAIT_FOR_EVIDENCE`, `WAIT_FOR_CAPACITY`, `ESCALATE_HUMAN`, `STOP`), transition precedence,
-  automatic remediation policy with finite limits, focused and phase validation levels,
-  baseline lineage, checkpoint policy, capacity handoff record, external-action authority
-  policy (default-deny), legacy host fallback policy (fail-closed), delegated phase state
-  machine, and token-efficiency requirements.
-- Added `docs/project/DELEGATED_GOVERNANCE_IMPLEMENTATION_PLAN.md` as the multi-phase
-  implementation roadmap (Phase A through Phase E) with explicit authorization boundaries.
-
-### Fixed
-- Fixed repository-memory branch reference validation in detached-HEAD pull-request CI by discovering exact known local, remote-tracking, and `GITHUB_HEAD_REF` branch identities without weakening missing-path detection. No workflow changes were required.
-
-### Changed
-- Updated `docs/governance/GOVERNANCE_DECISION_PROTOCOL.md` with additive delegated
-  execution section: decision-versus-disposition separation, six dispositions, automatic
-  progression requirements, and fail-closed rule. Existing decision values unchanged.
-- Updated `docs/governance/GOVERNANCE_LAYER.md` with additive phase-level delegated
-  governance section, re-entry triggers, phase status table, and corrected enforcement
-  limitation distinguishing route-level from phase-level enforcement.
-- Updated `docs/governance/GOVERNANCE_REVIEW_FLOW.md` with additive target delegated
-  execution flow, clearly labeled as Phase B target behavior and not yet active.
-- Updated `scripts/validate_governance_protocol_consistency.py` with additive Phase A
-  checks for all required contracts, dispositions, authority principles, fail-closed rule,
-  remediation limits, external-action default-deny, and integration references.
-- Updated `tests/behavior/test_governance_protocol_consistency.py` with one positive and
-  nine negative Phase A test cases asserting actual validator behavior.
-
-## v1.0.0 - Portable Runtime
-
-Portable Runtime is the first Orchestra release that normalizes the repository around a shared runtime core, thin adapters, and a versioned adapter protocol.
-
-### Release Highlights
-- Added `orchestra_runtime/` as the shared runtime core for routing, manifest parsing, skill loading, governance validation, execution flow, and audit logging.
-- Added `PRAP v1` as the stable Portable Runtime Adapter Protocol for host metadata, capabilities, compatibility, and validation.
-- Added thin adapter support for Codex, Claude Code, Antigravity, Cursor, Windsurf, VS Code, VSCodium compatibility, JetBrains, Zed, and Neovim.
-- Added scaffold-only packaging surfaces for Cursor, Windsurf, VS Code, JetBrains, Zed, and Neovim.
-- Normalized release-facing documentation, compatibility guidance, and manifest metadata for the `v1.0.0 Portable Runtime` baseline.
-
-## Pre-release Build History
-
-### Phase 4B Post-Merge Hardening
-
-- **Artificer Governance Validators:** Added rigorous rejection of ancestor-directory symlinks for governance registries, records, and pattern bundles.
-- **Artificer Governance Validators:** Corrected cross-platform list stability by introducing dual-key tuples `(item.name.casefold(), item.name)` in deterministic sort tie-breakers.
-
-## v1.1.0 - Specialist Governance & Boundary Standard
-
-Specialist Governance & Boundary Standard is a documentation-, governance-, metadata-, and specialist-definition-focused release that builds on the `v1.0.0 Portable Runtime` baseline without changing runtime behavior, routing policy, validation logic, CI workflows, Dagger live-execution behavior, or governance decision semantics.
-
-### Added
-- Added a shared `docs/project/SPECIALIST_AUTHORING_STANDARD.md` reference for future specialist authoring, with short cross-links from contributing, plugin-readiness, and manifest-schema documentation.
-
-### Changed
-- Clarified governance authority boundaries for Arbiter status vocabulary, Steward hygiene wording, and Governor/Cipher release-security ownership without changing governance semantics.
-- Clarified Governance Strictness Levels as a derived scale over existing project type, operating mode, release stage, and risk classifications without changing governance semantics.
-- Strengthened Cloak's documentation-only frontend review contract with artifact-evidence requirements, clearer form and validation messaging review, explicit loading/empty/error/success/retry/permission-state review, sharper frontend handoff blueprint guidance, and matching tracked Codex export parity for the updated Cloak docs.
-- Normalized Conductor's skill documentation against the shared specialist authoring standard by clarifying activation conditions, supported work, scope enforcement, validation expectations, local-only safety, and direct-route versus orchestration versus reroute guidance, with matching tracked Codex export parity.
-- Normalized Ponytail specialist documentation with explicit activation conditions, supported work, scope enforcement, validation expectations, local-only safety, and direct handoff boundaries for implementation-owned code changes, with matching tracked Codex export parity.
-- Normalized Clockwork specialist documentation with explicit activation conditions, supported work, role boundaries, scope enforcement, validation expectations, local-only safety, and direct architecture-boundary handoff guidance, with matching tracked Codex export parity.
-- Normalized Cipher specialist documentation with explicit defensive-security ownership boundaries, validation expectations, local-only safety, handoff guidance, and output-format selection while preserving its defensive-only scope.
-- Normalized Overseer specialist documentation with explicit validation ownership boundaries, evidence expectations, local-only safety, expanded handoff guidance, and output-format selection while preserving its validation/readiness scope.
-- Normalized Chronicler specialist documentation with explicit persistence ownership boundaries, supported work, validation expectations, output-format selection, and expanded handoff guidance while preserving its database and data-integrity scope.
-- Normalized Scribe specialist documentation with explicit documentation ownership boundaries, activation conditions, validation expectations, output-format selection, and expanded handoff guidance while preserving its source-backed documentation scope.
-- Normalized Weaver specialist documentation with explicit diagram ownership boundaries, activation conditions, validation expectations, output-format selection, and expanded handoff guidance while preserving its visual-modeling scope.
-- Cleaned up cross-specialist consistency by aligning Scribe output-format headings and adding compact Cloak role-boundary and validation-expectation sections without changing specialist behavior.
-- Clarified Governor and Cipher skill-source authority boundaries between governance/compliance sufficiency and technical defensive security review.
+---
 
 ## v1.1.1 - Post-Release Hardening
 
 ### Changed
-- Hardened release-surface and startup-state validation by aligning Codex metadata to v1.1.0, removing the drifted example manifest, adding `.codex-plugin/plugin.json` to update consistency checks, and checking structured branch/version claims in repo memory files.
-- Converted PowerShell and shell validation entrypoints into thin wrappers around canonical Python validators to prevent cross-platform validation drift.
-- Hardened update and rollback guidance by requiring fast-forward-only pulls, running canonical validation after updates, and documenting recovery-branch creation before hard resets.
-- Fixed runtime context assembly so adapter-provided ContextPackage metadata is preserved and enriched instead of bypassed during execution.
 
-## v1.1.2 - Trusted Runtime Authority
+- Hardened release-surface and startup-state validation, including Codex metadata and structured branch/version claims.
+- Converted PowerShell and shell validation entrypoints into thin wrappers around canonical Python validators to reduce cross-platform drift.
+- Hardened update and rollback guidance with fast-forward-only pulls, canonical post-update validation, and recovery-branch guidance.
+- Fixed runtime context assembly so adapter-provided `ContextPackage` metadata is preserved and enriched rather than bypassed.
 
-This patch was published on July 14, 2026 as the `v1.1.2` GitHub Release.
+---
 
-### Added
-- Implemented Issue #182 Phase 6B-D trusted runtime composition and Phase 6C adversarial validation, including explicit finite authority modes, immutable route bindings, authority and capability enforcement before governance, single initialization per root or child run identity, manifest-grant provenance and binding-owner validation, structured lifecycle and terminal-result integration, bounded in-process delegated execution, deterministic audit evidence, and lifecycle source-state enforcement for `ACTIVATE`, `WAIT`, and `RESUME`. Missing capability identifiers retain runtime `CAPABILITY_DENIED` behavior.
-- Implemented Issue #180 Phase 6B-C bounded delegation validation, immutable effective child resolutions, exact lifecycle control, deterministic terminal replay, conflict rejection, and structured audit-event factories.
-- Implemented Issue #178 Phase 6B-A immutable runtime domain contracts, typed error taxonomy, authority/capability/delegation/lifecycle models, stable interfaces, deterministic serialization, and additive public exports.
-- Implemented Phase 6B-B repository-contained trusted policy loading, fail-closed authority evaluation and intersection, immutable runtime capability manifest resolution and intersection, deterministic collision rejection, typed enforcement, and structured audit-event creation.
-- Added Issue #176 Phase 6A runtime-gap and trust-boundary architecture for trusted authority, immutable per-run capabilities, bounded delegation, typed lifecycle control, and structured audit evidence.
-- Added implementation-ready authority, runtime capability, delegation, lifecycle, interface, error, compatibility, and fail-closed contracts distinct from PRAP adapter support.
-- Added sequenced Phase 6B through Phase 6D implementation and verification planning.
-
-### Changed
-- Finalized the four canonical authority, capability, delegation, and lifecycle promotions as `IMPLEMENTED` and manually synchronized the Pattern Catalog while preserving pinned provenance, Apache-2.0 attribution boundaries, conceptual-adaptation limits, and `automatic_promotion: false`.
-- Refreshed release, setup, compatibility, runtime, project-state, Codex, roadmap, architecture, and handoff documentation for the trusted runtime authority baseline.
-- Normalized approved plugin and scaffold-package version metadata to `1.1.2` without changing adapter maturity: Cursor, Windsurf, VS Code/VSCodium, JetBrains, Zed, and Neovim remain scaffold-only.
-
-## Unreleased
+## v1.1.0 - Specialist Governance & Boundary Standard
 
 ### Added
-- Added layered UI engineering and validation ownership across Cloak static risk analysis, Clockwork engineering integrity, renewed Cloak review, Overseer current-commit evidence validation, and explicit human approval boundaries.
-- Recorded unanimous Phase 5C-B Arbiter, Governor, and Steward approval plus conditional Butler disposition for the design-only authority/capability proposal, without runtime implementation or source-expression reuse authority.
-- Added four manual Phase 5D `APPROVED` promotion records with pinned Strix provenance, Apache-2.0 attribution boundaries, and `automatic_promotion: false`.
-- Manually synchronized the Phase 5E Pattern Catalog with the four canonical promotion records; Catalog projection remains separate from implementation authority.
-- Added the Phase 5C-A Evolution Proposal schema `1.1`, deterministic proposal lifecycle validation, focused behavior coverage, and one design-only Orchestra authority/capability proposal in `UNDER_REVIEW`, without promotion, Pattern Catalog, source-reuse, prompt-reuse, or implementation authority.
-- Added Phase 4.5-A OpenHero pilot source-intake, pattern, and audit records through a pinned static read-only GitHub inspection with no decisions, proposals, promotions, or Pattern Catalog changes.
-- Added Phase 5B-A governed OpenHero decision records for three approved concept-only patterns, one deferred concept-only UI pattern, and one rejected security anti-pattern, without creating proposals, promotions, Pattern Catalog entries, or implementation authority.
-- Added Phase 5B-B governed Strix decision records for four approved concept-only patterns and one rejected implementation-blocked prompt-safety anti-pattern, with mandatory Apache-2.0 Governor review and no proposal, promotion, Pattern Catalog, source-reuse, or implementation authority.
-- Added Phase 4.5-B Strix pilot source-intake, pattern, and audit records through a pinned static high-risk read-only GitHub inspection with no decisions, proposals, promotions, or Pattern Catalog changes.
-- Added Phase 4C-B deterministic, read-only Pattern Catalog synchronization validation, canonical Catalog projection, strict governance integration, and behavior coverage without automatic Catalog writes or promotion authority.
-- Added Phase 4C-A deterministic, read-only Markdown rendering for validated Artificer audit reports, with stdout-only CLI output, canonical ordering, Markdown safety, governance integration, and behavior coverage.
-- Added Phase 4A Artificer governance contracts, including native JSON schemas for Individual Source Audits (`AUDIT_REPORT_SCHEMA.json`), Orchestra Evolution Proposals (`EVOLUTION_PROPOSAL_SCHEMA.json`), Governance Decisions (`GOVERNANCE_DECISION_SCHEMA.json`), and Pattern Catalog Promotion Records (`PROMOTION_RECORD_SCHEMA.json`).
-- Established isolated read-only registries for Phase 4A records (`reviews/`, `decisions/`, `proposals/`, and `promotions/`).
-- Documented Phase 4A read-only and no-execution boundaries in `EXTERNAL_SOURCE_INTAKE.md`, `SECURITY_BOUNDARIES.md`, and `EVIDENCE_REQUIREMENTS.md`.
-- Added Phase 3 Artificer record-instance validator (`scripts/validate_artificer_records.py`) with Draft-7 schema subset validation, POSIX-safe repository path constraints, and cross-record registry bundle verification.
-- Added 61 behavior tests (`tests/behavior/test_artificer_records.py`) providing a rigorous regression matrix that executes real validator instances against real schema copies for passing/failing conditions, empty examined-ranges, cross-platform paths, and strict schema configurations.
-- Wired `scripts/validate_artificer_records.py` into the CI governance script and automated runner `tests/behavior/run_tests.py`.
-- Added Phase 4B deterministic governance-record validation for audit reports, decisions, proposals, promotions, and cross-record integrity.
-- Added Phase 4B behavior coverage and strict-governance/behavior-runner integration without external execution or Pattern Catalog mutation.
 
-### Changed
-- Completed specialist-boundary polarity enforcement in the Artificer boundary validator (`scripts/validate_artificer_internal.py`), refactoring keyword-only checks in `check_artificer_boundaries_md()` to require explicit Artificer-bound negative polarity.
-- Prevented mixed-polarity bypasses by splitting sentences into clauses and detecting explicit positive permissions alongside prohibitions.
-- Expanded behavior test suite (`tests/behavior/test_artificer_internal.py`) with 6 new regression tests covering positive implementation, test, evidence-decision, licensing, and adversarial-testing permissions, plus mixed-polarity assertions.
-- Strengthened the Artificer boundary validator (`scripts/validate_artificer_internal.py`) by refactoring it into pure functions returning `ValidationFailure` dataclass instances, and introducing strict semantic checks requiring explicit Artificer-bound negative polarity.
-- Hardened the behavior test suite (`tests/behavior/test_artificer_internal.py`) by replacing placeholder `pass` blocks, ensuring all regression tests assert specific validator failures, adding a quality gate check on test source code, and verifying the entire repository via `validate_repository()`.
-- Added explicit no-self-implementation and no-self-approval contract checks and statements to `internal/artificer/ARTIFICER.md`.
-- Changed startup-state validation to use stable canonical-branch semantics instead of comparing committed files with the transient checkout branch.
-- Improved prompt-load reporting with Group B and Group C status output, largest-contributor reporting, clarified original versus observed baselines, focused regression coverage, and narrow repository-state alignment.
-
-### Added
-- Added the Artificer internal boundary validator (`scripts/validate_artificer_internal.py`) and behavioral test coverage (`tests/behavior/test_artificer_internal.py`) to enforce schema integrity, documentation boundaries, and ensure public non-registration.
-- Added the Phase 1 Artificer internal architecture specification, source-intake schemas, evidence requirements, classification taxonomy, security boundaries, and maintainer-only evolution workflow without exposing Artificer through public commands, routing, runtime registration, or adapter exports.
-- Added an App Release Compliance Gate plus reusable privacy review, data inventory, IP clearance, privacy policy, terms, and retention/deletion governance templates for app and public release workflows.
-
-### Changed
-- Added Windows coverage and runtime test execution to cross-platform CI validation.
-- Integrated Release Mode governance docs so The Governor now treats app release compliance artifacts as required when applicable and returns `REVISION_REQUIRED` or `BLOCKED` when release-gate documentation is missing.
-- Clarified optional project governance rulesets so `PROJECT_CONTEXT.md` enforcement depends on project type, risk level, and declared governance level.
-- Wired `tests/runtime` into CI, enforced portable runtime coverage with `pytest-cov --cov-fail-under=90`, switched `validate.yml` to `python tests/behavior/run_tests.py`, and added runtime tests for alias loading, default-command fallback, and unresolved command-to-skill handling.
-
-### Added
-- Added root `PROJECT_CONTEXT.md` for Orchestra and wired project-context validation into governance CI.
-- Added a reusable `PROJECT_CONTEXT.md` template and aligned the Python project-context validator with advisory, recommended, and strict-governed enforcement behavior.
-- Added a context-sensitive `PROJECT_CONTEXT.md` enforcement policy defining advisory, recommended, and strict-governed validation modes based on project type and risk level.
-- Added a Steward-led `PROJECT_CONTEXT.md` decision prompt for choosing advisory or governed project context workflows before introducing hard enforcement.
-- Added scaffold adapter graduation criteria defining promotion levels, validation requirements, documentation requirements, and recommended graduation order for scaffold-only adapters.
-- Added `scripts/check_for_updates.py` for notification-only release checks against the latest GitHub release using local manifest and adapter metadata.
-- Added update-check metadata defaults to the root manifest, Claude plugin manifest, and scaffold adapter package metadata.
-- Added runtime tests covering current-version, newer-release, invalid-version, unavailable-GitHub, and disabled-update-check behavior.
-- Added a temp-staged Codex runtime refresh pipeline that exports to a temporary directory, validates staged output, installs into repo-local and global Codex runtime locations, verifies file-list and SHA-256 parity, and deletes staged output by default.
-- Added reusable PowerShell directory parity helpers for recursive file-list and SHA-256 comparison across staged and installed runtime surfaces.
-
-### Added
-- Added `orchestra_runtime/protocol/` with the Portable Runtime Adapter Protocol (`PRAP v1`), including versioned adapter metadata, capabilities, compatibility records, and protocol validation.
-- Added runtime protocol tests covering metadata completeness, capability validation, compatibility matrix coverage, VSCodium compatibility, and unknown adapter rejection.
-- Added `docs/project/PORTABLE_ADAPTER_PROTOCOL.md` to document protocol flow, ownership boundaries, compatibility guarantees, and future extension points.
-- Added scaffold-only Zed and Neovim packaging files and metadata that point to the existing `ZedAdapter` and `NeovimAdapter` runtime contracts without introducing marketplace publication.
-- Added scaffold-only JetBrains packaging files and metadata that point to the existing `JetBrainsAdapter` runtime contract without introducing marketplace publication.
-- Added scaffold-only packaging folders and package manifests for Cursor, Windsurf, and VS Code that point to the shared runtime adapters without introducing marketplace publication.
-- Added contract-ready runtime adapters for Cursor, Windsurf, VS Code, JetBrains, Zed, and Neovim without introducing marketplace packaging.
-- Added `orchestra_runtime/` runtime core models, services, factories, repositories, and thin Codex, Antigravity, and Claude Code adapters.
-- Added runtime-core pytest coverage for skill loading, adapter contracts, and governance blocking for destructive and high-risk routes.
-- Added `docs/project/OOP_RUNTIME_ARCHITECTURE.md` to document the runtime-core-first branch architecture and current integration points.
-- Added Claude Code plugin compatibility files: `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `docs/setup/INSTALLATION.md` with Claude Code installation instructions.
-- Added validation script for Claude Code plugin: `scripts/validate_claude_plugin.py`
-
-### Fixed
-- Extended IDE packaging validation so runtime adapter scaffolds are checked against PRAP metadata and packaging/runtime adapter alignment.
-- Added IDE packaging validation so scaffold manifests, required files, and runtime adapter references are checked centrally.
-- Refactored manifest, skill, and adapter validation scripts to use the shared runtime repositories and registry instead of duplicating core loading logic.
-- Fixed Claude Code marketplace source path from "." to "./" and aligned Claude plugin metadata with the release baseline so Claude Code can detect and refresh the plugin correctly.
-- Fixed Codex refresh so normal installs no longer dirty tracked export folders during runtime refreshes.
-
-
-
-- Added Cloak progressive disclosure template `bryl-minimal-design` for monochrome, typography-driven UI styling.
-- Added behavior test scenario in `BEHAVIOR_TEST_MATRIX.md` to verify Cloak progressive disclosure template loading.
-- Registered the new template in the Codex export validation allowlist to ensure proper structural verification.
-
-- Added explicit Clockwork foundational OOP guidance and audit checklist coverage for encapsulation, abstraction, polymorphism, and inheritance.
-- Added README open-source philosophy section clarifying Orchestra's reuse, attribution, and collaborative development stance.
-
+- Added the shared `docs/project/SPECIALIST_AUTHORING_STANDARD.md` and normalized specialist authoring expectations.
 
 ### Changed
 
-- Removed Docker-specific validation artifacts while preserving native Ubuntu/macOS cross-platform validation.
-- Packaged Conductor router context docs into the Codex export and validated required backtick file references before runtime install.
+- Clarified governance, specialist, routing, validation, local-safety, and handoff boundaries across the public specialist set and Codex exports without changing trusted runtime behavior.
+- Strengthened Cloak, Conductor, Ponytail, Clockwork, Cipher, Overseer, Chronicler, Scribe, Weaver, Governor, and Steward documentation consistency.
 
-### Added
+---
 
-- Added branch protection setup guide for configuring Orchestra required status checks on `main`.
+## v1.0.0 - Portable Runtime
 
-### Added
+### Release Highlights
 
-- Added required status checks review for Orchestra branch protection and CI workflow policy.
+- Added `orchestra_runtime/` as the shared runtime core for routing, manifest parsing, skill loading, governance validation, execution flow, and audit logging.
+- Added `PRAP v1` as the stable Portable Runtime Adapter Protocol for host metadata, capabilities, compatibility, and validation.
+- Added thin adapter support for Codex, Claude Code, Antigravity, Cursor, Windsurf, VS Code/VSCodium compatibility, JetBrains, Zed, and Neovim.
+- Added scaffold-only packaging surfaces for Cursor, Windsurf, VS Code, JetBrains, Zed, and Neovim.
+- Normalized release-facing documentation, compatibility guidance, and manifest metadata for the Portable Runtime baseline.
 
-### Added
+---
 
-- Added CI workflow consolidation review covering validate, Governance Check, and Cross-platform Validation workflow roles.
+## Earlier Repository History
 
-### Changed
-
-- Clarified Steward context-validator negative test output so expected Release Mode blocking no longer appears as an unqualified CI error.
-
-### Added
-
-- Added native GitHub Actions cross-platform validation for Ubuntu and macOS.
-
-### Changed
-
-- Improved strict governance workflow logging so failed governance reports are printed before the job exits.
-
-### Added
-
-- Added Docker-based Linux validation support through `scripts/run-linux-validation.sh` and POSIX executable script handling.
-
-- Strengthened Codex adapter export validation so governance skills, routable skills, and relative Markdown links are verified before Codex installation.
-
-- Added Issue #56 router-first closeout note.
-
-- Added final router-first readiness review for Issue #56 closeout.
-
-- Added Phase 8 router-first hardening completion review.
-
-- Added README maintainer entry points for router-first validation and observability docs.
-
-- Cleaned router-first documentation terminology and consistency.
-
-- Added router-first documentation cross-links for Phase 8 hardening.
-
-- Added Phase 8A router-first integration hardening audit documentation.
-
-- Documented the `tests/fixtures/router_benchmarks.json` schema in `ROUTER_BENCHMARK_FIXTURE_SCHEMA.md` and updated the benchmark validation runner to enforce the root shape and `schema_version`.
-
-- Refactored `scripts/router_benchmark_runner.py` to extract hardcoded definitions into a machine-readable fixture at `tests/fixtures/router_benchmarks.json`, preserving existing validation capabilities.
-
-- Documented CI artifact outputs in `CI_ARTIFACT_INDEX.md` to explain the reports generated during governance validation.
-
-- Configured `governance-check.yml` CI workflow to run and publish the dry-run prompt load threshold checker report as a downloadable artifact.
-
-- Added `scripts/check_prompt_load_thresholds.py` as a dry-run prompt load threshold checker to validate current metrics against documented soft limits without breaking CI.
-
-- Defined `PROMPT_LOAD_THRESHOLD_POLICY.md` to establish soft limits and review triggers for context sizes in the router-first architecture, without introducing hard CI enforcement yet.
-
-- Configured `governance-check.yml` CI workflow to run and publish `measure_prompt_load.py` output as a downloadable artifact for observability, without introducing hard prompt-size failure thresholds yet.
-
-- Wired router benchmark validation (`scripts/router_benchmark_runner.py`) into the `governance-check.yml` CI workflow to automatically verify benchmark definitions on pull requests.
-
-- Added structured automated router benchmark runner (`scripts/router_benchmark_runner.py`) to validate test case definitions without triggering live LLM behavior.
-
-- Reduced `skills/conductor/SKILL.md` prompt payload by consolidating duplicate execution mode rules into canonical pointers, while preserving strict behavior conformance.
-
-- Created `docs/performance/CONDUCTOR_LOAD_REDUCTION_PLAN.md` outlining a strategy to safely reduce `skills/conductor/SKILL.md` prompt load while preserving governance behavior and test fixtures.
-
-- Created `scripts/measure_prompt_load.py` to calculate approximate token sizes of contextual documentation.
-- Added `PROMPT_LOAD_METRICS.md` defining token estimation heuristics and context exclusion groups.
-
-- Defined `ROUTER_VALIDATION_BENCHMARKS.md` to benchmark the efficiency, accuracy, and safety of the router-first execution model against the legacy monolithic context approach.
-
-- Wired Execution Modes Policy (`docs/routing/EXECUTION_MODES_POLICY.md`) into Conductor.
-- Replaced legacy Ideation/Prototype/Release modes with formal FAST, STANDARD, GOVERNED, AUDIT, and DESTRUCTIVE modes.
-
-- Created `EXECUTION_MODES_POLICY.md` to formalize FAST, STANDARD, GOVERNED, AUDIT, and DESTRUCTIVE modes.
-- Defined mode escalation paths, exclusions, and matrix.
-
-- Implemented router-first execution and selective context loading policy to optimize Conductor prompt payload.
-- Added `ROUTER_FIRST_ARCHITECTURE.md`, `CONTEXT_RETRIEVAL_RULES.md`, and `MINIMAL_PROMPT_FORMAT.md`.
-- Synced plugin manifest, `SKILL_INDEX.md`, and skill frontmatter metadata for precise validation parity.
-
-- Added behavior fixtures validating Conductor routing for Cloak multi-stage workflow preservation and frontend/backend alignment with Clockwork, Cipher, and Chronicler.
-
-- Added Conductor routing rules for Cloak and backend alignment, requiring Clockwork, Cipher, and/or Chronicler before implementation when frontend work affects data, auth, APIs, persistence, security, privacy, integrations, payments, or compliance-sensitive workflows.
-
-- Added Cloak multi-stage frontend design workflow guidance covering discovery, strategy, pattern intelligence, semantic HTML, design review, and backend alignment triggers.
-
-- Added explicit least-privilege permissions to the Governance Check workflow.
-
-### Changed
-- Updated GitHub Actions dependencies for the governance workflow:
-  - actions/checkout from v4 to v7
-  - actions/setup-python from v5 to v6
-  - actions/upload-artifact from v4 to v7
-
-Additional release-prep changes included in this checkout:
-
-- Added local repository sync preflight governance check (`scripts/preflight_sync_check.py`) for new development phases and editing sessions.
-- Added contributor, agent, and governance rules requiring preflight sync verification against `origin/main` before local editing begins.
-- Added Codex Marketplace installation instructions to README and setup guides.
-- Expanded specialist foundations for Arbiter, Clockwork, Cipher, Cloak, and Ponytail.
-- Aligned Conductor routing, Codex export, and stale-reference handling, including routing arrow and encoding fixes.
-- Added governance guardrails, access and visibility evidence rules, CI validation notes, and refined visual validation guidance.
-- Refreshed README presentation and selective skill icons, and added Ponytail and Caveman companion links.
-
-Issue #171 follow-up changes in this checkout:
-
-- Added canonical governance decision protocol at `docs/governance/GOVERNANCE_DECISION_PROTOCOL.md`.
-- Deduplicated shared governance rules from governance layer, Steward, and Governor skill files while preserving role-specific output fields.
-- Recalibrated Conductor, `SKILL_INDEX.md`, and `ROUTING_MAP.md` to restore lightweight routing and ordered cross-domain sequencing.
-- Added deterministic routing-contract, governance-protocol-consistency, and prompt-load-budget validators plus focused behavior tests.
-- Added strict prompt-load baseline and recalibration audit artifacts.
-- Synced Codex exports for Conductor, Steward, and Governor governance/routing canon.
+Pre-`v1.0.0` implementation detail, router-first evolution, Artificer phases, governance calibration, prompt-load work, cross-platform validation changes, and specialist foundation history remain preserved in Git history and the repository's decision, roadmap, governance, and handoff records. The changelog is intentionally release-oriented rather than a duplicate of every commit.

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -10,7 +10,7 @@ A governance-first specialist skill framework that routes complex AI-assisted so
 Open-source developer tooling and AI orchestration framework
 
 ## Current Stage
-Public release `v1.1.2` (Trusted Runtime Authority). Unreleased `main` includes the merged Spec Kitty-derived governed phase execution contracts through PR #208, the completed Phase 3 design and implementation sequence through PRs #210, #212, and #214, and the merged frontend-to-backend synchronicity audit contract through PR #216 (merge commit `3a2f8b7e65cdab0f7e6a3113d1096ec9dccc23d3`). Phase 3A through Phase 3E are complete and merged. The post-`v1.1.2` capability set remains unreleased and no policy activation has occurred.
+Release-candidate metadata `v1.2.0` (`PREPARED_NOT_RELEASED`). The current public GitHub Release remains `v1.1.2` until the separate publication gate completes. Canonical `main` includes the clean replay through R5B/PR #228: Spec Kitty-derived governed phase execution contracts, The Tuner Phases 1-4, frontend/backend plus backend/persistence and cross-module integrity contracts, the delegated Phase C repository continuity contract, the Phase D `NO_DUPLICATE_RUNTIME_EXTENSION_REQUIRED` disposition, and fail-closed autonomous merge-readiness hardening. Phase C live installed-host evidence remains `PENDING_LOCAL_HOST_VALIDATION`; R7 is still required before tag or GitHub Release publication. No deployment or policy activation has occurred.
 
 ## Primary Users
 Developers and maintainers who install Orchestra as a plugin, skill set, or runtime package inside a supported or scaffold-only IDE or coding host (Claude Code, Codex, Antigravity, Cursor, Windsurf, JetBrains, Zed, Neovim)
@@ -38,6 +38,7 @@ Guidance used for this classification:
 - `OrchestraStatusProjection` is read-only and derived; it does not mutate repository state, Git refs, or governance policy. It is not a source of truth. Missing or conflicting data reports UNKNOWN. Exit codes report command execution success only and do not create governance authority.
 - `OrchestraWorktreeContract` is optional and host-capability-dependent. Worktree isolation must not be mandatory for single-agent or lightweight execution. Cleanup is `EXPLICIT_HOST_ACTION_ONLY`; no automatic deletion of dirty, unrelated, or user-owned worktrees is permitted.
 - The cross-module audit protocol coordinates specialist-owned findings and evidence; it creates no implementation, Git, merge, release, deployment, or policy authority.
+- Repository simulation and GitHub CI are not live installed-host evidence. Installed Codex/Antigravity continuity and Claude Code Phase C runtime-continuity claims remain subject to R7 evidence.
 - No vendoring of external plugin code, and no claiming unsupported compatibility or compliance, per `docs/CONTRIBUTING.md`.
 
 ## Validation Requirements
@@ -53,12 +54,13 @@ Guidance used for this classification:
 - `tests/behavior/run-tests.ps1` is intentionally maintained in parallel with `run_tests.py` as the primary validation path for Windows environments, per `docs/MATURITY.md`.
 - Direct pushes to `main` are not part of the normal workflow; changes go through a branch and pull request except for documented maintainer bypass recovery cases.
 - Installed Codex and Antigravity parity, host context-reset behavior, and Windows filesystem-specific behavior require host-local evidence in addition to repository CI.
+- `v1.2.0` metadata in the repository is release-candidate state, not evidence of a published tag or GitHub Release.
 
 ## Known Non-Goals
 - Orchestra does not store, process, or transmit end-user or client data itself.
 - Orchestra does not aim to make `PROJECT_CONTEXT.md` universally mandatory for every project that adopts it, per `docs/governance/PROJECT_CONTEXT_ENFORCEMENT_POLICY.md`.
 - This document does not modify CI enforcement on its own.
-- A merged implementation is not a released capability until the separate version, tag, and GitHub Release gates complete.
+- A merged implementation or version bump is not a released capability until the separate tag and GitHub Release gates complete.
 
 ## Maintainer Approval Rules
 - Changes to governance level, scaffold graduation status, CI enforcement gates, merge state, or release state require their applicable pull-request and human-authorization gates.
@@ -68,4 +70,4 @@ Guidance used for this classification:
 Not yet decided. No project-specific maintainer preferences beyond `docs/CONTRIBUTING.md` are currently documented for this field.
 
 ## Last Reviewed
-2026-08-07
+2026-08-08

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -8,7 +8,8 @@
 - **Current Public Release:** `v1.1.2`
 - **Release Status:** Published July 14, 2026
 - **Target Release:** `v1.2.0`
-- **Post-`v1.1.2` Release State:** `NOT_RELEASED`
+- **Release-Candidate Metadata:** `1.2.0`
+- **Post-`v1.1.2` Release State:** `PREPARED_NOT_RELEASED`
 - **Policy Activation State:** `NOT_PERFORMED`
 
 ## Canonical Capability State
@@ -68,7 +69,8 @@ Clean replay results:
 - **R3:** host-reliability replay initially failed runtime validation; the merge was blocked, the malformed fixture was corrected, all earlier evidence was discarded, a completely fresh all-green matrix ran, and the remediated head merged through PR #225.
 - **R4:** Phase D overlap assessment merged through PR #226 only after the canonical baseline was green and every fresh required check passed.
 - **R5:** autonomous merge-readiness hardening merged through PR #227 at merge commit `467008db683c346cd086442dbb909c20a9248a3a`.
-- **R5B:** delegated-governance current-state reconciliation is the bounded baseline-remediation phase required before R6.
+- **R5B:** delegated-governance current-state reconciliation merged and was independently verified through PR #228 at merge commit `fbe4532ba2083feaa7ed9fcda2988843f1237a78`.
+- **R6:** `v1.2.0` release-candidate metadata and documentation are prepared on the governed release-preparation revision. This state is `PREPARED_NOT_RELEASED` and does not authorize publication.
 
 The incident-derived invariant is:
 
@@ -76,7 +78,7 @@ The incident-derived invariant is:
 GITHUB_CAN_MERGE != GOVERNANCE_READY_TO_MERGE
 ```
 
-Autonomous merges must follow `docs/governance/AUTONOMOUS_MERGE_READINESS_PROTOCOL.md` once R5 is canonical.
+Autonomous merges follow `docs/governance/AUTONOMOUS_MERGE_READINESS_PROTOCOL.md`.
 
 ## Validation and Continuation
 
@@ -85,10 +87,9 @@ Autonomous merges must follow `docs/governance/AUTONOMOUS_MERGE_READINESS_PROTOC
 - **Baseline Rule:** A new phase must not begin from a red canonical `main`.
 - **Post-Merge Rule:** An API response is not completion evidence; the PR and canonical `main` must be independently re-read before state advances.
 - **Issue #215:** Open umbrella finalization issue targeting `v1.2.0`.
-- **Active Remote Task:** R5B delegated-governance state reconciliation.
-- **Next Remote Task:** R6 README, changelog, version, and release-candidate preparation only after R5B is merged and independently verified.
-- **Next Local Task:** Fast-forward local Orchestra and KB, run preflight, refresh installed integrations as governed, and execute the R7 live installed-host validation matrix.
-- **Publication Boundary:** `v1.2.0` tag/GitHub Release remains blocked until R7 live-host evidence is reconciled and release state is independently verified.
+- **R6 Repository State:** `PREPARED_NOT_RELEASED`; candidate version surfaces are `1.2.0`, while the current public GitHub Release remains `v1.1.2`.
+- **Next Required Gate:** R7 live installed Codex/Antigravity continuity and Claude Code compatibility evidence.
+- **Publication Boundary:** R8 `v1.2.0` tag/GitHub Release remains blocked until R7 host-derived evidence is reconciled and release state is independently verified.
 
 ## Local Startup Verification
 
@@ -99,4 +100,4 @@ git pull --ff-only origin main
 python scripts\preflight_sync_check.py
 ```
 
-This file records stable current state and the active replay phase only. Historical decisions remain in `DECISION_LOG.md`, `CHANGELOG.md`, the archived autonomous-run branch, and immutable handoff evidence.
+This file records stable current state. Historical decisions remain in `DECISION_LOG.md`, `CHANGELOG.md`, the archived autonomous-run branch, and immutable handoff evidence.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
     <a href="CHANGELOG.md">Changelog</a>
   </p>
   <p>
-    <img src="https://img.shields.io/badge/current_release-v1.1.2-blue" alt="Current public release v1.1.2" />
+    <img src="https://img.shields.io/badge/public_release-v1.1.2-blue" alt="Current public release v1.1.2" />
+    <img src="https://img.shields.io/badge/release_candidate-v1.2.0-orange" alt="Repository release candidate v1.2.0" />
     <a href="https://github.com/Baelfyre/Orchestra/actions/workflows/validate.yml">
       <img src="https://github.com/Baelfyre/Orchestra/actions/workflows/validate.yml/badge.svg" alt="Repository validation status" />
     </a>
@@ -22,29 +23,31 @@
 
 ---
 
+> [!IMPORTANT]
+> Repository metadata is prepared for `v1.2.0`, but the latest published GitHub Release remains `v1.1.2`. The `v1.2.0` candidate is `PREPARED_NOT_RELEASED`. Live installed-host evidence remains `PENDING_LOCAL_HOST_VALIDATION`; no `v1.2.0` tag, GitHub Release, deployment, marketplace graduation, or policy activation is implied by the version bump.
+
 ## AI can generate fast. Building well still requires structure.
 
 AI-assisted projects rarely fail because a model cannot produce another answer. They fail when context drifts, architecture and implementation blur together, specialist assumptions conflict, unchecked output becomes the next input, evidence goes stale, decisions arrive out of order, and tool access is mistaken for permission.
 
-Orchestra turns those scattered interactions into one coordinated workflow. Like a conductor keeping each section on the same score, it gives every responsibility a defined place, controls when work moves forward, and sends failed or invalidated work back to the correct owner. After that opening metaphor, the mechanics are precise: trusted runtime composition, explicit routing, bounded authority, immutable capabilities, conditional cross-specialist coordination, separate governance, structured lifecycle state, validation, and deterministic evidence.
+Orchestra turns those scattered interactions into one coordinated workflow. It gives each responsibility a defined owner, controls when work may move forward, sends invalidated work back to the correct boundary, and preserves reviewable state across long-running tasks.
 
 ## What Orchestra Is
 
-Orchestra is a structured, standardized, and governance-driven framework for coordinating AI-assisted software work across specialist responsibilities, tools, validation stages, and human approval points.
+Orchestra is a structured, governance-driven framework for coordinating AI-assisted software work across specialist responsibilities, tools, validation stages, and human approval points.
 
 It is not an AI model and does not replace one. The model generates or reviews work. Orchestra is the coordination layer that routes, sequences, constrains, coordinates, validates, records, and connects that work to the next responsible boundary.
 
-This structure helps students see which engineering question comes next, helps experienced developers reduce context drift and repeated prompting, and gives maintainers reviewable state and evidence across long-running tasks. It does not replace software fundamentals or engineering judgment.
+The framework is designed to help developers reduce context drift, make cross-domain dependencies explicit, keep permission separate from routing and governance, and produce evidence that can be reviewed instead of inferred from generated text.
 
 ## How Orchestra Works
 
-The runtime establishes permission before it accepts work. Routing selects responsibility, but does not grant authority. Authority and capability checks run before governance. Governance may block authorized work, but cannot create a missing permission. For material multi-domain work, Conductor activates The Tuner to assemble specialist-owned contracts, expose missing ownership or contradictions, and identify stale dependent evidence. Single-owner work bypasses that coordination overhead. Validation failure returns work to its owning boundary before any result is accepted.
+The runtime establishes permission before execution. Routing selects responsibility but does not grant authority. Authority and capability checks run before governance. Governance may block already-authorized work, but cannot create missing permission. For material multi-domain work, Conductor activates The Tuner to assemble specialist-owned contracts, expose missing ownership or contradictions, and identify stale dependent evidence. Single-owner work bypasses that coordination overhead.
 
 ~~~mermaid
 flowchart TD
     Request["Request + Project Context"]
     Compose["Trusted Runtime Composition"]
-    Context["Context + Command"]
     Route["Conductor Routes Work"]
     Authority{"Authority Allowed?"}
     Capability{"Capability Granted?"}
@@ -55,10 +58,10 @@ flowchart TD
     Validate{"Validation Passed?"}
     Revise["Return to Owning Boundary"]
     Lifecycle["Structured Lifecycle Result"]
-    Audit["Deterministic Audit Evidence"]
+    Evidence["Deterministic Evidence"]
     Review["Human Review or Accepted Output"]
 
-    Request --> Compose --> Context --> Route --> Authority
+    Request --> Compose --> Route --> Authority
     Authority -- No --> Lifecycle
     Authority -- Yes --> Capability
     Capability -- No --> Lifecycle
@@ -71,285 +74,97 @@ flowchart TD
     Tuner -- Yes --> Specialist
     Specialist --> Validate
     Validate -- No --> Revise --> Specialist
-    Validate -- Yes --> Lifecycle --> Audit --> Review
-
-    classDef input fill:#161616,stroke:#777,color:#fff
-    classDef runtime fill:#24143a,stroke:#9d6cff,color:#f3eaff
-    classDef coord fill:#332712,stroke:#d4af37,color:#fff3bd
-    classDef work fill:#102a43,stroke:#58a6ff,color:#e5f2ff
-    classDef pass fill:#12351f,stroke:#4ac26b,color:#e7ffed
-    classDef stop fill:#3b1717,stroke:#ff6b6b,color:#ffe8e8
-    class Request,Context input
-    class Compose,Lifecycle runtime
-    class Route,Authority,Capability,Governance,Multi,Tuner coord
-    class Specialist work
-    class Validate,Audit,Review pass
-    class Revise stop
+    Validate -- Yes --> Lifecycle --> Evidence --> Review
 ~~~
 
-Accessible summary: a request moves through trusted composition, context and command parsing, routing, authority, capability, and governance. Direct single-owner work proceeds to its specialist. Material cross-domain work must first reach a ready cross-layer coordination state. A failed validation returns to the owning boundary. Allowed, denied, blocked, failed, waiting, or completed work ends in a structured lifecycle result, deterministic audit evidence, and review.
+Accessible summary: a request moves through trusted composition, routing, authority, capability, and governance. Single-owner work proceeds directly to its specialist. Material cross-domain work must first reach a ready coordination state. Validation failure returns work to the owning boundary. Accepted or blocked work ends in structured lifecycle state and deterministic evidence.
 
-The sequence is deliberate:
+## v1.2.0 Release Candidate Capability Set
 
-1. Project context and the request enter a trusted runtime composition.
-2. Root authority, runtime capabilities, route bindings, coordination services, and run identity are validated before execution.
-3. Host context and a command are parsed, then Conductor selects the smallest effective skill stack.
-4. Exact authority and capability decisions run against immutable trusted contracts.
-5. Governance evaluates whether already-authorized work should proceed.
-6. Conductor routes single-owner work directly or activates The Tuner when the change has material cross-domain dependencies.
-7. The Tuner assembles immutable references to specialist-owned contracts, detects missing ownership, contradictions, stale revisions, and invalidated evidence, then returns a coordination status and next-route recommendation.
-8. Specialists execute only inside their accepted boundaries. The Tuner does not implement, route specialists directly, resolve domain tradeoffs, validate its own work, or authorize continuation.
-9. Validation either returns the work for correction or allows it to continue.
-10. Structured lifecycle signals record waiting or a distinct terminal result.
-11. Run-linked audit events record what happened without granting permission.
+The candidate consolidates the substantial backward-compatible work merged after `v1.1.2`:
+
+- **Delegated Phase B progression:** approved units, six transition dispositions, checkpoints, bounded remediation, capacity handoff, evidence freshness, and fail-closed external-action authority.
+- **The Tuner Phases 1-4:** cross-specialist contract assembly, contradiction detection, semantic invalidation, minimal specialist re-entry, typed in-memory coordination, and bounded Conductor-owned runtime integration.
+- **Spec Kitty-derived governed execution contracts:** `OrchestraRuntimeEnvelope`, `OrchestraCorrelationID`, `OrchestraPhaseRetrospective`, the 15-field `ApprovedUnitPlan` extension, `OrchestraStatusProjection`, and `OrchestraWorktreeContract`.
+- **Cross-layer integrity auditing:** frontend-to-backend, backend-to-persistence, and language-neutral cross-module logical-flow profiles using the existing Conductor -> Tuner -> specialist -> Overseer -> Arbiter ownership model.
+- **Delegated Phase C repository reliability:** deterministic repository-verifiable reset/resume, handoff, capacity, stale identity, incomplete checkpoint, authority expansion, scaffold-only host, and replay behavior.
+- **Delegated Phase D reconciliation:** `NO_DUPLICATE_RUNTIME_EXTENSION_REQUIRED` for `v1.2.0`; existing trusted runtime contracts cover the material overlap.
+- **Autonomous merge-readiness hardening:** green canonical baseline, exact-head evidence, complete required checks, expected-head merge guard where supported, and independent post-merge verification.
+- **Current-state reconciliation:** stale Phase C/D status and false live-host promotion are rejected by executable governance consistency checks.
+
+See [v1.2.0 release-candidate notes](docs/releases/v1.2.0-governed-orchestration-release-candidate.md).
 
 ## Delegated Phase Progression
 
-For an approved delegated phase, a human or maintainer authorizes the phase and its execution envelope once. Conductor may then route only the internal units already approved by that envelope. Specialists execute inside those bounds, while Overseer and repository validators produce current evidence. Arbiter evaluates that evidence and emits the next transition disposition.
-
-Accepted units create checkpoints. Unchanged approved units can continue without repeated owner relay, but Orchestra still escalates missing intent, contradictions, scope expansion, policy decisions, protected actions, and unauthorized external actions. The Tuner is activated only when an approved unit has material cross-specialist dependencies or when a change invalidates another specialist's contract, evidence, documentation, diagram, or generated artifact.
-
-~~~mermaid
-flowchart TD
-    Authorized["Authorized Phase + Execution Envelope"]
-    Unit["Approved Unit Execution"]
-    Evidence["Current Evidence"]
-    Arbiter{"Arbiter Disposition"}
-    Checkpoint["Checkpoint Accepted Unit"]
-    Next{"Another Approved Unit?"}
-    Remediate["Deterministic In-Scope Remediation"]
-    WaitEvidence["Wait for Evidence"]
-    WaitCapacity["Capacity Checkpoint + Resume Later"]
-    Human["Human Decision or Authority"]
-    Stop["Preserve State + Halt"]
-    PhaseValidation["Phase Validation"]
-    HumanReview["Human Review"]
-
-    Authorized --> Unit --> Evidence --> Arbiter
-    Arbiter -- AUTO_CONTINUE --> Checkpoint --> Next
-    Next -- Yes --> Unit
-    Next -- No --> PhaseValidation --> HumanReview
-    Arbiter -- AUTO_REMEDIATE_AND_REVALIDATE --> Remediate --> Unit
-    Arbiter -- WAIT_FOR_EVIDENCE --> WaitEvidence --> Evidence
-    Arbiter -- WAIT_FOR_CAPACITY --> WaitCapacity --> Unit
-    Arbiter -- ESCALATE_HUMAN --> Human --> Authorized
-    Arbiter -- STOP --> Stop
-~~~
-
-Accessible summary: an authorized phase executes one approved unit, produces evidence, and asks Arbiter for the next disposition. Accepted units checkpoint before the next approved unit. Other dispositions remediate and revalidate, wait for evidence or capacity, escalate for human authority, or stop. After the final accepted unit, phase validation leads to human review.
+For an approved delegated phase, a maintainer authorizes the phase and its execution envelope once. Conductor may then route only internal units already allowed by that envelope. Specialists execute inside those bounds, Overseer and repository validators produce current evidence, and Arbiter emits the next transition disposition.
 
 | Transition disposition | Meaning |
 |---|---|
 | `AUTO_CONTINUE` | Begin the next approved unit. |
-| `AUTO_REMEDIATE_AND_REVALIDATE` | Correct a deterministic in-scope defect and rerun the required checks. |
+| `AUTO_REMEDIATE_AND_REVALIDATE` | Correct a deterministic in-scope defect and rerun required checks. |
 | `WAIT_FOR_EVIDENCE` | Pause until required evidence is produced. |
-| `WAIT_FOR_CAPACITY` | Checkpoint safely and resume later without treating capacity as a new owner decision. |
+| `WAIT_FOR_CAPACITY` | Checkpoint safely and resume later without inventing new authority. |
 | `ESCALATE_HUMAN` | Request missing intent, policy, scope, or external-action authority. |
 | `STOP` | Preserve a prohibited, unsafe, or invalid state and halt. |
 
-Validation proves conformance to the authorized envelope; it cannot create authority. Stage, commit, push, pull-request, merge, release, deployment, production, infrastructure, secret, and destructive actions remain separately governed.
+Validation proves conformance to an authorized envelope; it cannot create authority. Stage, commit, push, pull-request, merge, tag, release, deployment, production, infrastructure, secret, and destructive actions remain separately governed.
 
-Phase B instruction-level delegated progression is merged and canonical on `main` through PR #190. The current public release remains `v1.1.2`; Phase B has not yet been included in a new tagged release or deployment.
-
-See the [Delegated Execution Policy](docs/governance/DELEGATED_EXECUTION_POLICY.md) for the canonical contract and the [Governance Review Flow](docs/governance/GOVERNANCE_REVIEW_FLOW.md) for the review sequence.
-
-## One Request, Coordinated Responsibilities
-
-Consider one request:
-
-> Build a secure employee payroll system.
-
-That sentence contains business, legal, architecture, data, implementation, security, validation, documentation, and continuity concerns. Orchestra does not activate every specialist automatically. Conductor selects the smallest effective stack and activates The Tuner only because this example contains material dependencies across several specialist-owned domains.
-
-| Responsibility | Example contribution | Boundary |
-|---|---|---|
-| The Steward | Confirms business purpose, scope, requirements, and required delivery artifacts | Does not decide legal or technical implementation details |
-| The Governor | Reviews privacy, licensing, IP, and release obligations | Does not provide legal advice or grant runtime authority |
-| Conductor | Chooses and sequences the required specialist work | Routes work but does not implement it |
-| The Tuner | Assembles cross-layer contract references, detects missing ownership or contradictions, and marks dependent evidence or documentation stale when an accepted decision changes | Does not route specialists, rewrite domain decisions, implement, validate, or authorize continuation |
-| Clockwork | Defines application architecture and service boundaries | Does not write the implementation |
-| Chronicler | Defines payroll data and persistence semantics | Does not own UI or security policy |
-| Ponytail | Applies the approved implementation with minimal safe edits | Does not invent architecture or policy |
-| Cipher | Reviews access control, secrets, and defensive security boundaries | Does not perform offensive testing |
-| Overseer | Defines validation gates and release evidence | Does not write application code |
-| Scribe | Produces source-backed documentation | Does not invent system behavior |
-| Arbiter | Checks continuity, branch state, evidence freshness, and transition readiness | Does not override Steward, Governor, or specialist-owned decisions |
-
-If security validation detects unauthorized payroll access, work does not move directly to approval. It returns to the owning implementation boundary, the access control is corrected, validation runs again, and any contracts or evidence invalidated by that correction are refreshed before review.
-
-## Why Orchestra Instead of Direct Prompting?
-
-| Direct prompting | Orchestra |
-|---|---|
-| One answer may mix architecture, code, testing, and assumptions | Defined specialists own distinct responsibilities |
-| Several locally valid answers may still conflict at the system boundary | The Tuner exposes missing owners, contradictions, stale contracts, and required specialist re-entry |
-| Context can drift across prompts, tools, and sessions | Project state, contracts, decisions, and handoffs preserve continuity |
-| Tool access may be mistaken for permission | Exact authority and immutable runtime capability grants define permission |
-| A route can be treated as an implicit grant | Routing selects responsibility only |
-| Governance may be confused with authorization | Governance is a separate blocking layer that cannot create authority or capabilities |
-| Failure may be explained without re-entering the workflow | Validation returns work to correction and revalidation |
-| Completion may be inferred from generated text | Structured lifecycle signals control waiting and terminal state |
-| Logs may be treated as proof of permission | Audit events record evidence but never authorize work |
-
-Orchestra does not make output automatically correct. It makes ownership, ordering, coordination, constraints, failure, and evidence visible enough to review.
+See the [Delegated Execution Policy](docs/governance/DELEGATED_EXECUTION_POLICY.md) and [Governance Review Flow](docs/governance/GOVERNANCE_REVIEW_FLOW.md).
 
 ## Runtime Trust Model
 
 ### Trusted composition
 
-Every run starts from an explicit immutable <code>RuntimeComposition</code>. <code>ACTIVE</code> mode requires trusted authority, a run-scoped capability manifest, lifecycle and delegation services, coordination services, audit integration, and finite route bindings. Missing, malformed, mismatched, or untrusted active configuration fails closed before execution.
+Every active run starts from an explicit immutable `RuntimeComposition`. `ACTIVE` mode requires trusted authority, a run-scoped capability manifest, lifecycle and delegation services, coordination services, audit integration, and finite route bindings. Missing, malformed, mismatched, or untrusted active configuration fails closed before execution.
 
-<code>COMPATIBILITY</code> mode is also explicit and trusted. It uses finite repository-owned mappings for documented routes. It is not inferred when active configuration is missing, and it is never unlimited authority.
+`COMPATIBILITY` mode is also explicit and trusted. It uses finite repository-owned mappings for documented routes. It is not inferred when active configuration is missing, and it is never unlimited authority.
 
 ### Authority, capabilities, governance, and coordination
 
-Authority scopes define exact targets, operations, and constraints. Run-scoped capability manifests define exact executable capabilities and allowed operations. Capability grant provenance must match manifest provenance, and a present capability must belong to the specialist binding that uses it.
-
-The distinction is fundamental:
+Authority scopes define exact targets, operations, and constraints. Run-scoped capability manifests define exact executable capabilities and allowed operations. Governance asks whether already-authorized work should proceed. Coordination asks whether specialist-owned contracts are complete, consistent, and current enough to proceed.
 
 ~~~text
 governance_approval != authority_grant
 governance_approval != capability_grant
 coordination_ready != authority_grant
 coordination_ready != capability_grant
-governance_denial may block authorized work
-authority_denial cannot be reversed by governance
-capability_denial cannot be reversed by governance
+validation_success != authority_grant
+GITHUB_CAN_MERGE != GOVERNANCE_READY_TO_MERGE
+REPOSITORY_SIMULATION != LIVE_HOST_EVIDENCE
 ~~~
-
-Governance asks whether authorized work should proceed. Coordination asks whether specialist-owned contracts are complete, consistent, and current enough to proceed. Neither layer decides what the runtime is permitted to do in the first place.
-
-### One-time run identity
-
-Root and child run identities initialize once. Reusing the same identity raises <code>RUN_ALREADY_INITIALIZED</code> before trusted-contract revalidation, adapter access, parsing, routing, governance, or execution. A distinct run identity remains independently executable.
 
 ### Bounded delegation
 
-Child work requires an accepted <code>DelegationResolution</code>. A child receives an authority subset, capability subset, bounded depth, and only explicitly allowlisted context keys. Sensitive or unavailable context requests are rejected. Rejected delegation creates no executable child run. Accepted child execution stays in process; Orchestra does not create remote agents, worker processes, or background infrastructure.
+Accepted child work receives an authority subset, capability subset, bounded depth, and only explicitly allowlisted context keys. Rejected delegation creates no executable child run. Accepted child execution stays in process; Orchestra does not create remote workers or background infrastructure.
 
-~~~mermaid
-flowchart TD
-    Trusted["Trusted runtime construction or repository-owned policy"]
-    Parent["Parent Run<br/>Authority + Capabilities + Permitted Context Keys"]
-    Bound{"Strict bounded delegation validation"}
-    Child["Child Run<br/>Authority subset<br/>Capability subset<br/>Explicit Context Keys"]
-    Reject["Rejected<br/>No executable child run"]
-    Untrusted["Prompt text<br/>Adapter metadata<br/>Route<br/>Governance approval<br/>Coordination status<br/>Audit record"]
-    NoGrant["Cannot create or widen authority"]
+### Structured lifecycle and deterministic evidence
 
-    Trusted --> Parent --> Bound
-    Bound -- Accepted --> Child
-    Bound -- Rejected --> Reject
-    Untrusted -.-> NoGrant
-    NoGrant -.-> Bound
-
-    classDef trusted fill:#24143a,stroke:#9d6cff,color:#f3eaff
-    classDef parent fill:#102a43,stroke:#58a6ff,color:#e5f2ff
-    classDef gate fill:#332712,stroke:#d4af37,color:#fff3bd
-    classDef accepted fill:#12351f,stroke:#4ac26b,color:#e7ffed
-    classDef rejected fill:#3b1717,stroke:#ff6b6b,color:#ffe8e8
-    class Trusted trusted
-    class Parent,Untrusted parent
-    class Bound gate
-    class Child accepted
-    class Reject,NoGrant rejected
-~~~
-
-Accessible summary: trusted construction creates the parent run. Strict validation can create a narrower in-process child or reject the request without creating a child. Prompt text, adapter metadata, routing, governance approval, coordination status, and audit records cannot create or widen authority.
-
-### Structured lifecycle
-
-A run begins in <code>INITIALIZING</code>. <code>ACTIVATE</code> is accepted only from that state. An active run may <code>WAIT</code>; only a waiting run may <code>RESUME</code>. <code>WAITING</code> is non-terminal. <code>COMPLETED</code>, <code>FAILED</code>, <code>CANCELLED</code>, <code>TIMED_OUT</code>, and <code>BLOCKED</code> remain distinct terminal outcomes. Ordinary generated text cannot transition or complete a run.
-
-Exact replay of an accepted terminal signal is idempotent. Altered or conflicting terminal signals are rejected while the original immutable result remains intact.
+Runs use typed lifecycle signals and distinct waiting or terminal states. Exact replay of an accepted terminal signal is idempotent; conflicting replay is rejected. Run-linked audit events record authority, capabilities, delegation, coordination, lifecycle, and terminal outcomes without granting permission.
 
 ### Coordination state and evidence freshness
 
-The Tuner's typed coordination runtime records collaboration graphs, specialist-domain contracts, cross-layer packets, contradictions, invalidation events, artifact lifecycles, signals, sessions, and deterministic fingerprints. Runtime execution accepts an explicitly supplied collaboration session only for validation preflight; that preflight does not apply signals or infer transitions. A supplied collaboration session that is incomplete, contradicted, stale, malformed, or otherwise not ready fails closed at the runtime boundary. Exact idempotent signal replay preserves the existing immutable session without duplicating transition evidence.
-
-A ready coordination state does not grant implementation, Git, release, deployment, or external-action authority. Conductor remains the exclusive router, Overseer remains the validation-evidence owner, and Arbiter remains the continuation and transition-decision authority.
-
-### Deterministic evidence
-
-Run-linked events record root authority creation, capability manifests, authority and capability decisions, delegation acceptance or rejection, coordination transitions or rejections, lifecycle transitions, terminal results, and initialization failure. Audit evidence is non-authorizing. Even an audit sink failure cannot turn denied work into allowed work or replace an accepted terminal result.
-
-## Architecture
-
-These are ownership layers, not a shortcut around the runtime sequence:
-
-| Layer | Responsibility | Canonical detail |
-|---|---|---|
-| Governance | Business alignment, compliance, privacy obligations, IP, continuity, and release gates | [Governance Layer](docs/governance/GOVERNANCE_LAYER.md) |
-| Orchestration | Intent classification, routing, and ordered specialist handoffs | [Router-First Architecture](docs/routing/ROUTER_FIRST_ARCHITECTURE.md) |
-| Cross-Specialist Coordination | Contract assembly, missing-owner detection, contradiction reporting, invalidation, and re-entry recommendations | [Cross-Specialist Coordination Protocol](docs/routing/CROSS_SPECIALIST_COORDINATION_PROTOCOL.md) |
-| Trusted Runtime | Composition, authority, capabilities, coordination, delegation, lifecycle, execution, and audit evidence | [Runtime Architecture](docs/project/AUTHORITY_CAPABILITY_RUNTIME_ARCHITECTURE.md) |
-| Specialist Execution | Focused architecture, implementation, data, security, QA, documentation, and visual work | [Skill Index](SKILL_INDEX.md) |
-| Validation and Evidence | Behavior, runtime, packaging, governance, and release-readiness proof | [Validation Guide](docs/setup/VALIDATION.md) |
-
-The [Authority and Capability Contracts](docs/project/AUTHORITY_CAPABILITY_CONTRACTS.md) define the immutable runtime rules. The [Cross-Specialist Coordination Protocol](docs/routing/CROSS_SPECIALIST_COORDINATION_PROTOCOL.md) defines the coordination contract and strict ownership boundaries. The [Evidence Identity and Freshness Protocol](docs/governance/EVIDENCE_IDENTITY_AND_FRESHNESS_PROTOCOL.md) defines change identity and stale-evidence handling. Host integration remains separated by the [Portable Runtime Adapter Protocol](docs/project/PORTABLE_ADAPTER_PROTOCOL.md).
+The Tuner's coordination runtime records specialist-owned contracts, dependencies, contradictions, invalidations, artifact lifecycles, evidence, and deterministic fingerprints. A supplied collaboration session that is incomplete, contradicted, stale, malformed, or otherwise not ready fails closed. Conductor remains the exclusive router, Overseer remains the validation-evidence owner, and Arbiter remains the continuation authority.
 
 ## Roles and Specialist Responsibilities
 
-### Governance authorities
-
-| Role | Use it for | Key boundary |
+| Role | Primary responsibility | Key boundary |
 |---|---|---|
-| The Steward | Business alignment, scope, requirements, acceptance criteria, and SDLC sufficiency | Does not own legal or technical decisions |
-| The Governor | Legal, privacy-obligation, IP, licensing, and compliance governance | Identifies risks and escalation points, not legal advice |
-| Arbiter | Continuity, source of truth, validation state, handoff, and merge readiness | Uses verified repository evidence and does not override specialist-owned decisions |
-
-### Orchestration and execution
-
-| Role | Use it for | Key boundary |
-|---|---|---|
-| Conductor | Routing and multi-skill sequencing | Does not execute specialist work |
-| The Tuner | Cross-specialist contract assembly, contradiction detection, invalidation, and re-entry recommendations | Cannot route, implement, validate itself, grant authority, or issue an Arbiter disposition |
-| Clockwork | Architecture, layering, and refactor structure | Does not implement |
-| Cloak | UI, UX, accessibility, and responsive behavior | Does not own backend policy |
+| The Steward | Business alignment, scope, requirements, acceptance criteria | Does not decide legal or technical implementation details |
+| The Governor | Legal, privacy-obligation, IP, licensing, compliance governance | Does not provide legal advice or grant runtime authority |
+| Conductor | Routing and ordered specialist handoffs | Routes work but does not implement it |
+| The Tuner | Cross-specialist contract assembly, contradictions, invalidation, re-entry recommendations | Cannot route, implement, validate itself, or grant authority |
+| Clockwork | Architecture, layering, code structure | Does not implement |
+| Cloak | UI/UX, accessibility, responsive behavior | Does not own backend policy |
 | Chronicler | Database and persistence semantics | Does not own UI or general QA |
 | Ponytail | Minimal, reversible implementation | Requires upstream decisions to be settled |
-| Cipher | Defensive security, access control, secrets, and privacy controls | No offensive testing or legal decisions |
-| Overseer | QA strategy, validation gates, and release readiness | Does not write application code |
-| Scribe | README, release, setup, and handoff documentation | Uses source-backed facts |
-| Weaver | Mermaid and PlantUML diagrams | Does not invent architecture or relationships |
-
-### Gated resilience
-
-| Role | Use it for | Key boundary |
-|---|---|---|
+| Cipher | Defensive security, access control, secrets, privacy controls | No offensive testing or legal decisions |
+| Overseer | QA strategy, validation gates, release readiness | Does not write application code |
+| Scribe | Source-backed documentation and knowledge transfer | Does not invent system behavior |
+| Weaver | Mermaid and PlantUML visual models | Does not invent architecture |
+| Arbiter | Continuity, evidence freshness, transition and merge readiness | Does not override specialist-owned decisions |
 | Dagger | Guarded destructive-path simulation and resilience review | Simulation only unless separately authorized with guardrails |
 
-### Internal repository evolution
-
-| Role | Use it for | Key boundary |
-|---|---|---|
-| Artificer | Maintainer-only, static, read-only audits of selected external repositories for useful patterns, risks, provenance, and licensing considerations | Not publicly routable; does not execute external code, implement findings, approve its own recommendations, or appear in runtime and adapter exports |
-
-Artificer is intentionally separate from Orchestra's public runtime specialist roster. Its audit records support transparent repository evolution, specialist review, provenance tracking, licensing analysis, and governed Pattern Catalog decisions.
-
-See the [Artificer workflow](docs/internal/ARTIFICER_WORKFLOW.md), [Artificer boundaries](docs/internal/ARTIFICER_BOUNDARIES.md), and governed [Pattern Catalog](docs/internal/PATTERN_CATALOG.md).
-
-## External Repository Reviews and Incorporated Patterns
-
-Orchestra may inspect selected external open-source repositories through source-pinned, static Artificer audits. A repository can be audited without being incorporated, and an audit does not authorize copying or implementation.
-
-| Source repository | Relationship to Orchestra | Current outcome |
-|---|---|---|
-| [`usestrix/strix`](https://github.com/usestrix/strix) | Reference source for lifecycle-gated completion, declared authority scope, run-scoped capabilities, and validated specialist delegation | Four governed reference-only patterns were independently implemented as Orchestra-native runtime contracts and released in `v1.1.2` |
-| [`CristianOlivera1/openhero`](https://github.com/CristianOlivera1/openhero) | Static review covering UI orchestration, resilience, archive validation, and defensive-security observations | Audit findings were retained for reference; no OpenHero pattern has been promoted or implemented in Orchestra |
-| [`bryllim/bryl-minimal-design`](https://github.com/bryllim/bryl-minimal-design) | MIT-licensed design-language source for Cloak's `bryl-minimal` template | Orchestra includes an attributed framework-native design profile based on Bryl Lim's repository; the source repository remains separately owned and maintained |
-| [`DietrichGebert/ponytail`](https://github.com/DietrichGebert/ponytail) | Historical external implementation companion and reference for minimal, focused code changes | The upstream repository remains separately owned and maintained by Dietrich Gebert; Orchestra's current Ponytail specialist is an independently maintained Orchestra component, not a vendored copy or required dependency |
-| [`JuliusBrussee/caveman`](https://github.com/JuliusBrussee/caveman) | Historical external communication companion for concise, token-efficient output | The upstream repository remains separately owned and maintained by Julius Brussee; Caveman is not bundled, vendored, or required by Orchestra |
-
-### External-source incorporation boundary
-
-Listing a repository here does not mean that its entire codebase, data, or knowledge base was imported into Orchestra. Orchestra does not wholesale-copy external repositories.
-
-Where incorporation occurs, it is limited to approved concepts, useful logic, reusable skills and knowledge, validation lessons, and independently written Orchestra-native components that improve the framework and its governed knowledge base.
-
-External source code, datasets, prompts, payloads, examples, media, assets, and documentation are not incorporated unless a governed record explicitly authorizes reuse and the applicable license, attribution, security, and maintainer-review requirements are satisfied.
-
-The authoritative incorporation record is the governed [Pattern Catalog](docs/internal/PATTERN_CATALOG.md). An Artificer audit alone does not mean that a repository, pattern, or finding has been incorporated into Orchestra.
+Artificer remains a maintainer-only internal repository-evolution surface. It is not publicly routable and does not execute external code, implement its own findings, or approve its own recommendations. See the governed [Pattern Catalog](docs/internal/PATTERN_CATALOG.md).
 
 ## Supported Hosts and Maturity
 
@@ -357,9 +172,9 @@ Support means a validated integration surface. Scaffold-only means the repositor
 
 | Host | Maturity | Notes |
 |---|---|---|
-| Codex | Supported | Marketplace-first installation with repo-local fallback |
-| Claude Code | Supported | Marketplace metadata and namespaced plugin skills |
-| Antigravity | Supported | Native <code>agy</code> plugin path |
+| Codex | Supported | Marketplace-first installation with repo-local fallback; R7 live continuity evidence remains pending for publication. |
+| Claude Code | Supported packaging/integration | Marketplace metadata and namespaced plugin skills; Phase C active runtime continuity is not inferred from packaging support. |
+| Antigravity | Supported | Native `agy` plugin path; R7 live continuity evidence remains pending for publication. |
 | Cursor | Scaffold-only | Runtime adapter and packaging instructions, not marketplace-published |
 | Windsurf | Scaffold-only | Runtime adapter and packaging instructions, not marketplace-published |
 | VS Code / VSCodium | Scaffold-only | Shared VS Code-family adapter and scaffold |
@@ -368,18 +183,18 @@ Support means a validated integration surface. Scaffold-only means the repositor
 | Neovim | Scaffold-only | Runtime adapter and local editor scaffold |
 | Local AI systems | Manual documentation surface | Load selected Markdown and supporting files deliberately |
 
-Orchestra does not claim to work everywhere. See [Compatibility](docs/setup/COMPATIBILITY.md) and the [scaffold graduation criteria](docs/project/SCAFFOLD_ADAPTER_GRADUATION_CRITERIA.md).
+Repository CI and Phase C fixtures are not live installed-host evidence. R7 must reconcile the applicable installed Codex/Antigravity continuity evidence before `v1.2.0` publication. See [Compatibility](docs/setup/COMPATIBILITY.md).
 
 ## Installation
 
 Use the host-native path:
 
-- Codex: add <code>https://github.com/Baelfyre/Orchestra</code> as a Marketplace source, install Orchestra, then invoke <code>@Orchestra</code>.
-- Claude Code: run <code>/plugin marketplace add Baelfyre/Orchestra</code>, then <code>/plugin install orchestra@orchestra</code>.
-- Antigravity: run <code>agy plugin install https://github.com/Baelfyre/Orchestra</code>.
+- Codex: add `https://github.com/Baelfyre/Orchestra` as a Marketplace source, install Orchestra, then invoke `@Orchestra`.
+- Claude Code: run `/plugin marketplace add Baelfyre/Orchestra`, then `/plugin install orchestra@orchestra`.
+- Antigravity: run `agy plugin install https://github.com/Baelfyre/Orchestra`.
 - Manual or scaffold-only hosts: follow the exact host boundary in the [Installation Guide](docs/setup/INSTALLATION.md).
 
-Repo-local Codex skill copies are an advanced fallback. Persistent project changes belong in tracked <code>skills/</code> source, not generated <code>.agents/</code> runtime copies.
+During R6, repository manifests identify the candidate as `1.2.0`; the latest public GitHub Release remains `v1.1.2`. See the Installation Guide for the candidate/public-release distinction.
 
 ## Quick Start
 
@@ -387,7 +202,7 @@ Repo-local Codex skill copies are an advanced fallback. Persistent project chang
 2. Describe the concrete task and acceptance criteria.
 3. Let Conductor select the smallest effective specialist stack and activate The Tuner only when material cross-domain coordination is required.
 4. Review governance decisions and specialist outputs at their owning boundaries.
-5. Run the required validation before accepting the result.
+5. Run required validation before accepting the result.
 6. Preserve project state and a concise handoff before changing session, branch, or maintainer.
 
 Example:
@@ -407,61 +222,46 @@ Implement the command, validate it, and leave the diff unstaged for review.
 
 ## Validation and Evidence
 
-Validation results are revision-specific. The README intentionally avoids treating an older test count or coverage percentage as the current result for a newer `main` revision. Use the repository workflow status and the canonical commands in [Validation](docs/setup/VALIDATION.md) for the exact revision being reviewed.
+Validation results are revision-specific. An older green run cannot authorize a newer head. Use repository workflow status and the canonical commands in [Validation](docs/setup/VALIDATION.md) for the exact revision being reviewed.
 
 The validation chain covers:
 
-- Artificer internal, record, governance-record, and Pattern Catalog validation;
 - structure, manifests, Claude plugin, IDE packaging, and Codex export;
+- Artificer internal, record, governance-record, and Pattern Catalog validation;
 - prompt-load thresholds and budget;
-- governance protocol, routing contract, Tuner collaboration contract, evidence identity, and strict governance;
-- behavior validation;
-- runtime tests with the required coverage threshold;
-- runtime import smoke;
-- release-readiness, version, licensing, security, and compatibility review;
-- link checks, <code>git diff --check</code>, and exact authorized scope.
+- governance protocol, routing contracts, Tuner collaboration, evidence identity, and strict governance;
+- behavior validation and runtime tests with the required coverage threshold;
+- security, compatibility, licensing, version consistency, stale references, and release readiness;
+- native Windows, Ubuntu, and macOS validation;
+- `git diff --check` and exact authorized scope.
 
-## Current Main After v1.1.2
+For autonomous or delegated merges, Orchestra additionally requires the fail-closed [Autonomous Merge Readiness Protocol](docs/governance/AUTONOMOUS_MERGE_READINESS_PROTOCOL.md): a green canonical baseline, exact-head evidence, complete successful required checks, expected-head merge guard where supported, and independent post-merge verification.
 
-The current public release remains <code>v1.1.2</code>. The canonical `main` branch also includes later, unreleased work:
+## Release Status
 
-- Phase B instruction-level delegated progression merged through PR #190;
-- The Tuner's cross-specialist coordination protocol, evidence-continuity controls, typed in-memory coordination contracts, and bounded Conductor-owned runtime integration;
-- deterministic coordination transition and rejection evidence;
-- fail-closed handling for incomplete, contradicted, stale, or malformed supplied collaboration sessions;
-- direct single-owner bypass with no unnecessary coordination calls or coordination audit events;
-- canonical SCN-01 through SCN-06 scenario coverage;
-- portable Codex export support for The Tuner's canonical protocol references.
+### Current public release: v1.1.2
 
-The Tuner Phase 4 implementation merged through PR #200, and its post-merge continuity record merged through PR #201. These changes have not been included in a new tagged release or deployment. See the [Cross-Specialist Coordination Protocol](docs/routing/CROSS_SPECIALIST_COORDINATION_PROTOCOL.md) and [Phase 4 Post-Merge State](docs/routing/TUNER_PHASE_4_POST_MERGE_STATE.md).
+The published `v1.1.2` release established trusted runtime authority, run-scoped capabilities, bounded delegation, structured lifecycle control, `RuntimeExecutor` authority/capability ordering, adversarial fail-closed validation, deterministic non-authorizing audit evidence, and four governed Artificer promotions.
 
-## v1.1.2 Release Highlights
+See [v1.1.2 Trusted Runtime Authority release notes](docs/releases/v1.1.2-trusted-runtime-authority.md) and the published [`v1.1.2` GitHub Release](https://github.com/Baelfyre/Orchestra/releases/tag/v1.1.2).
 
-The published <code>v1.1.2</code> release includes:
+### Repository release candidate: v1.2.0
 
-- trusted authority and run-scoped runtime capability enforcement;
-- explicit finite <code>ACTIVE</code> and <code>COMPATIBILITY</code> composition;
-- bounded in-process specialist delegation;
-- structured lifecycle control and same-run replay rejection;
-- <code>RuntimeExecutor</code> integration with authority and capability checks before governance;
-- adversarial fail-closed validation;
-- deterministic non-authorizing audit evidence;
-- completion of the four governed Artificer promotions;
-- synchronized README, setup, compatibility, and release surfaces.
+`v1.2.0` candidate metadata is prepared, but publication remains blocked. Phase C repository reliability is complete through PR #225; live installed-host evidence remains `PENDING_LOCAL_HOST_VALIDATION`. Phase D reconciliation is complete through PR #226 with no duplicate runtime extension required. R5/R5B added merge-readiness hardening and canonical current-state reconciliation.
 
-See the [v1.1.2 Trusted Runtime Authority release notes](docs/releases/v1.1.2-trusted-runtime-authority.md) and the published [`v1.1.2` GitHub Release](https://github.com/Baelfyre/Orchestra/releases/tag/v1.1.2).
+The candidate becomes a public release only after R6 is merged and independently verified, R7 host-derived evidence is reconciled, and the separately authorized R8 annotated-tag/GitHub-Release gate completes.
 
 ## Honest Limitations
 
 - Orchestra does not replace human review or engineering judgment.
 - It does not guarantee correct or secure output and does not eliminate hallucinations.
-- Prompt content, metadata, routes, governance approvals, coordination status, and audit records do not grant authority.
-- Governance can block work but cannot create authority or capabilities.
+- Prompt content, metadata, routes, governance approvals, coordination status, validation success, audit records, GitHub mergeability, and API success do not create authority.
 - The Tuner cannot activate itself, route specialists directly, select a winning domain requirement, implement code, validate its own output, issue an Arbiter transition disposition, or perform Git, release, deployment, or external actions.
 - The current coordination runtime is in-memory and does not add persistent collaboration storage, SQLite, migrations, RPC, or host-process orchestration.
 - Orchestra does not create remote workers, background agents, or distributed orchestration infrastructure.
 - Compatibility mode is explicit, finite, and intended for bounded existing routes.
 - Cursor, Windsurf, VS Code/VSCodium, JetBrains, Zed, and Neovim remain scaffold-only.
+- Repository simulation is not live installed-host evidence; R7 remains required before `v1.2.0` publication.
 - Orchestra is developer tooling and a local runtime. It does not store or transmit downstream project data by default.
 - Data sensitivity, privacy, retention, deletion, platform disclosure, and IP obligations depend on the downstream project and host environment.
 - Release governance may require revision or block publication.
@@ -489,16 +289,25 @@ See the [v1.1.2 Trusted Runtime Authority release notes](docs/releases/v1.1.2-tr
 - [Governance Layer](docs/governance/GOVERNANCE_LAYER.md)
 - [Governance Review Flow](docs/governance/GOVERNANCE_REVIEW_FLOW.md)
 - [Delegated Execution Policy](docs/governance/DELEGATED_EXECUTION_POLICY.md)
+- [Autonomous Merge Readiness Protocol](docs/governance/AUTONOMOUS_MERGE_READINESS_PROTOCOL.md)
 - [Release Gates](docs/governance/RELEASE_GATES.md)
 - [App Release Compliance Gate](docs/governance/APP_RELEASE_COMPLIANCE_GATE.md)
 
-### Maintainers
+### Release and maintainers
 
+- [v1.2.0 Release Candidate Notes](docs/releases/v1.2.0-governed-orchestration-release-candidate.md)
+- [v1.1.2 Release Notes](docs/releases/v1.1.2-trusted-runtime-authority.md)
 - [Contributing](docs/CONTRIBUTING.md)
 - [Project State](PROJECT_STATE.md)
-- [The Tuner Phase 4 Post-Merge State](docs/routing/TUNER_PHASE_4_POST_MERGE_STATE.md)
+- [Session Handoff](SESSION_HANDOFF.md)
 - [Decision Log](DECISION_LOG.md)
 - [Changelog](CHANGELOG.md)
+
+## External Pattern Governance
+
+Orchestra may inspect selected external open-source repositories through source-pinned, static Artificer audits. An audit does not authorize copying or implementation. Where a concept is incorporated, it must pass governed provenance, licensing, security, ownership, and maintainer-review boundaries and be independently implemented as Orchestra-native work.
+
+The authoritative incorporation record is the governed [Pattern Catalog](docs/internal/PATTERN_CATALOG.md). External source code, datasets, prompts, payloads, examples, media, assets, or documentation expression are not incorporated unless a governed record explicitly authorizes that reuse.
 
 ## Contributing, Security, and License
 
@@ -506,4 +315,4 @@ Contributions should preserve specialist ownership, cross-specialist contract bo
 
 Report vulnerabilities privately through the process in [SECURITY.md](SECURITY.md). Do not commit secrets, credentials, personal data, client information, or private project material.
 
-Orchestra is licensed under the [MIT License](LICENSE). The four finalized Artificer promotions preserve governed conceptual provenance and Apache-2.0 attribution boundaries. They do not authorize copying external source code, prompts, payloads, examples, media, or documentation expression.
+Orchestra is licensed under the [MIT License](LICENSE). Governed external-pattern records preserve applicable provenance and attribution boundaries; they do not authorize wholesale copying of external projects.

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -4,8 +4,9 @@
 - **Canonical Branch:** `main`
 - **Base Branch:** `main`
 - **Current Public Release:** `v1.1.2`
+- **Release-Candidate Metadata:** `v1.2.0`
 - **Target Release:** `v1.2.0`
-- **Post-`v1.1.2` Capability State:** `IMPLEMENTED_MERGED_NOT_RELEASED`
+- **Post-`v1.1.2` Capability State:** `PREPARED_NOT_RELEASED`
 - **Policy Activation:** `NOT_PERFORMED`
 - **Live Installed-Host Validation:** `PENDING_LOCAL_HOST_VALIDATION`
 
@@ -24,43 +25,34 @@ backup/main-pre-v1.2-autonomous-2026-08-07
 3a2f8b7e65cdab0f7e6a3113d1096ec9dccc23d3
 ```
 
-That recovery baseline already includes the successfully validated frontend/backend synchronicity merge from PR #216.
+The clean replay then completed R1 through R5B:
 
-The replay then completed:
+- **R1 / PR #223:** Spec Kitty Phase 3 and roadmap reconciliation.
+- **R2 / PR #224:** additive backend-persistence and cross-module logical-flow integrity.
+- **R3 / PR #225:** delegated Phase C repository host-reliability contract after bounded fixture remediation and a fully fresh validation matrix.
+- **R4 / PR #226:** delegated Phase D runtime-overlap reconciliation with `NO_DUPLICATE_RUNTIME_EXTENSION_REQUIRED` for v1.2.0.
+- **R5 / PR #227:** fail-closed autonomous merge-readiness hardening.
+- **R5B / PR #228:** delegated-governance current-state reconciliation, merged at `fbe4532ba2083feaa7ed9fcda2988843f1237a78` and independently verified on canonical `main`.
 
-- **R1 / replay PR #223:** Spec Kitty Phase 3 and roadmap reconciliation. Fresh Governance, behavior, runtime, Windows, Ubuntu, and macOS validation passed before exact-head merge.
-- **R2 / replay PR #224:** Additive backend-persistence and cross-module logical-flow integrity profiles. The focused changelog update omitted in the first experiment was included. All fresh required checks passed before merge.
-- **R3 / replay PR #225:** Delegated Phase C repository host-reliability contract. An initial replay head failed runtime validation and was not merged. The malformed SHA fixture was corrected, all old evidence was invalidated, the entire fresh matrix reran successfully, and only the corrected exact head was merged.
-- **R4 / replay PR #226:** Delegated Phase D runtime-overlap assessment. No duplicate runtime extension is justified; the phase merged only from a green baseline with a fresh all-green matrix.
+## Current Release-Candidate State - R6
 
-## Active Phase - R5B Delegated Governance State Reconciliation
+R6 normalizes repository release-candidate metadata to `1.2.0`, consolidates README/setup/current-state/release notes, and prepares exact-head release-readiness evidence.
 
-R5 merged through PR #227 at `467008db683c346cd086442dbb909c20a9248a3a`. R5B is the bounded prerequisite that reconciles delegated-governance current-state documentation and executable consistency checks before R6.
-
-Current verified state:
-- Phase C repository contract: complete through PR #225.
-- Phase C live installed-host evidence: `PENDING_LOCAL_HOST_VALIDATION`.
-- Phase D overlap reconciliation: complete through PR #226.
-- Phase D runtime extension: `NO_DUPLICATE_RUNTIME_EXTENSION_REQUIRED` for v1.2.0.
-- v1.2.0: not released or deployed.
-## Phase C Evidence Boundary
-
-Repository CI proves deterministic repository contract behavior only.
-
-It does **not** prove:
-
-- an actual installed Codex context reset/resume;
-- an actual installed Antigravity context reset/resume;
-- a real Codex-to-Antigravity live continuation;
-- active Claude Code runtime continuity.
-
-Therefore:
+This is preparation, not publication:
 
 ```text
+RELEASE_CANDIDATE_VERSION=1.2.0
+CURRENT_PUBLIC_RELEASE=v1.1.2
+RELEASE_STATE=PREPARED_NOT_RELEASED
+POLICY_ACTIVATION=NOT_PERFORMED
 LIVE_INSTALLED_HOST_VALIDATION=PENDING_LOCAL_HOST_VALIDATION
 ```
 
-This does not block R5/R6 repository preparation, but it remains an R7 publication gate before `v1.2.0` can be tagged or published.
+Phase C repository continuity is complete through PR #225, but repository simulation and GitHub CI do not prove installed-host continuity. Phase D reconciliation is complete through PR #226 and requires no duplicate runtime extension for v1.2.0.
+
+## R7 Live-Host Gate
+
+Before a `v1.2.0` tag or GitHub Release can be created, R7 must produce host-derived evidence for the applicable installed Codex and Antigravity reset/resume and cross-host continuation cases. Claude Code packaging remains supported, while Phase C active runtime-continuity capability must not be promoted beyond the evidence actually obtained.
 
 ## Local Continuation
 
@@ -81,15 +73,14 @@ git switch main
 git pull --ff-only origin main
 ```
 
-After synchronization, R7 must exercise the real installed-host continuity/parity cases and produce host-derived evidence before release publication.
-
 ## Remaining Sequence
 
 ```text
 R5   merged - autonomous merge-readiness hardening
-R5B  delegated-governance state reconciliation
-R6   README + changelog + version + v1.2.0 release-candidate preparation
+R5B  merged - delegated-governance state reconciliation
+R6   v1.2.0 release-candidate repository preparation
 R7   live installed Codex/Antigravity/Claude compatibility evidence
 R8   tag/GitHub Release only from independently verified release state
 ```
+
 Historical first-run failures remain preserved as audit evidence in the KB and archive branch. They must not be silently rewritten or deleted during cleanup.

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -1,15 +1,19 @@
 # Codex Adapter for Orchestra
 
-This adapter provides a Codex-compatible export of the current Orchestra skills for the published `v1.1.2` release.
+This adapter provides a Codex-compatible export of the current Orchestra skills. Repository release-candidate metadata is `1.2.0`; the latest public GitHub Release remains `v1.1.2` until the separate publication gate completes.
 
 ## Purpose
 
-Codex may reject extended frontmatter fields (like `role`, `activation_level`, etc.) in `SKILL.md`. It expects skill discovery to rely purely on simple `name` and `description` metadata. 
+Codex may reject extended frontmatter fields (like `role`, `activation_level`, etc.) in `SKILL.md`. It expects skill discovery to rely purely on simple `name` and `description` metadata.
 
-This adapter exports Codex-compatible skills with only `name` and `description` in the frontmatter while perfectly preserving the original Markdown body, instructions, and progressive disclosure boundaries of the canonical skills.
+This adapter exports Codex-compatible skills with only `name` and `description` in the frontmatter while preserving the original Markdown body, instructions, and progressive disclosure boundaries of the canonical skills.
+
+## Release-Candidate Boundary
+
+The `1.2.0` repository version is preparation metadata, not proof of a published release or installed-host parity. R7 live-host evidence and the separate R8 tag/GitHub Release gate remain required before `v1.2.0` is represented as published.
 
 ## Note
 
-* The canonical Orchestra skills remain the absolute source of truth. They are metadata-rich and Markdown-first.
-* This adapter is exclusively for Codex compatibility.
-* It does not replace the Markdown-first framework.
+- The canonical Orchestra skills remain the source of truth. They are metadata-rich and Markdown-first.
+- This adapter is exclusively for Codex compatibility.
+- It does not replace the Markdown-first framework.

--- a/adapters/cursor/package.json
+++ b/adapters/cursor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-cursor-scaffold",
   "displayName": "Orchestra Cursor Scaffold",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "private": true,
   "description": "Scaffold-only Cursor packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/jetbrains/package.json
+++ b/adapters/jetbrains/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-jetbrains-scaffold",
   "displayName": "Orchestra JetBrains Scaffold",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "private": true,
   "description": "Scaffold-only JetBrains packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/jetbrains/plugin.xml
+++ b/adapters/jetbrains/plugin.xml
@@ -2,7 +2,7 @@
   <id>com.baelfyre.orchestra.scaffold</id>
   <name>Orchestra JetBrains Scaffold</name>
   <vendor>Baelfyre</vendor>
-  <version>1.1.2</version>
+  <version>1.2.0</version>
   <description>Scaffold-only JetBrains packaging metadata for Orchestra runtime adapter integration.</description>
   <depends>com.intellij.modules.platform</depends>
   <extensions defaultExtensionNs="com.intellij">

--- a/adapters/neovim/package.json
+++ b/adapters/neovim/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-neovim-scaffold",
   "displayName": "Orchestra Neovim Scaffold",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "private": true,
   "description": "Scaffold-only Neovim packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/vscode/package.json
+++ b/adapters/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-vscode-scaffold",
   "displayName": "Orchestra VS Code Scaffold",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "private": true,
   "description": "Scaffold-only VS Code packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/windsurf/package.json
+++ b/adapters/windsurf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-windsurf-scaffold",
   "displayName": "Orchestra Windsurf Scaffold",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "private": true,
   "description": "Scaffold-only Windsurf packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/zed/package.json
+++ b/adapters/zed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-zed-scaffold",
   "displayName": "Orchestra Zed Scaffold",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "private": true,
   "description": "Scaffold-only Zed packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -41,7 +41,23 @@ Phase 3A through Phase 3E are complete and merged. The Spec Kitty-derived capabi
 - [x] Phase 6C: run adversarial authority, capability, delegation, lifecycle, and fail-closed validation.
 - [x] Phase 6D: finalize promotion lifecycle, Catalog synchronization, release readiness, and target patch preparation after implementation completes.
 
-Phases 6B-A through 6C are complete and merged through PR #183. Phase 6D is complete locally under Issue #184 after promotion, Catalog, documentation, version, two-pass validation, and exact-scope gates. The prepared branch still requires maintainer review, merge, and separate publication authorization.
+Phases 6B-A through 6C are complete and merged through PR #183. Phase 6D produced the published `v1.1.2` baseline after PR #185 and the separate publication gate.
+
+## v1.2.0 Finalization
+
+- [x] F0/R0: preserve and verify the recovery baseline after the first autonomous-run incident.
+- [x] F1/R1: Spec Kitty Phase 3 and roadmap closeout through replay PR #223.
+- [x] F2/R2: backend-to-persistence and cross-module logical-flow integrity through replay PR #224.
+- [x] F3/R3 repository contract: delegated host-reliability protocol and deterministic repository evidence through replay PR #225.
+- [ ] F3/R7 live host evidence: installed Codex/Antigravity continuity and applicable cross-host verification remain `PENDING_LOCAL_HOST_VALIDATION`.
+- [x] F4/R4: delegated Phase D overlap reconciliation through PR #226 with `NO_DUPLICATE_RUNTIME_EXTENSION_REQUIRED` for v1.2.0.
+- [x] R5: autonomous merge-readiness hardening through PR #227.
+- [x] R5B: delegated-governance current-state reconciliation through PR #228.
+- [x] R6 repository preparation: version surfaces, public current-state documentation, compatibility/install boundaries, changelog consolidation, and `v1.2.0` release-candidate notes prepared as `PREPARED_NOT_RELEASED`.
+- [ ] R7: reconcile live installed-host evidence and complete the publication readiness gate.
+- [ ] R8: create annotated `v1.2.0` tag and GitHub Release only from independently verified release state.
+
+## Deferred and Future Work
 
 - [ ] Add host-specific update commands after the shared notification-only update check stabilizes.
 - [ ] Add host-specific update commands on top of the reproducible temp-staged runtime refresh pipeline.
@@ -65,4 +81,4 @@ Phases 6B-A through 6C are complete and merged through PR #183. Phase 6D is comp
 - [ ] Add an optional local-model retrieval index.
 - [ ] Improve adapters as tool capabilities change.
 - [ ] Expand fictional, project-agnostic examples.
-- [ ] Prepare and publish `v1.2.0` only after Issue #215 release preparation, exact-head validation, and the separate F6 publication gate are completed.
+- [ ] Publish `v1.2.0` only after R7 host-derived evidence, exact-head release verification, and the separate R8 publication gate are completed.

--- a/docs/releases/v1.2.0-governed-orchestration-release-candidate.md
+++ b/docs/releases/v1.2.0-governed-orchestration-release-candidate.md
@@ -1,0 +1,55 @@
+# Orchestra v1.2.0 Release Candidate: Governed Orchestration
+
+`v1.2.0` is prepared as a release candidate. It is **not yet a published release**. The latest public GitHub Release remains `v1.1.2` until R7 live installed-host evidence is reconciled and the separate R8 publication gate explicitly authorizes the annotated tag and GitHub Release.
+
+## Release Theme
+
+This minor release consolidates the post-`v1.1.2` governed-orchestration capability set. It expands delegated phase progression, cross-specialist coordination, governed phase execution contracts, cross-layer integrity auditing, repository-verifiable host continuity, and autonomous merge safety while preserving authority, maturity, and publication boundaries.
+
+## Candidate Scope
+
+- Delegated Phase B instruction-level progression with explicit transition dispositions, checkpoints, bounded remediation, evidence freshness, and fail-closed external-action authority.
+- The Tuner Phases 1-4: specialist-owned cross-layer contract assembly, contradiction detection, evidence invalidation, minimal re-entry, typed in-memory coordination, and bounded Conductor-owned runtime integration.
+- Spec Kitty-derived contracts: `OrchestraRuntimeEnvelope`, `OrchestraCorrelationID`, `OrchestraPhaseRetrospective`, the 15-field `ApprovedUnitPlan` extension, `OrchestraStatusProjection`, and `OrchestraWorktreeContract`.
+- Frontend-to-backend, backend-to-persistence, and language-neutral cross-module logical-flow integrity profiles using the existing Conductor -> Tuner -> specialist -> Overseer -> Arbiter ownership model.
+- Delegated Phase C repository host-reliability protocol and deterministic adversarial fixtures for reset/resume, handoff, capacity, stale identity, incomplete checkpoint, scaffold-only host, authority expansion, and duplicate replay cases.
+- Delegated Phase D overlap reconciliation with `NO_DUPLICATE_RUNTIME_EXTENSION_REQUIRED` for v1.2.0.
+- Autonomous merge-readiness hardening requiring green canonical baseline, exact-head evidence, complete required checks, expected-head merge guards where supported, and independent post-merge verification.
+- R5B current-state reconciliation so canonical governance documents reject obsolete Phase C/D status and false live-host promotion.
+
+## Compatibility and Maturity Boundaries
+
+Codex, Claude Code, and Antigravity retain their supported integration surfaces. Cursor, Windsurf, VS Code/VSCodium, JetBrains, Zed, and Neovim remain scaffold-only. Version normalization does not graduate a scaffold or publish an IDE marketplace artifact.
+
+For Phase C continuity specifically, repository simulation is not live installed-host evidence. Installed Codex and Antigravity continuity remains `PENDING_LOCAL_HOST_VALIDATION`, and Claude Code active runtime-continuity capability must not be inferred from packaging support alone.
+
+## Authority and Security Boundaries
+
+Routing, governance approval, coordination readiness, validation success, audit evidence, GitHub mergeability, and API success do not create runtime or release authority. Existing trusted authority, immutable run-scoped capabilities, bounded delegation, lifecycle, evidence identity, and default-deny external-action controls remain in force.
+
+No new database, collaboration persistence, SQLite, migrations, RPC, network daemon, remote worker, background agent, production deployment, secret handling, or automatic policy activation is introduced by R6 release preparation.
+
+## Release-Candidate Validation
+
+The authoritative release-candidate evidence is the fresh exact-head matrix for the R6 pull request. Historical green runs are supporting context only and cannot authorize a newer head. Required repository evidence includes behavior, runtime, strict governance, prompt-load, structure, manifests, Claude plugin, Codex export, IDE packaging, compatibility, security, stale-reference, version consistency, and native Windows/Ubuntu/macOS validation as applicable to the exact candidate revision.
+
+## Publication Boundary
+
+R6 prepares repository metadata and documentation only. It does not create a `v1.2.0` tag, GitHub Release, deployment, marketplace publication, installed-host refresh, or policy activation.
+
+Publication requires:
+
+1. R6 release-preparation merge and independent canonical-main verification.
+2. R7 live installed-host evidence reconciliation.
+3. A fresh independently verified release state.
+4. Separate R8 publication authorization.
+5. Annotated `v1.2.0` tag and GitHub Release verification.
+
+Until those gates complete:
+
+```text
+RELEASE_CANDIDATE_VERSION=1.2.0
+CURRENT_PUBLIC_RELEASE=v1.1.2
+RELEASE_STATE=PREPARED_NOT_RELEASED
+LIVE_INSTALLED_HOST_VALIDATION=PENDING_LOCAL_HOST_VALIDATION
+```

--- a/docs/setup/COMPATIBILITY.md
+++ b/docs/setup/COMPATIBILITY.md
@@ -1,14 +1,14 @@
 # Compatibility
 
-The current public release is Orchestra `v1.1.2`. It keeps the Markdown-first, runtime-core-first baseline and adds trusted runtime authority, capabilities, delegation, lifecycle control, and audit evidence without changing host maturity claims.
+The current public GitHub Release is Orchestra `v1.1.2`. Repository release-candidate metadata is normalized to `1.2.0` for R6 preparation, but `v1.2.0` is `PREPARED_NOT_RELEASED` until the separate R8 tag/GitHub Release gate completes.
 
-Scaffold-only hosts are not yet full support claims. Promotion requirements and graduation order live in `docs/project/SCAFFOLD_ADAPTER_GRADUATION_CRITERIA.md`.
+Scaffold-only hosts are not full support claims. Promotion requirements and graduation order live in `docs/project/SCAFFOLD_ADAPTER_GRADUATION_CRITERIA.md`.
 
 | Host | Runtime Adapter | Status | Notes |
 |---|---|---|---|
-| Codex | `codex` | Supported | Marketplace-first, with repo-local fallback. |
-| Claude Code | `claude-code` | Supported | Marketplace metadata included. |
-| Antigravity | `antigravity` | Supported | Plugin install path remains host-native. |
+| Codex | `codex` | Supported | Marketplace-first, with repo-local fallback. R7 live continuity evidence remains pending for the v1.2.0 publication gate. |
+| Claude Code | `claude-code` | Supported packaging/integration | Marketplace metadata included. Phase C active runtime-continuity capability is not promoted beyond repository/scaffold evidence. |
+| Antigravity | `antigravity` | Supported | Plugin install path remains host-native. R7 live continuity evidence remains pending for the v1.2.0 publication gate. |
 | Cursor | `cursor` | Scaffold-only | Runtime adapter exists; packaging surface remains scaffold-only. |
 | Windsurf | `windsurf` | Scaffold-only | Runtime adapter exists; packaging surface remains scaffold-only. |
 | VS Code | `vscode` | Scaffold-only | Shared VS Code-family runtime adapter and packaging scaffold. |
@@ -17,5 +17,7 @@ Scaffold-only hosts are not yet full support claims. Promotion requirements and 
 | Zed | `zed` | Scaffold-only | Runtime adapter exists; packaging surface remains scaffold-only. |
 | Neovim | `neovim` | Scaffold-only | Runtime adapter exists; packaging surface remains scaffold-only. |
 | Local AI systems | manual | Supported | Load selected Markdown and supporting files manually. |
+
+Repository CI and deterministic host-reliability fixtures prove repository contracts only. They are not live installed-host evidence. R7 must reconcile the applicable installed Codex/Antigravity continuity evidence before `v1.2.0` publication.
 
 The repository does not guarantee automatic discovery in every IDE or model runtime. Use the adapter templates, packaging scaffolds, and runtime documentation when host behavior is uncertain.

--- a/docs/setup/INSTALLATION.md
+++ b/docs/setup/INSTALLATION.md
@@ -1,15 +1,17 @@
 # Installation
 
-Orchestra can be installed in several ways depending on your AI host or IDE:
+Orchestra can be installed in several ways depending on your AI host or IDE.
 
 ## Release Status
 
-The current public release is `v1.1.2`, published July 14, 2026 after the Phase 6D release gate completed.
+The current public GitHub Release is `v1.1.2`, published July 14, 2026. Repository manifests are normalized to release-candidate version `1.2.0` during R6, but `v1.2.0` is `PREPARED_NOT_RELEASED`: no `v1.2.0` tag or GitHub Release exists until the separate R8 publication gate is authorized and completed.
+
+If you install directly from the repository's `main` branch during this preparation window, treat `1.2.0` metadata as candidate state rather than proof of a published stable release. The update checker compares against the latest GitHub Release, which remains the publication source of truth.
 
 | Host | Install Surface | Current Status |
 |---|---|---|
 | Codex | Marketplace or repo-local fallback | Supported |
-| Claude Code | Marketplace plugin | Supported |
+| Claude Code | Marketplace plugin | Supported packaging/integration |
 | Antigravity | Native plugin install | Supported |
 | Cursor | Scaffold-only packaging and workspace instructions | Scaffold-only |
 | Windsurf | Scaffold-only packaging and workspace instructions | Scaffold-only |
@@ -19,6 +21,8 @@ The current public release is `v1.1.2`, published July 14, 2026 after the Phase 
 | Zed | Scaffold-only packaging and workspace instructions | Scaffold-only |
 | Neovim | Scaffold-only packaging and workspace instructions | Scaffold-only |
 | Local AI systems | Manual skill loading | Supported |
+
+R7 live installed-host continuity evidence remains a publication gate for `v1.2.0`; repository validation does not replace that evidence.
 
 ## 1. Antigravity Plugin Setup
 
@@ -67,7 +71,7 @@ powershell -ExecutionPolicy Bypass -File .\scripts\refresh-installed-integration
 
 Do not commit `.agents/` unless the repo intentionally shares those Codex skill files. For local-only setup, add `.agents/` to `.git/info/exclude`.
 
-The Codex refresh path now uses a temporary staging export by default. It reads tracked repository source, exports into a temp directory outside the repo, validates the staged export, installs from that staged copy, verifies parity, and then removes the temp directory. Generated runtime output is not written into tracked export folders during a normal refresh.
+The Codex refresh path uses a temporary staging export by default. It reads tracked repository source, exports into a temp directory outside the repo, validates the staged export, installs from that staged copy, verifies parity, and then removes the temp directory. Generated runtime output is not written into tracked export folders during a normal refresh.
 
 ## 3. Claude Code Plugin Setup
 
@@ -151,9 +155,9 @@ Run:
 python .\scripts\check_for_updates.py
 ```
 
-The script reads local version metadata from the root manifest, Claude plugin manifest, and adapter package manifests where applicable, then compares it to the latest GitHub release.
+The script reads local version metadata from the root manifest, Claude and Codex plugin manifests, and adapter package manifests, then compares it to the latest GitHub Release. During R6, local candidate metadata can be newer than the latest published release; that does not publish or downgrade either state.
 
-If a newer release exists, use your host-specific refresh or reinstall flow to update.
+If a newer public release exists, use your host-specific refresh or reinstall flow to update.
 
 ## Verify
 

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "name": "conductor",
   "display_name": "Orchestra",
   "description": "An installable AI workflow plugin that routes tasks through focused specialist skills. See SKILL_INDEX.md and ROUTING_MAP.md for detailed routing behavior.",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "license": "MIT",
   "repository": "https://github.com/Baelfyre/Orchestra",
   "icon_path": "assets/icons/conductor.ico",


### PR DESCRIPTION
## Summary

Prepares the Orchestra `v1.2.0` repository release candidate from the independently verified R5B baseline.

This PR is **release preparation only**. It does not create a tag, GitHub Release, deployment, marketplace graduation, installed-host mutation, or policy activation.

## Candidate state

- Repository candidate metadata: `1.2.0`
- Current public GitHub Release: `v1.1.2`
- Release state: `PREPARED_NOT_RELEASED`
- Phase C repository contract: complete through PR #225
- Phase C live installed-host evidence: `PENDING_LOCAL_HOST_VALIDATION`
- Phase D: complete through PR #226 with `NO_DUPLICATE_RUNTIME_EXTENSION_REQUIRED`
- R5 autonomous merge-readiness hardening: complete through PR #227
- R5B current-state reconciliation: merged and independently verified through PR #228

## Scope

Exactly 21 release-preparation paths:

- root/Claude/Codex version manifests
- six scaffold adapter package manifests plus JetBrains plugin metadata
- `README.md`
- `CHANGELOG.md`
- `PROJECT_CONTEXT.md`
- `PROJECT_STATE.md`
- `SESSION_HANDOFF.md`
- `docs/project/ROADMAP.md`
- `docs/setup/INSTALLATION.md`
- `docs/setup/COMPATIBILITY.md`
- `adapters/codex/README.md`
- new `docs/releases/v1.2.0-governed-orchestration-release-candidate.md`

No runtime code, skills, routing behavior, workflows, governance policy, persistence, database, deployment, or installed integrations are modified.

## Documentation closeout

- Consolidates the previously fragmented post-`v1.1.2` changelog into a release-oriented `v1.2.0` candidate record while retaining detailed history in Git/PR/decision/handoff evidence.
- Refreshes the README around the complete candidate capability set and explicit public-release/candidate distinction.
- Preserves scaffold-only host maturity and the repository-simulation versus live-host evidence boundary.

## Required evidence

This exact head must pass the repository's fresh Governance Check, behavior/runtime validation, and native Windows/Ubuntu/macOS validation. Any head change invalidates prior CI evidence.

`REPOSITORY_SIMULATION != LIVE_HOST_EVIDENCE`

R7 live installed-host validation remains mandatory before R8 publication.