### PR TITLE
docs: refresh pre-R8 release readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Reconciled the README across R7, the R7R Squash-aware governance remediation, GA-0 through GA-7, revision-bound release readiness, host maturity, and the separately authorized R8 publication boundary.
 - Added source-pinned acknowledgements for Spec Kitty, OpenHero, and Strix with explicit concept-only, no-wholesale-integration, no-affiliation, and no-unsupported-reuse boundaries.
 - Classified every tracked candidate path and every observed local and remote branch, preserving canonical, recovery, archive, open-PR, active-worktree, unique-commit, and release-history refs; no file or branch deletion was performed.
+- Squash-merged the pre-R8 hygiene reconciliation through PR #234 as signed no-bypass canonical commit `8cca62109b10aa06abaf25fc4c9982a02160bcbf`, then refreshed the full revision-bound release-readiness matrix against that exact canonical revision.
 - Completed the GA-0 architecture and overlap assessment at baseline `8163c64838d369ea5c4abf45df36f6d6504db9fd`.
 - Recorded `NO_DUPLICATE_AUTHORITY_MODEL`: existing runtime authority, delegation, lifecycle, evidence, host-continuity, and Squash-aware merge contracts remain canonical.
 - Authorized only an instruction-level profile/effective-action contract, deterministic fixture validation, Conductor selection behavior, and documentation parity for GA-1 through GA-7.

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -10,7 +10,7 @@ A governance-first specialist skill framework that routes complex AI-assisted so
 Open-source developer tooling and AI orchestration framework
 
 ## Current Stage
-Release-candidate metadata `v1.2.0` (`PREPARED_NOT_RELEASED`). The current public GitHub Release remains `v1.1.2` until the separate publication gate completes. Canonical `main` includes R7/R7R and Governed Autonomy Modes through signed Squash commit `900f88d7a3ed480ae8b910e6ba204008a72d2784` from PR #232. GA-0 concluded `NO_DUPLICATE_AUTHORITY_MODEL`; GA-1 through GA-7 are `MERGED_VERIFIED`, and invalidated release evidence is refreshed and independently green. No release, deployment, installed-integration refresh, or policy activation has occurred. R8 remains separately human-authorized.
+Release-candidate metadata `v1.2.0` (`PREPARED_NOT_RELEASED`). The current public GitHub Release remains `v1.1.2` until the separate publication gate completes. Canonical `main` includes R7/R7R, Governed Autonomy Modes, and pre-R8 repository hygiene through signed Squash commit `8cca62109b10aa06abaf25fc4c9982a02160bcbf` from PR #234. GA-0 concluded `NO_DUPLICATE_AUTHORITY_MODEL`; GA-1 through GA-7 and the source-pinned README/hygiene reconciliation are `MERGED_VERIFIED`, and revision-bound release evidence has been refreshed against the hygiene canonical revision. No release, deployment, installed-integration refresh, branch deletion, or policy activation has occurred. R8 remains separately human-authorized.
 
 ## Primary Users
 Developers and maintainers who install Orchestra as a plugin, skill set, or runtime package inside a supported or scaffold-only IDE or coding host (Claude Code, Codex, Antigravity, Cursor, Windsurf, JetBrains, Zed, Neovim)

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -153,7 +153,8 @@ The current bypass list is intentionally retained for repository-operational acc
 - **R6 Repository State:** `PREPARED_NOT_RELEASED`; candidate version surfaces are `1.2.0`, while the current public GitHub Release remains `v1.1.2`.
 - **R7 State:** R7 and R7R are `MERGED_VERIFIED`; PR #230 incident history is preserved forward-only and PR #231 is the signed Squash trust anchor.
 - **Governed Autonomy Modes:** GA-0 through GA-7 are `MERGED_VERIFIED` through PR #232 and signed canonical Squash commit `900f88d7a3ed480ae8b910e6ba204008a72d2784`.
