### PR TITLE
docs: reconcile v1.2.0 current documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 - Preserved R7-E2, R7-F, R7-G, and R7-H evidence identities, Claude Code `SCAFFOLD_ONLY` maturity, and the repository simulation fixture as pending/empty by design.
 - Performed no deployment, marketplace publication, installed-integration refresh, policy activation, force push, history rewrite, or branch deletion.
 
-## [Unreleased] - Governed Autonomy Modes and Release-Readiness Closeout
+## v1.2.0 Pre-Publication History - Governed Autonomy Modes and Release-Readiness Closeout
+
+The following entries preserve the verified candidate chronology before the separately authorized August 9, 2026 publication. They are historical release evidence, not current unpublished state.
 
 - Reconciled the README across R7, the R7R Squash-aware governance remediation, GA-0 through GA-7, revision-bound release readiness, host maturity, and the separately authorized R8 publication boundary.
 - Added source-pinned acknowledgements for Spec Kitty, OpenHero, and Strix with explicit concept-only, no-wholesale-integration, no-affiliation, and no-unsupported-reuse boundaries.
@@ -16,19 +18,19 @@
 - Completed the GA-0 architecture and overlap assessment at baseline `8163c64838d369ea5c4abf45df36f6d6504db9fd`.
 - Recorded `NO_DUPLICATE_AUTHORITY_MODEL`: existing runtime authority, delegation, lifecycle, evidence, host-continuity, and Squash-aware merge contracts remain canonical.
 - Authorized only an instruction-level profile/effective-action contract, deterministic fixture validation, Conductor selection behavior, and documentation parity for GA-1 through GA-7.
-- Preserved `v1.2.0` as `PREPARED_NOT_RELEASED`, Claude Code as `SCAFFOLD_ONLY`, and R8 as a separate human publication gate.
+- At that checkpoint, preserved `v1.2.0` as `PREPARED_NOT_RELEASED`, Claude Code as `SCAFFOLD_ONLY`, and R8 as a separate human publication gate.
 - Added the GA-1 through GA-7 profile, execution, selection, continuity, adversarial-validation, Codex-parity, and adoption contracts without changing `orchestra_runtime/**`.
 - Squash-merged GA-0 through GA-7 through PR #232 as signed canonical commit `900f88d7a3ed480ae8b910e6ba204008a72d2784`, with exact reviewed/canonical tree equivalence, an empty content diff, green exact-head CI, and a passing rulesuite.
 - Refreshed the canonical behavior, runtime-coverage, strict-governance, packaging, R7 reliability, GA, and merge-readiness evidence after the GA merge; recorded the result in `docs/validation/V1_2_0_RELEASE_READINESS_EVIDENCE.md`.
-- Independently verified that the latest public release remains `v1.1.2`, no `v1.2.0` tag or GitHub Release exists, and R8 remains blocked pending separate human authorization.
+- Before R8, independently verified that the latest public release remained `v1.1.2`, no `v1.2.0` tag or GitHub Release existed, and publication remained blocked pending separate human authorization.
 
 This changelog records release-level Orchestra history. Detailed implementation chronology remains available in Git history, merged pull requests, `DECISION_LOG.md`, `PROJECT_STATE.md`, and immutable handoff records.
 
-## v1.2.0 Release Candidate - NOT RELEASED
+## v1.2.0 Pre-Publication Release-Candidate History
 
-`v1.2.0` is prepared as a minor release candidate. Repository manifests are normalized to `1.2.0`, but the latest published GitHub Release remains `v1.1.2`. R7, R7R, and Governed Autonomy Modes are `MERGED_VERIFIED`, and invalidated release evidence has been refreshed and independently verified. Release publication remains blocked at the separately authorized R8 publication gate.
+This section records the final pre-publication candidate state. Repository manifests had been normalized to `1.2.0` while the latest public release was still `v1.1.2`. R7, R7R, and Governed Autonomy Modes were `MERGED_VERIFIED`, and invalidated release evidence had been refreshed. R8 later published `v1.2.0` under separate authority.
 
-### R7 Live-Host Evidence Reconciliation - Unreleased
+### R7 Live-Host Evidence Reconciliation - Pre-Publication History
 
 - Reconciled accepted locally installed-host evidence for Antigravity same-host reset/resume, Codex same-host reset/resume, and Codex -> Antigravity portable handoff.
 - Recorded Claude Code `SCAFFOLD_ONLY` packaging/contract compatibility without claiming active runtime continuity.
@@ -52,7 +54,7 @@ This changelog records release-level Orchestra history. Detailed implementation 
 - Cross-layer integrity audit profiles for frontend-to-backend synchronicity, backend-to-persistence integrity, and language-neutral cross-module logical flow using the existing Conductor -> Tuner -> specialist -> Overseer -> Arbiter ownership model.
 - Delegated Phase C repository host-reliability contracts and deterministic adversarial fixtures covering reset/resume, active-host handoff, capacity waits, stale identity, incomplete checkpoints, scaffold-only hosts, authority expansion, and duplicate replay.
 - Fail-closed autonomous merge-readiness protocol, machine-readable evaluation fixtures, and runtime regressions requiring green canonical baseline, exact-head evidence, complete successful required checks, changelog freshness, expected-head merge guards where supported, and independent post-merge verification.
-- `docs/releases/v1.2.0-governed-orchestration-release-candidate.md` as the source-backed candidate release note and publication-boundary record.
+- Source-backed candidate notes later promoted to stable `docs/releases/v1.2.0-governed-orchestration.md`; the former candidate path remains as a compatibility pointer for immutable historical references.
 
 ### Changed
 
