### PR TITLE
docs: record v1.2.0 release readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,21 @@
 # Changelog
 
-## [Unreleased] - Governed Autonomy Modes GA-0
+## [Unreleased] - Governed Autonomy Modes and Release-Readiness Closeout
 
 - Completed the GA-0 architecture and overlap assessment at baseline `8163c64838d369ea5c4abf45df36f6d6504db9fd`.
 - Recorded `NO_DUPLICATE_AUTHORITY_MODEL`: existing runtime authority, delegation, lifecycle, evidence, host-continuity, and Squash-aware merge contracts remain canonical.
 - Authorized only an instruction-level profile/effective-action contract, deterministic fixture validation, Conductor selection behavior, and documentation parity for GA-1 through GA-7.
 - Preserved `v1.2.0` as `PREPARED_NOT_RELEASED`, Claude Code as `SCAFFOLD_ONLY`, and R8 as a separate human publication gate.
 - Added the GA-1 through GA-7 profile, execution, selection, continuity, adversarial-validation, Codex-parity, and adoption contracts without changing `orchestra_runtime/**`.
+- Squash-merged GA-0 through GA-7 through PR #232 as signed canonical commit `900f88d7a3ed480ae8b910e6ba204008a72d2784`, with exact reviewed/canonical tree equivalence, an empty content diff, green exact-head CI, and a passing rulesuite.
+- Refreshed the canonical behavior, runtime-coverage, strict-governance, packaging, R7 reliability, GA, and merge-readiness evidence after the GA merge; recorded the result in `docs/validation/V1_2_0_RELEASE_READINESS_EVIDENCE.md`.
+- Independently verified that the latest public release remains `v1.1.2`, no `v1.2.0` tag or GitHub Release exists, and R8 remains blocked pending separate human authorization.
 
 This changelog records release-level Orchestra history. Detailed implementation chronology remains available in Git history, merged pull requests, `DECISION_LOG.md`, `PROJECT_STATE.md`, and immutable handoff records.
 
 ## v1.2.0 Release Candidate - NOT RELEASED
 
-`v1.2.0` is prepared as a minor release candidate. Repository manifests are normalized to `1.2.0`, but the latest published GitHub Release remains `v1.1.2`. Accepted R7 live installed-host evidence and the signed Squash-aware R7R remediation are `MERGED_VERIFIED`; release publication remains blocked pending Governed Autonomy Modes, refreshed release evidence, and the separately authorized R8 publication gate.
+`v1.2.0` is prepared as a minor release candidate. Repository manifests are normalized to `1.2.0`, but the latest published GitHub Release remains `v1.1.2`. R7, R7R, and Governed Autonomy Modes are `MERGED_VERIFIED`, and invalidated release evidence has been refreshed and independently verified. Release publication remains blocked at the separately authorized R8 publication gate.
 
 ### R7 Live-Host Evidence Reconciliation - Unreleased
 

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -10,7 +10,7 @@ A governance-first specialist skill framework that routes complex AI-assisted so
 Open-source developer tooling and AI orchestration framework
 
 ## Current Stage
-Release-candidate metadata `v1.2.0` (`PREPARED_NOT_RELEASED`). The current public GitHub Release remains `v1.1.2` until the separate publication gate completes. Canonical `main` includes R7 live-host reconciliation and the signed Squash-aware R7R merge-governance remediation through PR #231 at `8163c64838d369ea5c4abf45df36f6d6504db9fd`. Governed Autonomy Modes is the active candidate extension: GA-0 concluded `NO_DUPLICATE_AUTHORITY_MODEL`, and GA-1 through GA-7 add instruction-level profiles, deterministic validation, Conductor selection behavior, and documentation without changing runtime authority. No release, deployment, installed-integration refresh, or policy activation has occurred.
+Release-candidate metadata `v1.2.0` (`PREPARED_NOT_RELEASED`). The current public GitHub Release remains `v1.1.2` until the separate publication gate completes. Canonical `main` includes R7/R7R and Governed Autonomy Modes through signed Squash commit `900f88d7a3ed480ae8b910e6ba204008a72d2784` from PR #232. GA-0 concluded `NO_DUPLICATE_AUTHORITY_MODEL`; GA-1 through GA-7 are `MERGED_VERIFIED`, and invalidated release evidence is refreshed and independently green. No release, deployment, installed-integration refresh, or policy activation has occurred. R8 remains separately human-authorized.
 
 ## Primary Users
 Developers and maintainers who install Orchestra as a plugin, skill set, or runtime package inside a supported or scaffold-only IDE or coding host (Claude Code, Codex, Antigravity, Cursor, Windsurf, JetBrains, Zed, Neovim)

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -152,8 +152,9 @@ The current bypass list is intentionally retained for repository-operational acc
 - **Issue #215:** Open umbrella finalization issue targeting `v1.2.0`.
 - **R6 Repository State:** `PREPARED_NOT_RELEASED`; candidate version surfaces are `1.2.0`, while the current public GitHub Release remains `v1.1.2`.
 - **R7 State:** R7 and R7R are `MERGED_VERIFIED`; PR #230 incident history is preserved forward-only and PR #231 is the signed Squash trust anchor.
