### PR TITLE
fix: align autonomous merge governance with Protect main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,23 @@ This changelog records release-level Orchestra history. Detailed implementation 
 
 ## v1.2.0 Release Candidate - NOT RELEASED
 
-`v1.2.0` is prepared as a minor release candidate. Repository manifests are normalized to `1.2.0`, but the latest published GitHub Release remains `v1.1.2`. Accepted R7 live installed-host evidence is verified and reconciled locally; repository merge/post-merge verification and the separately governed R8 publication gate remain pending.
+`v1.2.0` is prepared as a minor release candidate. Repository manifests are normalized to `1.2.0`, but the latest published GitHub Release remains `v1.1.2`. Accepted R7 live installed-host evidence is verified and reconciled; release publication remains blocked pending merge-governance remediation, Governed Autonomy Modes, refreshed release evidence, and the separately authorized R8 publication gate.
 
 ### R7 Live-Host Evidence Reconciliation - Unreleased
 
 - Reconciled accepted locally installed-host evidence for Antigravity same-host reset/resume, Codex same-host reset/resume, and Codex -> Antigravity portable handoff.
 - Recorded Claude Code `SCAFFOLD_ONLY` packaging/contract compatibility without claiming active runtime continuity.
 - Preserved the repository-simulation/live-evidence boundary, including the unchanged pending/empty fixture live record set and canonical validator.
+- PR #230 merged the reviewed R7 content to canonical `main`; reviewed and canonical trees are equivalent, but GitHub's then-used rebase merge rewrote the reviewed commit identity and produced an unsigned canonical commit.
+- The maintainer chose a forward-only disposition: preserve canonical history, perform no force push/history rewrite, and treat PR #230 as incident evidence rather than future merge precedent.
 - Performed no publication, tag creation, deployment, installed-integration refresh, or policy activation.
+
+### R7 Merge-Governance Remediation - Unreleased
+
+- Align the autonomous merge-readiness contract with the current solo-maintainer `Protect main` ruleset: zero required approvals, conversation resolution, Squash-only merge, signed commits, linear history, branch-up-to-date enforcement, restricted deletion, and blocked force pushes.
+- Mirror all eight current required status checks: `governance-check`, `validate`, `runtime-tests`, native Windows/Ubuntu/macOS, `Analyze (actions)`, and `Analyze (python)`.
+- Replace ancestry-only post-merge verification with Squash-aware proof of exact pre-merge base, reviewed/canonical tree equivalence, empty content diff, and verified canonical commit signature.
+- Preserve the existing bypass list as operational repository capability while making `BYPASS_CAPABILITY != GOVERNANCE_AUTHORIZATION` an explicit fail-closed rule.
 
 ### Added
 
@@ -30,6 +39,7 @@ This changelog records release-level Orchestra history. Detailed implementation 
 - Normalized the root, Claude Code, Codex, and scaffold adapter version surfaces to `1.2.0` without changing adapter maturity or publishing any IDE marketplace package.
 - Updated README, project context/state, session handoff, roadmap, compatibility, installation, and Codex adapter documentation to distinguish release-candidate metadata from the current public release.
 - Consolidated the previously fragmented post-`v1.1.2` unreleased changelog entries into this release-candidate record while preserving detailed implementation evidence in Git and pull-request history.
+- Added Governed Autonomy Modes to the `v1.2.0` scope after R7 closeout and before R8 publication; affected release evidence must be refreshed after implementation.
 
 ### Clean Replay and Governance Hardening
 
@@ -42,8 +52,9 @@ The first autonomous finalization experiment was rolled back to the verified rec
 - R5 / PR #227 - autonomous merge-readiness hardening.
 - R5B / PR #228 - delegated-governance current-state reconciliation, merged at `fbe4532ba2083feaa7ed9fcda2988843f1237a78` and independently verified on canonical `main`.
 - R6 - `v1.2.0` release-candidate metadata, public documentation, changelog, and release-note preparation.
+- R7 / PR #230 - accepted live-host evidence merged; subsequent verification exposed the ancestry/signature mismatch caused by the then-used rebase merge and triggered forward-only ruleset/protocol remediation.
 
-Historical fail-open merge behavior from the first experiment is not successful validation precedent.
+Historical fail-open or bypass-capable platform behavior is not successful validation precedent.
 
 ### Capability Merge Map
 
@@ -66,12 +77,14 @@ Key post-`v1.1.2` canonical milestones include:
 - PR #226 - Delegated Phase D overlap reconciliation.
 - PR #227 - autonomous merge-readiness hardening.
 - PR #228 - delegated-governance current-state reconciliation.
+- PR #230 - R7 live installed-host evidence reconciliation.
 
 ### Compatibility and Authority Boundaries
 
 - Codex, Claude Code, and Antigravity retain supported integration surfaces; version normalization does not by itself prove live installed-host continuity.
 - Cursor, Windsurf, VS Code/VSCodium, JetBrains, Zed, and Neovim remain scaffold-only. No scaffold is graduated or marketplace-published by R6.
 - Existing authority, immutable run-scoped capabilities, bounded delegation, lifecycle, coordination ownership, evidence identity, and default-deny external-action controls remain unchanged.
+- Repository ruleset bypass capability is operational access only and does not itself authorize Orchestra to skip governance evidence or transitions.
 - No persistent collaboration storage, SQLite, migrations, RPC, network daemon, remote worker, background agent, production deployment, or automatic policy activation is added by the release candidate.
 
 ### Evidence Boundary
@@ -83,13 +96,13 @@ REPOSITORY_SIMULATION != LIVE_HOST_EVIDENCE
 LIVE_INSTALLED_HOST_VALIDATION=VERIFIED_RECONCILED_LOCALLY
 ```
 
-R7 host-derived evidence is verified and reconciled locally. Repository merge/post-merge verification and the separately authorized R8 publication gate remain required for publication.
+R7 host-derived evidence is verified and canonical content is merged. Forward-only merge-governance remediation, Governed Autonomy Modes, refreshed release verification, and the separately authorized R8 publication gate remain required for publication.
 
 ### Publication Boundary
 
-R6 does **not** create or publish `v1.2.0`. It performs no tag creation, GitHub Release publication, deployment, marketplace graduation, installed-host mutation, policy activation, force push, or history rewrite.
+The `v1.2.0` candidate is not a public release. No `v1.2.0` tag, GitHub Release publication, deployment, marketplace graduation, installed-host mutation, policy activation, force push, or history rewrite is authorized by the current finalization work.
 
-Publication requires a separately authorized R8 gate after R6 is merged and independently verified and R7 live-host evidence is reconciled.
+Publication requires R7 merge-governance remediation, GA-0 through GA-7 completion, refreshed release-readiness evidence, independent final verification, and a separately authorized R8 gate.
 
 ---
 

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -70,26 +70,77 @@ Clean replay results:
 - **R4:** Phase D overlap assessment merged through PR #226 only after the canonical baseline was green and every fresh required check passed.
 - **R5:** autonomous merge-readiness hardening merged through PR #227 at merge commit `467008db683c346cd086442dbb909c20a9248a3a`.
 - **R5B:** delegated-governance current-state reconciliation merged and was independently verified through PR #228 at merge commit `fbe4532ba2083feaa7ed9fcda2988843f1237a78`.
-- **R6:** `v1.2.0` release-candidate metadata and documentation are prepared on the governed release-preparation revision. This state is `PREPARED_NOT_RELEASED` and does not authorize publication.
+- **R6:** `v1.2.0` release-candidate metadata and documentation were prepared as `PREPARED_NOT_RELEASED` without publication authority.
+- **R7 / PR #230:** accepted live-host evidence was reviewed at head `f49a03c929be7df7c10c457a227a46532ef47854` and merged to canonical `main` as `80f9bc71f00cc86c0021fd9da258f2eec596d7e0`. GitHub's then-used rebase merge rewrote the reviewed commit identity. The reviewed and canonical trees are equal and their content diff is empty, but the canonical rebase commit is unsigned and the reviewed head is not in `main` ancestry.
 
-The incident-derived invariant is:
+Maintainer disposition for the PR #230 incident is forward-only:
+
+```text
+PRESERVE_CURRENT_CANONICAL_HISTORY=true
+HISTORY_REWRITE=false
+FORCE_PUSH=false
+PR230_REBASE_RESULT_IS_NOT_FUTURE_PRECEDENT=true
+```
+
+The incident exposed an ancestry-only post-merge verification assumption. R7 is not recorded as fully `MERGED_VERIFIED` until the forward-only merge-governance remediation is merged and independently verified under the current Squash-only ruleset.
+
+The incident-derived invariants are:
 
 ```text
 GITHUB_CAN_MERGE != GOVERNANCE_READY_TO_MERGE