@@ -118,13 +120,13 @@ REPOSITORY_SIMULATION != LIVE_HOST_EVIDENCE
 LIVE_INSTALLED_HOST_VALIDATION=VERIFIED_RECONCILED_LOCALLY
 ```
 
-R7 host-derived evidence and the forward-only merge-governance remediation are verified and canonical. Governed Autonomy Modes, refreshed release verification, and the separately authorized R8 publication gate remain required for publication.
+At this pre-publication checkpoint, R7 host-derived evidence and the forward-only merge-governance remediation were verified and canonical. Governed Autonomy Modes, refreshed release verification, and separate R8 authority still remained required.
 
-### Publication Boundary
+### Historical Publication Boundary
 
-The `v1.2.0` candidate is not a public release. No `v1.2.0` tag, GitHub Release publication, deployment, marketplace graduation, installed-host mutation, policy activation, force push, or history rewrite is authorized by the current finalization work.
+At this recorded pre-R8 checkpoint, the `v1.2.0` candidate was not yet a public release. The finalization work itself authorized no tag, GitHub Release publication, deployment, marketplace graduation, installed-host mutation, policy activation, force push, or history rewrite.
 
-Publication requires GA-0 through GA-7 canonical completion, refreshed release-readiness evidence, independent final verification, and a separately authorized R8 gate.
+Publication subsequently required and received GA-0 through GA-7 canonical completion, refreshed release-readiness evidence, independent final verification, and separate R8 authority.
 
 ---
 

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -23,7 +23,7 @@
 - **Phase 3C:** `OrchestraWorktreeContract` implemented and merged through PR #214.
 - **Phase 3D:** Consolidated exact-head validation complete.
 - **Phase 3E:** Immutable review, bounded remediation, and merge complete.
-- **Phase 3 Verdict:** `COMPLETE_MERGED_NOT_RELEASED`.
+- **Phase 3 Verdict:** `COMPLETE_MERGED_RELEASED_IN_V1_2_0`.
 
 ### Cross-Layer Integrity
 
@@ -70,7 +70,7 @@ Clean replay results:
 - **R4:** Phase D overlap assessment merged through PR #226 only after the canonical baseline was green and every fresh required check passed.
 - **R5:** autonomous merge-readiness hardening merged through PR #227 at merge commit `467008db683c346cd086442dbb909c20a9248a3a`.
 - **R5B:** delegated-governance current-state reconciliation merged and was independently verified through PR #228 at merge commit `fbe4532ba2083feaa7ed9fcda2988843f1237a78`.
-- **R6:** `v1.2.0` release-candidate metadata and documentation were prepared as `PREPARED_NOT_RELEASED` without publication authority.
+- **Historical R6:** `v1.2.0` release-candidate metadata and documentation were prepared as `PREPARED_NOT_RELEASED` without publication authority. R8 later published the separately authorized release.
 - **R7 / PR #230:** accepted live-host evidence was reviewed at head `f49a03c929be7df7c10c457a227a46532ef47854` and merged to canonical `main` as `80f9bc71f00cc86c0021fd9da258f2eec596d7e0`. GitHub's then-used rebase merge rewrote the reviewed commit identity. The reviewed and canonical trees are equal and their content diff is empty, but the canonical rebase commit is unsigned and the reviewed head is not in `main` ancestry.
 
 Maintainer disposition for the PR #230 incident is forward-only:
@@ -149,7 +149,7 @@ The current bypass list is intentionally retained for repository-operational acc
 - **Ruleset Rule:** Live ruleset drift, non-Squash merge selection, unresolved review threads, or unauthorized bypass use blocks ordinary autonomous merge.
 - **Baseline Rule:** A new phase must not begin from a red canonical `main`.
 - **Post-Merge Rule:** An API response is not completion evidence. For Squash, canonical parent/tree/content/signature evidence and a canonical remote read are required before state advances.
-- **Issue #215:** Publication closeout is in progress; close only after repository and KB state synchronization are merged and verified.
+- **Issue #215:** `CLOSED_VERIFIED` after the published release, Orchestra post-publication PR #236, KB publication-closeout PR #32, and the evidence-backed completion comment were independently verified.
 - **R6 Repository State:** Release-candidate preparation completed with version surfaces normalized to `1.2.0`.
 - **R7 State:** R7 and R7R are `MERGED_VERIFIED`; PR #230 incident history is preserved forward-only and PR #231 is the signed Squash trust anchor.
 - **Governed Autonomy Modes:** GA-0 through GA-7 are `MERGED_VERIFIED` through PR #232 and signed canonical Squash commit `900f88d7a3ed480ae8b910e6ba204008a72d2784`.

--- a/README.md
+++ b/README.md
@@ -41,59 +41,57 @@ The framework is designed to help developers reduce context drift, make cross-do
 
 ## How Orchestra Works
 
-The runtime establishes permission before execution. Routing selects responsibility but does not grant authority. Authority and capability checks run before governance. Governance may block already-authorized work, but cannot create missing permission. For material multi-domain work, Conductor activates The Tuner to assemble specialist-owned contracts, expose missing ownership or contradictions, and identify stale dependent evidence. Single-owner work bypasses that coordination overhead.
+Each run begins with project context and three separate choices: risk mode, progression mode, and governance profile. Those choices affect review depth and pause frequency, but they do not create permission. Orchestra composes the trusted runtime, calculates effective authority as the intersection of explicit grants and all applicable constraints, and only then lets Conductor route work. Material multi-domain work uses The Tuner to coordinate specialist-owned contracts; single-owner work bypasses that overhead.
 
 ~~~mermaid
 flowchart TD
     Request["Request + Project Context"]
+    Select["Select Risk Mode + Progression Mode + Governance Profile"]
     Compose["Trusted Runtime Composition"]
-    Route["Conductor Routes Work"]
-    Authority{"Authority Allowed?"}
-    Capability{"Capability Granted?"}
-    Governance{"Governance Satisfied?"}
-    Multi{"Material Cross-Domain Work?"}
-    Tuner{"Cross-Layer Contract Ready?"}
-    Specialist["Specialist Execution"]
-    Validate{"Validation Passed?"}
+    Effective{"Effective Authority Intersection Allows Action?"}
+    Route["Conductor Routes Smallest Responsible Stack"]
+    Multi{"Material Multi-Domain Work?"}
+    Tuner{"Tuner Contract Ready and Current?"}
+    Specialist["Owning Specialist Execution"]
+    Validate{"Current Validation + Evidence Pass?"}
     Revise["Return to Owning Boundary"]
-    Lifecycle["Structured Lifecycle Result"]
-    Evidence["Deterministic Evidence"]
-    Review["Human Review or Accepted Output"]
+    Arbiter{"Arbiter Transition Disposition"}
+    Continue["Bounded Continuation to Next Approved Unit"]
+    Remediate["In-Scope Remediation + Revalidation"]
+    Wait["Checkpoint and Wait for Evidence or Capacity"]
+    Escalate["Escalate Missing Intent, Scope, Policy, or Authority"]
+    Stop["Stop and Preserve Safe State"]
 
-    Request --> Compose --> Route --> Authority
-    Authority -- No --> Lifecycle
-    Authority -- Yes --> Capability
-    Capability -- No --> Lifecycle
-    Capability -- Yes --> Governance
-    Governance -- No --> Lifecycle
-    Governance -- Yes --> Multi
+    Request --> Select --> Compose --> Effective
+    Effective -- No --> Escalate
+    Effective -- Yes --> Route --> Multi
     Multi -- No --> Specialist
     Multi -- Yes --> Tuner
-    Tuner -- No --> Lifecycle
+    Tuner -- No --> Wait
     Tuner -- Yes --> Specialist
     Specialist --> Validate
     Validate -- No --> Revise --> Specialist
-    Validate -- Yes --> Lifecycle --> Evidence --> Review
+    Validate -- Yes --> Arbiter
+    Arbiter -- AUTO_CONTINUE --> Continue --> Route
+    Arbiter -- AUTO_REMEDIATE_AND_REVALIDATE --> Remediate --> Specialist
+    Arbiter -- WAIT_FOR_EVIDENCE / WAIT_FOR_CAPACITY --> Wait
+    Arbiter -- ESCALATE_HUMAN --> Escalate
+    Arbiter -- STOP --> Stop
 ~~~
 
-Accessible summary: a request moves through trusted composition, routing, authority, capability, and governance. Single-owner work proceeds directly to its specialist. Material cross-domain work must first reach a ready coordination state. Validation failure returns work to the owning boundary. Accepted or blocked work ends in structured lifecycle state and deterministic evidence.
+Accessible summary: a request supplies project context and selects separate risk, progression, and governance-profile settings. Trusted composition and the effective-authority intersection run before Conductor routes work. Single-owner work goes directly to its specialist; material multi-domain work first requires current Tuner coordination. Validation failure returns to the owning boundary. Current evidence goes to Arbiter, which may continue or remediate inside existing authority, wait for evidence or capacity, escalate to a human, or stop safely.
 
-## v1.2.0 Capability Set
+## What v1.2.0 Gives You
 
-The release consolidates the substantial backward-compatible work merged after `v1.1.2`:
+- **Governed autonomy without invented permission:** choose Human-Governed, Semi-Autonomous, or Full Autonomous pause behavior while effective authority remains the most restrictive intersection of explicit grant, policy, host capability, phase scope, and current evidence.
+- **Delegated progression with predictable outcomes:** approved phases can advance through six explicit Arbiter dispositions, bounded remediation, checkpoints, and resumable capacity waits instead of relying on ambiguous generated prose.
+- **Integrated multi-specialist coordination:** Conductor activates The Tuner only for material multi-domain work so ownership gaps, contradictions, stale contracts, generated artifacts, and minimal specialist re-entry remain visible.
+- **Cross-layer integrity review:** reusable frontend-to-backend, backend-to-persistence, and cross-module logical-flow profiles connect findings to one owner, validation evidence, and fail-closed re-entry.
+- **Revision-bound validation and merge safety:** canonical baseline health, exact-head checks, evidence freshness, expected-head merge guards, signed Squash verification, and independent canonical reads prevent stale green results from authorizing a newer state.
+- **Portable governed execution contracts:** runtime envelopes, correlation identity, phase retrospectives, approved-unit plans, status projections, and worktree contracts preserve bounded context and reviewable state.
+- **Evidence-backed host continuity boundaries:** accepted Codex and Antigravity continuity evidence is separated from repository simulation, while Claude Code remains explicitly `SCAFFOLD_ONLY` for active runtime continuity.
 
-- **Delegated Phase B progression:** approved units, six transition dispositions, checkpoints, bounded remediation, capacity handoff, evidence freshness, and fail-closed external-action authority.
-- **The Tuner Phases 1-4:** cross-specialist contract assembly, contradiction detection, semantic invalidation, minimal specialist re-entry, typed in-memory coordination, and bounded Conductor-owned runtime integration.
-- **Spec Kitty-derived governed execution contracts:** `OrchestraRuntimeEnvelope`, `OrchestraCorrelationID`, `OrchestraPhaseRetrospective`, the 15-field `ApprovedUnitPlan` extension, `OrchestraStatusProjection`, and `OrchestraWorktreeContract`.
-- **Cross-layer integrity auditing:** frontend-to-backend, backend-to-persistence, and language-neutral cross-module logical-flow profiles using the existing Conductor -> Tuner -> specialist -> Overseer -> Arbiter ownership model.
-- **Delegated Phase C repository reliability:** deterministic repository-verifiable reset/resume, handoff, capacity, stale identity, incomplete checkpoint, authority expansion, scaffold-only host, and replay behavior.
-- **Delegated Phase D reconciliation:** `NO_DUPLICATE_RUNTIME_EXTENSION_REQUIRED` for `v1.2.0`; existing trusted runtime contracts cover the material overlap.
-- **Autonomous merge-readiness hardening:** green canonical baseline, exact-head evidence, complete required checks, expected-head merge guard where supported, and independent post-merge verification.
-- **R7R Squash-aware verification:** exact pre-merge parent, reviewed/canonical tree equality, empty reviewed-to-canonical content diff, verified canonical signature, and no-bypass evidence replace ancestry-only assumptions.
-- **Current-state reconciliation:** stale Phase C/D status and false live-host promotion are rejected by executable governance consistency checks.
-- **Governed Autonomy Modes:** user-selectable Human-Governed, Semi-Autonomous, and Full Autonomous profiles reduce repetitive gates without creating authority or weakening evidence, repository-policy, release, deployment, destructive-action, or policy-activation boundaries.
-
-See [v1.2.0 release notes](docs/releases/v1.2.0-governed-orchestration-release-candidate.md).
+Implementation chronology and source provenance remain available in [Project State](PROJECT_STATE.md), the [Roadmap](docs/project/ROADMAP.md), and the stable [v1.2.0 release notes](docs/releases/v1.2.0-governed-orchestration.md).
 
 ## Governed Autonomy Profiles
 
@@ -207,12 +205,12 @@ Repository manifests identify the current published release as `1.2.0`. See the 
 
 ## Quick Start
 
-1. Provide the project type, purpose, release target, data sensitivity, dependencies, and constraints.
-2. Describe the concrete task and acceptance criteria.
-3. Let Conductor select the smallest effective specialist stack and activate The Tuner only when material cross-domain coordination is required.
-4. Review governance decisions and specialist outputs at their owning boundaries.
-5. Run required validation before accepting the result.
-6. Preserve project state and a concise handoff before changing session, branch, or maintainer.
+Start by defining four things:
+
+1. **Governance profile:** use `HUMAN_GOVERNED` unless a human explicitly grants a more autonomous profile.
+2. **Authorized scope:** name the repository, branch or baseline, allowed paths, behaviors, and external actions.
+3. **Hard boundaries:** state what must not happen, such as release, deployment, policy activation, destructive action, force push, or history rewrite.
+4. **Terminal boundary:** say exactly where Orchestra must stop, such as an unstaged diff, validated commit, open PR, or independently verified merge.
 
 Example:
 
@@ -220,14 +218,18 @@ Example:
 @Orchestra
 
 Project: Open-source developer tool
-Goal: Add a bounded export command
-Release target: Public patch release
-Data use: No end-user data
-Constraints: Preserve public APIs; no new dependency
+Governance profile: HUMAN_GOVERNED
+Repository: example/tool
+Authorized scope: src/export/** and tests/export/**
+Allowed actions: inspect, implement, and validate
+Hard boundaries: no dependency change, push, merge, release, or deployment
+Terminal boundary: validated unstaged diff ready for human review
 
 Task:
-Implement the command, validate it, and leave the diff unstaged for review.
+Add a bounded export command without changing public APIs.
 ~~~
+
+With `HUMAN_GOVERNED`, material Git and phase transitions pause for approval. `SEMI_AUTONOMOUS` may continue through explicitly granted commit, push, PR, exact-head CI, and bounded remediation, but still stops before merge and major phase progression. `FULL_AUTONOMOUS` may also merge and continue through later explicitly granted phases when every current governance gate passes. All three profiles remain inside the same explicit scope and hard boundaries.
 
 ## Validation and Evidence
 
@@ -252,7 +254,7 @@ For autonomous or delegated merges, Orchestra additionally requires the fail-clo
 
 `v1.2.0` is published from annotated tag `v1.2.0` at release commit `4f3c45f6d1e5f290aca108ddf5810c1b18f1dc76`. Phase C repository reliability, accepted R7 live installed-host evidence, the signed Squash-aware R7R remediation, Phase D overlap reconciliation, R5/R5B merge-readiness hardening, Governed Autonomy Modes, pre-R8 repository hygiene, and final release readiness are complete and independently verified.
 
-See the [v1.2.0 release notes](docs/releases/v1.2.0-governed-orchestration-release-candidate.md) and the published [`v1.2.0` GitHub Release](https://github.com/Baelfyre/Orchestra/releases/tag/v1.2.0). The previous [`v1.1.2` release](https://github.com/Baelfyre/Orchestra/releases/tag/v1.1.2) remains historical release evidence.
+See the [v1.2.0 release notes](docs/releases/v1.2.0-governed-orchestration.md) and the published [`v1.2.0` GitHub Release](https://github.com/Baelfyre/Orchestra/releases/tag/v1.2.0). The previous [`v1.1.2` release](https://github.com/Baelfyre/Orchestra/releases/tag/v1.1.2) remains historical release evidence.
 
 ## Honest Limitations
 
@@ -298,7 +300,7 @@ See the [v1.2.0 release notes](docs/releases/v1.2.0-governed-orchestration-relea
 
 ### Release and maintainers
 
-- [v1.2.0 Release Notes](docs/releases/v1.2.0-governed-orchestration-release-candidate.md)
+- [v1.2.0 Release Notes](docs/releases/v1.2.0-governed-orchestration.md)
 - [v1.1.2 Release Notes](docs/releases/v1.1.2-trusted-runtime-authority.md)
 - [Contributing](docs/CONTRIBUTING.md)
 - [Project State](PROJECT_STATE.md)

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -34,14 +34,15 @@ The clean replay then completed R1 through R5B:
 - **R5 / PR #227:** fail-closed autonomous merge-readiness hardening.
 - **R5B / PR #228:** delegated-governance current-state reconciliation, merged at `fbe4532ba2083feaa7ed9fcda2988843f1237a78` and independently verified on canonical `main`.
 
-## Current Release-Candidate State - R6
+## Historical R6 Release-Candidate Preparation
 
-R6 normalizes repository release-candidate metadata to `1.2.0`, consolidates README/setup/current-state/release notes, and prepares exact-head release-readiness evidence.
+R6 normalized repository release-candidate metadata to `1.2.0`, consolidated README/setup/current-state/release notes, and prepared exact-head release-readiness evidence. This section records the pre-publication checkpoint; it is not the current release state.
 
-This is preparation, not publication:
+Historical R6 and current publication state:
 
 ```text
 RELEASE_CANDIDATE_VERSION=1.2.0