-- **Governed Autonomy Modes:** GA-0 through GA-7 are implemented on the active candidate branch and require exact-head validation/merge before canonical completion is recorded.
-- **Publication Boundary:** R8 `v1.2.0` tag/GitHub Release remains blocked until Governed Autonomy Modes is implemented, invalidated release evidence is refreshed, release state is independently verified, and separate publication authorization is granted.
+- **Governed Autonomy Modes:** GA-0 through GA-7 are `MERGED_VERIFIED` through PR #232 and signed canonical Squash commit `900f88d7a3ed480ae8b910e6ba204008a72d2784`.
+- **Release Readiness:** Invalidated candidate evidence has been refreshed on canonical `main`; behavior, 541 runtime tests at 94.31% coverage, strict governance, packaging, exact-head CI, signature/tree/base verification, and release-boundary reads are green. See `docs/validation/V1_2_0_RELEASE_READINESS_EVIDENCE.md`.
+- **Publication Boundary:** `v1.2.0` remains `PREPARED_NOT_RELEASED`. R8 tag/GitHub Release publication is blocked and requires separate human authorization.
 
 ## Local Startup Verification
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ See [v1.1.2 Trusted Runtime Authority release notes](docs/releases/v1.1.2-truste
 
 `v1.2.0` candidate metadata is prepared, but publication remains blocked. Phase C repository reliability is complete through PR #225; accepted R7 live installed-host evidence and the signed Squash-aware R7R remediation are `MERGED_VERIFIED`. Phase D reconciliation is complete through PR #226 with no duplicate runtime extension required. R5/R5B added merge-readiness hardening and canonical current-state reconciliation.
 
-The candidate becomes a public release only after Governed Autonomy Modes is merged and independently verified, fresh release evidence is green, and the separately authorized R8 annotated-tag/GitHub-Release gate completes.
+Governed Autonomy Modes is merged and independently verified, and refreshed candidate evidence is green. The candidate becomes a public release only when the separately authorized R8 annotated-tag/GitHub-Release gate completes.
 
 ## Honest Limitations
 
@@ -270,7 +270,7 @@ The candidate becomes a public release only after Governed Autonomy Modes is mer
 - Orchestra does not create remote workers, background agents, or distributed orchestration infrastructure.
 - Compatibility mode is explicit, finite, and intended for bounded existing routes.
 - Cursor, Windsurf, VS Code/VSCodium, JetBrains, Zed, and Neovim remain scaffold-only.
-- Repository simulation is not live installed-host evidence. R7 evidence is verified and reconciled locally, while repository merge/post-merge verification and the separately authorized R8 publication gate remain required before `v1.2.0` publication.
+- Repository simulation is not live installed-host evidence. Accepted R7 evidence is `MERGED_VERIFIED`; the simulated fixture remains pending/empty by design. The separately authorized R8 publication gate remains required before `v1.2.0` publication.
 - Orchestra is developer tooling and a local runtime. It does not store or transmit downstream project data by default.
 - Data sensitivity, privacy, retention, deletion, platform disclosure, and IP obligations depend on the downstream project and host environment.
 - Release governance may require revision or block publication.

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -56,7 +56,7 @@ R7 live-host validation and repository reconciliation are `MERGED_VERIFIED`. PR 
 
 ## Governed Autonomy Modes
 
-GA-0 concluded `NO_DUPLICATE_AUTHORITY_MODEL`. GA-1 through GA-7 are implemented on `codex/governed-autonomy-modes-v1.2.0` as instruction-level profile/effective-action contracts, deterministic fixtures/validation, Conductor selection behavior, Codex export parity, and current-state documentation. Runtime authority, plugin manifests, versions, the R7 fixture/validator, and installed integrations remain unchanged.
+GA-0 concluded `NO_DUPLICATE_AUTHORITY_MODEL`. GA-1 through GA-7 are `MERGED_VERIFIED` through PR #232 and signed Squash commit `900f88d7a3ed480ae8b910e6ba204008a72d2784`. Exact-head checks and canonical release-readiness validation are green. Runtime authority, plugin manifests, versions, the R7 fixture/validator, and installed integrations remain unchanged.
 
 ## Local Continuation
 
@@ -85,8 +85,8 @@ R5B  merged - delegated-governance state reconciliation
 R6   v1.2.0 release-candidate repository preparation
 R7   live installed Codex/Antigravity/Claude compatibility evidence - merged verified
 R7R  signed Squash-aware merge-governance remediation - merged verified
-GA-0..GA-7  governed autonomy profiles - implementation and exact-head validation in progress
-R8   tag/GitHub Release only from independently verified release state and separate authorization
+GA-0..GA-7  governed autonomy profiles - merged verified; release evidence refreshed
+R8   next gate - tag/GitHub Release only with separate human authorization
 ```
 
 Historical first-run failures remain preserved as audit evidence in the KB and archive branch. They must not be silently rewritten or deleted during cleanup.

--- a/docs/project/DELEGATED_GOVERNANCE_IMPLEMENTATION_PLAN.md
+++ b/docs/project/DELEGATED_GOVERNANCE_IMPLEMENTATION_PLAN.md
@@ -150,7 +150,7 @@ Additional Phase D runtime implementation for v1.2.0 is **not required**.
 
 ## Phase E - Release Preparation
 
-**Status:** R6 release-candidate preparation is complete. R7 live-host evidence reconciliation is prepared on the isolated reconciliation branch and pending maintainer review, repository merge, and independent post-merge verification. R8 publication remains blocked and requires separate authorization.
+**Status:** R6 release-candidate preparation is complete. R7 and R7R are `MERGED_VERIFIED`. Governed Autonomy Modes GA-0 through GA-7 are `MERGED_VERIFIED` through PR #232, and invalidated release-readiness evidence is refreshed and independently green. R8 publication remains blocked and requires separate human authorization.
 
 **Clean replay continuation:**
 
@@ -158,8 +158,9 @@ Additional Phase D runtime implementation for v1.2.0 is **not required**.
 R5   autonomous merge-readiness hardening â€” merged through PR #227
 R5B  delegated governance state reconciliation â€” current bounded remediation
 R6   release-candidate repository preparation
-R7   live installed-host validation - VERIFIED_RECONCILED_LOCALLY; merge/post-merge verification pending
-R8   tag/GitHub Release from independently verified release state and separate authorization
+R7   live installed-host validation and reconciliation - MERGED_VERIFIED
+GA-0..GA-7  governed autonomy profiles - MERGED_VERIFIED; release evidence refreshed
+R8   tag/GitHub Release from independently verified release state and separate human authorization
 ```
 
 Commit, push, pull request, merge, tag, GitHub Release, marketplace publication,

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -64,7 +64,7 @@ Phases 6B-A through 6C are complete and merged through PR #183. Phase 6D produce
 - [x] GA-5: Audit, provenance, interruption recovery, delegation inheritance, and portable-resume preservation.
 - [x] GA-6: Adversarial fixture validation for authority, profile, policy, evidence, bypass, merge-method, signature, scope, and continuity boundaries.
 - [x] GA-7: Governance, routing, Conductor/Codex parity, project-state, README, roadmap, and release-candidate documentation.
-- [ ] Refresh every release-readiness artifact invalidated by R7R or GA implementation and independently verify the final candidate.
+- [x] Refresh every release-readiness artifact invalidated by R7R or GA implementation and independently verify the final candidate; canonical evidence is recorded in `docs/validation/V1_2_0_RELEASE_READINESS_EVIDENCE.md`.
 - [ ] R8: create annotated `v1.2.0` tag and GitHub Release only after the refreshed candidate is independently verified and separate publication authority is granted.
 
 ### Current `Protect main` Development Baseline

--- a/docs/releases/v1.2.0-governed-orchestration-release-candidate.md
+++ b/docs/releases/v1.2.0-governed-orchestration-release-candidate.md
@@ -1,6 +1,6 @@
 # Orchestra v1.2.0 Release Candidate: Governed Orchestration
 
-`v1.2.0` is prepared as a release candidate. It is **not yet a published release**. The latest public GitHub Release remains `v1.1.2`. R7 and R7R are `MERGED_VERIFIED`; Governed Autonomy Modes is included in the candidate, and the separate R8 publication gate must still explicitly authorize the annotated tag and GitHub Release.
+`v1.2.0` is prepared as a release candidate. It is **not yet a published release**. The latest public GitHub Release remains `v1.1.2`. R7, R7R, and Governed Autonomy Modes are `MERGED_VERIFIED`; refreshed candidate evidence is independently green, and the separate R8 publication gate must still explicitly authorize the annotated tag and GitHub Release.
 
 ## Release Theme
 
@@ -46,6 +46,8 @@ Publication requires:
 4. A fresh independently verified release state.
 5. Separate R8 publication authorization.
 6. Annotated `v1.2.0` tag and GitHub Release verification.
+
+Items 1 through 4 are complete. Item 5 is the current hard human boundary; item 6 has not started. See [v1.2.0 release-readiness evidence](../validation/V1_2_0_RELEASE_READINESS_EVIDENCE.md).
 
 Until those gates complete:
 

--- a/docs/validation/V1_2_0_RELEASE_READINESS_EVIDENCE.md
+++ b/docs/validation/V1_2_0_RELEASE_READINESS_EVIDENCE.md
@@ -1,0 +1,134 @@
+# Orchestra v1.2.0 Release-Readiness Evidence
+
+## Disposition
+
+```text
+EVIDENCE_REVISION=2026-08-09
+RELEASE_CANDIDATE=v1.2.0
+RELEASE_STATE=PREPARED_NOT_RELEASED
+CURRENT_PUBLIC_RELEASE=v1.1.2
+RELEASE_READINESS=VERIFIED
+R8_PUBLICATION=BLOCKED_REQUIRES_SEPARATE_HUMAN_AUTHORIZATION
+```
+
+This record refreshes release evidence invalidated by the R7R merge-governance remediation and Governed Autonomy Modes implementation. It records readiness for the separate R8 human gate. It does not authorize or perform publication.
+
+## Canonical Identity
+
+```text
+PRE_GA_BASE=8163c64838d369ea5c4abf45df36f6d6504db9fd
+GA_PR=232
+GA_REVIEWED_HEAD=13f1f39929b4ddaa6d6a7d2290f145dd5f435c3a
+GA_CANONICAL_SQUASH=900f88d7a3ed480ae8b910e6ba204008a72d2784
+GA_CANONICAL_PARENT=8163c64838d369ea5c4abf45df36f6d6504db9fd
+GA_REVIEWED_TREE=a439e41a9baca24a17aea814c5f3a2f01bc11144
+GA_CANONICAL_TREE=a439e41a9baca24a17aea814c5f3a2f01bc11144
+REVIEWED_TO_CANONICAL_CONTENT_DIFF_PATH_COUNT=0
+CANONICAL_SIGNATURE=VERIFIED_VALID
+RULESUITE_RESULT=PASS
+```
+
+PR #232 was merged through the normal Squash-only protected-branch path. The canonical commit has one parent, its parent is the exact pre-merge base, its tree equals the reviewed-head tree, the reviewed-to-canonical content diff is empty, its signature is valid, and the rulesuite result is `pass`.
+
+## Exact-Head CI
+
+All required checks completed successfully on reviewed head `13f1f39929b4ddaa6d6a7d2290f145dd5f435c3a`:
+
+- `governance-check`
+- `validate`
+- `runtime-tests`
+- `native-windows-latest`
+- `native-ubuntu-latest`
+- `native-macos-latest`
+- `Analyze (actions)`
+- `Analyze (python)`
+- `CodeQL`
+
+No required evidence was missing, pending, stale, skipped, cancelled, timed out, or attached to another head.
+
+## Canonical Validation Matrix
+
+The following commands were rerun on clean canonical `main` at `900f88d7a3ed480ae8b910e6ba204008a72d2784`:
+
+```powershell
+$env:ORCHESTRA_APPROVED_BASE_SHA='8163c64838d369ea5c4abf45df36f6d6504db9fd'
+python tests\behavior\run_tests.py
+python -m pytest tests\runtime --cov=orchestra_runtime --cov-report=term-missing --cov-fail-under=90
+python scripts\governance_check.py --strict
+python scripts\validate_claude_plugin.py
+python scripts\validate_ide_packaging.py
+python scripts\validate_governed_autonomy_modes_contract.py
+python scripts\validate_autonomous_merge_readiness_contract.py
+python scripts\validate_delegated_host_reliability_contract.py
+git diff --check
+```
+
+Results:
+
+```text
+BEHAVIOR_SUITE=PASS
+RUNTIME_TESTS=541_PASSED
+RUNTIME_COVERAGE=94.31_PERCENT
+STRICT_GOVERNANCE=PASS_0_ERRORS_0_WARNINGS
+CLAUDE_PACKAGING=PASS
+IDE_PACKAGING=PASS
+GOVERNED_AUTONOMY_CONTRACT=PASS
+AUTONOMOUS_MERGE_READINESS_CONTRACT=PASS
+DELEGATED_HOST_RELIABILITY_CONTRACT=PASS
+DIFF_CHECK=PASS
+```
+
+The delegated-host validator continues to describe the repository fixture as simulated with pending/empty live records by design. No R7 installed-host scenario was rerun because GA changed no host-sensitive runtime, plugin, adapter capability, manifest, fixture, skill capability, or command surface.
+
+## Preserved R7 Evidence
+
+Accepted source identities remain unchanged:
+
+```text
+R7_E2=VERIFIED
+R7_E2_SOURCE_JSON_SHA256=c1aa412d40c4e267c37fe9886d5c75a9768da93d1d6bd69f06466c38b7363562
+R7_F=VERIFIED
+R7_F_SOURCE_JSON_SHA256=1cc11631742e02bcd872a87dc2cd4f5b75cff2182c2baebe5dc6b444dd5deb95
+R7_G=VERIFIED
+R7_G_SOURCE_JSON_SHA256=88eea125bb4f945199112287c993ebe90044b8ef28cb000309fa2de39603e08e
+R7_H=VERIFIED
+R7_H_SOURCE_JSON_SHA256=268b5debcbcb034288b22916eab97a91b211d0d55881d2ddd81a9548e686ecd8
+```
+
+Claude Code maturity remains `SCAFFOLD_ONLY`. Claude active runtime continuity is not claimed. Repository simulation is not live installed-host evidence.
+
+## Publication Boundary Verification
+
+Canonical GitHub reads established:
+
+```text
+LATEST_PUBLIC_RELEASE=v1.1.2
+LATEST_PUBLIC_RELEASE_DRAFT=false
+LATEST_PUBLIC_RELEASE_PRERELEASE=false
+V1_2_0_TAG=NOT_FOUND
+V1_2_0_GITHUB_RELEASE=NOT_FOUND
+TAG_AT_GA_CANONICAL_HEAD=NONE
+```
+
+## Required Stop State
+
+```text
+RUNTIME_CODE_CHANGED=false
+PLUGIN_MANIFESTS_CHANGED=false
+R7_FIXTURE_LIVE_RECORDS_CHANGED=false
+R7_VALIDATOR_CHANGED=false
+CLAUDE_MATURITY=SCAFFOLD_ONLY
+CLAUDE_ACTIVE_RUNTIME_CONTINUITY_CLAIMED=false
+CURRENT_PUBLIC_RELEASE=v1.1.2
+TARGET_RELEASE=v1.2.0
+RELEASE_STATE=PREPARED_NOT_RELEASED
+TAG_CREATED=false
+RELEASE_CREATED=false
+DEPLOYMENT_PERFORMED=false
+MARKETPLACE_PUBLICATION_PERFORMED=false
+INSTALLED_INTEGRATION_REFRESHED=false
+POLICY_ACTIVATION_PERFORMED=false
+R8_PUBLICATION=BLOCKED_REQUIRES_SEPARATE_HUMAN_AUTHORIZATION
+```
+
+The next permitted transition is a separately authorized human R8 publication decision. No profile or prior green evidence creates that authority.


### PR DESCRIPTION
## Summary

- records PR #232 and canonical signed Squash commit `900f88d7a3ed480ae8b910e6ba204008a72d2784` as `MERGED_VERIFIED`
- records refreshed canonical behavior, runtime coverage, strict governance, packaging, GA, R7 reliability, merge-readiness, and GitHub release-boundary evidence
- reconciles active project state, roadmap, handoff, README, release notes, and delegated-governance plan
- leaves `v1.2.0` at `PREPARED_NOT_RELEASED` and stops before R8

## Validation

- full behavior suite: pass
- runtime suite: 541 passed, 94.31% coverage
- strict governance: 0 errors, 0 warnings
- Claude/IDE packaging and focused GA/R7/merge contracts: pass

## Boundaries

- documentation/evidence only, nine paths
- no runtime, test, validator, plugin, manifest, fixture, version, CI, or installed integration change
- Claude Code remains `SCAFFOLD_ONLY`; active runtime continuity is not claimed
- latest public release remains `v1.1.2`; no `v1.2.0` tag or GitHub Release exists
- R8 publication remains blocked and requires separate human authorization