+BYPASS_CAPABILITY != GOVERNANCE_AUTHORIZATION
 ```
 
 Autonomous merges follow `docs/governance/AUTONOMOUS_MERGE_READINESS_PROTOCOL.md`.
+
+## Current `Protect main` Ruleset
+
+The accepted solo-maintainer ruleset is:
+
+```text
+Required approvals: 0
+Dismiss stale approvals on new reviewable commits: ON
+Specific-team review: OFF
+Code Owner review: OFF
+Most-recent-push approval: OFF
+Conversation resolution: ON
+Allowed merge method: Squash only
+Restrict deletions: ON
+Linear history: ON
+Signed commits: ON
+Pull request required: ON
+Required status checks: ON
+Branch up to date before merge: ON
+Force pushes blocked: ON
+```
+
+Required status checks are:
+
+```text
+governance-check
+validate
+runtime-tests
+native-windows-latest
+native-ubuntu-latest
+native-macos-latest
+Analyze (actions)
+Analyze (python)
+```
+
+The current bypass list is intentionally retained for repository-operational access. Bypass capability is not governance authorization; ordinary governed automation must not rely on it to skip evidence or policy gates.
 
 ## Validation and Continuation
 
 - **Validation Rule:** Validation results are revision-specific. Historical green runs cannot authorize a newer head.
 - **Fail-Closed Rule:** Missing, pending, stale, skipped, cancelled, timed-out, or failed required checks cannot authorize merge.
+- **Ruleset Rule:** Live ruleset drift, non-Squash merge selection, unresolved review threads, or unauthorized bypass use blocks ordinary autonomous merge.
 - **Baseline Rule:** A new phase must not begin from a red canonical `main`.
-- **Post-Merge Rule:** An API response is not completion evidence; the PR and canonical `main` must be independently re-read before state advances.
+- **Post-Merge Rule:** An API response is not completion evidence. For Squash, canonical parent/tree/content/signature evidence and a canonical remote read are required before state advances.
 - **Issue #215:** Open umbrella finalization issue targeting `v1.2.0`.
 - **R6 Repository State:** `PREPARED_NOT_RELEASED`; candidate version surfaces are `1.2.0`, while the current public GitHub Release remains `v1.1.2`.
-- **R7 State:** Live installed-host evidence is verified and reconciled locally on the dedicated reconciliation worktree. Repository reconciliation merge and independent post-merge verification remain pending.
-- **Publication Boundary:** R8 `v1.2.0` tag/GitHub Release remains separately blocked pending independent post-R7 release verification and separate authorization.
+- **R7 State:** Live host evidence is accepted and PR #230 content is canonical, but the post-merge governance incident requires forward-only remediation before R7 closeout is recorded as `MERGED_VERIFIED`.
+- **Governed Autonomy Modes:** GA-0 through GA-7 are now part of the `v1.2.0` scope after R7 closeout and before R8 publication.
+- **Publication Boundary:** R8 `v1.2.0` tag/GitHub Release remains blocked until Governed Autonomy Modes is implemented, invalidated release evidence is refreshed, release state is independently verified, and separate publication authorization is granted.
 
 ## Local Startup Verification
 

--- a/docs/governance/AUTONOMOUS_MERGE_READINESS_PROTOCOL.md
+++ b/docs/governance/AUTONOMOUS_MERGE_READINESS_PROTOCOL.md
@@ -2,12 +2,13 @@
 
 ## Purpose
 
-This protocol defines Orchestra's fail-closed evidence gate for autonomous or delegated pull-request merges. It exists because GitHub may technically accept a merge even when repository validation is missing or red. Platform capability is not governance readiness.
+This protocol defines Orchestra's fail-closed evidence gate for autonomous or delegated pull-request merges. It exists because GitHub may technically accept a merge even when repository validation is missing, red, stale, or bypassable. Platform capability is not governance readiness.
 
-Canonical merge rule:
+Canonical merge rules:
 
 ```text
 GITHUB_CAN_MERGE != GOVERNANCE_READY_TO_MERGE
+BYPASS_CAPABILITY != GOVERNANCE_AUTHORIZATION
 ```
 
 This protocol does not grant merge authority. It constrains how already-authorized merge authority may be exercised.
@@ -21,11 +22,41 @@ PLATFORM_CAN_EXECUTE != GOVERNANCE_READY_TO_TRANSITION
 GITHUB_CAN_MERGE != GOVERNANCE_READY_TO_MERGE
 API_SUCCESS != VERIFIED_STATE
 NO_EVIDENCE != APPROVAL
+BYPASS_CAPABILITY != GOVERNANCE_AUTHORIZATION
 ```
 
 The parent rule applies to governed phase advancement and other material state transitions, including merge, release, deployment, policy activation, protected-state mutation, destructive operations, permanent deletion, and history rewrite. Missing, pending, stale, contradictory, or failed required evidence never grants permission. Evidence belongs to the exact current state and becomes invalid when that state changes. A red canonical baseline blocks ordinary progression except for explicitly authorized bounded remediation. A successful write is not a completed transition until an independent canonical read verifies the resulting state.
 
 Neither this protocol nor its parent rule creates or widens authority.
+
+## Canonical `Protect main` Profile
+
+The current Orchestra repository policy is a solo-maintainer profile. The ruleset may expose operational bypass capability to trusted roles/apps, but autonomous governance does not treat that capability as permission to skip this protocol.
+
+The canonical profile is:
+
+```text
+Required approving reviews: 0
+Dismiss stale approvals after new reviewable commits: ON
+Require review from specific teams: OFF
+Require Code Owner review: OFF
+Require approval of most recent reviewable push: OFF
+Require conversation resolution: ON
+
+Allowed merge methods: Squash only
+
+Restrict deletions: ON
+Require linear history: ON
+Require signed commits: ON
+Require pull request before merging: ON
+Require status checks to pass: ON
+Require branches to be up to date before merging: ON
+Block force pushes: ON
+```
+
+The bypass list is intentionally retained as repository-operational capability. It is non-authorizing for governed autonomous progression unless a separate explicit bypass authority is granted. Ordinary autonomous merge execution records `bypass_used=false`.
+
+A live ruleset that is stricter than this profile may constrain progression further. A live ruleset that materially weakens this profile is policy drift and blocks autonomous merge until reviewed.
 
 ## Required Evidence Snapshot
 
@@ -34,12 +65,16 @@ A pre-merge snapshot must bind all evidence to one exact current PR head SHA and
 - canonical base health;
 - current PR head SHA;
 - whether that head was re-read immediately before merge;
+- the live `Protect main` profile;
+- selected merge method;
+- whether bypass was used;
 - changelog freshness when significant paths changed;
 - unresolved blocking findings;
+- unresolved review-thread count;
 - Git mergeability state;
 - every required workflow/job result with its exact head SHA, status, and conclusion.
 
-The canonical minimum check inventory is:
+The canonical exact required-check inventory is:
 
 | Workflow | Required job |
 | --- | --- |
@@ -49,8 +84,10 @@ The canonical minimum check inventory is:
 | Cross-platform Validation | `native-windows-latest` |
 | Cross-platform Validation | `native-ubuntu-latest` |
 | Cross-platform Validation | `native-macos-latest` |
+| CodeQL | `Analyze (actions)` |
+| CodeQL | `Analyze (python)` |
 
-Repository rules may require additional checks. Additional required checks must also pass; this table is a minimum, not a bypass list.
+Repository rules may become stricter and require additional checks. Additional required checks must also pass; this table is a minimum exact profile for the current Orchestra ruleset, not a bypass list.
 
 ## Fail-Closed Interpretation
 
@@ -66,10 +103,14 @@ TIMED_OUT_REQUIRED_CHECK = BLOCK
 SKIPPED_REQUIRED_CHECK = BLOCK
 RED_CANONICAL_BASELINE = REMEDIATE_BASELINE_FIRST
 UNRESOLVED_BLOCKER = BLOCK
+UNRESOLVED_REVIEW_THREAD = BLOCK
 REQUIRED_CHANGELOG_MISSING = BLOCK