+HISTORICAL_R6_RELEASE_STATE=PREPARED_NOT_RELEASED
 CURRENT_PUBLIC_RELEASE=v1.2.0
 RELEASE_STATE=PUBLISHED_VERIFIED
 POLICY_ACTIVATION=NOT_PERFORMED
@@ -58,9 +59,9 @@ R7 live-host validation and repository reconciliation are `MERGED_VERIFIED`. PR 
 
 GA-0 concluded `NO_DUPLICATE_AUTHORITY_MODEL`. GA-1 through GA-7 are `MERGED_VERIFIED` through PR #232 and signed Squash commit `900f88d7a3ed480ae8b910e6ba204008a72d2784`. Exact-head checks and canonical release-readiness validation are green. Runtime authority, plugin manifests, versions, the R7 fixture/validator, and installed integrations remain unchanged.
 
-## Pre-R8 Repository Hygiene
+## Historical Pre-R8 Repository Hygiene and Publication
 
-PR #234 reconciled README R7/R7R/GA state, Claude `SCAFFOLD_ONLY` maturity, source-pinned Spec Kitty/OpenHero/Strix acknowledgements, and complete conservative tracked-file/local-branch/remote-branch classifications. It is `MERGED_VERIFIED` as signed no-bypass Squash commit `8cca62109b10aa06abaf25fc4c9982a02160bcbf`. Canonical behavior, 541 runtime tests at 94.31% coverage, strict governance, packaging, Artificer, autonomy, host-reliability, JSON, and diff validation are green. No tracked file or branch was deleted. Release readiness was refreshed and R8 published annotated tag `v1.2.0` and the immutable GitHub Release from exact release commit `4f3c45f6d1e5f290aca108ddf5810c1b18f1dc76`.
+PR #234 reconciled README R7/R7R/GA state, Claude `SCAFFOLD_ONLY` maturity, source-pinned Spec Kitty/OpenHero/Strix acknowledgements, and complete conservative tracked-file/local-branch/remote-branch classifications. It is `MERGED_VERIFIED` as signed no-bypass Squash commit `8cca62109b10aa06abaf25fc4c9982a02160bcbf`. Canonical behavior, 541 runtime tests at 94.31% coverage, strict governance, packaging, Artificer, autonomy, host-reliability, JSON, and diff validation were green. No tracked file or branch was deleted. Release readiness was refreshed, R8 published annotated tag `v1.2.0` and the immutable GitHub Release from exact release commit `4f3c45f6d1e5f290aca108ddf5810c1b18f1dc76`, and Issue #215 is `CLOSED_VERIFIED`.
 
 ## Local Continuation
 

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -3,7 +3,7 @@
 ## Spec Kitty-Derived Orchestra Contracts
 
 Design Status: `DESIGN_COMPLETE`