-- **Release Readiness:** Invalidated candidate evidence has been refreshed on canonical `main`; behavior, 541 runtime tests at 94.31% coverage, strict governance, packaging, exact-head CI, signature/tree/base verification, and release-boundary reads are green. See `docs/validation/V1_2_0_RELEASE_READINESS_EVIDENCE.md`.
+- **Pre-R8 Repository Hygiene:** README provenance/host/release state and complete conservative file/branch classifications are `MERGED_VERIFIED` through PR #234 and signed canonical Squash commit `8cca62109b10aa06abaf25fc4c9982a02160bcbf`. No tracked file or branch was deleted.
+- **Release Readiness:** Hygiene-invalidated candidate evidence has been refreshed against canonical `8cca62109b10aa06abaf25fc4c9982a02160bcbf`; behavior, 541 runtime tests at 94.31% coverage, strict governance, packaging, exact-head CI, signature/tree/base verification, and release-boundary reads are green. See `docs/validation/V1_2_0_RELEASE_READINESS_EVIDENCE.md`.
 - **Publication Boundary:** `v1.2.0` remains `PREPARED_NOT_RELEASED`. R8 tag/GitHub Release publication is blocked and requires separate human authorization.
 
 ## Local Startup Verification

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ See [v1.1.2 Trusted Runtime Authority release notes](docs/releases/v1.1.2-truste
 
 `v1.2.0` candidate metadata is prepared, but publication remains blocked. Phase C repository reliability is complete through PR #225; accepted R7 live installed-host evidence and the signed Squash-aware R7R remediation are `MERGED_VERIFIED`. Phase D reconciliation is complete through PR #226 with no duplicate runtime extension required. R5/R5B added merge-readiness hardening and canonical current-state reconciliation.
 
-Governed Autonomy Modes is merged and independently verified, and refreshed candidate evidence is green. The candidate becomes a public release only when the separately authorized R8 annotated-tag/GitHub-Release gate completes.
+Governed Autonomy Modes and the pre-R8 repository-hygiene reconciliation are merged and independently verified. Candidate evidence has been refreshed against hygiene canonical revision `8cca62109b10aa06abaf25fc4c9982a02160bcbf` and is green. The candidate becomes a public release only when the separately authorized R8 annotated-tag/GitHub-Release gate completes.
 
 ## Honest Limitations
 

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -58,6 +58,10 @@ R7 live-host validation and repository reconciliation are `MERGED_VERIFIED`. PR 
 
 GA-0 concluded `NO_DUPLICATE_AUTHORITY_MODEL`. GA-1 through GA-7 are `MERGED_VERIFIED` through PR #232 and signed Squash commit `900f88d7a3ed480ae8b910e6ba204008a72d2784`. Exact-head checks and canonical release-readiness validation are green. Runtime authority, plugin manifests, versions, the R7 fixture/validator, and installed integrations remain unchanged.
 
+## Pre-R8 Repository Hygiene
+
+PR #234 reconciled README R7/R7R/GA state, Claude `SCAFFOLD_ONLY` maturity, source-pinned Spec Kitty/OpenHero/Strix acknowledgements, and complete conservative tracked-file/local-branch/remote-branch classifications. It is `MERGED_VERIFIED` as signed no-bypass Squash commit `8cca62109b10aa06abaf25fc4c9982a02160bcbf`. Canonical behavior, 541 runtime tests at 94.31% coverage, strict governance, packaging, Artificer, autonomy, host-reliability, JSON, and diff validation are green. No tracked file or branch was deleted. Release readiness was refreshed against this exact canonical revision; R8 remains the next separate human gate.
+
 ## Local Continuation
 
 When local access resumes, synchronize without rewriting local state:
@@ -85,7 +89,8 @@ R5B  merged - delegated-governance state reconciliation
 R6   v1.2.0 release-candidate repository preparation
 R7   live installed Codex/Antigravity/Claude compatibility evidence - merged verified
 R7R  signed Squash-aware merge-governance remediation - merged verified
-GA-0..GA-7  governed autonomy profiles - merged verified; release evidence refreshed
+GA-0..GA-7  governed autonomy profiles - merged verified
+R7H  pre-R8 repository hygiene - merged verified; release evidence refreshed
 R8   next gate - tag/GitHub Release only with separate human authorization
 ```
 

--- a/docs/validation/V1_2_0_RELEASE_READINESS_EVIDENCE.md
+++ b/docs/validation/V1_2_0_RELEASE_READINESS_EVIDENCE.md
@@ -3,7 +3,7 @@
 ## Disposition
 
 ```text
-EVIDENCE_REVISION=2026-08-09
+EVIDENCE_REVISION=2026-08-09-PRE-R8-HYGIENE-REFRESH
 RELEASE_CANDIDATE=v1.2.0
 RELEASE_STATE=PREPARED_NOT_RELEASED
 CURRENT_PUBLIC_RELEASE=v1.1.2
@@ -11,28 +11,29 @@ RELEASE_READINESS=VERIFIED
 R8_PUBLICATION=BLOCKED_REQUIRES_SEPARATE_HUMAN_AUTHORIZATION
 ```
 
-This record refreshes release evidence invalidated by the R7R merge-governance remediation and Governed Autonomy Modes implementation. It records readiness for the separate R8 human gate. It does not authorize or perform publication.
+This record refreshes release evidence invalidated by the pre-R8 repository-hygiene merge. It records readiness for the separate R8 human gate. It does not authorize or perform tag creation, publication, deployment, installed-integration refresh, or policy activation.
 
 ## Canonical Identity
 
 ```text
-PRE_GA_BASE=8163c64838d369ea5c4abf45df36f6d6504db9fd
-GA_PR=232
-GA_REVIEWED_HEAD=13f1f39929b4ddaa6d6a7d2290f145dd5f435c3a
-GA_CANONICAL_SQUASH=900f88d7a3ed480ae8b910e6ba204008a72d2784
-GA_CANONICAL_PARENT=8163c64838d369ea5c4abf45df36f6d6504db9fd
-GA_REVIEWED_TREE=a439e41a9baca24a17aea814c5f3a2f01bc11144
-GA_CANONICAL_TREE=a439e41a9baca24a17aea814c5f3a2f01bc11144
+PRE_HYGIENE_BASE=81ce2b440fc4e1091637045a7227f6192e93a042
+HYGIENE_PR=234
+HYGIENE_REVIEWED_HEAD=b849e2db3d6fe07e106d9044f982f51e61ce022a
+HYGIENE_CANONICAL_SQUASH=8cca62109b10aa06abaf25fc4c9982a02160bcbf
+HYGIENE_CANONICAL_PARENT=81ce2b440fc4e1091637045a7227f6192e93a042
+HYGIENE_REVIEWED_TREE=eb3df71582d484d0f74463040030e0a0b3686abb
+HYGIENE_CANONICAL_TREE=eb3df71582d484d0f74463040030e0a0b3686abb
 REVIEWED_TO_CANONICAL_CONTENT_DIFF_PATH_COUNT=0
 CANONICAL_SIGNATURE=VERIFIED_VALID
 RULESUITE_RESULT=PASS
+BYPASS_USED=false
 ```
 
-PR #232 was merged through the normal Squash-only protected-branch path. The canonical commit has one parent, its parent is the exact pre-merge base, its tree equals the reviewed-head tree, the reviewed-to-canonical content diff is empty, its signature is valid, and the rulesuite result is `pass`.
+PR #234 merged through the normal Squash-only protected-branch path. Its canonical commit has one parent, that parent is the exact pre-merge base, its tree equals the reviewed-head tree, the reviewed-to-canonical content diff is empty, its GitHub signature is verified and valid, and the applicable rulesuite result is `pass`, not `bypass`.
 
 ## Exact-Head CI
 
-All required checks completed successfully on reviewed head `13f1f39929b4ddaa6d6a7d2290f145dd5f435c3a`:
+All discovered checks completed successfully on reviewed head `b849e2db3d6fe07e106d9044f982f51e61ce022a`:
 
 - `governance-check`
 - `validate`
@@ -44,22 +45,27 @@ All required checks completed successfully on reviewed head `13f1f39929b4ddaa6d6
 - `Analyze (python)`
 - `CodeQL`
 
-No required evidence was missing, pending, stale, skipped, cancelled, timed out, or attached to another head.
+No required evidence was missing, pending, stale, skipped, cancelled, timed out, or attached to another head. No unresolved review thread remained at merge time. The quota-exhaustion `COMMENTED` review on the earlier PR revision was not an approval and created no readiness claim.
 
 ## Canonical Validation Matrix
 
-The following commands were rerun on clean canonical `main` at `900f88d7a3ed480ae8b910e6ba204008a72d2784`:
+The following commands were rerun on clean canonical `main` at `8cca62109b10aa06abaf25fc4c9982a02160bcbf`:
 
 ```powershell
-$env:ORCHESTRA_APPROVED_BASE_SHA='8163c64838d369ea5c4abf45df36f6d6504db9fd'
+$env:ORCHESTRA_APPROVED_BASE_SHA='81ce2b440fc4e1091637045a7227f6192e93a042'
 python tests\behavior\run_tests.py
 python -m pytest tests\runtime --cov=orchestra_runtime --cov-report=term-missing --cov-fail-under=90
 python scripts\governance_check.py --strict
+python scripts\validate_artificer_internal.py
+python scripts\validate_artificer_records.py
+python scripts\validate_artificer_governance_records.py
+python scripts\validate_artificer_pattern_catalog.py
 python scripts\validate_claude_plugin.py
 python scripts\validate_ide_packaging.py
 python scripts\validate_governed_autonomy_modes_contract.py
 python scripts\validate_autonomous_merge_readiness_contract.py
 python scripts\validate_delegated_host_reliability_contract.py
+python -m json.tool docs\validation\PRE_R8_REPOSITORY_HYGIENE_CLASSIFICATION.json
 git diff --check
 ```
 
@@ -70,19 +76,23 @@ BEHAVIOR_SUITE=PASS
 RUNTIME_TESTS=541_PASSED
 RUNTIME_COVERAGE=94.31_PERCENT
 STRICT_GOVERNANCE=PASS_0_ERRORS_0_WARNINGS
+ARTIFICER_INTERNAL=PASS
+ARTIFICER_RECORDS=PASS
+ARTIFICER_GOVERNANCE_RECORDS=PASS
+ARTIFICER_PATTERN_CATALOG=PASS
 CLAUDE_PACKAGING=PASS
 IDE_PACKAGING=PASS
 GOVERNED_AUTONOMY_CONTRACT=PASS
 AUTONOMOUS_MERGE_READINESS_CONTRACT=PASS
 DELEGATED_HOST_RELIABILITY_CONTRACT=PASS
+HYGIENE_CLASSIFICATION_JSON=PASS
+HYGIENE_CLASSIFICATION_SHA256=d8de185a2200308093c5bbeaf9fa0f7bcc5ed85abf2821e3a4573f9ac3d095ca
 DIFF_CHECK=PASS
 ```
 
-The delegated-host validator continues to describe the repository fixture as simulated with pending/empty live records by design. No R7 installed-host scenario was rerun because GA changed no host-sensitive runtime, plugin, adapter capability, manifest, fixture, skill capability, or command surface.
+The hygiene change modified documentation and evidence only. No R7 installed-host scenario was rerun. The delegated-host validator continues to describe the repository fixture as simulated with pending/empty live records by design.
 
-## Preserved R7 Evidence
-
-Accepted source identities remain unchanged:
+## Preserved R7 and Host Boundaries
 
 ```text
 R7_E2=VERIFIED
@@ -93,13 +103,29 @@ R7_G=VERIFIED
 R7_G_SOURCE_JSON_SHA256=88eea125bb4f945199112287c993ebe90044b8ef28cb000309fa2de39603e08e
 R7_H=VERIFIED
 R7_H_SOURCE_JSON_SHA256=268b5debcbcb034288b22916eab97a91b211d0d55881d2ddd81a9548e686ecd8
+CLAUDE_MATURITY=SCAFFOLD_ONLY
+CLAUDE_ACTIVE_RUNTIME_CONTINUITY_CLAIMED=false
+REPOSITORY_SIMULATION_IS_LIVE_EVIDENCE=false
 ```
 
-Claude Code maturity remains `SCAFFOLD_ONLY`. Claude active runtime continuity is not claimed. Repository simulation is not live installed-host evidence.
+## Repository Hygiene Boundary
+
+```text
+TRACKED_CANDIDATE_PATH_COUNT=743
+CLASSIFIED_BRANCH_SNAPSHOT_COUNT=314
+TRACKED_FILE_DELETION_PERFORMED=false
+BRANCH_DELETION_PERFORMED=false
+RECOVERY_BACKUP_PRESERVED=true
+AUTONOMOUS_RUN_ARCHIVE_PRESERVED=true
+ACTIVE_WORKTREE_BRANCHES_PRESERVED=true
+OPEN_PR_BRANCHES_PRESERVED=true
+UNIQUE_COMMIT_BRANCHES_PRESERVED=true
+RELEASE_AND_RECOVERY_HISTORY_PRESERVED=true
+```
 
 ## Publication Boundary Verification
 
-Canonical GitHub reads established:
+Canonical GitHub reads after the hygiene merge established:
 
 ```text
 LATEST_PUBLIC_RELEASE=v1.1.2
@@ -107,7 +133,7 @@ LATEST_PUBLIC_RELEASE_DRAFT=false
 LATEST_PUBLIC_RELEASE_PRERELEASE=false
 V1_2_0_TAG=NOT_FOUND
 V1_2_0_GITHUB_RELEASE=NOT_FOUND
-TAG_AT_GA_CANONICAL_HEAD=NONE
+TAG_AT_HYGIENE_CANONICAL_HEAD=NONE
 ```
 
 ## Required Stop State
@@ -131,4 +157,4 @@ POLICY_ACTIVATION_PERFORMED=false
 R8_PUBLICATION=BLOCKED_REQUIRES_SEPARATE_HUMAN_AUTHORIZATION
 ```
 
-The next permitted transition is a separately authorized human R8 publication decision. No profile or prior green evidence creates that authority.
+The next permitted transition is a separately authorized human R8 publication decision. No profile, hygiene classification, or prior green evidence creates that authority.


### PR DESCRIPTION
## Summary

- refreshes v1.2.0 release-readiness evidence invalidated by the merged pre-R8 hygiene revision
- records PR #234 exact-head CI, signed Squash parent/tree/content/signature/rulesuite proof, and canonical validation at 8cca621
- reconciles README and startup state to the verified hygiene canonical revision
- preserves v1.1.2 as the current public release, v1.2.0 as PREPARED_NOT_RELEASED, Claude as SCAFFOLD_ONLY, and R8 as a separate human gate
- performs no runtime, plugin, fixture, validator, manifest, workflow, version, tag, release, deployment, installed refresh, branch deletion, or policy activation

## Validation

- behavior suite: PASS
- runtime tests: 541 passed, 94.31% coverage
- strict governance: PASS, 0 errors / 0 warnings
- Artificer, Claude, IDE packaging, governed-autonomy, merge-readiness, delegated-host, hygiene JSON, and diff checks: PASS