+RULESET_PROFILE_DRIFT = BLOCK
+MERGE_METHOD_NOT_SQUASH = BLOCK
+BYPASS_USED_WITHOUT_SEPARATE_AUTHORITY = BLOCK
 ```
 
-A high passing-test count, passing coverage threshold, `mergeable: true`, or a successful merge API call cannot override a failed or missing required check.
+A high passing-test count, passing coverage threshold, `mergeable: true`, a bypass-capable actor, or a successful merge API call cannot override a failed or missing required check.
 
 `mergeable: true` is informational only: it means Git can construct a merge. It never proves governance readiness.
 
@@ -82,14 +123,18 @@ Validation evidence is revision-specific.
 Before merge:
 
 1. Read the PR and capture the current head SHA.
-2. Fetch fresh required workflow/job state for that exact head.
-3. Require every required job to exist.
-4. Require every required job status to be `completed`.
-5. Require every required job conclusion to be `success`.
-6. Require every job's evidence head SHA to equal the current PR head SHA.
-7. Re-read the PR immediately before merge.
-8. If the head changed, discard prior evidence and return `STALE_EVIDENCE`.
-9. Use `expected_head_sha` or the platform's equivalent compare-and-swap guard when issuing the merge.
+2. Read the live ruleset and verify the effective policy remains compatible with the canonical profile.
+3. Require `Squash` as the selected merge method.
+4. Require ordinary governed execution to use no bypass.
+5. Fetch fresh required workflow/job state for that exact head.
+6. Require every required job to exist.
+7. Require every required job status to be `completed`.
+8. Require every required job conclusion to be `success`.
+9. Require every job's evidence head SHA to equal the current PR head SHA.
+10. Require zero unresolved review threads.
+11. Re-read the PR immediately before merge.
+12. If the head changed, discard prior evidence and return `STALE_EVIDENCE`.
+13. Use `expected_head_sha` or the platform's equivalent compare-and-swap guard when issuing the merge.
 
 Any remediation commit invalidates all earlier check evidence. The complete required matrix must be collected again for the new head.
 
@@ -107,6 +152,37 @@ A low-risk documentation-only next phase cannot bypass a failure inherited from 
 
 When repository governance classifies changed paths as significant, `CHANGELOG.md` must be updated in the same change set. A later release consolidation does not satisfy a current strict changelog gate unless the gate itself explicitly permits that behavior.
 
+## Squash-Merge Verification
+
+The Orchestra ruleset permits Squash only. A squash merge intentionally creates a new canonical commit SHA, so successful post-merge verification must not require the reviewed PR head SHA itself to remain in canonical `main` ancestry.
+
+Instead, the controller must prove that the canonical squash result is the exact reviewed change applied to the exact pre-merge base.
+
+Required evidence:
+
+- exact reviewed PR head SHA;
+- exact pre-merge base SHA;
+- exact reviewed head tree SHA;
+- exact canonical main SHA after merge;
+- exact canonical main parent SHA;
+- exact canonical tree SHA after merge;
+- empty content diff between the reviewed head tree and canonical result;
+- verified signature on the canonical squash commit;
+- independent canonical remote read.
+
+Required equivalence:
+
+```text
+canonical_tree == reviewed_tree
+canonical_parent == pre_merge_base
+content_diff_empty == true
+canonical_signature_verified == true
+```
+
+Tree/content equivalence is not a substitute for pre-merge exact-head CI. It is the post-write proof that the newly created squash commit contains exactly the already-reviewed result.
+
+A rebase merge is not valid under the current ruleset. A merge commit is not valid while linear history is required.
+
 ## Post-Merge Verification
 
 A merge write is not complete merely because an API returned success.
@@ -114,8 +190,12 @@ A merge write is not complete merely because an API returned success.
 The controller must perform a canonical remote read after the write and verify:
 
 - the PR now reports `merged == true`;
-- the reviewed head is contained in canonical `main`;
-- the canonical main SHA is resolved from the remote;
+- the observed merge method is `squash`;
+- the exact canonical main SHA is resolved from the remote;
+- the canonical parent equals the exact pre-merge base;
+- the canonical tree equals the reviewed head tree;
+- the reviewed-head-to-canonical content diff is empty;
+- the canonical squash commit has a verified signature;
 - the remote read corresponds to the intended repository and PR.
 
 Only then may state advance to:
@@ -130,13 +210,19 @@ Otherwise:
 MERGE_STATE_UNVERIFIED
 ```
 
-An intended action, attempted action, or successful API response must not be recorded as executed fact without this independent canonical remote read.
+An intended action, attempted action, successful API response, or actor bypass capability must not be recorded as executed governance fact without this independent canonical remote read.
+
+## PR #230 Historical Incident Boundary
+
+PR #230 exposed the previous ancestry-only post-merge assumption. Its reviewed head `f49a03c929be7df7c10c457a227a46532ef47854` and canonical rebase result `80f9bc71f00cc86c0021fd9da258f2eec596d7e0` have equivalent trees/content, but the reviewed head is not in canonical ancestry and the platform-generated canonical commit is unsigned.
+
+The repository history must not be rewritten merely to satisfy the old validator. That incident requires an explicit human canonical-history disposition and forward-only governance remediation. It is not successful precedent for future unsigned or rebase merges.
 
 ## Server-Side Protection
 
-Repository branch protection or rulesets should independently require the same current checks and should apply to administrators/automation where practical. The client-side protocol remains mandatory even when server-side protection exists.
+Repository rulesets should independently enforce the current profile and required checks where practical. The client-side protocol remains mandatory even when server-side protection exists or an actor is present on the bypass list.
 
-The existence of this protocol must not be used to claim that GitHub branch protection is configured. Repository settings must be verified separately.
+The existence of this protocol must not be used to claim a ruleset is configured. Repository settings must be verified separately.
 
 ## Repository Simulation vs Live Evidence
 
@@ -150,4 +236,4 @@ The executable contract is:
 - `tests/behavior/autonomous-merge-readiness-fixtures.json`
 - `tests/runtime/test_autonomous_merge_readiness_contract.py`
 
-The fixtures intentionally cover the failure modes observed during the first autonomous finalization experiment, including missing check data, pending jobs, failed governance/runtime/cross-platform checks, stale heads, red baseline progression, changelog omission, mergeability misuse, and unverified post-merge state.
+The fixtures intentionally cover missing check data, pending jobs, failed governance/runtime/cross-platform/CodeQL checks, stale heads, red baseline progression, changelog omission, mergeability misuse, ruleset drift, unauthorized bypass use, non-Squash merge selection, unresolved review threads, tree mismatch, parent drift, unsigned canonical commits, and unverified post-merge state.

--- a/docs/governance/BRANCH_PROTECTION_SETUP_GUIDE.md
+++ b/docs/governance/BRANCH_PROTECTION_SETUP_GUIDE.md
@@ -2,15 +2,15 @@
 
 ## Purpose
 
-This guide provides the recommended GitHub branch protection or ruleset setup for Orchestra's `main` branch.
+This guide records the current GitHub `Protect main` ruleset baseline for Orchestra's `main` branch and the validation signals that the automation layer must mirror.
 
-It mirrors the fail-closed merge evidence defined by `REQUIRED_STATUS_CHECKS_REVIEW.md` and `AUTONOMOUS_MERGE_READINESS_PROTOCOL.md`.
+It is aligned with `REQUIRED_STATUS_CHECKS_REVIEW.md` and `AUTONOMOUS_MERGE_READINESS_PROTOCOL.md`.
 
 ## Scope
 
 This guide is documentation-only. It does not configure GitHub settings automatically.
 
-The existence of this file must never be treated as evidence that protection is active. Repository settings must be inspected and tested separately by an administrator with access to the live configuration.
+The existence of this file must never be treated as evidence that protection is active. Repository settings must be inspected and tested separately through the live GitHub configuration.
 
 ## Protected Branch
 
@@ -18,81 +18,110 @@ Protect:
 
 - `main`
 
-## Minimum Required Validation Signals
+## Current Required Validation Signals
 
-Require the active GitHub check contexts corresponding to these minimum jobs before merging into `main`:
+Require the active GitHub check contexts corresponding to these jobs before merging into `main`:
 
 - Governance Check / `governance-check`;
 - validate / `validate`;
 - validate / `runtime-tests`;
 - Cross-platform Validation / `native-windows-latest`;
 - Cross-platform Validation / `native-ubuntu-latest`;
-- Cross-platform Validation / `native-macos-latest`.
-
-Additional security, CodeQL, or repository-specific required checks remain additive.
+- Cross-platform Validation / `native-macos-latest`;
+- CodeQL / `Analyze (actions)`;
+- CodeQL / `Analyze (python)`.
 
 Workflow and job names are distinct concepts in GitHub. When configuring rules, select the actual check contexts presented by a current pull request rather than assuming the human-readable workflow title is the exact stored context.
 
-## Recommended Protection Settings
+## Current Solo-Maintainer Protection Profile
 
-Enable, where supported by the repository plan:
+The accepted `Protect main` settings are:
 