-Runtime Status: `IMPLEMENTED_MERGED` | `NOT_RELEASED`
+Runtime Status: `IMPLEMENTED_MERGED_RELEASED_IN_V1_2_0`
 
 - [x] Phase 1A: Architecture Ownership and Contract Placement (`docs/project/SPEC_KITTY_DERIVED_CONTRACT_OWNERSHIP.md`).
 - [x] Phase 1B: `OrchestraRuntimeEnvelope` Schema Specification (`docs/project/ORCHESTRA_RUNTIME_ENVELOPE.md`).
@@ -27,7 +27,7 @@ Runtime Status: `IMPLEMENTED_MERGED` | `NOT_RELEASED`
 - [x] Phase 3D: Consolidated cross-platform, behavior, governance, security, packaging, compatibility, and exact-head validation completed for the final PR #214 revision.
 - [x] Phase 3E: Maintainer immutable review, bounded remediation, commit and push authorization, remote verification, and PR #214 merge completed on August 6, 2026.
 
-Phase 3A through Phase 3E are complete and merged. The Spec Kitty-derived capability set remains unreleased and no policy activation has occurred.
+Phase 3A through Phase 3E are complete and merged. The Spec Kitty-derived capability set was released in `v1.2.0`; no policy activation occurred.
 
 ## Authority and Capability Runtime Progression
 
@@ -43,7 +43,7 @@ Phase 3A through Phase 3E are complete and merged. The Spec Kitty-derived capabi
 
 Phases 6B-A through 6C are complete and merged through PR #183. Phase 6D produced the published `v1.1.2` baseline after PR #185 and the separate publication gate.
 
-## v1.2.0 Finalization
+## v1.2.0 Finalization - Complete
 
 - [x] F0/R0: preserve and verify the recovery baseline after the first autonomous-run incident.
 - [x] F1/R1: Spec Kitty Phase 3 and roadmap closeout through replay PR #223.
@@ -65,7 +65,7 @@ Phases 6B-A through 6C are complete and merged through PR #183. Phase 6D produce
 - [x] GA-6: Adversarial fixture validation for authority, profile, policy, evidence, bypass, merge-method, signature, scope, and continuity boundaries.
 - [x] GA-7: Governance, routing, Conductor/Codex parity, project-state, README, roadmap, and release-candidate documentation.
 - [x] Refresh every release-readiness artifact invalidated by R7R or GA implementation and independently verify the final candidate; canonical evidence is recorded in `docs/validation/V1_2_0_RELEASE_READINESS_EVIDENCE.md`.
-- [x] R8: annotated `v1.2.0` tag and immutable GitHub Release published and independently verified at release commit `4f3c45f6d1e5f290aca108ddf5810c1b18f1dc76`.
+- [x] R8: annotated `v1.2.0` tag and immutable [GitHub Release](https://github.com/Baelfyre/Orchestra/releases/tag/v1.2.0) published and independently verified at release commit `4f3c45f6d1e5f290aca108ddf5810c1b18f1dc76`.
 
 ### Current `Protect main` Development Baseline
 

--- a/docs/releases/v1.2.0-governed-orchestration-release-candidate.md
+++ b/docs/releases/v1.2.0-governed-orchestration-release-candidate.md
@@ -1,51 +1,7 @@
-# Orchestra v1.2.0: Governed Orchestration
+# Orchestra v1.2.0 Release-Candidate Path Compatibility
 
-`v1.2.0` is the current published GitHub Release. It was published from annotated tag `v1.2.0` at exact release commit `4f3c45f6d1e5f290aca108ddf5810c1b18f1dc76`. R7, R7R, Governed Autonomy Modes, pre-R8 hygiene, final release readiness, and R8 publication are independently verified.
+`v1.2.0` is published. Current release notes are maintained at [Orchestra v1.2.0: Governed Orchestration](v1.2.0-governed-orchestration.md), and the immutable GitHub Release is available at [Orchestra v1.2.0: Governed Orchestration](https://github.com/Baelfyre/Orchestra/releases/tag/v1.2.0).
 
-## Release Theme
+This former candidate path remains as a compatibility pointer because immutable pre-R8 classification, architecture, and provenance records reference it. Those historical records remain accurate for their original revisions and are not rewritten as current state.
 
-This minor release consolidates the post-`v1.1.2` governed-orchestration capability set. It expands delegated phase progression, cross-specialist coordination, governed phase execution contracts, cross-layer integrity auditing, repository-verifiable host continuity, and autonomous merge safety while preserving authority, maturity, and publication boundaries.
-
-## Released Scope
-
-- Delegated Phase B instruction-level progression with explicit transition dispositions, checkpoints, bounded remediation, evidence freshness, and fail-closed external-action authority.
-- The Tuner Phases 1-4: specialist-owned cross-layer contract assembly, contradiction detection, evidence invalidation, minimal re-entry, typed in-memory coordination, and bounded Conductor-owned runtime integration.
-- Spec Kitty-derived contracts: `OrchestraRuntimeEnvelope`, `OrchestraCorrelationID`, `OrchestraPhaseRetrospective`, the 15-field `ApprovedUnitPlan` extension, `OrchestraStatusProjection`, and `OrchestraWorktreeContract`.
-- Frontend-to-backend, backend-to-persistence, and language-neutral cross-module logical-flow integrity profiles using the existing Conductor -> Tuner -> specialist -> Overseer -> Arbiter ownership model.
-- Delegated Phase C repository host-reliability protocol and deterministic adversarial fixtures for reset/resume, handoff, capacity, stale identity, incomplete checkpoint, scaffold-only host, authority expansion, and duplicate replay cases.
-- Delegated Phase D overlap reconciliation with `NO_DUPLICATE_RUNTIME_EXTENSION_REQUIRED` for v1.2.0.
-- Autonomous merge-readiness hardening requiring green canonical baseline, exact-head evidence, complete required checks, expected-head merge guards where supported, and independent post-merge verification.
-- R5B current-state reconciliation so canonical governance documents reject obsolete Phase C/D status and false live-host promotion.
-- Governed Autonomy Modes with Human-Governed, Semi-Autonomous, and Full Autonomous profiles, reduction-only effective-authority evaluation, Conductor selection, portable continuity, and adversarial contract validation.
-
-## Compatibility and Maturity Boundaries
-
-Codex, Claude Code, and Antigravity retain their supported integration surfaces. Cursor, Windsurf, VS Code/VSCodium, JetBrains, Zed, and Neovim remain scaffold-only. Version normalization does not graduate a scaffold or publish an IDE marketplace artifact.
-
-For Phase C continuity specifically, repository simulation is not live installed-host evidence. Accepted R7 evidence verifies installed Codex and Antigravity continuity and a supported Codex -> Antigravity handoff in the separate source-controlled evidence record. Claude Code packaging/contract compatibility is verified, but active runtime-continuity capability remains unclaimed under `SCAFFOLD_ONLY` maturity.
-
-## Authority and Security Boundaries
-
-Routing, governance approval, coordination readiness, validation success, audit evidence, GitHub mergeability, and API success do not create runtime or release authority. Existing trusted authority, immutable run-scoped capabilities, bounded delegation, lifecycle, evidence identity, and default-deny external-action controls remain in force.
-
-No new database, collaboration persistence, SQLite, migrations, RPC, network daemon, remote worker, background agent, production deployment, secret handling, or automatic policy activation is introduced by R6 release preparation.
-
-## Release Validation
-
-The authoritative release evidence is the fresh exact-head and canonical-main matrix bound to release commit `4f3c45f6d1e5f290aca108ddf5810c1b18f1dc76`. Historical green runs are supporting context only. Required repository evidence includes behavior, runtime, strict governance, prompt-load, structure, manifests, Claude plugin, Codex export, IDE packaging, compatibility, security, stale-reference, version consistency, and native Windows/Ubuntu/macOS validation.
-
-## Publication Verification
-
-R6 prepared repository metadata and documentation only. R8 subsequently published annotated tag `v1.2.0` and the immutable GitHub Release. No deployment, marketplace publication, installed-host refresh, or policy activation was performed.
-
-Publication required verified R6 preparation, R7 evidence, Governed Autonomy Modes, fresh release readiness, separate R8 authority, and annotated-tag/GitHub-Release verification. All gates are complete. See [v1.2.0 release-readiness evidence](../validation/V1_2_0_RELEASE_READINESS_EVIDENCE.md).
-
-Published state:
-
-```text
-RELEASE_VERSION=1.2.0
-CURRENT_PUBLIC_RELEASE=v1.2.0
-RELEASE_STATE=PUBLISHED_VERIFIED
-RELEASE_COMMIT=4f3c45f6d1e5f290aca108ddf5810c1b18f1dc76
-LIVE_INSTALLED_HOST_VALIDATION=VERIFIED_RECONCILED_LOCALLY
-```
+For the exact published snapshot, use annotated tag `v1.2.0` at release commit `4f3c45f6d1e5f290aca108ddf5810c1b18f1dc76`.

--- a/docs/releases/v1.2.0-governed-orchestration.md
+++ b/docs/releases/v1.2.0-governed-orchestration.md
@@ -1,0 +1,51 @@
+# Orchestra v1.2.0: Governed Orchestration
+
+`v1.2.0` is the current published GitHub Release. It was published from annotated tag `v1.2.0` at exact release commit `4f3c45f6d1e5f290aca108ddf5810c1b18f1dc76`. R7, R7R, Governed Autonomy Modes, pre-R8 hygiene, final release readiness, and R8 publication are independently verified.
+
+## Release Theme
+
+This minor release consolidates the post-`v1.1.2` governed-orchestration capability set. It expands delegated phase progression, cross-specialist coordination, governed phase execution contracts, cross-layer integrity auditing, repository-verifiable host continuity, and autonomous merge safety while preserving authority, maturity, and publication boundaries.
+
+## Released Scope
+
+- Delegated Phase B instruction-level progression with explicit transition dispositions, checkpoints, bounded remediation, evidence freshness, and fail-closed external-action authority.
+- The Tuner Phases 1-4: specialist-owned cross-layer contract assembly, contradiction detection, evidence invalidation, minimal re-entry, typed in-memory coordination, and bounded Conductor-owned runtime integration.
+- Spec Kitty-derived contracts: `OrchestraRuntimeEnvelope`, `OrchestraCorrelationID`, `OrchestraPhaseRetrospective`, the 15-field `ApprovedUnitPlan` extension, `OrchestraStatusProjection`, and `OrchestraWorktreeContract`.
+- Frontend-to-backend, backend-to-persistence, and language-neutral cross-module logical-flow integrity profiles using the existing Conductor -> Tuner -> specialist -> Overseer -> Arbiter ownership model.
+- Delegated Phase C repository host-reliability protocol and deterministic adversarial fixtures for reset/resume, handoff, capacity, stale identity, incomplete checkpoint, scaffold-only host, authority expansion, and duplicate replay cases.
+- Delegated Phase D overlap reconciliation with `NO_DUPLICATE_RUNTIME_EXTENSION_REQUIRED` for v1.2.0.
+- Autonomous merge-readiness hardening requiring green canonical baseline, exact-head evidence, complete required checks, expected-head merge guards where supported, and independent post-merge verification.
+- R5B current-state reconciliation so canonical governance documents reject obsolete Phase C/D status and false live-host promotion.
+- Governed Autonomy Modes with Human-Governed, Semi-Autonomous, and Full Autonomous profiles, reduction-only effective-authority evaluation, Conductor selection, portable continuity, and adversarial contract validation.
+
+## Compatibility and Maturity Boundaries
+
+Codex, Claude Code, and Antigravity retain their supported integration surfaces. Cursor, Windsurf, VS Code/VSCodium, JetBrains, Zed, and Neovim remain scaffold-only. Version normalization does not graduate a scaffold or publish an IDE marketplace artifact.
+
+For Phase C continuity specifically, repository simulation is not live installed-host evidence. Accepted R7 evidence verifies installed Codex and Antigravity continuity and a supported Codex -> Antigravity handoff in the separate source-controlled evidence record. Claude Code packaging/contract compatibility is verified, but active runtime-continuity capability remains unclaimed under `SCAFFOLD_ONLY` maturity.
+
+## Authority and Security Boundaries
+
+Routing, governance approval, coordination readiness, validation success, audit evidence, GitHub mergeability, and API success do not create runtime or release authority. Existing trusted authority, immutable run-scoped capabilities, bounded delegation, lifecycle, evidence identity, and default-deny external-action controls remain in force.
+
+No new database, collaboration persistence, SQLite, migrations, RPC, network daemon, remote worker, background agent, production deployment, secret handling, or automatic policy activation is introduced by `v1.2.0`.
+
+## Release Validation
+
+The authoritative release evidence is the fresh exact-head and canonical-main matrix bound to release commit `4f3c45f6d1e5f290aca108ddf5810c1b18f1dc76`. Historical green runs are supporting context only. Required repository evidence includes behavior, runtime, strict governance, prompt-load, structure, manifests, Claude plugin, Codex export, IDE packaging, compatibility, security, stale-reference, version consistency, and native Windows/Ubuntu/macOS validation.
+
+## Publication Verification
+
+R6 prepared repository metadata and documentation only. R8 subsequently published annotated tag `v1.2.0` and the immutable GitHub Release. No deployment, marketplace publication, installed-host refresh, or policy activation was performed.
+
+Publication required verified R6 preparation, R7 evidence, Governed Autonomy Modes, fresh release readiness, separate R8 authority, and annotated-tag/GitHub-Release verification. All gates are complete. See [v1.2.0 release-readiness evidence](../validation/V1_2_0_RELEASE_READINESS_EVIDENCE.md).
+
+Published state:
+
+```text
+RELEASE_VERSION=1.2.0
+CURRENT_PUBLIC_RELEASE=v1.2.0
+RELEASE_STATE=PUBLISHED_VERIFIED
+RELEASE_COMMIT=4f3c45f6d1e5f290aca108ddf5810c1b18f1dc76
+LIVE_INSTALLED_HOST_VALIDATION=VERIFIED_RECONCILED_LOCALLY
+```

--- a/docs/setup/COMPATIBILITY.md
+++ b/docs/setup/COMPATIBILITY.md
@@ -6,9 +6,9 @@ Scaffold-only hosts are not full support claims. Promotion requirements and grad
 
 | Host | Runtime Adapter | Status | Notes |
 |---|---|---|---|
-| Codex | `codex` | Supported | Marketplace-first, with repo-local fallback. R7 same-host and cross-host continuity evidence is verified locally; repository merge/post-merge verification remains pending for publication. |
-| Claude Code | `claude-code` | Supported packaging/integration | Marketplace metadata included. Phase C active runtime-continuity capability is not promoted beyond repository/scaffold evidence. |
-| Antigravity | `antigravity` | Supported | Plugin install path remains host-native. R7 same-host and cross-host continuity evidence is verified locally; repository merge/post-merge verification remains pending for publication. |
+| Codex | `codex` | Supported | Marketplace-first, with repo-local fallback. Accepted R7 same-host and cross-host continuity evidence is merged and verified. |
+| Claude Code | `claude-code` | Supported packaging/integration; runtime continuity `SCAFFOLD_ONLY` | Marketplace metadata and package/contract compatibility are verified. Active runtime continuity is not claimed. |
+| Antigravity | `antigravity` | Supported | Plugin install path remains host-native. Accepted R7 same-host and cross-host continuity evidence is merged and verified. |
 | Cursor | `cursor` | Scaffold-only | Runtime adapter exists; packaging surface remains scaffold-only. |
 | Windsurf | `windsurf` | Scaffold-only | Runtime adapter exists; packaging surface remains scaffold-only. |
 | VS Code | `vscode` | Scaffold-only | Shared VS Code-family runtime adapter and packaging scaffold. |

--- a/docs/setup/INSTALLATION.md
+++ b/docs/setup/INSTALLATION.md
@@ -11,7 +11,7 @@ The latest GitHub Release remains the publication source of truth. Installing di
 | Host | Install Surface | Current Status |
 |---|---|---|
 | Codex | Marketplace or repo-local fallback | Supported |
-| Claude Code | Marketplace plugin | Supported packaging/integration |
+| Claude Code | Marketplace plugin | Supported packaging/integration; runtime continuity `SCAFFOLD_ONLY` |
 | Antigravity | Native plugin install | Supported |
 | Cursor | Scaffold-only packaging and workspace instructions | Scaffold-only |
 | Windsurf | Scaffold-only packaging and workspace instructions | Scaffold-only |
@@ -96,7 +96,7 @@ You can also run validation from your terminal at the repository root:
 claude plugin validate .
 ```
 
-*Note: Claude Code plugin skills are expected to be namespaced after installation.*
+*Note: Claude Code plugin skills are expected to be namespaced after installation. Packaging and contract compatibility are supported, but active runtime continuity remains `SCAFFOLD_ONLY` and is not claimed.*
 
 ## 4. Skills-only Setup (Manual)
 
@@ -155,7 +155,7 @@ Run:
 python .\scripts\check_for_updates.py
 ```
 
-The script reads local version metadata from the root manifest, Claude and Codex plugin manifests, and adapter package manifests, then compares it to the latest GitHub Release. During R6, local candidate metadata can be newer than the latest published release; that does not publish or downgrade either state.
+The script reads local version metadata from the root manifest, Claude and Codex plugin manifests, and adapter package manifests, then compares it to the latest GitHub Release. A post-release `main` revision may contain documentation or later unreleased work; local metadata alone never publishes or downgrades a release.
 
 If a newer public release exists, use your host-specific refresh or reinstall flow to update.
 


### PR DESCRIPTION
Reconciles current-facing Orchestra documentation with the published v1.2.0 state under the canonical KB ecosystem tracker authorization. Promotes stable release notes while preserving the former candidate path as a compatibility pointer for immutable historical references. Updates README workflow, outcomes, governed profiles, exact-authority boundaries, current release state, R7/R7R/GA completion, host maturity, and Issue #215 closeout. Scope is exactly nine documentation paths. No runtime, plugin, fixture, validator, version, tag, release, deployment, installed-integration refresh, or policy activation change. Claude active runtime continuity remains SCAFFOLD_ONLY and repository simulation remains separate from accepted live evidence. Local behavior, strict governance, structure, manifest, packaging, routing, host-reliability, autonomy, merge-readiness, stale-reference, link, and diff validation are green.