-1. Require a pull request before merging.
-2. Require status checks to pass before merging.
-3. Require the minimum validation signals above.
-4. Require branches to be up to date before merging when that does not conflict with the repository's merge strategy.
-5. Require conversation resolution before merging.
-6. Block force pushes to `main`.
-7. Block deletion of `main`.
-8. Apply protection to administrators and automation/bot identities where practical so privileged credentials do not silently bypass red checks.
+```text
+Restrict creations: OFF
+Restrict updates: OFF
+Restrict deletions: ON
+Require linear history: ON
+Require deployments to succeed: OFF
+Require signed commits: ON
+Require a pull request before merging: ON
+Required approvals: 0
+Dismiss stale approvals when new commits are pushed: ON
+Require review from specific teams: OFF
+Require review from Code Owners: OFF
+Require approval of the most recent reviewable push: OFF
+Require conversation resolution before merging: ON
+Allowed merge methods: Squash only
+Require status checks to pass: ON
+Require branches to be up to date before merging: ON
+Do not require status checks on creation: OFF
+Block force pushes: ON
+Require code scanning results: OFF
+Require code quality results: OFF
+Restrict code coverage: OFF
+Automatically request Copilot code review: OFF
+```
 
-Optional according to maintainer policy:
+The bypass list is intentionally retained for operational access by trusted roles/apps. Do not treat membership in that list as governance authorization.
 
-- signed commits;
-- linear history;
-- independent review approval;
-- merge queue.
+```text
+BYPASS_CAPABILITY != GOVERNANCE_AUTHORIZATION
+```
 
-A merge queue is preferable for high-concurrency development because GitHub can validate the final merge candidate instead of relying only on an earlier head snapshot.
+Ordinary governed autonomous execution must still use the pull-request path, exact-head evidence, Squash merge, and independent post-merge verification. Any deliberate bypass is a separate authority decision.
 
-## Setup Steps
+## Why Squash Only
+
+The ruleset requires linear history and signed commits. Orchestra therefore standardizes autonomous merging on Squash for this repository.
+
+A squash merge creates a new canonical commit SHA. Post-merge verification must validate the canonical squash result rather than require the reviewed PR head SHA to remain in `main` ancestry.
+
+Required post-merge proof includes:
+
+- reviewed head SHA and tree;
+- exact pre-merge base;
+- canonical squash commit and parent;
+- canonical tree equals reviewed tree;
+- reviewed-to-canonical content diff is empty;
+- canonical squash commit signature is verified;
+- independent canonical remote read.
+
+Rebase is not an allowed merge method under the current ruleset. Merge commits are incompatible with the current linear-history requirement.
+
+## Setup / Review Steps
 
 1. Open the Orchestra repository on GitHub.
-2. Open `Settings` and the repository's branch-protection or ruleset controls.
-3. Create or edit the rule targeting `main`.
-4. Enable pull-request and required-status-check enforcement.
-5. Use a current test PR to identify the actual check contexts for:
-   - `governance-check`;
-   - `validate`;
-   - `runtime-tests`;
-   - `native-windows-latest`;
-   - `native-ubuntu-latest`;
-   - `native-macos-latest`.
-6. Add those contexts as required.
-7. Configure administrator/automation bypass policy deliberately; avoid broad bypass for autonomous development credentials.
-8. Block force pushes and branch deletion for `main`.
-9. Save the rule.
+2. Open `Settings` -> `Rules` -> `Rulesets` -> `Protect main`.
+3. Confirm the rule targets `main` and is Active.
+4. Confirm the solo-maintainer protection profile above.
+5. Confirm Allowed merge methods is `Squash` only.
+6. Confirm all eight required check contexts are present.
+7. Confirm required approvals remains `0` while the repository has no independent maintainer reviewer.
+8. Confirm conversation resolution, signed commits, linear history, branch-up-to-date, restricted deletion, and blocked force pushes remain enabled.
+9. Leave the current bypass list unchanged unless a separate repository-hardening decision explicitly changes it.
+10. Save changes and use a current PR to verify enforcement behavior.
 
 ## Mandatory Verification After Setup
 
-Use a disposable test PR or another safe controlled change and prove all of the following from the live GitHub UI/settings behavior:
+Use a safe controlled PR and prove all of the following from live GitHub behavior:
 
-1. The PR cannot merge while a required check is queued or in progress.
-2. The PR cannot merge when `governance-check` fails.
-3. The PR cannot merge when `runtime-tests` fails even if coverage remains above threshold.
-4. The PR cannot merge when any native Windows, Ubuntu, or macOS job fails.
-5. The PR cannot merge when a required check is missing.
-6. The PR can merge only after all required checks pass.
-7. The automation identity used for autonomous development cannot bypass these failures unless a separately governed emergency path explicitly permits it.
-8. Direct pushes, force pushes, and deletion of `main` behave exactly as the documented policy expects.
+1. The PR cannot ordinarily merge while a required check is queued or in progress.
+2. The PR cannot ordinarily merge when `governance-check` fails.
+3. The PR cannot ordinarily merge when `runtime-tests` fails.
+4. The PR cannot ordinarily merge when any native Windows, Ubuntu, or macOS job fails.
+5. The PR cannot ordinarily merge when either required CodeQL Analyze job fails or is missing.
+6. The PR cannot ordinarily merge with unresolved review conversations.
+7. The branch must be up to date before merge.
+8. Squash is the only ordinary merge method offered by the ruleset.
+9. The resulting canonical squash commit has a verified signature.
+10. Direct force pushes and deletion of `main` are blocked for non-bypass operation.
+11. The existence of bypass-capable actors does not cause Orchestra's client-side controller to skip evidence or record a bypassed transition as governance-ready.
 
-Do not mark branch protection verified until these behaviors are observed. A settings screenshot or configured rule name alone is weaker evidence than an actual blocked-merge test.
+Do not mark branch protection verified solely from a screenshot or rule name. Live merge behavior and independent canonical reads are stronger evidence.
 
 ## Client-Side Protocol Still Applies
 
 Server-side protection is defense in depth. Autonomous execution must still follow `AUTONOMOUS_MERGE_READINESS_PROTOCOL.md`.
-
-In particular:
 
 ```text
 missing checks -> WAIT_FOR_EVIDENCE
@@ -100,20 +129,23 @@ pending checks -> WAIT_FOR_EVIDENCE
 failed required check -> BLOCK
 stale head -> STALE_EVIDENCE
 red main baseline -> REMEDIATE_BASELINE_FIRST
+ruleset drift -> BLOCK
+non-Squash merge -> BLOCK
+unauthorized bypass -> BLOCK
 ```
 
-`mergeable: true` and a merge API that would accept the request do not override those results.
+`mergeable: true`, a bypass-capable actor, and a merge API that would accept the request do not override those results.
 
 ## Workflow Migration Notes
 
-Do not retire or rename a validation workflow/job until:
+Do not retire or rename a required validation workflow/job until:
 
 - the replacement signal is visible and green on `main` and pull requests;
-- the live branch protection/ruleset is updated;
+- the live ruleset is updated;
 - the autonomous merge-readiness inventory is updated;
 - the migration is documented in `CHANGELOG.md`;
-- the new signal has been proven to block a deliberately failing test PR.
+- the new signal has been proven on a controlled pull request.
 
 ## Current Recommendation
 
-Keep Governance Check, validate, and Cross-platform Validation active. Require their six minimum jobs as merge evidence until a separately validated CI consolidation replaces this contract.
+Keep the current `Protect main` profile unchanged unless a separately reviewed repository-policy change is required. Keep all eight required checks active and keep Squash as the only allowed merge method.

--- a/docs/governance/REQUIRED_STATUS_CHECKS_REVIEW.md
+++ b/docs/governance/REQUIRED_STATUS_CHECKS_REVIEW.md
@@ -2,17 +2,18 @@
 
 ## Purpose
 
-This document defines Orchestra's current minimum validation evidence for pull requests targeting `main` and the recommended GitHub protection that should mirror it.
+This document defines Orchestra's current validation evidence for pull requests targeting `main` and the live GitHub `Protect main` ruleset that mirrors it.
 
-The first autonomous finalization experiment demonstrated that GitHub may technically accept a merge while repository validation is red. Therefore required-check policy is fail-closed at both the automation layer and, where configured, the GitHub branch-protection/ruleset layer.
+The autonomous finalization incidents demonstrated that GitHub may technically accept a merge while repository validation is red, while a privileged actor has bypass capability, or while the selected merge method does not preserve the evidence assumptions used by the controller. Required-check policy is therefore fail-closed at both the automation layer and the GitHub ruleset layer.
 
-Canonical rule:
+Canonical rules:
 
 ```text
 GITHUB_CAN_MERGE != GOVERNANCE_READY_TO_MERGE
+BYPASS_CAPABILITY != GOVERNANCE_AUTHORIZATION
 ```
 
-## Current Validation Workflows and Minimum Jobs
+## Current Required Validation Signals
 
 | Workflow | Required job | Requirement | Reason |
 | --- | --- | --- | --- |
@@ -22,8 +23,33 @@ GITHUB_CAN_MERGE != GOVERNANCE_READY_TO_MERGE
 | Cross-platform Validation | `native-windows-latest` | Required | Native Windows repository/runtime validation |
 | Cross-platform Validation | `native-ubuntu-latest` | Required | Native Ubuntu repository/runtime validation |
 | Cross-platform Validation | `native-macos-latest` | Required | Native macOS repository/runtime validation |
+| CodeQL | `Analyze (actions)` | Required | GitHub Actions security/code-analysis signal required by the live ruleset |
+| CodeQL | `Analyze (python)` | Required | Python security/code-analysis signal required by the live ruleset |
 
-Additional checks required by repository rules, security tooling, CodeQL, or a specific phase remain additive. This table is the minimum autonomous merge evidence inventory, not a bypass list.
+Additional checks required by a stricter future repository rule or a specific phase remain additive. This table is the current exact autonomous merge evidence inventory, not a bypass list.
+
+## Current `Protect main` Ruleset Baseline
+
+The live Orchestra ruleset is intentionally configured for a solo maintainer:
+
+```text
+Required approvals: 0
+Dismiss stale PR approvals when new commits are pushed: ON
+Require review from specific teams: OFF
+Require Code Owner review: OFF
+Require approval of most recent reviewable push: OFF
+Require conversation resolution: ON
+Allowed merge methods: Squash only
+Restrict deletions: ON
+Require linear history: ON
+Require signed commits: ON
+Require pull request before merging: ON
+Require status checks to pass: ON
+Require branches to be up to date before merging: ON
+Block force pushes: ON
+```
+
+The repository bypass list remains available for operational access by trusted roles/apps. Its existence does not grant Orchestra governance authority and does not make a bypassed transition valid. Ordinary governed automation records and requires `bypass_used=false`; any future deliberate bypass requires separate explicit authority and evidence.
 
 ## Fail-Closed Interpretation
 
@@ -43,50 +69,53 @@ The following states do not authorize merge:
 - check evidence tied to an earlier PR head;
 - red canonical `main` baseline;
 - unresolved blocking finding;
-- missing changelog update when strict governance classifies changed paths as significant.
+- unresolved review thread;
+- missing changelog update when strict governance classifies changed paths as significant;
+- live ruleset drift from the accepted protection profile;
+- merge method other than Squash;
+- use of bypass without separate explicit authority.
 
 Missing or pending evidence maps to `WAIT_FOR_EVIDENCE`. Failed required evidence maps to `BLOCK` or bounded remediation followed by complete revalidation.
 
 ## Exact-Head Requirement
 
-A remediation commit invalidates prior check evidence. The complete minimum matrix must be collected again on the new head.
+A remediation commit invalidates prior check evidence. The complete required matrix must be collected again on the new head.
 
 Immediately before merge:
 
 1. Re-read the PR and confirm its exact head SHA.
-2. Re-read every required workflow/job for that SHA.
-3. Require all minimum jobs and any additional repository-required checks to be completed and successful.
-4. Use `expected_head_sha` or the platform's equivalent compare-and-swap guard where supported.
-5. After the merge write, independently re-read the PR and canonical `main` before recording `MERGED_VERIFIED`.
+2. Re-read the live ruleset and selected merge method.
+3. Require all eight current required jobs and any additional repository-required checks to be completed and successful for that exact head.
+4. Require zero unresolved review threads.
+5. Require Squash as the selected merge method.
+6. Require no bypass for ordinary governed execution.
+7. Use `expected_head_sha` or the platform's equivalent compare-and-swap guard where supported.
+8. After the merge write, independently re-read the PR and canonical `main` before recording `MERGED_VERIFIED`.
 
 `mergeable: true` is informational only. It means Git can construct a merge; it does not prove validation or governance readiness.
 
+Because Squash creates a new canonical commit identity, post-merge verification follows `AUTONOMOUS_MERGE_READINESS_PROTOCOL.md`: verify the exact canonical parent, tree/content equivalence to the reviewed head, and verified signature on the canonical squash commit rather than requiring the reviewed head SHA itself to remain in `main` ancestry.
+
 The executable companion contract is `docs/governance/AUTONOMOUS_MERGE_READINESS_PROTOCOL.md` with `scripts/validate_autonomous_merge_readiness_contract.py` and its regression fixtures/tests.
 
-## GitHub Protection Recommendation
+## GitHub Protection Alignment
 
-GitHub branch protection or rulesets for `main` should require the active check contexts corresponding to the minimum jobs above and should apply to administrators and automation identities where practical.
+The live `Protect main` ruleset should continue to require the active contexts listed above, Squash-only merging, signed and linear canonical history, current-base testing, conversation resolution, pull-request flow, restricted deletion, and blocked force pushes.
 
-Do not infer that repository protection is configured merely because this document exists. The live repository settings must be inspected and tested separately.
+The current bypass list is an operational repository setting. The automation-side fail-closed protocol remains mandatory even for actors technically capable of bypassing the ruleset.
 
-The automation-side fail-closed protocol remains mandatory even when GitHub protection is configured, because governance must not rely on a platform merge button or API call as its only safety boundary.
+Do not infer that the repository settings still match this document merely because the document exists. The live ruleset must be re-read before an autonomous merge.
 
 ## Workflow Migration Policy
 
 Do not remove, rename, consolidate, or convert a workflow to manual-only while it supplies a required merge signal unless all of the following are true:
 
 1. The replacement workflow/job is already running successfully on `main` and pull requests.
-2. Branch protection/rulesets have been reviewed and updated.
+2. The live ruleset has been reviewed and updated.
 3. The autonomous merge-readiness inventory has been updated.
 4. The migration is recorded in `CHANGELOG.md`.
 5. A PR proves the old and new check names are observable before the old check disappears.
 
 ## Current Recommendation
 
-Keep all three workflow families active:
-
-- Governance Check;
-- validate;
-- Cross-platform Validation.
-
-Treat all six minimum jobs listed above as required autonomous merge evidence until a separately validated CI consolidation changes this contract.
+Keep Governance Check, validate, Cross-platform Validation, and the two CodeQL Analyze jobs active. Treat all eight jobs listed above as required autonomous merge evidence until a separately validated CI or ruleset change replaces this contract.

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -54,8 +54,33 @@ Phases 6B-A through 6C are complete and merged through PR #183. Phase 6D produce
 - [x] R5: autonomous merge-readiness hardening through PR #227.
 - [x] R5B: delegated-governance current-state reconciliation through PR #228.
 - [x] R6 repository preparation: version surfaces, public current-state documentation, compatibility/install boundaries, changelog consolidation, and `v1.2.0` release-candidate notes prepared as `PREPARED_NOT_RELEASED`.
-- [x] R7: reconcile live installed-host evidence locally; maintainer review, repository reconciliation merge, and independent post-merge verification remain pending.
-- [ ] R8: create annotated `v1.2.0` tag and GitHub Release only from independently verified release state.
+- [x] R7 evidence reconciliation: PR #230 merged accepted live-host evidence into canonical `main`; reviewed and canonical trees are byte-equivalent.
+- [ ] R7R merge-governance remediation: close the PR #230 ancestry/signature incident forward-only by aligning autonomous merge verification with the current Squash-only `Protect main` ruleset, eight required status checks, signed/linear history, and non-authorizing bypass capability.
+- [ ] GA-0: Governed Autonomy Modes architecture and overlap audit; prove `NO_DUPLICATE_AUTHORITY_MODEL` before implementation.
+- [ ] GA-1: Canonical `HUMAN_GOVERNED`, `SEMI_AUTONOMOUS`, and `FULL_AUTONOMOUS` profile contract.
+- [ ] GA-2: Authority-envelope integration and precedence enforcement.
+- [ ] GA-3: Host-neutral user mode-selection gate with safe Human-Governed default.
+- [ ] GA-4: Autonomous transition integration across implementation, remediation, commit, push, PR, CI, Squash merge, post-merge verification, and authorized next-phase progression.
+- [ ] GA-5: Audit, provenance, interruption recovery, delegation inheritance, and portable-resume preservation.
+- [ ] GA-6: Adversarial validation, including solo-maintainer approvals=0, ruleset drift, bypass capability without authority, missing/stale CI, non-Squash merge attempts, unsigned canonical commits, and scope escalation.
+- [ ] GA-7: Documentation and adoption after the implemented architecture is validated.
+- [ ] Refresh every release-readiness artifact invalidated by R7R or GA implementation and independently verify the final candidate.
+- [ ] R8: create annotated `v1.2.0` tag and GitHub Release only after the refreshed candidate is independently verified and separate publication authority is granted.
+
+### Current `Protect main` Development Baseline
+
+The current repository policy is a solo-maintainer ruleset with zero required approvals, conversation resolution, Squash-only merge, signed commits, linear history, branch-up-to-date enforcement, restricted deletion, blocked force pushes, and these eight required check contexts:
+
+- `governance-check`;
+- `validate`;
+- `runtime-tests`;
+- `native-windows-latest`;
+- `native-ubuntu-latest`;
+- `native-macos-latest`;
+- `Analyze (actions)`;
+- `Analyze (python)`.
+
+The existing bypass list remains operationally available. Orchestra governance must not treat bypass capability as transition authority.
 
 ## Deferred and Future Work
 
@@ -81,4 +106,4 @@ Phases 6B-A through 6C are complete and merged through PR #183. Phase 6D produce
 - [ ] Add an optional local-model retrieval index.
 - [ ] Improve adapters as tool capabilities change.
 - [ ] Expand fictional, project-agnostic examples.
-- [ ] Publish `v1.2.0` only after R7 host-derived evidence, exact-head release verification, and the separate R8 publication gate are completed.
+- [ ] Publish `v1.2.0` only after R7R, GA-0 through GA-7, refreshed release evidence, independent final verification, and the separate R8 publication gate are completed.

--- a/scripts/validate_autonomous_merge_readiness_contract.py
+++ b/scripts/validate_autonomous_merge_readiness_contract.py
@@ -4,7 +4,7 @@ import re
 import sys
 from pathlib import Path
 
-SCHEMA_VERSION = "orchestra-autonomous-merge-readiness-v1"
+SCHEMA_VERSION = "orchestra-autonomous-merge-readiness-v2"
 
 REQUIRED_CHECKS = (
     ("Governance Check", "governance-check"),
@@ -13,7 +13,26 @@ REQUIRED_CHECKS = (
     ("Cross-platform Validation", "native-windows-latest"),
     ("Cross-platform Validation", "native-ubuntu-latest"),
     ("Cross-platform Validation", "native-macos-latest"),
+    ("CodeQL", "Analyze (actions)"),
+    ("CodeQL", "Analyze (python)"),
 )
+
+EXPECTED_RULESET = {
+    "required_approvals": 0,
+    "dismiss_stale_approvals": True,
+    "require_specific_teams": False,
+    "require_code_owner_review": False,
+    "require_latest_push_approval": False,
+    "require_conversation_resolution": True,
+    "allowed_merge_methods": ["squash"],
+    "require_linear_history": True,
+    "require_signed_commits": True,
+    "require_pull_request": True,
+    "require_status_checks": True,
+    "require_branches_up_to_date": True,
+    "block_force_pushes": True,
+    "restrict_deletions": True,
+}
 
 CHECK_STATUSES = {"queued", "in_progress", "completed"}
 PASS_CONCLUSION = "success"
@@ -36,6 +55,13 @@ def check_token(check):
     return f"{check.get('workflow', '')}/{check.get('job', '')}"
 
 
+def ruleset_matches(snapshot):
+    ruleset = snapshot.get("ruleset")
+    if not isinstance(ruleset, dict):
+        return False
+    return all(ruleset.get(key) == value for key, value in EXPECTED_RULESET.items())
+
+
 def evaluate_pre_merge(snapshot):
     if snapshot.get("base_health") != "GREEN":
         return "REMEDIATE_BASELINE_FIRST"
@@ -44,7 +70,19 @@ def evaluate_pre_merge(snapshot):
     if not SHA40.fullmatch(current_head):
         return "BLOCK"
 
+    if not ruleset_matches(snapshot):
+        return "BLOCK"
+
+    if snapshot.get("selected_merge_method") != "squash":
+        return "BLOCK"
+
+    if snapshot.get("bypass_used") is not False:
+        return "BLOCK"
+
     if snapshot.get("unresolved_blockers", 0) != 0:
+        return "BLOCK"
+
+    if snapshot.get("unresolved_review_threads", 0) != 0:
         return "BLOCK"
 
     if snapshot.get("changelog_required") and not snapshot.get("changelog_updated"):
@@ -94,12 +132,34 @@ def evaluate_post_merge(snapshot):
         return "MERGE_STATE_UNVERIFIED"
     if snapshot.get("pr_merged") is not True:
         return "MERGE_STATE_UNVERIFIED"
-    if snapshot.get("main_contains_reviewed_head") is not True:
+    if snapshot.get("merge_method") != "squash":
         return "MERGE_STATE_UNVERIFIED"
 
     reviewed = str(snapshot.get("reviewed_head_sha", ""))
     canonical_main = str(snapshot.get("canonical_main_sha", ""))
-    if not SHA40.fullmatch(reviewed) or not SHA40.fullmatch(canonical_main):
+    reviewed_tree = str(snapshot.get("reviewed_tree_sha", ""))
+    canonical_tree = str(snapshot.get("canonical_tree_sha", ""))
+    pre_merge_base = str(snapshot.get("pre_merge_base_sha", ""))
+    canonical_parent = str(snapshot.get("canonical_parent_sha", ""))
+
+    for value in (
+        reviewed,
+        canonical_main,
+        reviewed_tree,
+        canonical_tree,
+        pre_merge_base,
+        canonical_parent,
+    ):
+        if not SHA40.fullmatch(value):
+            return "MERGE_STATE_UNVERIFIED"
+
+    if reviewed_tree != canonical_tree:
+        return "MERGE_STATE_UNVERIFIED"
+    if snapshot.get("content_diff_empty") is not True:
+        return "MERGE_STATE_UNVERIFIED"
+    if canonical_parent != pre_merge_base:
+        return "MERGE_STATE_UNVERIFIED"
+    if snapshot.get("canonical_signature_verified") is not True:
         return "MERGE_STATE_UNVERIFIED"
 
     return "MERGED_VERIFIED"
@@ -110,6 +170,10 @@ def materialize_pre_merge_case(data, case):
 
     for key, value in case.get("overrides", {}).items():
         snapshot[key] = copy.deepcopy(value)
+
+    ruleset_overrides = case.get("ruleset_overrides", {})
+    if ruleset_overrides:
+        snapshot.setdefault("ruleset", {}).update(copy.deepcopy(ruleset_overrides))
 
     remove_check = case.get("remove_check")
     if remove_check:
@@ -142,6 +206,9 @@ def validate_fixtures(data):
         errors.append(
             "required_checks must match the canonical exact required-check inventory"
         )
+
+    if data.get("expected_ruleset") != EXPECTED_RULESET:
+        errors.append("expected_ruleset must match the canonical Protect main profile")
 
     base_snapshot = data.get("base_snapshot")
     if not isinstance(base_snapshot, dict):
@@ -223,11 +290,14 @@ def validate(root):
         "GITHUB_CAN_MERGE != GOVERNANCE_READY_TO_MERGE",
         "API_SUCCESS != VERIFIED_STATE",
         "NO_EVIDENCE != APPROVAL",
+        "BYPASS_CAPABILITY != GOVERNANCE_AUTHORIZATION",
         "NO_CHECK_DATA = WAIT_FOR_EVIDENCE",
-        "mergeable",
+        "Squash",
         "expected_head_sha",
         "MERGED_VERIFIED",
         "canonical remote read",
+        "canonical tree",
+        "verified signature",
         "red canonical baseline",
     )
     for term in required_terms:

--- a/tests/behavior/autonomous-merge-readiness-fixtures.json
+++ b/tests/behavior/autonomous-merge-readiness-fixtures.json
@@ -1,13 +1,31 @@
 {
-  "schema_version": "orchestra-autonomous-merge-readiness-v1",
+  "schema_version": "orchestra-autonomous-merge-readiness-v2",
   "required_checks": [
     {"workflow": "Governance Check", "job": "governance-check"},
     {"workflow": "validate", "job": "validate"},
     {"workflow": "validate", "job": "runtime-tests"},
     {"workflow": "Cross-platform Validation", "job": "native-windows-latest"},
     {"workflow": "Cross-platform Validation", "job": "native-ubuntu-latest"},
-    {"workflow": "Cross-platform Validation", "job": "native-macos-latest"}
+    {"workflow": "Cross-platform Validation", "job": "native-macos-latest"},
+    {"workflow": "CodeQL", "job": "Analyze (actions)"},
+    {"workflow": "CodeQL", "job": "Analyze (python)"}
   ],
+  "expected_ruleset": {
+    "required_approvals": 0,
+    "dismiss_stale_approvals": true,
+    "require_specific_teams": false,
+    "require_code_owner_review": false,
+    "require_latest_push_approval": false,
+    "require_conversation_resolution": true,
+    "allowed_merge_methods": ["squash"],
+    "require_linear_history": true,
+    "require_signed_commits": true,
+    "require_pull_request": true,
+    "require_status_checks": true,
+    "require_branches_up_to_date": true,
+    "block_force_pushes": true,
+    "restrict_deletions": true
+  },
   "base_snapshot": {
     "base_health": "GREEN",
     "current_head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -15,24 +33,47 @@
     "changelog_required": true,
     "changelog_updated": true,
     "unresolved_blockers": 0,
+    "unresolved_review_threads": 0,
     "mergeable": true,
+    "selected_merge_method": "squash",
+    "bypass_used": false,
+    "ruleset": {
+      "required_approvals": 0,
+      "dismiss_stale_approvals": true,
+      "require_specific_teams": false,
+      "require_code_owner_review": false,
+      "require_latest_push_approval": false,
+      "require_conversation_resolution": true,
+      "allowed_merge_methods": ["squash"],
+      "require_linear_history": true,
+      "require_signed_commits": true,
+      "require_pull_request": true,
+      "require_status_checks": true,
+      "require_branches_up_to_date": true,
+      "block_force_pushes": true,
+      "restrict_deletions": true
+    },
     "checks": [
       {"workflow": "Governance Check", "job": "governance-check", "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "completed", "conclusion": "success"},
       {"workflow": "validate", "job": "validate", "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "completed", "conclusion": "success"},
       {"workflow": "validate", "job": "runtime-tests", "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "completed", "conclusion": "success"},
       {"workflow": "Cross-platform Validation", "job": "native-windows-latest", "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "completed", "conclusion": "success"},
       {"workflow": "Cross-platform Validation", "job": "native-ubuntu-latest", "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "completed", "conclusion": "success"},
-      {"workflow": "Cross-platform Validation", "job": "native-macos-latest", "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "completed", "conclusion": "success"}
+      {"workflow": "Cross-platform Validation", "job": "native-macos-latest", "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "completed", "conclusion": "success"},
+      {"workflow": "CodeQL", "job": "Analyze (actions)", "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "completed", "conclusion": "success"},
+      {"workflow": "CodeQL", "job": "Analyze (python)", "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "completed", "conclusion": "success"}
     ]
   },
   "pre_merge_cases": [
     {"id": "fully-green", "expected_disposition": "READY_FOR_MERGE"},
     {"id": "no-check-data", "overrides": {"checks": null}, "expected_disposition": "WAIT_FOR_EVIDENCE"},
     {"id": "missing-runtime", "remove_check": "validate/runtime-tests", "expected_disposition": "WAIT_FOR_EVIDENCE"},
+    {"id": "missing-codeql-actions", "remove_check": "CodeQL/Analyze (actions)", "expected_disposition": "WAIT_FOR_EVIDENCE"},
     {"id": "queued-windows", "check_overrides": {"Cross-platform Validation/native-windows-latest": {"status": "queued", "conclusion": null}}, "expected_disposition": "WAIT_FOR_EVIDENCE"},
     {"id": "in-progress-macos", "check_overrides": {"Cross-platform Validation/native-macos-latest": {"status": "in_progress", "conclusion": null}}, "expected_disposition": "WAIT_FOR_EVIDENCE"},
     {"id": "governance-failed", "check_overrides": {"Governance Check/governance-check": {"conclusion": "failure"}}, "expected_disposition": "BLOCK"},
     {"id": "runtime-failed", "check_overrides": {"validate/runtime-tests": {"conclusion": "failure"}}, "expected_disposition": "BLOCK"},
+    {"id": "codeql-python-failed", "check_overrides": {"CodeQL/Analyze (python)": {"conclusion": "failure"}}, "expected_disposition": "BLOCK"},
     {"id": "cross-platform-failed", "check_overrides": {"Cross-platform Validation/native-ubuntu-latest": {"conclusion": "failure"}}, "expected_disposition": "BLOCK"},
     {"id": "required-skipped", "check_overrides": {"validate/validate": {"conclusion": "skipped"}}, "expected_disposition": "BLOCK"},
     {"id": "required-cancelled", "check_overrides": {"validate/runtime-tests": {"conclusion": "cancelled"}}, "expected_disposition": "BLOCK"},
@@ -43,19 +84,31 @@
     {"id": "head-not-reconfirmed", "overrides": {"head_reconfirmed": false}, "expected_disposition": "WAIT_FOR_EVIDENCE"},
     {"id": "merge-conflict", "overrides": {"mergeable": false}, "expected_disposition": "BLOCK"},
     {"id": "mergeable-is-not-enough", "overrides": {"checks": null, "mergeable": true}, "expected_disposition": "WAIT_FOR_EVIDENCE"},
-    {"id": "unresolved-blocker", "overrides": {"unresolved_blockers": 1}, "expected_disposition": "BLOCK"}
+    {"id": "unresolved-blocker", "overrides": {"unresolved_blockers": 1}, "expected_disposition": "BLOCK"},
+    {"id": "unresolved-thread", "overrides": {"unresolved_review_threads": 1}, "expected_disposition": "BLOCK"},
+    {"id": "approval-requirement-drift", "ruleset_overrides": {"required_approvals": 1}, "expected_disposition": "BLOCK"},
+    {"id": "merge-method-drift", "ruleset_overrides": {"allowed_merge_methods": ["rebase"]}, "expected_disposition": "BLOCK"},
+    {"id": "selected-rebase", "overrides": {"selected_merge_method": "rebase"}, "expected_disposition": "BLOCK"},
+    {"id": "signature-rule-disabled", "ruleset_overrides": {"require_signed_commits": false}, "expected_disposition": "BLOCK"},
+    {"id": "bypass-used", "overrides": {"bypass_used": true}, "expected_disposition": "BLOCK"}
   ],
   "post_merge_cases": [
     {
-      "id": "verified",
+      "id": "verified-squash",
       "expected_disposition": "MERGED_VERIFIED",
       "snapshot": {
         "merge_api_result": "success",
         "canonical_read_completed": true,
         "pr_merged": true,
-        "main_contains_reviewed_head": true,
+        "merge_method": "squash",
         "reviewed_head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "canonical_main_sha": "cccccccccccccccccccccccccccccccccccccccc"
+        "canonical_main_sha": "cccccccccccccccccccccccccccccccccccccccc",
+        "reviewed_tree_sha": "dddddddddddddddddddddddddddddddddddddddd",
+        "canonical_tree_sha": "dddddddddddddddddddddddddddddddddddddddd",
+        "pre_merge_base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "canonical_parent_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "content_diff_empty": true,
+        "canonical_signature_verified": true
       }
     },
     {
@@ -65,9 +118,15 @@
         "merge_api_result": "success",
         "canonical_read_completed": false,
         "pr_merged": false,
-        "main_contains_reviewed_head": false,
+        "merge_method": "squash",
         "reviewed_head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "canonical_main_sha": "cccccccccccccccccccccccccccccccccccccccc"
+        "canonical_main_sha": "cccccccccccccccccccccccccccccccccccccccc",
+        "reviewed_tree_sha": "dddddddddddddddddddddddddddddddddddddddd",
+        "canonical_tree_sha": "dddddddddddddddddddddddddddddddddddddddd",
+        "pre_merge_base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "canonical_parent_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "content_diff_empty": true,
+        "canonical_signature_verified": true
       }
     },
     {
@@ -77,21 +136,105 @@
         "merge_api_result": "success",
         "canonical_read_completed": true,
         "pr_merged": false,
-        "main_contains_reviewed_head": true,
+        "merge_method": "squash",
         "reviewed_head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "canonical_main_sha": "cccccccccccccccccccccccccccccccccccccccc"
+        "canonical_main_sha": "cccccccccccccccccccccccccccccccccccccccc",
+        "reviewed_tree_sha": "dddddddddddddddddddddddddddddddddddddddd",
+        "canonical_tree_sha": "dddddddddddddddddddddddddddddddddddddddd",
+        "pre_merge_base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "canonical_parent_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "content_diff_empty": true,
+        "canonical_signature_verified": true
       }
     },
     {
-      "id": "main-missing-reviewed-head",
+      "id": "wrong-merge-method",
       "expected_disposition": "MERGE_STATE_UNVERIFIED",
       "snapshot": {
         "merge_api_result": "success",
         "canonical_read_completed": true,
         "pr_merged": true,
-        "main_contains_reviewed_head": false,
+        "merge_method": "rebase",
         "reviewed_head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "canonical_main_sha": "cccccccccccccccccccccccccccccccccccccccc"
+        "canonical_main_sha": "cccccccccccccccccccccccccccccccccccccccc",
+        "reviewed_tree_sha": "dddddddddddddddddddddddddddddddddddddddd",
+        "canonical_tree_sha": "dddddddddddddddddddddddddddddddddddddddd",
+        "pre_merge_base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "canonical_parent_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "content_diff_empty": true,
+        "canonical_signature_verified": true
+      }
+    },
+    {
+      "id": "tree-mismatch",
+      "expected_disposition": "MERGE_STATE_UNVERIFIED",
+      "snapshot": {
+        "merge_api_result": "success",
+        "canonical_read_completed": true,
+        "pr_merged": true,
+        "merge_method": "squash",
+        "reviewed_head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "canonical_main_sha": "cccccccccccccccccccccccccccccccccccccccc",
+        "reviewed_tree_sha": "dddddddddddddddddddddddddddddddddddddddd",
+        "canonical_tree_sha": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "pre_merge_base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "canonical_parent_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "content_diff_empty": false,
+        "canonical_signature_verified": true
+      }
+    },
+    {
+      "id": "content-diff-not-empty",
+      "expected_disposition": "MERGE_STATE_UNVERIFIED",
+      "snapshot": {
+        "merge_api_result": "success",
+        "canonical_read_completed": true,
+        "pr_merged": true,
+        "merge_method": "squash",
+        "reviewed_head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "canonical_main_sha": "cccccccccccccccccccccccccccccccccccccccc",
+        "reviewed_tree_sha": "dddddddddddddddddddddddddddddddddddddddd",
+        "canonical_tree_sha": "dddddddddddddddddddddddddddddddddddddddd",
+        "pre_merge_base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "canonical_parent_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "content_diff_empty": false,
+        "canonical_signature_verified": true
+      }
+    },
+    {
+      "id": "parent-drift",
+      "expected_disposition": "MERGE_STATE_UNVERIFIED",
+      "snapshot": {
+        "merge_api_result": "success",
+        "canonical_read_completed": true,
+        "pr_merged": true,
+        "merge_method": "squash",
+        "reviewed_head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "canonical_main_sha": "cccccccccccccccccccccccccccccccccccccccc",
+        "reviewed_tree_sha": "dddddddddddddddddddddddddddddddddddddddd",
+        "canonical_tree_sha": "dddddddddddddddddddddddddddddddddddddddd",
+        "pre_merge_base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "canonical_parent_sha": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "content_diff_empty": true,
+        "canonical_signature_verified": true
+      }
+    },
+    {
+      "id": "unsigned-canonical-commit",
+      "expected_disposition": "MERGE_STATE_UNVERIFIED",
+      "snapshot": {
+        "merge_api_result": "success",
+        "canonical_read_completed": true,
+        "pr_merged": true,
+        "merge_method": "squash",
+        "reviewed_head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "canonical_main_sha": "cccccccccccccccccccccccccccccccccccccccc",
+        "reviewed_tree_sha": "dddddddddddddddddddddddddddddddddddddddd",
+        "canonical_tree_sha": "dddddddddddddddddddddddddddddddddddddddd",
+        "pre_merge_base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "canonical_parent_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "content_diff_empty": true,
+        "canonical_signature_verified": false
       }
     }
   ]

--- a/tests/runtime/test_autonomous_merge_readiness_contract.py
+++ b/tests/runtime/test_autonomous_merge_readiness_contract.py
@@ -46,6 +46,7 @@ def test_missing_and_pending_evidence_waits():
     for case_id in (
         "no-check-data",
         "missing-runtime",
+        "missing-codeql-actions",
         "queued-windows",
         "in-progress-macos",
         "head-not-reconfirmed",
@@ -60,6 +61,7 @@ def test_any_required_check_failure_blocks():
     for case_id in (
         "governance-failed",
         "runtime-failed",
+        "codeql-python-failed",
         "cross-platform-failed",
         "required-skipped",
         "required-cancelled",
@@ -96,8 +98,25 @@ def test_merge_conflict_blocks():
     assert validator.evaluate_pre_merge(snapshot) == "BLOCK"
 
 
-def test_unresolved_blocker_blocks():
-    _, snapshot = pre_case("unresolved-blocker")
+def test_unresolved_blocker_and_thread_block():
+    for case_id in ("unresolved-blocker", "unresolved-thread"):
+        _, snapshot = pre_case(case_id)
+        assert validator.evaluate_pre_merge(snapshot) == "BLOCK"
+
+
+def test_ruleset_and_merge_method_drift_block():
+    for case_id in (
+        "approval-requirement-drift",
+        "merge-method-drift",
+        "selected-rebase",
+        "signature-rule-disabled",
+    ):
+        _, snapshot = pre_case(case_id)
+        assert validator.evaluate_pre_merge(snapshot) == "BLOCK"
+
+
+def test_bypass_capability_is_not_governance_authority():
+    _, snapshot = pre_case("bypass-used")
     assert validator.evaluate_pre_merge(snapshot) == "BLOCK"
 
 
@@ -106,14 +125,21 @@ def test_merge_api_success_alone_is_not_verified():
     assert validator.evaluate_post_merge(case["snapshot"]) == "MERGE_STATE_UNVERIFIED"
 
 
-def test_post_merge_requires_canonical_read_and_containment():
-    for case_id in ("pr-not-merged", "main-missing-reviewed-head"):
+def test_post_merge_requires_squash_equivalence_and_signature():
+    for case_id in (
+        "pr-not-merged",
+        "wrong-merge-method",
+        "tree-mismatch",
+        "content-diff-not-empty",
+        "parent-drift",
+        "unsigned-canonical-commit",
+    ):
         case = post_case(case_id)
         assert validator.evaluate_post_merge(case["snapshot"]) == "MERGE_STATE_UNVERIFIED"
 
 
-def test_verified_post_merge_state_is_accepted():
-    case = post_case("verified")
+def test_verified_squash_post_merge_state_is_accepted():
+    case = post_case("verified-squash")
     assert validator.evaluate_post_merge(case["snapshot"]) == "MERGED_VERIFIED"
 
 


### PR DESCRIPTION
## Summary

Forward-only remediation for the R7 / PR #230 post-merge governance incident.

This PR aligns Orchestra's autonomous merge-readiness contract with the current live `Protect main` policy:

- solo-maintainer required approvals = 0
- dismiss stale approvals = enabled
- conversation resolution = required
- Squash-only merge
- signed commits + linear history
- branch must be up to date
- restricted deletion + blocked force pushes
- eight required checks: `governance-check`, `validate`, `runtime-tests`, native Windows/Ubuntu/macOS, `Analyze (actions)`, and `Analyze (python)`
- existing bypass list remains operationally available, but bypass capability is explicitly non-authorizing

## PR #230 disposition

PR #230 reviewed head `f49a03c929be7df7c10c457a227a46532ef47854` was merged as canonical commit `80f9bc71f00cc86c0021fd9da258f2eec596d7e0`. The trees/content are equivalent, but the then-used rebase merge rewrote commit identity and produced an unsigned canonical commit.

Maintainer disposition is forward-only:

- preserve canonical history
- no force push
- no history rewrite
- do not treat PR #230 as future rebase/unsigned precedent

## Contract correction

The previous post-merge rule required the reviewed head SHA to remain in `main` ancestry. That does not fit the current Squash-only policy because Squash deliberately creates a new canonical commit identity.

The new post-merge proof requires:

- exact reviewed head and pre-merge base
- exact-head CI on all required checks
- zero unresolved review threads
- Squash merge
- canonical parent equals pre-merge base
- canonical tree equals reviewed tree
- reviewed-to-canonical content diff is empty
- canonical Squash commit has a verified signature
- independent canonical remote read

## v1.2.0 sequencing

This PR also aligns the Orchestra roadmap with the approved `v1.2.0` sequence:

`R7R -> GA-0..GA-7 Governed Autonomy Modes -> refresh invalidated release evidence -> independent release-readiness verification -> separately authorized R8`

No tag, release, deployment, installed-integration refresh, policy activation, force push, or history rewrite is authorized by this PR.