### PR TITLE
feat(ponytail): add specialist implementation knowledge layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Post-v1.2.0 Specialist Knowledge Layer - SK1 Ponytail - Pending
+
+- Added an Orchestra-native Ponytail implementation knowledge layer while preserving Ponytail's established specialist ownership and upstream minimalism principles.
+- Added stack discovery, implementation foundations, language/runtime references for JavaScript/TypeScript, Python, Java/JVM, Go/Rust, shell/PowerShell, and browser/web runtime work, plus build/test tooling and worked cross-specialist implementation patterns.
+- Added progressive-disclosure loading so stack-specific references are loaded only after repository evidence confirms they are relevant.
+- Preserved source/Codex portable parity by mirroring the Markdown support files under `adapters/codex/skills/ponytail/**` without changing exporter semantics.
+- Recorded the August 12, 2026 upstream check: `Baelfyre/ponytail` remained on package `4.8.4`, upstream `DietrichGebert/ponytail` was on package `4.9.0`, and the core upstream Ponytail skill blob was unchanged between the reviewed revisions.
+- Adopted Markdown-primary, JSON-selective knowledge storage for this campaign. No prose-heavy JSON knowledge files were added.
+- No routing, runtime, manifest contract, package version, workflow, release, deployment, installed-integration, policy, production, force-push, history-rewrite, or branch-deletion behavior is changed by SK1.
+
 ## Post-v1.2.0 README direct-main governance reconciliation - Pending
 
 - Preserved canonical README commit `807bda608d65cb10bf65cdf313916d9d0fd62320` after exact local content validation confirmed the intended public-facing documentation change.

--- a/adapters/codex/skills/ponytail/BUILD_TEST_TOOLING_GUIDE.md
+++ b/adapters/codex/skills/ponytail/BUILD_TEST_TOOLING_GUIDE.md
@@ -1,0 +1,161 @@
+# Build and Test Tooling Guide
+
+## Purpose
+
+Select implementation and validation commands from repository evidence instead of ecosystem habit. This guide does not authorize installation, deployment, release, external mutation, or production access.
+
+## Command Selection Order
+
+Use the strongest repository-owned source available:
+
+1. explicit project validation documentation;
+2. package/task scripts;
+3. wrapper scripts checked into the repository;
+4. CI workflow commands;
+5. framework/build configuration;
+6. only then, a conventional direct tool invocation when the repository clearly supports it.
+
+If two sources conflict, inspect which one is current and used by CI. Do not guess.
+
+## JavaScript and TypeScript
+
+Read `package.json` scripts before choosing a command.
+
+Common script shapes are:
+
+```text
+npm test
+npm run lint
+npm run typecheck
+npm run build
+npm run validate
+```
+
+These are examples, not defaults. Use `pnpm`, Yarn, Bun, or another package manager only when lockfiles/configuration prove that choice.
+
+Rules:
+- do not run install with a different package manager because it is locally convenient;
+- do not rewrite a lockfile unless the accepted dependency change requires it;
+- prefer `npm ci` in CI-like clean installs only when the repository uses npm and has a compatible lockfile;
+- do not invoke a framework CLI globally when the repository provides a local script or package binary.
+
+## Python
+
+Determine environment management from `pyproject.toml`, lockfiles, requirements files, project docs, and CI.
+
+Common repository-owned commands may wrap:
+
+```text
+python -m pytest
+python -m ruff check .
+python -m mypy ...
+python -m package.module
+```
+
+Do not assume pytest, Ruff, mypy, uv, Poetry, pip-tools, or another tool is present. Preserve the supported Python version.
+
+## Java and JVM
+
+Prefer checked-in wrappers:
+
+```text
+./mvnw test
+./gradlew test
+gradlew.bat test
+```
+
+Use exact repository goals/tasks. Do not switch between Maven and Gradle, bypass wrappers, or add plugin goals by convention.
+
+When integration tests use containers, databases, or external services, confirm whether the repository supplies an isolated test harness before running them.
+
+## Go
+
+Use `go.mod`/workspace evidence and existing scripts. Common commands include:
+
+```text
+go test ./...
+go vet ./...
+go build ./...
+```
+
+Do not assume all packages, tags, race tests, or integration tests are safe without repository guidance.
+
+## Rust
+
+Read `Cargo.toml`, workspace metadata, toolchain configuration, and CI. Common commands include:
+
+```text
+cargo test
+cargo check
+cargo clippy
+cargo fmt --check
+```
+
+Do not modify the lockfile or toolchain configuration unless required by the accepted change.
+
+## Shell and PowerShell
+
+Prefer repository wrappers rather than reconstructing long command sequences manually. Check native process exit codes and fail when required validation fails.
+
+When a repository has both `.ps1` and `.sh` wrappers, use the one appropriate to the current host unless a cross-platform comparison is itself part of the required gate.
+
+## Validation Layers
+
+Classify checks before running them:
+
+- **format**: deterministic style or whitespace checks;
+- **lint/static**: rule and code-quality checks;
+- **typecheck/compile**: type and compilation contracts;
+- **unit**: isolated behavior;
+- **integration**: component/service/persistence interaction;
+- **contract**: API/schema/interface compatibility;
+- **browser/E2E**: rendered workflow behavior;
+- **security**: repository-approved security scans and control checks;
+- **packaging/export**: generated artifacts and portable distribution parity;
+- **release**: complete release-readiness gate owned by Overseer and repository governance.
+
+Ponytail may execute checks but does not redefine which layers are required for release.
+
+## Narrow Check vs Transition Gate
+
+During implementation, run the narrowest useful check after each bounded edit when practical. Before PR publication/update, merge, or another governed transition, run the repository-required complete gate on the exact current head.
+
+```text
+narrow implementation check != release readiness
+passing one test != full validation
+validation on old head != validation on current head
+```
+
+Any source change after validation invalidates the affected exact-head evidence.
+
+## Generated Artifacts
+
+Before editing a generated file:
+1. identify its canonical input/generator;
+2. confirm the generation command;
+3. edit the canonical source;
+4. regenerate through the repository-owned command;
+5. confirm the generated delta is deterministic and scoped.
+
+Do not manually patch generated output unless the repository explicitly treats it as canonical source.
+
+## Dependency Changes
+
+If a dependency must change:
+- verify the package manager;
+- identify the minimum compatible change;
+- update manifest and lockfile through the native package manager when possible;
+- run the repository's dependency/security policy checks;
+- review transitive changes and unexpected lockfile churn;
+- route license/compliance uncertainty to The Governor and security implications to Cipher.
+
+## Failure Handling
+
+If validation fails:
+- capture the exact command and failure;
+- determine whether the failure is introduced by the change, pre-existing, environmental, or capacity-related;
+- fix only within the authorized scope;
+- rerun the failed narrow check, then rerun every required gate invalidated by the correction;
+- never mark the phase complete because a different check passed.
+
+If the required tool or environment is unavailable, report the gate as unavailable or blocked. Do not substitute an informal review and call it equivalent.

--- a/adapters/codex/skills/ponytail/CHECKLIST.md
+++ b/adapters/codex/skills/ponytail/CHECKLIST.md
@@ -2,13 +2,41 @@
 
 Use only the sections relevant to the selected task.
 
-## Safe Implementation Checks
-- [ ] branch confirmed
-- [ ] working tree checked
-- [ ] source files inspected
-- [ ] smallest safe change identified and applied
-- [ ] unrelated files avoided
-- [ ] generated/runtime folders avoided (e.g. `.agents/`)
-- [ ] validation run (e.g., compile, lint, test)
-- [ ] diff reviewed
-- [ ] handoff needed if crossing specialist boundary (Clockwork, Cipher, Cloak, etc.)
+## Baseline and Stack
+
+- [ ] repository and branch confirmed
+- [ ] approved baseline/current head confirmed
+- [ ] working tree or exact PR diff checked
+- [ ] relevant source files and callers inspected
+- [ ] language/runtime/framework versions confirmed from repository evidence when syntax depends on them
+- [ ] package manager, build system, and test commands discovered rather than assumed
+- [ ] generated-source ownership identified when generated files are involved
+
+## Safe Implementation
+
+- [ ] owning specialist contracts are clear and current
+- [ ] existing helper/pattern/native capability checked before adding new code or dependencies
+- [ ] smallest correct root-cause change identified and applied
+- [ ] public contracts preserved unless an accepted change requires modification
+- [ ] unrelated files and formatting churn avoided
+- [ ] generated/runtime/cache folders avoided unless explicitly in scope
+- [ ] trust-boundary validation, security, accessibility, and data-integrity requirements preserved
+- [ ] new architecture, persistence, security, UI/UX, or QA decisions rerouted instead of guessed
+
+## Validation
+
+- [ ] narrow changed-surface check executed where applicable
+- [ ] focused regression coverage added or updated for non-trivial changed behavior where the repository has an applicable test path
+- [ ] repository-required validation gate run against the exact current state before transition
+- [ ] exact commands and results recorded
+- [ ] any post-validation source change caused affected checks to rerun
+- [ ] final diff reviewed for accidental edits, debug output, placeholders, temporary files, generated drift, and secrets
+
+## Handoff and Transition
+
+- [ ] behavioral handoff delta produced for material multi-domain work
+- [ ] changed paths and affected layers recorded
+- [ ] potential contract invalidations and specialist re-entry recorded
+- [ ] generated artifacts identified
+- [ ] no readiness claim exceeds executed evidence
+- [ ] staging, commit, push, PR, merge, release, deployment, or protected-state changes occur only under their required authority

--- a/adapters/codex/skills/ponytail/IMPLEMENTATION_FOUNDATIONS_GUIDE.md
+++ b/adapters/codex/skills/ponytail/IMPLEMENTATION_FOUNDATIONS_GUIDE.md
@@ -1,26 +1,134 @@
 # Implementation Foundations Guide
 
-## Safe Code-Change Principles
+## Purpose
 
-- **Inspect before editing**: Always read the target files and relevant dependencies before applying changes.
-- **Identify source of truth**: Ensure you are editing the correct Git-tracked file before making changes.
-- **Preserve user intent and approved specialist decisions**: Do not silently override architectural, security, database, or UI decisions made by the user or other specialists.
-- **Make the smallest safe code change**: Fix the specific issue without rewriting adjacent logic.
-- **Avoid broad rewrites without approval**: Stick to targeted edits unless a broader refactor was explicitly requested and approved.
-- **Avoid unrelated formatting churn**: Do not reformat code or change spacing in areas you are not directly editing.
-- **Avoid modifying runtime/generated folders**: Do not edit `.agents/`, `node_modules/`, `build/`, `dist/`, or similar directories unless explicitly required.
-- **Isolate changes to approved files**: Only modify the files directly relevant to the task.
-- **Keep source changes in Git-tracked source files**: Ensure all persistent updates are applied to the primary repository.
-- **Maintain existing conventions and naming patterns**: Follow the established style of the project.
-- **Preserve public APIs unless change is approved**: Do not break existing API contracts without explicit permission.
-- **Avoid hidden behavior changes**: Keep logic transparent.
-- **Avoid swallowing exceptions silently**: Do not catch exceptions without handling or logging them properly.
-- **Avoid adding placeholder logic as final implementation**: Implement real logic unless a placeholder is explicitly requested.
-- **Avoid hardcoded secrets, credentials, tokens, or private paths**: Ensure secrets are passed via environment variables or secure configuration.
-- **Avoid destructive commands or data mutation unless explicitly approved**: Do not drop tables, delete files, or truncate data unless instructed.
+Give Ponytail enough implementation knowledge to make safe, minimal code changes without relying only on generic model intuition. This guide defines universal implementation reasoning. Load stack-specific syntax only after the repository proves which stack is in use.
 
-## Validation and Workflow
-- **Check branch and git status before editing**: Know your working state.
-- **Review diff before commit**: Ensure your changes match the requested scope.
-- **Validate after edits**: Run the necessary tests, linters, or build commands to verify your work.
-- **Stop before stage/commit/push unless explicitly approved**: Never assume approval for source control operations.
+## Implementation Order
+
+Before writing code:
+
+1. Read the requested behavior and the files that own it.
+2. Trace the real call or data path far enough to locate the correct edit point.
+3. Check whether the codebase already has a helper, abstraction, component, convention, or dependency that solves the problem.
+4. Prefer standard-library or native-platform capabilities when they satisfy the accepted contract.
+5. Use the smallest change that fixes the shared root cause.
+6. Preserve public contracts unless the approved change explicitly modifies them.
+7. Add or update the smallest useful regression check for non-trivial changed behavior.
+8. Run repository-owned validation for the affected surface.
+
+This retains Ponytail's minimalism heritage while keeping Orchestra specialist decisions authoritative.
+
+## Source of Truth
+
+- Inspect before editing.
+- Edit the Git-tracked source of truth, not generated output, installed copies, caches, or runtime mirrors unless explicitly required.
+- Never invent files, functions, types, tables, routes, configuration keys, environment variables, scripts, framework behavior, or runtime versions.
+- Treat lockfiles, manifests, build files, CI workflows, existing tests, and nearby code as evidence of project conventions.
+- Preserve user-approved and specialist-owned architecture, security, persistence, UI, and QA decisions.
+
+## Root-Cause Implementation
+
+A small diff is only useful when it is placed at the correct ownership point.
+
+Prefer:
+- one fix in a shared parser over duplicate guards in every caller;
+- one boundary validation at the real trust boundary over repeated downstream checks;
+- one reusable existing helper over a second implementation;
+- one transaction-safe operation over compensating cleanup after partial mutation.
+
+Do not widen the refactor merely because a broader redesign would be cleaner.
+
+## Control Flow and State
+
+- Keep control flow explicit enough to understand locally.
+- Prefer early returns when they reduce nesting and preserve readability.
+- Do not silently swallow exceptions.
+- Make state transitions explicit when behavior depends on lifecycle or status.
+- Preserve idempotency when an operation may be retried.
+- Avoid hidden mutation across module boundaries.
+- Clean up listeners, file handles, connections, locks, timers, tasks, and temporary resources according to the language/runtime pattern already used by the project.
+
+## Input and Output Boundaries
+
+At every external or trust boundary:
+- validate shape and required values using the project's existing validation mechanism;
+- normalize only when normalization is explicitly part of the accepted behavior;
+- distinguish invalid input from missing optional input;
+- avoid exposing secrets, internal stack traces, private identifiers, or raw infrastructure details;
+- preserve encoding, locale, timezone, numeric precision, and serialization rules already established by the codebase.
+
+Cipher owns security requirements. Chronicler owns persistence semantics. Ponytail implements their accepted contracts.
+
+## Error Handling
+
+- Handle errors at the layer that can make a meaningful decision.
+- Preserve the original cause when wrapping errors.
+- Do not turn every error into success or a generic null value.
+- Use cleanup/finally/defer/context-manager patterns where the language supports them.
+- User-visible error wording belongs to Cloak when it changes UX requirements.
+- Retry policy, backoff policy, and failure-domain design belong to Clockwork/Cipher/Dagger when not already decided.
+
+## Async and Concurrency
+
+Before changing concurrent code:
+- identify the shared mutable state;
+- identify ordering assumptions;
+- identify cancellation and timeout behavior;
+- preserve existing locking, queueing, transactional, or actor ownership patterns;
+- avoid fire-and-forget work unless the project deliberately uses it;
+- make retries idempotent or protected against duplicate effects.
+
+New concurrency architecture belongs to Clockwork. Resilience pressure scenarios belong to Dagger.
+
+## Configuration and Secrets
+
+- Reuse the project's existing configuration system.
+- Do not add a new config source for one value when an established source exists.
+- Never hardcode secrets, tokens, credentials, private keys, or machine-specific paths.
+- Preserve precedence rules among environment variables, config files, defaults, and runtime arguments.
+- Do not rewrite a configuration object in a way that discards unrelated existing keys.
+
+## Dependency Discipline
+
+Before adding a dependency:
+1. search the repository for an existing solution;
+2. check the standard library or platform;
+3. check already-installed dependencies;
+4. add a new dependency only when the accepted task justifies ownership of it.
+
+Respect the project's lockfile and package-manager conventions. Do not regenerate unrelated dependency state.
+
+## Tests and Checks
+
+Non-trivial changed behavior should leave a focused regression check when the repository has an applicable test path.
+
+Prefer:
+- extending a nearby test file;
+- one test proving the reported failure and expected result;
+- existing fixtures and helpers;
+- deterministic inputs;
+- no new testing framework unless explicitly approved.
+
+Overseer owns test strategy and release readiness. Ponytail implements tests and runs narrow checks.
+
+## Diff Discipline
+
+- Keep the changed-file set narrow.
+- Avoid unrelated formatting churn.
+- Avoid changing generated files unless the project's generation contract requires it.
+- Review the final diff for accidental edits, debug output, placeholders, TODOs, temporary files, and secrets.
+- Run `git diff --check` or the project-equivalent whitespace validation when available.
+
+## Specialist Handoffs
+
+Route unresolved decisions instead of guessing:
+- architecture or ownership -> Clockwork
+- security requirements -> Cipher
+- persistence semantics -> Chronicler
+- visible UI/UX requirements -> Cloak
+- test strategy or readiness -> Overseer
+- multi-domain sequencing -> Conductor
+- continuity or transition readiness -> Arbiter
+
+Ponytail is the implementation owner after those contracts are clear.

--- a/adapters/codex/skills/ponytail/SKILL.md
+++ b/adapters/codex/skills/ponytail/SKILL.md
@@ -2,16 +2,16 @@
 name: ponytail
 description: Implementation and Navigation Specialist. Owns minimal safe edits. See SKILL_INDEX.md.
 ---
-
 # Ponytail
 
-Act as the Implementation and Navigation Specialist. You own code navigation, file inspection, targeted implementation, approved refactoring, integration wiring, and applying fixes within defined architecture, security, UI, and QA constraints.
+Act as the Implementation and Navigation Specialist. You own code navigation, file inspection, targeted implementation, approved refactoring, integration wiring, and applying fixes within defined architecture, security, persistence, UI, and QA constraints.
 
 ## Quick Reference
-* **Role**: Implementation and Navigation Specialist.
-* **Scope**: Code edits, navigation, patching, validation runs.
-* **Avoid When**: Architecture design, security policy creation, UI/UX requirements.
-* **Output Format**: IMPLEMENTATION_PLAN, CODE_REVIEW, or QUICK_FIX.
+
+- **Role**: Implementation and Navigation Specialist.
+- **Scope**: Code edits, navigation, patching, integration wiring, and narrow validation runs.
+- **Avoid When**: Architecture design, security policy creation, persistence design, UI/UX requirements, or QA strategy.
+- **Output Format**: `IMPLEMENTATION_PLAN`, `CODE_REVIEW`, or `QUICK_FIX`.
 
 ## Activation Conditions
 
@@ -19,110 +19,105 @@ Use Ponytail when the task needs code implementation, repository navigation, fil
 
 Do not use it for:
 - UI/UX requirements and frontend design decisions -> Cloak
-- architecture, state ownership, provider hierarchy, and service boundaries -> Clockwork
-- security policy, auth/RBAC, privacy, and secrets -> Cipher
-- schema, migrations, and persistence design -> Chronicler
-- QA strategy, test scope, and release-readiness gates -> Overseer
+- architecture, state ownership, provider hierarchy, service boundaries, or concurrency ownership -> Clockwork
+- security policy, auth/RBAC, privacy controls, or secrets requirements -> Cipher
+- schema, migrations, indexes, or persistence semantics -> Chronicler
+- QA strategy, test scope, or release-readiness gates -> Overseer
 - long-form documentation -> Scribe
 - ambiguous ownership or multi-specialist routing -> Conductor
 
-Body-level avoid_when guidance:
-- If the task is primarily deciding what should be built, who owns it, or how multiple specialists should sequence, reroute to Conductor before editing code.
-- If implementation depends on unresolved UI/UX, architecture, security, persistence, or validation decisions, stop and reroute to the owning specialist first.
+If implementation depends on an unresolved specialist decision, stop and return `SPECIALIST_REROUTE_REQUIRED` instead of guessing.
 
-## Supported work
+## Supported Work
 
 - code navigation and file inspection
 - targeted implementation and bug fixes
 - small approved refactors
-- integration wiring inside existing architecture boundaries
-- patching code to match already-decided specialist requirements
-- running narrow local validation commands for the changed surface
+- integration wiring inside accepted architecture boundaries
+- implementing accepted security, persistence, UI, and QA contracts
+- writing or updating focused tests owned by the implementation change
+- running narrow repository-owned validation commands
 
-## Progressive Disclosure Rule
+## Ponytail Implementation Heuristic
 
-Use `SKILL.md` first. Do not load every supporting document by default or consume context with unused material.
-- Load `OUTPUT_FORMATS.md` only when generating the final response.
-- Load `IMPLEMENTATION_FOUNDATIONS_GUIDE.md` only when the task involves code implementation, file edits, refactoring, repository navigation, patching, integration wiring, debugging fixes, or applying specialist-approved changes.
+Ponytail keeps the upstream minimalism principle, but Orchestra boundaries remain authoritative. Apply this order only after understanding the real execution path:
 
-## Implementation Boundaries (Handoff Rules)
+1. Confirm the requested behavior is actually required.
+2. Reuse an existing helper, type, pattern, component, or abstraction when it already solves the problem.
+3. Prefer the language standard library before custom utility code.
+4. Prefer a native platform capability before adding another abstraction or dependency.
+5. Reuse an already-installed dependency when it is the established project solution.
+6. Choose the smallest implementation that satisfies the accepted contract.
+7. Fix a shared root cause at the narrowest correct ownership point instead of patching each symptom separately.
+8. Leave a focused regression check for non-trivial changed behavior when the repository has an applicable test path.
 
-Ponytail owns:
-- code navigation
-- file inspection
-- targeted implementation
-- small refactors approved by specialist guidance
-- wiring approved changes
-- applying fixes within defined architecture/security/database/UI/QA constraints
-- running local validation commands when approved
+Minimalism never overrides explicit requirements, trust-boundary validation, security controls, accessibility requirements, data-integrity rules, architecture contracts, or validation gates.
 
-Ponytail does not own:
-- routing or multi-specialist orchestration -> Conductor
-- governance decisions, compliance decisions, or continuity authority -> The Steward, The Governor, or Arbiter through Conductor
-- architecture design -> Clockwork
-- architecture ownership decisions for state boundaries, provider hierarchy, and service boundaries -> Clockwork
-- database schema, SQL, migrations, indexes, seed data -> Chronicler
-- persistence design and stored-record behavior -> Chronicler
-- security policy, auth/RBAC/secrets/privacy requirements -> Cipher
-- UI/UX requirements and visual design decisions -> Cloak
-- QA strategy, test scope, release readiness -> Overseer
-- documentation prose and long docs -> Scribe
-- continuity/merge readiness after interruption or branch drift -> Arbiter
+## Progressive Disclosure
+
+Start with this file. Load only the knowledge required by the confirmed stack and task.
+
+- Non-trivial implementation or debugging -> [IMPLEMENTATION_FOUNDATIONS_GUIDE.md](IMPLEMENTATION_FOUNDATIONS_GUIDE.md)
+- Unknown or ambiguous repository stack -> [STACK_DISCOVERY_GUIDE.md](STACK_DISCOVERY_GUIDE.md)
+- JavaScript or TypeScript -> [references/javascript-typescript.md](references/javascript-typescript.md)
+- Python -> [references/python.md](references/python.md)
+- Java or JVM code -> [references/java-jvm.md](references/java-jvm.md)
+- Go or Rust -> [references/go-rust.md](references/go-rust.md)
+- Shell or PowerShell -> [references/shell-powershell.md](references/shell-powershell.md)
+- HTML, CSS, browser APIs, or frontend runtime implementation -> [references/web-runtime.md](references/web-runtime.md)
+- Build, lint, typecheck, test, packaging, or generated-code commands -> [BUILD_TEST_TOOLING_GUIDE.md](BUILD_TEST_TOOLING_GUIDE.md)
+- Concrete implementation and handoff patterns -> [examples/implementation-patterns.md](examples/implementation-patterns.md)
+- Upstream Ponytail provenance or sync work -> [UPSTREAM_REFERENCE.md](UPSTREAM_REFERENCE.md)
+- Final response format -> [OUTPUT_FORMATS.md](OUTPUT_FORMATS.md)
+
+Existing repository conventions override generic examples in these references. A syntax reference is not permission to introduce that stack, dependency, framework, or tool.
 
 ## Cross-Layer Contract Implementation Gate
 
-For material multi-domain work, implement only against an accepted or frozen CrossLayerContractPacket plus separate implementation authority.
+For material multi-domain work, implement only against an accepted or frozen `CrossLayerContractPacket` plus separate implementation authority.
 
 Stop and return `SPECIALIST_REROUTE_REQUIRED` when:
-
 - an upstream contract is missing, contradictory, or stale;
 - implementation requires a new architecture, security, persistence, UI/UX, governance, or validation decision;
 - changed behavior crosses an undeclared specialist boundary;
 - an undeclared generated artifact or external action is required.
 
-After implementation, produce a behavioral handoff delta that states changed paths, affected layers, contract assumptions changed, potential invalidations, generated artifacts, validation performed, and known limitations. Phase 2 adds complete staged and untracked change-identity enforcement.
+After implementation, produce a behavioral handoff delta that states changed paths, affected layers, contract assumptions changed, potential invalidations, generated artifacts, validation performed, and known limitations.
 
 ## Safe Implementation Rules
 
-- No implementation without inspecting relevant files first.
-- No broad refactor unless explicitly approved.
-- No changing architecture boundaries without Clockwork.
-- No changing schema/migrations without Chronicler.
-- No changing auth/RBAC/secrets/security config without Cipher.
-- No changing UI/UX behavior without Cloak requirements.
-- No claiming validation passed unless commands actually ran.
-- No staging, committing, pushing, or PR creation unless explicitly approved.
-
-## Scope Enforcement
-
-Ponytail edits code, but does not absorb routing, governance, architecture, security policy, UI/UX decisions, persistence design, QA strategy, or long documentation.
-
-Required behavior:
-- Implement directly when the task is a scoped code change and the owning specialist decisions are already clear.
-- When the request is outside Ponytail's scope or belongs to another specialist, return `SPECIALIST_REROUTE_REQUIRED` and do not execute the work.
-- If the task crosses specialist boundaries but the next owner is obvious, recommend that specialist directly.
-- If the task crosses multiple specialist boundaries or ownership is unclear, return `SPECIALIST_REROUTE_REQUIRED` and route back to Conductor.
+- Inspect relevant files and their callers before editing.
+- Confirm the repository stack and existing commands before choosing syntax or tooling.
+- Prefer established project patterns over introducing a second framework or local convention.
+- Preserve public contracts unless the accepted change explicitly modifies them.
+- Do not broaden a refactor merely because a larger redesign appears cleaner.
+- Do not change architecture boundaries without Clockwork.
+- Do not change schema or persistence semantics without Chronicler.
+- Do not change auth, RBAC, secrets, or security-control requirements without Cipher.
+- Do not invent visible UI/UX requirements without Cloak.
+- Do not redefine test strategy or release readiness without Overseer.
+- Never infer a package manager, framework, runtime version, test command, generated-file contract, or environment variable that the repository does not prove.
+- Never claim validation passed unless the command actually ran against the stated revision.
+- Do not stage, commit, push, open a PR, merge, release, deploy, or modify protected state without the required authority.
 
 ## Validation Expectations
 
-- Inspect the relevant files before making implementation claims.
-- Run the narrowest relevant local validation for the changed surface when commands are allowed and available.
-- Report the exact validation command and result. Do not claim validation passed unless it actually ran.
-- If test strategy, release-readiness, or validation-gate ownership becomes the main task, hand off to Overseer instead of expanding Ponytail's role.
-- If a change implements requirements owned by Cloak, Clockwork, Cipher, or Chronicler, keep the validation claim limited to the implemented code and executed checks. Do not restate ownership of their design decisions.
+- Discover commands from repository-owned manifests, task files, workflows, and documentation before running them.
+- Run the narrowest relevant checks during implementation, then the repository-required gate before transition.
+- Report exact commands and outcomes.
+- Treat any source change after validation as invalidating affected exact-head evidence.
+- If validation strategy becomes the main task, return to Overseer.
 
-## Local-only safety
+## Local-Only Safety
 
-- Keep scratch notes, temporary implementation plans, debug logs, and one-off local artifacts untracked unless repository tracking is explicitly approved.
-- Do not stage, commit, push, create a pull request, or modify `.gitignore` without approval.
-- Edit tracked repository source by default. Do not modify runtime copies, installed-skill copies, or other local mirrors unless the task explicitly targets parity there.
-
+- Keep scratch notes, debug logs, temporary plans, and one-off artifacts untracked unless repository tracking is explicitly approved.
+- Edit tracked repository source by default. Do not modify runtime copies, installed-skill copies, caches, build output, or generated mirrors unless the task explicitly requires parity there.
 
 <!-- THE_TUNER_PHASE_2_EVIDENCE_CONTINUITY -->:skills/ponytail/SKILL.md
 
 ## Phase 2 Complete Handoff Delta
 
-For material multi-domain work, Ponytail must produce a complete SpecialistHandoffDelta after implementation. The handoff must include:
+For material multi-domain work, Ponytail must produce a complete `SpecialistHandoffDelta` after implementation. The handoff must include:
 
 - frozen packet revision and contract hash;
 - approved baseline, current commit, and working-tree fingerprint;

--- a/adapters/codex/skills/ponytail/SKILL.md
+++ b/adapters/codex/skills/ponytail/SKILL.md
@@ -26,7 +26,7 @@ Do not use it for:
 - long-form documentation -> Scribe
 - ambiguous ownership or multi-specialist routing -> Conductor
 
-If implementation depends on an unresolved specialist decision, stop and return `SPECIALIST_REROUTE_REQUIRED` instead of guessing.
+If implementation depends on an unresolved specialist decision, return `SPECIALIST_REROUTE_REQUIRED` and do not execute the work. Do not guess.
 
 ## Supported Work
 

--- a/adapters/codex/skills/ponytail/STACK_DISCOVERY_GUIDE.md
+++ b/adapters/codex/skills/ponytail/STACK_DISCOVERY_GUIDE.md
@@ -1,0 +1,84 @@
+# Stack Discovery Guide
+
+## Purpose
+
+Identify the actual language, runtime, framework, package manager, build system, and test tooling before Ponytail chooses implementation syntax or commands.
+
+## Discovery Sequence
+
+1. Confirm repository root and current branch.
+2. Read the closest project instructions and contribution guidance.
+3. Inspect manifests, lockfiles, build files, and CI workflows.
+4. Inspect the target file and nearby files for local conventions.
+5. Inspect existing tests for framework and fixture patterns.
+6. Inspect package scripts or task definitions before selecting commands.
+7. Load only the relevant section of `LANGUAGE_IMPLEMENTATION_GUIDE.md`.
+
+Do not infer a stack from the repository name or from a single file when stronger evidence exists.
+
+## Common Stack Evidence
+
+| Evidence | Likely meaning | Do not assume |
+| --- | --- | --- |
+| `package.json` | Node-based tooling exists | npm is the package manager |
+| `package-lock.json` | npm lockfile | every workspace uses npm |
+| `pnpm-lock.yaml` | pnpm lockfile | scripts are identical to npm |
+| `yarn.lock` | Yarn lockfile | Yarn classic vs modern without config |
+| `tsconfig.json` | TypeScript configuration | framework or runtime |
+| `pyproject.toml` | Python project/tool configuration | exact package manager |
+| `requirements*.txt` | pip-compatible dependency list | project is not also managed by another tool |
+| `uv.lock` | uv-managed Python environment is likely | allowed install command without project guidance |
+| `poetry.lock` | Poetry-managed dependencies | Poetry version |
+| `pom.xml` | Maven Java/JVM build | application framework |
+| `build.gradle` / `build.gradle.kts` | Gradle build | wrapper availability |
+| `gradlew` / `gradlew.bat` | Gradle wrapper | global Gradle should be used |
+| `Cargo.toml` | Rust package | workspace shape |
+| `go.mod` | Go module | target Go version without reading the file |
+| `composer.json` | PHP Composer project | framework |
+| `Gemfile` | Ruby Bundler project | framework |
+| `Dockerfile` | container build exists | container is the primary local dev path |
+| `Makefile` | project tasks may be wrapped by make | target names |
+| `.github/workflows/*` | CI command evidence | local environment exactly matches CI |
+
+## Framework Signals
+
+Confirm framework versions from manifests before using version-sensitive APIs.
+
+Examples of signals:
+- React/Next/Vite: dependencies and project scripts in `package.json`.
+- Express/Fastify/Nest: dependencies plus server bootstrap code.
+- Django/Flask/FastAPI: Python dependencies plus application entry points.
+- Spring: Maven/Gradle dependencies and annotated application classes.
+- JPA/Hibernate: persistence dependencies and entity/repository patterns.
+- pytest/Jest/Vitest/JUnit: existing test imports, config, and scripts.
+
+## Command Discovery
+
+Prefer commands already owned by the repository:
+
+- `package.json` scripts such as `test`, `lint`, `typecheck`, `build`, `validate`.
+- `Makefile`, `justfile`, `Taskfile.yml`, npm scripts, Maven goals, or Gradle tasks.
+- CI workflow commands when local scripts are absent.
+- Project documentation only when it matches current configuration.
+
+Never invent a command merely because it is common for the ecosystem.
+
+## File Ownership Discovery
+
+Before editing:
+- search references to the target function/class/module;
+- identify callers and consumers;
+- identify generated or mirrored copies;
+- identify tests for the same behavior;
+- identify whether the file is generated from another source.
+
+If a generated file has a canonical generator source, edit the generator source and regenerate only through the established project command.
+
+## Stop Conditions
+
+Return for specialist or user guidance when:
+- two conflicting package managers appear and ownership is unclear;
+- the runtime version required by the intended syntax cannot be confirmed;
+- generated-source ownership cannot be identified;
+- multiple implementations exist and architecture ownership is unclear;
+- the only apparent validation command performs deployment, destructive mutation, or production access.

--- a/adapters/codex/skills/ponytail/UPSTREAM_REFERENCE.md
+++ b/adapters/codex/skills/ponytail/UPSTREAM_REFERENCE.md
@@ -1,0 +1,75 @@
+# Upstream Ponytail Reference
+
+## Purpose
+
+Preserve provenance and sync boundaries for the Ponytail specialist without making the external repository an implicit authority over Orchestra.
+
+## Source Lineage
+
+Orchestra's Ponytail role was incorporated from the Ponytail project and then adapted to Orchestra's specialist ownership, governance, validation, handoff, and host-packaging contracts.
+
+Upstream source repository:
+
+`DietrichGebert/ponytail`
+
+Maintainer fork used during earlier Orchestra incorporation:
+
+`Baelfyre/ponytail`
+
+License reported by the upstream/fork repository: MIT.
+
+## 2026-08-12 Upstream Checkpoint
+
+At the start of Orchestra Specialist Knowledge Layer phase SK1:
+
+```text
+Baelfyre/ponytail main
+14a0d79548d4de8fc2de95c1b94bb0de63a739d3
+package 4.8.4
+
+DietrichGebert/ponytail main
+2ed6c52c9d7e5e56942508591085fd45dea277d3
+package 4.9.0
+
+skills/ponytail/SKILL.md blob at both revisions
+02c0712c86277d49d18a77da3a2b825657bf02d1
+```
+
+The package-level upstream delta after the fork checkpoint included host-adapter, compatibility, packaging, and release work. The core Ponytail `SKILL.md` blob was unchanged between those two revisions.
+
+## SK1 Disposition
+
+Do not import the upstream repository wholesale into Orchestra.
+
+Retain these useful Ponytail principles:
+- question speculative work through YAGNI;
+- inspect before editing;
+- reuse code already present in the repository;
+- prefer standard-library and native-platform capabilities;
+- avoid unnecessary dependencies and abstractions;
+- fix shared root causes rather than repeated symptoms;
+- keep the implementation diff as small as correctness allows;
+- leave a focused check for non-trivial changed logic.
+
+Orchestra adds stronger requirements that remain authoritative:
+- specialist ownership boundaries;
+- cross-layer contract gating;
+- evidence-bound validation;
+- exact-head continuity;
+- explicit external-action authority;
+- security, persistence, UI/UX, QA, and governance handoffs;
+- portable adapter parity.
+
+## Future Sync Rule
+
+When checking upstream Ponytail again:
+
+1. identify the true upstream repository and current main/tag;
+2. compare the last reviewed upstream revision with current upstream;
+3. inspect core skill/intelligence changes separately from packaging/adapter changes;
+4. classify each relevant delta as concept, instruction, runtime code, test, packaging, or documentation;
+5. import only improvements that fit Ponytail's Orchestra role and do not conflict with Orchestra governance;
+6. preserve attribution/license obligations when copying source text or code;
+7. run the full Orchestra validation workflow after any accepted integration.
+
+A newer upstream version does not automatically make Orchestra stale, and an unchanged core skill does not prevent Orchestra-native specialist improvements.

--- a/adapters/codex/skills/ponytail/examples/implementation-patterns.md
+++ b/adapters/codex/skills/ponytail/examples/implementation-patterns.md
@@ -1,0 +1,119 @@
+# Ponytail Implementation Patterns
+
+Use these as implementation reasoning examples, not as architecture or product requirements. Existing repository conventions and specialist-owned contracts remain authoritative.
+
+## Pattern 1: Fix the Shared Root Cause
+
+**Situation**: Three callers fail when a shared parser receives an empty string.
+
+Weak approach:
+- add the same empty-string guard in all three callers.
+
+Preferred Ponytail approach:
+- confirm the parser is the correct ownership point;
+- add one narrow parser-level correction;
+- add one regression test proving the shared behavior;
+- verify callers do not rely on the prior failure behavior.
+
+Why: the smaller correct diff removes the defect once instead of multiplying maintenance.
+
+## Pattern 2: Implement a Cipher Contract Without Rewriting Security Policy
+
+**Accepted Cipher requirement**:
+- the server must reject access when the authenticated principal does not own the requested object.
+
+Ponytail implementation behavior:
+1. locate the established authentication principal and repository/service boundary;
+2. reuse the current authorization helper if one exists;
+3. enforce the check on the server-side object path;
+4. return the project's accepted denial response;
+5. add/update a focused unauthorized-object regression test;
+6. do not invent a new role model or client-side-only check.
+
+If the correct ownership rule is ambiguous, reroute to Cipher.
+
+## Pattern 3: Implement a Chronicler Contract Without Inventing Persistence Semantics
+
+**Accepted Chronicler requirement**:
+- a record update must reject stale versions using the existing version column.
+
+Ponytail implementation behavior:
+1. inspect the current repository/ORM pattern;
+2. implement the accepted version predicate or framework-supported optimistic-lock mechanism;
+3. preserve the transaction boundary established by Clockwork/Chronicler;
+4. map stale-write failure to the existing application error contract;
+5. add a focused persistence/integration regression test.
+
+Do not add a new version column, isolation level, retry loop, or transaction boundary without Chronicler/Clockwork ownership.
+
+## Pattern 4: Implement a Cloak Interaction Contract
+
+**Accepted Cloak requirement**:
+- while a save-owned completion mutation is pending, the completion affordance must not dispatch another completion request.
+
+Ponytail implementation behavior:
+1. find the state that owns the active mutation;
+2. bind actionable state to that existing source of truth;
+3. preserve keyboard and disabled-state behavior specified by Cloak;
+4. remove duplicate dispatch paths rather than adding timers or ad hoc flags when one owner already exists;
+5. add a focused interaction test proving one completion dispatch.
+
+Do not redesign the workflow or change server completion authority.
+
+## Pattern 5: Implement an Overseer Test Request
+
+**Overseer asks**:
+- add regression coverage for malformed configuration without expanding the suite.
+
+Ponytail implementation behavior:
+1. inspect nearby tests and fixture style;
+2. add the smallest case that reproduces the failure;
+3. invoke the same public or internal boundary used by the defect;
+4. assert the observable contract, not incidental implementation details;
+5. run the narrow test, then required repository validation.
+
+Do not add a new test framework or broad fixture hierarchy for one case.
+
+## Pattern 6: Dependency Request
+
+**Request**: add a library for a small formatting operation.
+
+Ponytail ladder:
+1. search for an existing project helper;
+2. check standard library/native APIs;
+3. check installed dependencies already used for the same purpose;
+4. only add a new dependency when the accepted requirement still cannot be met cleanly.
+
+If a dependency is added, preserve the repository package manager and lockfile, then run dependency/security/license checks required by the project.
+
+## Pattern 7: Generated Source
+
+**Situation**: an exported client contains the wrong output.
+
+Ponytail behavior:
+1. determine whether the client is generated;
+2. find the OpenAPI/schema/template/generator input;
+3. fix the canonical input or generator;
+4. run the repository-owned generation command;
+5. inspect generated diff for deterministic scope;
+6. run compile/type/test checks for both source and generated consumer surfaces.
+
+Manual patching of generated output is only acceptable when the repository explicitly treats that file as editable source.
+
+## Pattern 8: Complete Handoff Delta
+
+For material cross-domain work, the implementation handoff should be compact but complete:
+
+```text
+baseline: <approved SHA>
+head/worktree: <current identity>
+changed paths: <exact list>
+implemented contracts: <contract IDs/revisions>
+behavioral delta: <what changed>
+potential invalidations: <owners to re-enter>
+generated artifacts: <none or exact identities>
+validation executed: <exact commands/results>
+known limitations: <bounded residuals>
+```
+
+Do not claim another specialist's decision as Ponytail's own. Do not claim readiness beyond the validation actually executed.

--- a/adapters/codex/skills/ponytail/references/go-rust.md
+++ b/adapters/codex/skills/ponytail/references/go-rust.md
@@ -1,0 +1,149 @@
+# Go and Rust Implementation Reference
+
+## Use When
+
+Load only after repository evidence confirms Go or Rust. Follow the repository's module/workspace structure, compiler/toolchain version, formatting, linting, testing, and error-handling conventions.
+
+## Go
+
+### Core patterns
+
+Prefer small concrete APIs and explicit errors.
+
+```go
+func NormalizeName(value string) string {
+    return strings.TrimSpace(value)
+}
+```
+
+Handle errors at the point where a meaningful decision can be made:
+
+```go
+value, err := loadValue(ctx, id)
+if err != nil {
+    return Result{}, fmt.Errorf("load value %q: %w", id, err)
+}
+```
+
+Use `%w` when wrapping errors that callers may need to inspect.
+
+### Context and concurrency
+
+- Pass `context.Context` through request/cancellation boundaries when the project uses it.
+- Do not store contexts in structs unless an established API requires it.
+- Close channels from the sending/owning side.
+- Avoid goroutines whose lifecycle has no clear owner.
+- Prevent goroutine leaks by respecting cancellation and terminal conditions.
+- Use mutexes, channels, atomics, or worker pools only when the existing design or Clockwork contract establishes the concurrency model.
+
+```go
+select {
+case <-ctx.Done():
+    return ctx.Err()
+case result := <-results:
+    return result.Err
+}
+```
+
+### Resources
+
+Use `defer` for cleanup when ownership is local and the deferred operation is safe.
+
+```go
+file, err := os.Open(path)
+if err != nil {
+    return err
+}
+defer file.Close()
+```
+
+Check close/flush errors when they can affect correctness, especially writes.
+
+### Testing
+
+Use the standard `testing` package and repository helpers unless another established harness exists.
+
+```go
+func TestNormalizeName(t *testing.T) {
+    if got := NormalizeName("  Ada  "); got != "Ada" {
+        t.Fatalf("got %q", got)
+    }
+}
+```
+
+Prefer table-driven tests when multiple cases genuinely share one behavior.
+
+### Common Go mistakes
+
+Avoid:
+- ignoring returned errors;
+- starting goroutines without lifecycle/cancellation ownership;
+- copying structs containing synchronization primitives;
+- adding interfaces solely for mocking when a concrete boundary is sufficient;
+- using `panic` for recoverable request/data errors;
+- introducing global mutable state for convenience.
+
+## Rust
+
+### Ownership and borrowing
+
+Prefer APIs whose ownership reflects the real lifecycle. Borrow data when the caller retains ownership and cloning adds no value.
+
+```rust
+fn normalize_name(value: &str) -> String {
+    value.trim().to_owned()
+}
+```
+
+Return borrowed data when the lifetime is naturally tied to the input and an owned value is unnecessary.
+
+### Result and Option
+
+Use `Result` for recoverable failures and `Option` for genuine absence. Propagate errors with `?` when the current layer cannot add a meaningful decision.
+
+```rust
+fn load(path: &Path) -> io::Result<String> {
+    fs::read_to_string(path)
+}
+```
+
+Do not use `unwrap()` or `expect()` on untrusted/runtime paths unless failure is provably impossible and the repository accepts that invariant. Tests and one-time initialization may have different conventions.
+
+### Iterators
+
+Use iterators when they remain readable and ownership is clear.
+
+```rust
+let names: Vec<_> = users.iter().map(|user| user.name.as_str()).collect();
+```
+
+Avoid dense combinator chains when explicit control flow communicates error or state transitions better.
+
+### Concurrency and async
+
+Confirm the runtime before using Tokio, async-std, Rayon, or other concurrency tooling. Do not introduce a runtime or synchronization model incidentally.
+
+- Make task ownership and cancellation explicit.
+- Avoid holding mutex guards across `.await` unless the lock type and design explicitly support it.
+- Preserve `Send`/`Sync` assumptions established by the architecture.
+- Use bounded channels/queues when backpressure is an accepted requirement.
+
+### Testing
+
+Use built-in tests and the repository's integration-test organization.
+
+```rust
+#[test]
+fn normalizes_whitespace() {
+    assert_eq!(normalize_name("  Ada  "), "Ada");
+}
+```
+
+### Common Rust mistakes
+
+Avoid:
+- cloning merely to satisfy the borrow checker without understanding ownership;
+- `unwrap()` on recoverable input/I/O paths;
+- introducing `unsafe` without explicit necessity, review, and validation;
+- selecting an async runtime from generic knowledge rather than repository evidence;
+- changing public lifetime/trait bounds casually because downstream effects can be broad.

--- a/adapters/codex/skills/ponytail/references/java-jvm.md
+++ b/adapters/codex/skills/ponytail/references/java-jvm.md
@@ -1,0 +1,144 @@
+# Java and JVM Implementation Reference
+
+## Use When
+
+Load this reference only after repository evidence confirms Java or another JVM language. Preserve the configured JDK, Maven/Gradle wrapper, framework version, package layout, nullability conventions, and existing dependency-injection style.
+
+## Core Java
+
+Prefer clear immutable state where practical. Use interfaces and abstractions when they serve an existing boundary, not merely because Java permits them.
+
+```java
+public final class NameNormalizer {
+    public static String normalize(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    private NameNormalizer() {}
+}
+```
+
+Use `final` where it reflects stable ownership and matches project style. Do not create utility classes for behavior that already belongs to a domain/service object.
+
+## Collections and Optional Values
+
+Program against the collection behavior the project expects. Avoid returning mutable internal collections directly.
+
+Use `Optional` according to project convention, typically for return values representing absence rather than entity fields or every method parameter.
+
+```java
+public Optional<User> findById(long id) {
+    return repository.findById(id);
+}
+```
+
+Do not use `Optional.get()` without proving presence.
+
+## Exceptions
+
+- Catch exceptions only where the layer can recover, translate, or add meaningful context.
+- Preserve the cause when wrapping.
+- Do not use exceptions for ordinary control flow.
+- Respect checked/unchecked exception conventions already established by the application.
+
+```java
+try {
+    return parser.parse(input);
+} catch (ParseException ex) {
+    throw new ConfigurationException("Invalid configuration", ex);
+}
+```
+
+## Resource Management
+
+Use try-with-resources for `AutoCloseable` resources.
+
+```java
+try (var input = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
+    return input.readLine();
+}
+```
+
+Preserve transaction and connection ownership defined by the persistence layer.
+
+## Concurrency
+
+Do not add threads, executors, futures, reactive streams, or virtual-thread behavior without confirming the project's runtime and accepted architecture.
+
+When concurrency is already present:
+- identify shared mutable state;
+- preserve executor ownership;
+- propagate interruption where appropriate;
+- preserve timeout and cancellation semantics;
+- avoid holding locks across external I/O;
+- keep retryable effects idempotent.
+
+New concurrency ownership belongs to Clockwork.
+
+## Maven and Gradle
+
+Prefer repository wrappers when present:
+
+```text
+./mvnw ...
+./gradlew ...
+gradlew.bat ...
+```
+
+Do not substitute global Maven or Gradle when the wrapper is the project contract. Discover exact goals/tasks from the build file, wrapper, CI, and project docs.
+
+## Spring and Dependency Injection
+
+Confirm the framework and version before using annotations or APIs.
+
+General principles:
+- preserve constructor injection when established;
+- keep controllers/adapters thin when service boundaries already exist;
+- do not move transaction ownership without Chronicler/Clockwork agreement;
+- do not weaken method or route authorization owned by Cipher;
+- do not add a new bean abstraction for a single call site without an accepted reason.
+
+```java
+@Service
+public final class AccountService {
+    private final AccountRepository repository;
+
+    public AccountService(AccountRepository repository) {
+        this.repository = repository;
+    }
+}
+```
+
+## JPA and ORM Boundaries
+
+Chronicler owns schema and persistence semantics. Ponytail may implement an accepted persistence contract.
+
+- Respect entity identity and lifecycle rules.
+- Do not expose persistence entities as API contracts when the architecture separates DTO/domain/entity models.
+- Avoid accidental lazy-loading assumptions across closed transactions.
+- Do not add cascade, orphan-removal, fetch-mode, or transaction changes without understanding their data effects.
+- Preserve optimistic locking/version columns where present.
+
+## Testing
+
+Use the existing framework, commonly JUnit in Java repositories, and existing mocking/integration conventions.
+
+```java
+@Test
+void normalizesWhitespace() {
+    assertEquals("Ada", NameNormalizer.normalize("  Ada  "));
+}
+```
+
+Prefer repository-provided integration harnesses for persistence and framework behavior instead of mocking away the contract being tested.
+
+## Common Failure Patterns
+
+Avoid:
+- introducing interfaces with one implementation without an established boundary need;
+- field injection when the repository uses constructor injection;
+- swallowing `InterruptedException`;
+- returning ORM entities through unrelated API layers when DTO separation exists;
+- transaction annotations added as trial-and-error fixes;
+- changing Java/JDK APIs without confirming the configured target version;
+- editing generated sources instead of their generator inputs.

--- a/adapters/codex/skills/ponytail/references/javascript-typescript.md
+++ b/adapters/codex/skills/ponytail/references/javascript-typescript.md
@@ -1,0 +1,151 @@
+# JavaScript and TypeScript Implementation Reference
+
+## Use When
+
+Load this reference only after repository evidence confirms JavaScript or TypeScript. Preserve the project's module system, compiler target, formatter, lint rules, framework conventions, and runtime version.
+
+## Core Syntax
+
+Prefer `const`; use `let` only when reassignment is required. Avoid `var` unless maintaining legacy code that already depends on it.
+
+```ts
+export function normalizeName(value: string | null | undefined): string {
+  return value?.trim() ?? "";
+}
+```
+
+Use `===` and `!==` unless the existing code deliberately relies on coercion.
+
+Prefer nullish coalescing when `0`, `false`, or an empty string are valid values:
+
+```ts
+const retries = config.retries ?? 3;
+```
+
+Use optional chaining only for genuinely optional paths. Do not use it to hide an invariant violation that should fail.
+
+## Types
+
+- Prefer specific domain types over `any`.
+- Use `unknown` for untrusted values until narrowed.
+- Narrow unions explicitly.
+- Preserve existing exported types and public signatures unless contract change is approved.
+- Do not use a type assertion to bypass a runtime trust boundary.
+
+```ts
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+```
+
+Discriminated unions are useful for explicit state machines:
+
+```ts
+type Result =
+  | { kind: "ok"; value: string }
+  | { kind: "error"; message: string };
+```
+
+## Async Code
+
+Use `async`/`await` when the project does. Preserve cancellation and timeout behavior already established by the repository.
+
+```ts
+export async function loadJson(url: string, signal?: AbortSignal): Promise<unknown> {
+  const response = await fetch(url, { signal });
+  if (!response.ok) {
+    throw new Error(`request failed: ${response.status}`);
+  }
+  return response.json();
+}
+```
+
+Rules:
+- await promises that own required effects;
+- do not create unhandled promises;
+- use `Promise.all` only when operations are independent and concurrent execution is safe;
+- preserve ordering when side effects depend on sequence;
+- do not invent retries or concurrency limits without an accepted contract.
+
+## Collections
+
+Prefer built-ins such as `map`, `filter`, `find`, `some`, `every`, `Set`, and `Map` when they make ownership and intent clearer. Avoid compressed chains when they obscure error handling or state changes.
+
+Use `Set` for uniqueness and `Map` when keys are not naturally object properties.
+
+## Errors
+
+Throw or return errors according to the established project convention. When wrapping, retain the original cause where supported:
+
+```ts
+try {
+  await persist();
+} catch (error) {
+  throw new Error("persist failed", { cause: error });
+}
+```
+
+Do not expose raw errors to users or API clients when they may contain internal details.
+
+## Node.js
+
+- Prefer `node:` built-ins where the repository already uses them.
+- Use `path.join`/`path.resolve` rather than string-building filesystem paths.
+- Specify text encoding when reading or writing text.
+- Avoid sync filesystem APIs on latency-sensitive server request paths unless the existing design accepts them.
+- Preserve ESM/CommonJS boundaries. Do not convert module systems incidentally.
+
+```ts
+import { readFile } from "node:fs/promises";
+
+const content = await readFile(path, "utf8");
+```
+
+## React and Component Code
+
+Cloak owns UI/UX requirements; Clockwork may own state or provider architecture. Ponytail implements accepted behavior.
+
+- Keep render functions pure.
+- Derive values instead of duplicating them in state.
+- Use effects for synchronization with external systems, not ordinary derivation.
+- Clean up listeners, subscriptions, timers, and requests in effects.
+- Preserve controlled/uncontrolled component conventions already used by the project.
+- Avoid memoization unless identity or measured performance requires it.
+
+```tsx
+useEffect(() => {
+  const controller = new AbortController();
+  void loadData(controller.signal);
+  return () => controller.abort();
+}, [loadData]);
+```
+
+Do not invent dependencies to silence effect linting. Fix stale closures or unstable ownership at the correct layer.
+
+## Validation and Serialization
+
+For external data:
+- use the repository's established schema/validation library if one exists;
+- otherwise perform narrow runtime checks before trusting values;
+- distinguish absent optional fields from invalid fields;
+- preserve JSON casing, numeric precision, and date/time conventions already in use.
+
+TypeScript types disappear at runtime and do not validate network, file, environment, or user input.
+
+## Testing
+
+Use the existing framework and nearby test style. Typical patterns may include Jest, Vitest, Node test runner, Playwright, or framework-specific tools, but repository evidence decides.
+
+Prefer a test that fails for the prior bug and passes for the corrected root cause. Do not add a second test framework for one change.
+
+## Common Failure Patterns
+
+Avoid:
+- `as any` or broad assertions used to silence real type errors;
+- catching and ignoring errors;
+- mutation hidden inside getters or render logic;
+- duplicate derived state;
+- `Promise.all` across operations that must be ordered;
+- defaulting with `||` when valid falsy values exist;
+- new dependencies for standard-library tasks;
+- framework-version-specific APIs without confirming the installed version.

--- a/adapters/codex/skills/ponytail/references/python.md
+++ b/adapters/codex/skills/ponytail/references/python.md
@@ -1,0 +1,141 @@
+# Python Implementation Reference
+
+## Use When
+
+Load this reference only after repository evidence confirms Python. Preserve the supported Python version, formatter, linter, type checker, package manager, framework, and repository conventions.
+
+## Core Syntax
+
+Prefer straightforward functions and data structures. Use type hints where the project uses them.
+
+```python
+def normalize_name(value: str | None) -> str:
+    return value.strip() if value is not None else ""
+```
+
+Use `is None` and `is not None` for `None` checks. Do not use mutable objects as default arguments.
+
+```python
+def append_value(value: str, items: list[str] | None = None) -> list[str]:
+    result = [] if items is None else list(items)
+    result.append(value)
+    return result
+```
+
+## Data Modeling
+
+Prefer existing project models. For simple internal records, `dataclasses` may be appropriate when the repository already uses standard-library modeling.
+
+```python
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class UserRef:
+    user_id: str
+    display_name: str
+```
+
+Do not introduce Pydantic, attrs, a new ORM, or another modeling package when the repository has an established approach.
+
+## Context Management and Cleanup
+
+Use context managers for files, locks, transactions, and resources when supported.
+
+```python
+from pathlib import Path
+
+text = Path(path).read_text(encoding="utf-8")
+```
+
+```python
+with open(path, "r", encoding="utf-8") as handle:
+    content = handle.read()
+```
+
+Use `try/finally` when cleanup cannot be expressed through an existing context manager.
+
+## Exceptions
+
+Catch only exceptions you can handle meaningfully. Preserve the cause when adding context.
+
+```python
+try:
+    payload = json.loads(raw)
+except json.JSONDecodeError as exc:
+    raise ValueError("invalid configuration JSON") from exc
+```
+
+Avoid bare `except:` and broad `except Exception:` unless the boundary intentionally converts all failures and still preserves diagnostics appropriately.
+
+## Filesystem and Paths
+
+Use `pathlib.Path` when consistent with the codebase. Avoid machine-specific path strings.
+
+```python
+config_path = Path(root) / "config" / "settings.json"
+```
+
+Explicitly choose encoding for text I/O. Use temporary files/directories through `tempfile` for test or transient state.
+
+## Iteration and Collections
+
+Use comprehensions when they remain readable. Prefer generators when streaming is materially useful and does not complicate ownership.
+
+Use `set` for uniqueness and dictionaries for keyed lookup. Preserve ordering requirements explicitly rather than relying on accidental traversal behavior.
+
+## Async Code
+
+Use `asyncio` only when the project already has an asynchronous execution model or the accepted architecture requires it.
+
+```python
+async def fetch_all(client, urls: list[str]):
+    return await asyncio.gather(*(client.fetch(url) for url in urls))
+```
+
+Do not add concurrency simply to make code look faster. Confirm independent operations, cancellation semantics, resource bounds, and failure behavior first.
+
+## HTTP and Framework Code
+
+Framework-specific APIs are version-sensitive. Confirm installed versions and copy established local patterns before using Django, Flask, FastAPI, Starlette, SQLAlchemy, or similar frameworks.
+
+At external boundaries:
+- validate untrusted input;
+- do not rely on type hints as runtime validation;
+- avoid leaking raw exception details;
+- preserve authentication and authorization middleware/dependencies defined by Cipher-owned requirements.
+
+## Packaging
+
+Determine management from repository evidence such as `pyproject.toml`, `uv.lock`, `poetry.lock`, requirements files, setup metadata, or CI. Do not mix package managers casually.
+
+Prefer invocation through the active environment:
+
+```text
+python -m pytest
+python -m package_or_module
+```
+
+when that convention is supported by the repository.
+
+## Testing
+
+Use existing test conventions. Common repositories may use `pytest` or `unittest`; do not assume which one applies.
+
+```python
+def test_normalize_name_trims_value():
+    assert normalize_name("  Ada  ") == "Ada"
+```
+
+Prefer deterministic fixtures, `tmp_path` or standard temporary directories for filesystem tests, and dependency boundaries already established by the project.
+
+## Common Failure Patterns
+
+Avoid:
+- mutable default arguments;
+- broad exception swallowing;
+- changing working directory as hidden global state;
+- relying on platform-specific paths;
+- blocking I/O inside an established async request path without evaluating the existing pattern;
+- adding package-manager metadata inconsistent with the repository;
+- returning `None` for every failure when callers need to distinguish failure modes;
+- using type-ignore directives to bypass a real contract error without justification.

--- a/adapters/codex/skills/ponytail/references/shell-powershell.md
+++ b/adapters/codex/skills/ponytail/references/shell-powershell.md
@@ -1,0 +1,126 @@
+# Shell and PowerShell Implementation Reference
+
+## Use When
+
+Load only after repository evidence confirms shell or PowerShell scripts are part of the supported workflow. Preserve cross-platform requirements, execution-policy assumptions, quoting style, error semantics, and existing helper functions.
+
+## General Rules
+
+- Treat paths, arguments, environment values, and user input as data, not executable code.
+- Quote values according to the shell actually executing the script.
+- Avoid dynamic evaluation such as `eval`, `Invoke-Expression`, or equivalent unless explicitly required and reviewed.
+- Prefer argument arrays or native command invocation over building command strings.
+- Fail on real errors and preserve useful diagnostics.
+- Make destructive behavior explicit and separately authorized.
+- Keep scripts idempotent when they may be rerun.
+
+## POSIX Shell
+
+When Bash is confirmed, strict mode may be useful if compatible with existing script behavior:
+
+```bash
+set -euo pipefail
+```
+
+Do not add it blindly to a legacy script because it can change failure semantics.
+
+Quote parameter expansions:
+
+```bash
+config_path="$root/config/settings.json"
+python "$script_path" --config "$config_path"
+```
+
+Use arrays in Bash when passing multiple arguments:
+
+```bash
+args=(--check --format json)
+python "$script" "${args[@]}"
+```
+
+Use temporary directories through established platform tools and clean them with a trap when appropriate:
+
+```bash
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+```
+
+Destructive cleanup must remain within an explicitly created temporary path and any broader deletion requires separate authorization.
+
+## PowerShell
+
+Prefer cmdlet parameters and arrays instead of concatenated command strings.
+
+```powershell
+$path = Join-Path $Root "config\settings.json"
+& python $ScriptPath --config $path
+if ($LASTEXITCODE -ne 0) {
+    throw "Validation failed with exit code $LASTEXITCODE"
+}
+```
+
+Use `-LiteralPath` when a path should not interpret wildcard characters.
+
+```powershell
+if (Test-Path -LiteralPath $path -PathType Leaf) {
+    Get-Content -LiteralPath $path -Raw
+}
+```
+
+For native commands, check `$LASTEXITCODE`. For PowerShell cmdlets, use exceptions/`-ErrorAction Stop` where failure must stop execution.
+
+```powershell
+Copy-Item -LiteralPath $source -Destination $target -ErrorAction Stop
+```
+
+Prefer `Join-Path` and .NET path APIs over hand-built separators for portable repository tooling.
+
+## Environment Variables
+
+Read environment variables without printing secrets. Preserve existing precedence rules.
+
+PowerShell:
+
+```powershell
+$mode = $env:ORCHESTRA_MODE
+```
+
+Bash:
+
+```bash
+mode="${ORCHESTRA_MODE:-}"
+```
+
+Do not persist secret environment values into tracked config, logs, or command output.
+
+## Cross-Platform Scripts
+
+When the same workflow runs on Windows and POSIX:
+- prefer cross-platform runtimes already used by the repo, such as Python or Node, for complex shared logic;
+- keep host-specific wrappers thin;
+- do not assume `bash`, `python3`, GNU flags, Windows drive letters, or PowerShell availability without evidence;
+- normalize line endings only when the repository contract requires it;
+- test path handling and subprocess behavior on supported OS runners.
+
+## Process Execution
+
+Avoid invoking a shell when direct process execution is available. Pass arguments separately to prevent quoting/injection bugs.
+
+Python example of the preferred subprocess shape:
+
+```python
+subprocess.run(["git", "status", "--short"], check=True)
+```
+
+Do not replace this with `shell=True` merely for convenience.
+
+## Common Failure Patterns
+
+Avoid:
+- unquoted shell expansions;
+- `Invoke-Expression` or `eval` for ordinary command execution;
+- treating PowerShell cmdlet success and native-process exit codes as identical;
+- relying on Bash-only builtins in commands consumed by PowerShell hosts;
+- hardcoded machine paths;
+- recursive force deletion outside a verified temporary/sandbox path;
+- swallowing command failures and continuing to a success message.

--- a/adapters/codex/skills/ponytail/references/shell-powershell.md
+++ b/adapters/codex/skills/ponytail/references/shell-powershell.md
@@ -8,7 +8,7 @@ Load only after repository evidence confirms shell or PowerShell scripts are par
 
 - Treat paths, arguments, environment values, and user input as data, not executable code.
 - Quote values according to the shell actually executing the script.
-- Avoid dynamic evaluation such as `eval`, `Invoke-Expression`, or equivalent unless explicitly required and reviewed.
+- Avoid dynamic command-string evaluation. Prefer direct process invocation and argument arrays.
 - Prefer argument arrays or native command invocation over building command strings.
 - Fail on real errors and preserve useful diagnostics.
 - Make destructive behavior explicit and separately authorized.
@@ -38,12 +38,7 @@ args=(--check --format json)
 python "$script" "${args[@]}"
 ```
 
-Use temporary directories through established platform tools and clean them with a trap when appropriate:
-
-```bash
-tmp_dir="$(mktemp -d)"
-trap 'rm -rf "$tmp_dir"' EXIT
-```
+Use temporary directories through established platform or repository helpers. Register cleanup only through a bounded cleanup primitive whose target is the verified temporary directory created by the current operation. Do not place broad recursive-force deletion commands in reusable specialist guidance.
 
 Destructive cleanup must remain within an explicitly created temporary path and any broader deletion requires separate authorization.
 
@@ -118,7 +113,7 @@ Do not replace this with `shell=True` merely for convenience.
 
 Avoid:
 - unquoted shell expansions;
-- `Invoke-Expression` or `eval` for ordinary command execution;
+- dynamic command-string evaluation for ordinary command execution;
 - treating PowerShell cmdlet success and native-process exit codes as identical;
 - relying on Bash-only builtins in commands consumed by PowerShell hosts;
 - hardcoded machine paths;

--- a/adapters/codex/skills/ponytail/references/web-runtime.md
+++ b/adapters/codex/skills/ponytail/references/web-runtime.md
@@ -1,0 +1,119 @@
+# Web Runtime Implementation Reference
+
+## Use When
+
+Load only for accepted HTML, CSS, browser API, or frontend runtime implementation. Cloak owns UI/UX and accessibility requirements; Clockwork owns frontend architecture/state boundaries when those decisions are not already established. Ponytail implements the accepted contract.
+
+## Semantic HTML
+
+Prefer native elements that already provide the required meaning and interaction.
+
+```html
+<button type="button">Save</button>
+<nav aria-label="Primary">...</nav>
+<label for="email">Email</label>
+<input id="email" name="email" type="email" autocomplete="email">
+```
+
+Do not replace native buttons, links, inputs, headings, lists, tables, or disclosure controls with generic containers unless the accepted design genuinely requires custom behavior.
+
+ARIA supplements semantics; it does not repair an inappropriate base element automatically. Do not add ARIA roles or properties by guesswork.
+
+## Keyboard and Focus
+
+Implement the keyboard contract supplied by Cloak or established component patterns.
+
+- Interactive elements must be keyboard reachable when the interaction is intended for keyboard users.
+- Do not add positive `tabindex` values to force custom focus order.
+- Move focus only when the interaction requires it, such as accepted modal/dialog workflows or explicit error recovery.
+- Restore focus when established component behavior requires it.
+- Do not trap focus outside a component that owns a legitimate modal interaction.
+
+## Forms
+
+Use native form behavior where possible.
+
+```html
+<form>
+  <label for="quantity">Quantity</label>
+  <input id="quantity" name="quantity" type="number" min="1" required>
+  <button type="submit">Add</button>
+</form>
+```
+
+Client-side validation improves usability but does not replace server-side trust-boundary validation.
+
+Preserve disabled, pending, error, success, and retry states required by Cloak. Prevent duplicate submissions when the accepted workflow requires single ownership of a mutation.
+
+## CSS Layout
+
+Prefer normal flow, Flexbox, and Grid before JavaScript layout calculations.
+
+```css
+.toolbar {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+```
+
+```css
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+  gap: 1rem;
+}
+```
+
+Avoid arbitrary fixed dimensions when content or responsive behavior requires flexibility. Preserve project tokens and design-system variables instead of inventing local color, spacing, typography, or z-index systems.
+
+## Browser APIs
+
+Use native APIs when sufficient and supported by the project's browser target.
+
+Examples include:
+- `URL` and `URLSearchParams` for URL manipulation;
+- `AbortController` for cancellable browser requests;
+- `FormData` for form payloads;
+- `Intl` for locale-aware formatting when project requirements allow it;
+- `matchMedia` for media-query state when CSS alone cannot satisfy the runtime need.
+
+Confirm browser support and existing polyfill policy before using newer APIs.
+
+## Events
+
+- Use the event appropriate to the semantic interaction.
+- Avoid duplicate handlers that can dispatch the same mutation twice.
+- Clean up manually registered listeners.
+- Do not rely on event ordering that is not guaranteed by the project/runtime contract.
+- Preserve event propagation intentionally; do not scatter `stopPropagation()` as a symptom fix.
+
+## Network State
+
+For client requests:
+- distinguish idle, pending, success, empty, and error states when required;
+- abort superseded requests when the project pattern does so;
+- do not treat client-side authorization checks as server authorization;
+- avoid optimistic mutation unless the accepted contract defines rollback/reconciliation behavior.
+
+## Security Boundaries
+
+Cipher owns security requirements. Ponytail must preserve them while implementing frontend behavior.
+
+Do not:
+- insert untrusted HTML with `innerHTML` or framework equivalents without an accepted sanitization boundary;
+- store secrets in browser code or public environment variables;
+- rely on hidden/disabled UI controls as authorization;
+- expose raw infrastructure identifiers or sensitive error payloads unless explicitly accepted.
+
+## Common Failure Patterns
+
+Avoid:
+- generic clickable `div` elements where a button/link fits;
+- JS layout code that CSS already solves;
+- local one-off styling that bypasses the design system;
+- positive `tabindex` ordering;
+- duplicate submit/completion paths;
+- missing cleanup for listeners, timers, observers, or requests;
+- new accessibility requirements invented by Ponytail rather than sourced from Cloak or established standards already adopted by the project.

--- a/skills/ponytail/BUILD_TEST_TOOLING_GUIDE.md
+++ b/skills/ponytail/BUILD_TEST_TOOLING_GUIDE.md
@@ -1,0 +1,161 @@
+# Build and Test Tooling Guide
+
+## Purpose
+
+Select implementation and validation commands from repository evidence instead of ecosystem habit. This guide does not authorize installation, deployment, release, external mutation, or production access.
+
+## Command Selection Order
+
+Use the strongest repository-owned source available:
+
+1. explicit project validation documentation;
+2. package/task scripts;
+3. wrapper scripts checked into the repository;
+4. CI workflow commands;
+5. framework/build configuration;
+6. only then, a conventional direct tool invocation when the repository clearly supports it.
+
+If two sources conflict, inspect which one is current and used by CI. Do not guess.
+
+## JavaScript and TypeScript
+
+Read `package.json` scripts before choosing a command.
+
+Common script shapes are:
+
+```text
+npm test
+npm run lint
+npm run typecheck
+npm run build
+npm run validate
+```
+
+These are examples, not defaults. Use `pnpm`, Yarn, Bun, or another package manager only when lockfiles/configuration prove that choice.
+
+Rules:
+- do not run install with a different package manager because it is locally convenient;
+- do not rewrite a lockfile unless the accepted dependency change requires it;
+- prefer `npm ci` in CI-like clean installs only when the repository uses npm and has a compatible lockfile;
+- do not invoke a framework CLI globally when the repository provides a local script or package binary.
+
+## Python
+
+Determine environment management from `pyproject.toml`, lockfiles, requirements files, project docs, and CI.
+
+Common repository-owned commands may wrap:
+
+```text
+python -m pytest
+python -m ruff check .
+python -m mypy ...
+python -m package.module
+```
+
+Do not assume pytest, Ruff, mypy, uv, Poetry, pip-tools, or another tool is present. Preserve the supported Python version.
+
+## Java and JVM
+
+Prefer checked-in wrappers:
+
+```text
+./mvnw test
+./gradlew test
+gradlew.bat test
+```
+
+Use exact repository goals/tasks. Do not switch between Maven and Gradle, bypass wrappers, or add plugin goals by convention.
+
+When integration tests use containers, databases, or external services, confirm whether the repository supplies an isolated test harness before running them.
+
+## Go
+
+Use `go.mod`/workspace evidence and existing scripts. Common commands include:
+
+```text
+go test ./...
+go vet ./...
+go build ./...
+```
+
+Do not assume all packages, tags, race tests, or integration tests are safe without repository guidance.
+
+## Rust
+
+Read `Cargo.toml`, workspace metadata, toolchain configuration, and CI. Common commands include:
+
+```text
+cargo test
+cargo check
+cargo clippy
+cargo fmt --check
+```
+
+Do not modify the lockfile or toolchain configuration unless required by the accepted change.
+
+## Shell and PowerShell
+
+Prefer repository wrappers rather than reconstructing long command sequences manually. Check native process exit codes and fail when required validation fails.
+
+When a repository has both `.ps1` and `.sh` wrappers, use the one appropriate to the current host unless a cross-platform comparison is itself part of the required gate.
+
+## Validation Layers
+
+Classify checks before running them:
+
+- **format**: deterministic style or whitespace checks;
+- **lint/static**: rule and code-quality checks;
+- **typecheck/compile**: type and compilation contracts;
+- **unit**: isolated behavior;
+- **integration**: component/service/persistence interaction;
+- **contract**: API/schema/interface compatibility;
+- **browser/E2E**: rendered workflow behavior;
+- **security**: repository-approved security scans and control checks;
+- **packaging/export**: generated artifacts and portable distribution parity;
+- **release**: complete release-readiness gate owned by Overseer and repository governance.
+
+Ponytail may execute checks but does not redefine which layers are required for release.
+
+## Narrow Check vs Transition Gate
+
+During implementation, run the narrowest useful check after each bounded edit when practical. Before PR publication/update, merge, or another governed transition, run the repository-required complete gate on the exact current head.
+
+```text
+narrow implementation check != release readiness
+passing one test != full validation
+validation on old head != validation on current head
+```
+
+Any source change after validation invalidates the affected exact-head evidence.
+
+## Generated Artifacts
+
+Before editing a generated file:
+1. identify its canonical input/generator;
+2. confirm the generation command;
+3. edit the canonical source;
+4. regenerate through the repository-owned command;
+5. confirm the generated delta is deterministic and scoped.
+
+Do not manually patch generated output unless the repository explicitly treats it as canonical source.
+
+## Dependency Changes
+
+If a dependency must change:
+- verify the package manager;
+- identify the minimum compatible change;
+- update manifest and lockfile through the native package manager when possible;
+- run the repository's dependency/security policy checks;
+- review transitive changes and unexpected lockfile churn;
+- route license/compliance uncertainty to The Governor and security implications to Cipher.
+
+## Failure Handling
+
+If validation fails:
+- capture the exact command and failure;
+- determine whether the failure is introduced by the change, pre-existing, environmental, or capacity-related;
+- fix only within the authorized scope;
+- rerun the failed narrow check, then rerun every required gate invalidated by the correction;
+- never mark the phase complete because a different check passed.
+
+If the required tool or environment is unavailable, report the gate as unavailable or blocked. Do not substitute an informal review and call it equivalent.

--- a/skills/ponytail/CHECKLIST.md
+++ b/skills/ponytail/CHECKLIST.md
@@ -2,13 +2,41 @@
 
 Use only the sections relevant to the selected task.
 
-## Safe Implementation Checks
-- [ ] branch confirmed
-- [ ] working tree checked
-- [ ] source files inspected
-- [ ] smallest safe change identified and applied
-- [ ] unrelated files avoided
-- [ ] generated/runtime folders avoided (e.g. `.agents/`)
-- [ ] validation run (e.g., compile, lint, test)
-- [ ] diff reviewed
-- [ ] handoff needed if crossing specialist boundary (Clockwork, Cipher, Cloak, etc.)
+## Baseline and Stack
+
+- [ ] repository and branch confirmed
+- [ ] approved baseline/current head confirmed
+- [ ] working tree or exact PR diff checked
+- [ ] relevant source files and callers inspected
+- [ ] language/runtime/framework versions confirmed from repository evidence when syntax depends on them
+- [ ] package manager, build system, and test commands discovered rather than assumed
+- [ ] generated-source ownership identified when generated files are involved
+
+## Safe Implementation
+
+- [ ] owning specialist contracts are clear and current
+- [ ] existing helper/pattern/native capability checked before adding new code or dependencies
+- [ ] smallest correct root-cause change identified and applied
+- [ ] public contracts preserved unless an accepted change requires modification
+- [ ] unrelated files and formatting churn avoided
+- [ ] generated/runtime/cache folders avoided unless explicitly in scope
+- [ ] trust-boundary validation, security, accessibility, and data-integrity requirements preserved
+- [ ] new architecture, persistence, security, UI/UX, or QA decisions rerouted instead of guessed
+
+## Validation
+
+- [ ] narrow changed-surface check executed where applicable
+- [ ] focused regression coverage added or updated for non-trivial changed behavior where the repository has an applicable test path
+- [ ] repository-required validation gate run against the exact current state before transition
+- [ ] exact commands and results recorded
+- [ ] any post-validation source change caused affected checks to rerun
+- [ ] final diff reviewed for accidental edits, debug output, placeholders, temporary files, generated drift, and secrets
+
+## Handoff and Transition
+
+- [ ] behavioral handoff delta produced for material multi-domain work
+- [ ] changed paths and affected layers recorded
+- [ ] potential contract invalidations and specialist re-entry recorded
+- [ ] generated artifacts identified
+- [ ] no readiness claim exceeds executed evidence
+- [ ] staging, commit, push, PR, merge, release, deployment, or protected-state changes occur only under their required authority

--- a/skills/ponytail/IMPLEMENTATION_FOUNDATIONS_GUIDE.md
+++ b/skills/ponytail/IMPLEMENTATION_FOUNDATIONS_GUIDE.md
@@ -1,26 +1,134 @@
 # Implementation Foundations Guide
 
-## Safe Code-Change Principles
+## Purpose
 
-- **Inspect before editing**: Always read the target files and relevant dependencies before applying changes.
-- **Identify source of truth**: Ensure you are editing the correct Git-tracked file before making changes.
-- **Preserve user intent and approved specialist decisions**: Do not silently override architectural, security, database, or UI decisions made by the user or other specialists.
-- **Make the smallest safe code change**: Fix the specific issue without rewriting adjacent logic.
-- **Avoid broad rewrites without approval**: Stick to targeted edits unless a broader refactor was explicitly requested and approved.
-- **Avoid unrelated formatting churn**: Do not reformat code or change spacing in areas you are not directly editing.
-- **Avoid modifying runtime/generated folders**: Do not edit `.agents/`, `node_modules/`, `build/`, `dist/`, or similar directories unless explicitly required.
-- **Isolate changes to approved files**: Only modify the files directly relevant to the task.
-- **Keep source changes in Git-tracked source files**: Ensure all persistent updates are applied to the primary repository.
-- **Maintain existing conventions and naming patterns**: Follow the established style of the project.
-- **Preserve public APIs unless change is approved**: Do not break existing API contracts without explicit permission.
-- **Avoid hidden behavior changes**: Keep logic transparent.
-- **Avoid swallowing exceptions silently**: Do not catch exceptions without handling or logging them properly.
-- **Avoid adding placeholder logic as final implementation**: Implement real logic unless a placeholder is explicitly requested.
-- **Avoid hardcoded secrets, credentials, tokens, or private paths**: Ensure secrets are passed via environment variables or secure configuration.
-- **Avoid destructive commands or data mutation unless explicitly approved**: Do not drop tables, delete files, or truncate data unless instructed.
+Give Ponytail enough implementation knowledge to make safe, minimal code changes without relying only on generic model intuition. This guide defines universal implementation reasoning. Load stack-specific syntax only after the repository proves which stack is in use.
 
-## Validation and Workflow
-- **Check branch and git status before editing**: Know your working state.
-- **Review diff before commit**: Ensure your changes match the requested scope.
-- **Validate after edits**: Run the necessary tests, linters, or build commands to verify your work.
-- **Stop before stage/commit/push unless explicitly approved**: Never assume approval for source control operations.
+## Implementation Order
+
+Before writing code:
+
+1. Read the requested behavior and the files that own it.
+2. Trace the real call or data path far enough to locate the correct edit point.
+3. Check whether the codebase already has a helper, abstraction, component, convention, or dependency that solves the problem.
+4. Prefer standard-library or native-platform capabilities when they satisfy the accepted contract.
+5. Use the smallest change that fixes the shared root cause.
+6. Preserve public contracts unless the approved change explicitly modifies them.
+7. Add or update the smallest useful regression check for non-trivial changed behavior.
+8. Run repository-owned validation for the affected surface.
+
+This retains Ponytail's minimalism heritage while keeping Orchestra specialist decisions authoritative.
+
+## Source of Truth
+
+- Inspect before editing.
+- Edit the Git-tracked source of truth, not generated output, installed copies, caches, or runtime mirrors unless explicitly required.
+- Never invent files, functions, types, tables, routes, configuration keys, environment variables, scripts, framework behavior, or runtime versions.
+- Treat lockfiles, manifests, build files, CI workflows, existing tests, and nearby code as evidence of project conventions.
+- Preserve user-approved and specialist-owned architecture, security, persistence, UI, and QA decisions.
+
+## Root-Cause Implementation
+
+A small diff is only useful when it is placed at the correct ownership point.
+
+Prefer:
+- one fix in a shared parser over duplicate guards in every caller;
+- one boundary validation at the real trust boundary over repeated downstream checks;
+- one reusable existing helper over a second implementation;
+- one transaction-safe operation over compensating cleanup after partial mutation.
+
+Do not widen the refactor merely because a broader redesign would be cleaner.
+
+## Control Flow and State
+
+- Keep control flow explicit enough to understand locally.
+- Prefer early returns when they reduce nesting and preserve readability.
+- Do not silently swallow exceptions.
+- Make state transitions explicit when behavior depends on lifecycle or status.
+- Preserve idempotency when an operation may be retried.
+- Avoid hidden mutation across module boundaries.
+- Clean up listeners, file handles, connections, locks, timers, tasks, and temporary resources according to the language/runtime pattern already used by the project.
+
+## Input and Output Boundaries
+
+At every external or trust boundary:
+- validate shape and required values using the project's existing validation mechanism;
+- normalize only when normalization is explicitly part of the accepted behavior;
+- distinguish invalid input from missing optional input;
+- avoid exposing secrets, internal stack traces, private identifiers, or raw infrastructure details;
+- preserve encoding, locale, timezone, numeric precision, and serialization rules already established by the codebase.
+
+Cipher owns security requirements. Chronicler owns persistence semantics. Ponytail implements their accepted contracts.
+
+## Error Handling
+
+- Handle errors at the layer that can make a meaningful decision.
+- Preserve the original cause when wrapping errors.
+- Do not turn every error into success or a generic null value.
+- Use cleanup/finally/defer/context-manager patterns where the language supports them.
+- User-visible error wording belongs to Cloak when it changes UX requirements.
+- Retry policy, backoff policy, and failure-domain design belong to Clockwork/Cipher/Dagger when not already decided.
+
+## Async and Concurrency
+
+Before changing concurrent code:
+- identify the shared mutable state;
+- identify ordering assumptions;
+- identify cancellation and timeout behavior;
+- preserve existing locking, queueing, transactional, or actor ownership patterns;
+- avoid fire-and-forget work unless the project deliberately uses it;
+- make retries idempotent or protected against duplicate effects.
+
+New concurrency architecture belongs to Clockwork. Resilience pressure scenarios belong to Dagger.
+
+## Configuration and Secrets
+
+- Reuse the project's existing configuration system.
+- Do not add a new config source for one value when an established source exists.
+- Never hardcode secrets, tokens, credentials, private keys, or machine-specific paths.
+- Preserve precedence rules among environment variables, config files, defaults, and runtime arguments.
+- Do not rewrite a configuration object in a way that discards unrelated existing keys.
+
+## Dependency Discipline
+
+Before adding a dependency:
+1. search the repository for an existing solution;
+2. check the standard library or platform;
+3. check already-installed dependencies;
+4. add a new dependency only when the accepted task justifies ownership of it.
+
+Respect the project's lockfile and package-manager conventions. Do not regenerate unrelated dependency state.
+
+## Tests and Checks
+
+Non-trivial changed behavior should leave a focused regression check when the repository has an applicable test path.
+
+Prefer:
+- extending a nearby test file;
+- one test proving the reported failure and expected result;
+- existing fixtures and helpers;
+- deterministic inputs;
+- no new testing framework unless explicitly approved.
+
+Overseer owns test strategy and release readiness. Ponytail implements tests and runs narrow checks.
+
+## Diff Discipline
+
+- Keep the changed-file set narrow.
+- Avoid unrelated formatting churn.
+- Avoid changing generated files unless the project's generation contract requires it.
+- Review the final diff for accidental edits, debug output, placeholders, TODOs, temporary files, and secrets.
+- Run `git diff --check` or the project-equivalent whitespace validation when available.
+
+## Specialist Handoffs
+
+Route unresolved decisions instead of guessing:
+- architecture or ownership -> Clockwork
+- security requirements -> Cipher
+- persistence semantics -> Chronicler
+- visible UI/UX requirements -> Cloak
+- test strategy or readiness -> Overseer
+- multi-domain sequencing -> Conductor
+- continuity or transition readiness -> Arbiter
+
+Ponytail is the implementation owner after those contracts are clear.

--- a/skills/ponytail/SKILL.md
+++ b/skills/ponytail/SKILL.md
@@ -33,7 +33,7 @@ Do not use it for:
 - long-form documentation -> Scribe
 - ambiguous ownership or multi-specialist routing -> Conductor
 
-If implementation depends on an unresolved specialist decision, stop and return `SPECIALIST_REROUTE_REQUIRED` instead of guessing.
+If implementation depends on an unresolved specialist decision, return `SPECIALIST_REROUTE_REQUIRED` and do not execute the work. Do not guess.
 
 ## Supported Work
 

--- a/skills/ponytail/SKILL.md
+++ b/skills/ponytail/SKILL.md
@@ -2,7 +2,7 @@
 name: ponytail
 description: Implementation and Navigation Specialist. Owns minimal safe edits. See SKILL_INDEX.md.
 slug: ponytail
-role: Implementation / Navigation
+role: Implementation and Navigation Specialist
 primary_use: Implementation, code editing, validation
 avoid_when: Architecture design, UI/UX decisions, security policies
 activation_level: Specialist

--- a/skills/ponytail/SKILL.md
+++ b/skills/ponytail/SKILL.md
@@ -2,7 +2,7 @@
 name: ponytail
 description: Implementation and Navigation Specialist. Owns minimal safe edits. See SKILL_INDEX.md.
 slug: ponytail
-role: Implementation and Navigation Specialist
+role: Implementation / Navigation
 primary_use: Implementation, code editing, validation
 avoid_when: Architecture design, UI/UX decisions, security policies
 activation_level: Specialist
@@ -11,13 +11,14 @@ output_formats: [IMPLEMENTATION_PLAN, CODE_REVIEW, QUICK_FIX]
 ---
 # Ponytail
 
-Act as the Implementation and Navigation Specialist. You own code navigation, file inspection, targeted implementation, approved refactoring, integration wiring, and applying fixes within defined architecture, security, UI, and QA constraints.
+Act as the Implementation and Navigation Specialist. You own code navigation, file inspection, targeted implementation, approved refactoring, integration wiring, and applying fixes within defined architecture, security, persistence, UI, and QA constraints.
 
 ## Quick Reference
-* **Role**: Implementation and Navigation Specialist.
-* **Scope**: Code edits, navigation, patching, validation runs.
-* **Avoid When**: Architecture design, security policy creation, UI/UX requirements.
-* **Output Format**: IMPLEMENTATION_PLAN, CODE_REVIEW, or QUICK_FIX.
+
+- **Role**: Implementation and Navigation Specialist.
+- **Scope**: Code edits, navigation, patching, integration wiring, and narrow validation runs.
+- **Avoid When**: Architecture design, security policy creation, persistence design, UI/UX requirements, or QA strategy.
+- **Output Format**: `IMPLEMENTATION_PLAN`, `CODE_REVIEW`, or `QUICK_FIX`.
 
 ## Activation Conditions
 
@@ -25,110 +26,105 @@ Use Ponytail when the task needs code implementation, repository navigation, fil
 
 Do not use it for:
 - UI/UX requirements and frontend design decisions -> Cloak
-- architecture, state ownership, provider hierarchy, and service boundaries -> Clockwork
-- security policy, auth/RBAC, privacy, and secrets -> Cipher
-- schema, migrations, and persistence design -> Chronicler
-- QA strategy, test scope, and release-readiness gates -> Overseer
+- architecture, state ownership, provider hierarchy, service boundaries, or concurrency ownership -> Clockwork
+- security policy, auth/RBAC, privacy controls, or secrets requirements -> Cipher
+- schema, migrations, indexes, or persistence semantics -> Chronicler
+- QA strategy, test scope, or release-readiness gates -> Overseer
 - long-form documentation -> Scribe
 - ambiguous ownership or multi-specialist routing -> Conductor
 
-Body-level avoid_when guidance:
-- If the task is primarily deciding what should be built, who owns it, or how multiple specialists should sequence, reroute to Conductor before editing code.
-- If implementation depends on unresolved UI/UX, architecture, security, persistence, or validation decisions, stop and reroute to the owning specialist first.
+If implementation depends on an unresolved specialist decision, stop and return `SPECIALIST_REROUTE_REQUIRED` instead of guessing.
 
-## Supported work
+## Supported Work
 
 - code navigation and file inspection
 - targeted implementation and bug fixes
 - small approved refactors
-- integration wiring inside existing architecture boundaries
-- patching code to match already-decided specialist requirements
-- running narrow local validation commands for the changed surface
+- integration wiring inside accepted architecture boundaries
+- implementing accepted security, persistence, UI, and QA contracts
+- writing or updating focused tests owned by the implementation change
+- running narrow repository-owned validation commands
 
-## Progressive Disclosure Rule
+## Ponytail Implementation Heuristic
 
-Use `SKILL.md` first. Do not load every supporting document by default or consume context with unused material.
-- Load `OUTPUT_FORMATS.md` only when generating the final response.
-- Load `IMPLEMENTATION_FOUNDATIONS_GUIDE.md` only when the task involves code implementation, file edits, refactoring, repository navigation, patching, integration wiring, debugging fixes, or applying specialist-approved changes.
+Ponytail keeps the upstream minimalism principle, but Orchestra boundaries remain authoritative. Apply this order only after understanding the real execution path:
 
-## Implementation Boundaries (Handoff Rules)
+1. Confirm the requested behavior is actually required.
+2. Reuse an existing helper, type, pattern, component, or abstraction when it already solves the problem.
+3. Prefer the language standard library before custom utility code.
+4. Prefer a native platform capability before adding another abstraction or dependency.
+5. Reuse an already-installed dependency when it is the established project solution.
+6. Choose the smallest implementation that satisfies the accepted contract.
+7. Fix a shared root cause at the narrowest correct ownership point instead of patching each symptom separately.
+8. Leave a focused regression check for non-trivial changed behavior when the repository has an applicable test path.
 
-Ponytail owns:
-- code navigation
-- file inspection
-- targeted implementation
-- small refactors approved by specialist guidance
-- wiring approved changes
-- applying fixes within defined architecture/security/database/UI/QA constraints
-- running local validation commands when approved
+Minimalism never overrides explicit requirements, trust-boundary validation, security controls, accessibility requirements, data-integrity rules, architecture contracts, or validation gates.
 
-Ponytail does not own:
-- routing or multi-specialist orchestration -> Conductor
-- governance decisions, compliance decisions, or continuity authority -> The Steward, The Governor, or Arbiter through Conductor
-- architecture design -> Clockwork
-- architecture ownership decisions for state boundaries, provider hierarchy, and service boundaries -> Clockwork
-- database schema, SQL, migrations, indexes, seed data -> Chronicler
-- persistence design and stored-record behavior -> Chronicler
-- security policy, auth/RBAC/secrets/privacy requirements -> Cipher
-- UI/UX requirements and visual design decisions -> Cloak
-- QA strategy, test scope, release readiness -> Overseer
-- documentation prose and long docs -> Scribe
-- continuity/merge readiness after interruption or branch drift -> Arbiter
+## Progressive Disclosure
+
+Start with this file. Load only the knowledge required by the confirmed stack and task.
+
+- Non-trivial implementation or debugging -> [IMPLEMENTATION_FOUNDATIONS_GUIDE.md](IMPLEMENTATION_FOUNDATIONS_GUIDE.md)
+- Unknown or ambiguous repository stack -> [STACK_DISCOVERY_GUIDE.md](STACK_DISCOVERY_GUIDE.md)
+- JavaScript or TypeScript -> [references/javascript-typescript.md](references/javascript-typescript.md)
+- Python -> [references/python.md](references/python.md)
+- Java or JVM code -> [references/java-jvm.md](references/java-jvm.md)
+- Go or Rust -> [references/go-rust.md](references/go-rust.md)
+- Shell or PowerShell -> [references/shell-powershell.md](references/shell-powershell.md)
+- HTML, CSS, browser APIs, or frontend runtime implementation -> [references/web-runtime.md](references/web-runtime.md)
+- Build, lint, typecheck, test, packaging, or generated-code commands -> [BUILD_TEST_TOOLING_GUIDE.md](BUILD_TEST_TOOLING_GUIDE.md)
+- Concrete implementation and handoff patterns -> [examples/implementation-patterns.md](examples/implementation-patterns.md)
+- Upstream Ponytail provenance or sync work -> [UPSTREAM_REFERENCE.md](UPSTREAM_REFERENCE.md)
+- Final response format -> [OUTPUT_FORMATS.md](OUTPUT_FORMATS.md)
+
+Existing repository conventions override generic examples in these references. A syntax reference is not permission to introduce that stack, dependency, framework, or tool.
 
 ## Cross-Layer Contract Implementation Gate
 
-For material multi-domain work, implement only against an accepted or frozen CrossLayerContractPacket plus separate implementation authority.
+For material multi-domain work, implement only against an accepted or frozen `CrossLayerContractPacket` plus separate implementation authority.
 
 Stop and return `SPECIALIST_REROUTE_REQUIRED` when:
-
 - an upstream contract is missing, contradictory, or stale;
 - implementation requires a new architecture, security, persistence, UI/UX, governance, or validation decision;
 - changed behavior crosses an undeclared specialist boundary;
 - an undeclared generated artifact or external action is required.
 
-After implementation, produce a behavioral handoff delta that states changed paths, affected layers, contract assumptions changed, potential invalidations, generated artifacts, validation performed, and known limitations. Phase 2 adds complete staged and untracked change-identity enforcement.
+After implementation, produce a behavioral handoff delta that states changed paths, affected layers, contract assumptions changed, potential invalidations, generated artifacts, validation performed, and known limitations.
 
 ## Safe Implementation Rules
 
-- No implementation without inspecting relevant files first.
-- No broad refactor unless explicitly approved.
-- No changing architecture boundaries without Clockwork.
-- No changing schema/migrations without Chronicler.
-- No changing auth/RBAC/secrets/security config without Cipher.
-- No changing UI/UX behavior without Cloak requirements.
-- No claiming validation passed unless commands actually ran.
-- No staging, committing, pushing, or PR creation unless explicitly approved.
-
-## Scope Enforcement
-
-Ponytail edits code, but does not absorb routing, governance, architecture, security policy, UI/UX decisions, persistence design, QA strategy, or long documentation.
-
-Required behavior:
-- Implement directly when the task is a scoped code change and the owning specialist decisions are already clear.
-- When the request is outside Ponytail's scope or belongs to another specialist, return `SPECIALIST_REROUTE_REQUIRED` and do not execute the work.
-- If the task crosses specialist boundaries but the next owner is obvious, recommend that specialist directly.
-- If the task crosses multiple specialist boundaries or ownership is unclear, return `SPECIALIST_REROUTE_REQUIRED` and route back to Conductor.
+- Inspect relevant files and their callers before editing.
+- Confirm the repository stack and existing commands before choosing syntax or tooling.
+- Prefer established project patterns over introducing a second framework or local convention.
+- Preserve public contracts unless the accepted change explicitly modifies them.
+- Do not broaden a refactor merely because a larger redesign appears cleaner.
+- Do not change architecture boundaries without Clockwork.
+- Do not change schema or persistence semantics without Chronicler.
+- Do not change auth, RBAC, secrets, or security-control requirements without Cipher.
+- Do not invent visible UI/UX requirements without Cloak.
+- Do not redefine test strategy or release readiness without Overseer.
+- Never infer a package manager, framework, runtime version, test command, generated-file contract, or environment variable that the repository does not prove.
+- Never claim validation passed unless the command actually ran against the stated revision.
+- Do not stage, commit, push, open a PR, merge, release, deploy, or modify protected state without the required authority.
 
 ## Validation Expectations
 
-- Inspect the relevant files before making implementation claims.
-- Run the narrowest relevant local validation for the changed surface when commands are allowed and available.
-- Report the exact validation command and result. Do not claim validation passed unless it actually ran.
-- If test strategy, release-readiness, or validation-gate ownership becomes the main task, hand off to Overseer instead of expanding Ponytail's role.
-- If a change implements requirements owned by Cloak, Clockwork, Cipher, or Chronicler, keep the validation claim limited to the implemented code and executed checks. Do not restate ownership of their design decisions.
+- Discover commands from repository-owned manifests, task files, workflows, and documentation before running them.
+- Run the narrowest relevant checks during implementation, then the repository-required gate before transition.
+- Report exact commands and outcomes.
+- Treat any source change after validation as invalidating affected exact-head evidence.
+- If validation strategy becomes the main task, return to Overseer.
 
-## Local-only safety
+## Local-Only Safety
 
-- Keep scratch notes, temporary implementation plans, debug logs, and one-off local artifacts untracked unless repository tracking is explicitly approved.
-- Do not stage, commit, push, create a pull request, or modify `.gitignore` without approval.
-- Edit tracked repository source by default. Do not modify runtime copies, installed-skill copies, or other local mirrors unless the task explicitly targets parity there.
-
+- Keep scratch notes, debug logs, temporary plans, and one-off artifacts untracked unless repository tracking is explicitly approved.
+- Edit tracked repository source by default. Do not modify runtime copies, installed-skill copies, caches, build output, or generated mirrors unless the task explicitly requires parity there.
 
 <!-- THE_TUNER_PHASE_2_EVIDENCE_CONTINUITY -->:skills/ponytail/SKILL.md
 
 ## Phase 2 Complete Handoff Delta
 
-For material multi-domain work, Ponytail must produce a complete SpecialistHandoffDelta after implementation. The handoff must include:
+For material multi-domain work, Ponytail must produce a complete `SpecialistHandoffDelta` after implementation. The handoff must include:
 
 - frozen packet revision and contract hash;
 - approved baseline, current commit, and working-tree fingerprint;

--- a/skills/ponytail/STACK_DISCOVERY_GUIDE.md
+++ b/skills/ponytail/STACK_DISCOVERY_GUIDE.md
@@ -1,0 +1,84 @@
+# Stack Discovery Guide
+
+## Purpose
+
+Identify the actual language, runtime, framework, package manager, build system, and test tooling before Ponytail chooses implementation syntax or commands.
+
+## Discovery Sequence
+
+1. Confirm repository root and current branch.
+2. Read the closest project instructions and contribution guidance.
+3. Inspect manifests, lockfiles, build files, and CI workflows.
+4. Inspect the target file and nearby files for local conventions.
+5. Inspect existing tests for framework and fixture patterns.
+6. Inspect package scripts or task definitions before selecting commands.
+7. Load only the relevant section of `LANGUAGE_IMPLEMENTATION_GUIDE.md`.
+
+Do not infer a stack from the repository name or from a single file when stronger evidence exists.
+
+## Common Stack Evidence
+
+| Evidence | Likely meaning | Do not assume |
+| --- | --- | --- |
+| `package.json` | Node-based tooling exists | npm is the package manager |
+| `package-lock.json` | npm lockfile | every workspace uses npm |
+| `pnpm-lock.yaml` | pnpm lockfile | scripts are identical to npm |
+| `yarn.lock` | Yarn lockfile | Yarn classic vs modern without config |
+| `tsconfig.json` | TypeScript configuration | framework or runtime |
+| `pyproject.toml` | Python project/tool configuration | exact package manager |
+| `requirements*.txt` | pip-compatible dependency list | project is not also managed by another tool |
+| `uv.lock` | uv-managed Python environment is likely | allowed install command without project guidance |
+| `poetry.lock` | Poetry-managed dependencies | Poetry version |
+| `pom.xml` | Maven Java/JVM build | application framework |
+| `build.gradle` / `build.gradle.kts` | Gradle build | wrapper availability |
+| `gradlew` / `gradlew.bat` | Gradle wrapper | global Gradle should be used |
+| `Cargo.toml` | Rust package | workspace shape |
+| `go.mod` | Go module | target Go version without reading the file |
+| `composer.json` | PHP Composer project | framework |
+| `Gemfile` | Ruby Bundler project | framework |
+| `Dockerfile` | container build exists | container is the primary local dev path |
+| `Makefile` | project tasks may be wrapped by make | target names |
+| `.github/workflows/*` | CI command evidence | local environment exactly matches CI |
+
+## Framework Signals
+
+Confirm framework versions from manifests before using version-sensitive APIs.
+
+Examples of signals:
+- React/Next/Vite: dependencies and project scripts in `package.json`.
+- Express/Fastify/Nest: dependencies plus server bootstrap code.
+- Django/Flask/FastAPI: Python dependencies plus application entry points.
+- Spring: Maven/Gradle dependencies and annotated application classes.
+- JPA/Hibernate: persistence dependencies and entity/repository patterns.
+- pytest/Jest/Vitest/JUnit: existing test imports, config, and scripts.
+
+## Command Discovery
+
+Prefer commands already owned by the repository:
+
+- `package.json` scripts such as `test`, `lint`, `typecheck`, `build`, `validate`.
+- `Makefile`, `justfile`, `Taskfile.yml`, npm scripts, Maven goals, or Gradle tasks.
+- CI workflow commands when local scripts are absent.
+- Project documentation only when it matches current configuration.
+
+Never invent a command merely because it is common for the ecosystem.
+
+## File Ownership Discovery
+
+Before editing:
+- search references to the target function/class/module;
+- identify callers and consumers;
+- identify generated or mirrored copies;
+- identify tests for the same behavior;
+- identify whether the file is generated from another source.
+
+If a generated file has a canonical generator source, edit the generator source and regenerate only through the established project command.
+
+## Stop Conditions
+
+Return for specialist or user guidance when:
+- two conflicting package managers appear and ownership is unclear;
+- the runtime version required by the intended syntax cannot be confirmed;
+- generated-source ownership cannot be identified;
+- multiple implementations exist and architecture ownership is unclear;
+- the only apparent validation command performs deployment, destructive mutation, or production access.

--- a/skills/ponytail/UPSTREAM_REFERENCE.md
+++ b/skills/ponytail/UPSTREAM_REFERENCE.md
@@ -1,0 +1,75 @@
+# Upstream Ponytail Reference
+
+## Purpose
+
+Preserve provenance and sync boundaries for the Ponytail specialist without making the external repository an implicit authority over Orchestra.
+
+## Source Lineage
+
+Orchestra's Ponytail role was incorporated from the Ponytail project and then adapted to Orchestra's specialist ownership, governance, validation, handoff, and host-packaging contracts.
+
+Upstream source repository:
+
+`DietrichGebert/ponytail`
+
+Maintainer fork used during earlier Orchestra incorporation:
+
+`Baelfyre/ponytail`
+
+License reported by the upstream/fork repository: MIT.
+
+## 2026-08-12 Upstream Checkpoint
+
+At the start of Orchestra Specialist Knowledge Layer phase SK1:
+
+```text
+Baelfyre/ponytail main
+14a0d79548d4de8fc2de95c1b94bb0de63a739d3
+package 4.8.4
+
+DietrichGebert/ponytail main
+2ed6c52c9d7e5e56942508591085fd45dea277d3
+package 4.9.0
+
+skills/ponytail/SKILL.md blob at both revisions
+02c0712c86277d49d18a77da3a2b825657bf02d1
+```
+
+The package-level upstream delta after the fork checkpoint included host-adapter, compatibility, packaging, and release work. The core Ponytail `SKILL.md` blob was unchanged between those two revisions.
+
+## SK1 Disposition
+
+Do not import the upstream repository wholesale into Orchestra.
+
+Retain these useful Ponytail principles:
+- question speculative work through YAGNI;
+- inspect before editing;
+- reuse code already present in the repository;
+- prefer standard-library and native-platform capabilities;
+- avoid unnecessary dependencies and abstractions;
+- fix shared root causes rather than repeated symptoms;
+- keep the implementation diff as small as correctness allows;
+- leave a focused check for non-trivial changed logic.
+
+Orchestra adds stronger requirements that remain authoritative:
+- specialist ownership boundaries;
+- cross-layer contract gating;
+- evidence-bound validation;
+- exact-head continuity;
+- explicit external-action authority;
+- security, persistence, UI/UX, QA, and governance handoffs;
+- portable adapter parity.
+
+## Future Sync Rule
+
+When checking upstream Ponytail again:
+
+1. identify the true upstream repository and current main/tag;
+2. compare the last reviewed upstream revision with current upstream;
+3. inspect core skill/intelligence changes separately from packaging/adapter changes;
+4. classify each relevant delta as concept, instruction, runtime code, test, packaging, or documentation;
+5. import only improvements that fit Ponytail's Orchestra role and do not conflict with Orchestra governance;
+6. preserve attribution/license obligations when copying source text or code;
+7. run the full Orchestra validation workflow after any accepted integration.
+
+A newer upstream version does not automatically make Orchestra stale, and an unchanged core skill does not prevent Orchestra-native specialist improvements.

--- a/skills/ponytail/examples/implementation-patterns.md
+++ b/skills/ponytail/examples/implementation-patterns.md
@@ -1,0 +1,119 @@
+# Ponytail Implementation Patterns
+
+Use these as implementation reasoning examples, not as architecture or product requirements. Existing repository conventions and specialist-owned contracts remain authoritative.
+
+## Pattern 1: Fix the Shared Root Cause
+
+**Situation**: Three callers fail when a shared parser receives an empty string.
+
+Weak approach:
+- add the same empty-string guard in all three callers.
+
+Preferred Ponytail approach:
+- confirm the parser is the correct ownership point;
+- add one narrow parser-level correction;
+- add one regression test proving the shared behavior;
+- verify callers do not rely on the prior failure behavior.
+
+Why: the smaller correct diff removes the defect once instead of multiplying maintenance.
+
+## Pattern 2: Implement a Cipher Contract Without Rewriting Security Policy
+
+**Accepted Cipher requirement**:
+- the server must reject access when the authenticated principal does not own the requested object.
+
+Ponytail implementation behavior:
+1. locate the established authentication principal and repository/service boundary;
+2. reuse the current authorization helper if one exists;
+3. enforce the check on the server-side object path;
+4. return the project's accepted denial response;
+5. add/update a focused unauthorized-object regression test;
+6. do not invent a new role model or client-side-only check.
+
+If the correct ownership rule is ambiguous, reroute to Cipher.
+
+## Pattern 3: Implement a Chronicler Contract Without Inventing Persistence Semantics
+
+**Accepted Chronicler requirement**:
+- a record update must reject stale versions using the existing version column.
+
+Ponytail implementation behavior:
+1. inspect the current repository/ORM pattern;
+2. implement the accepted version predicate or framework-supported optimistic-lock mechanism;
+3. preserve the transaction boundary established by Clockwork/Chronicler;
+4. map stale-write failure to the existing application error contract;
+5. add a focused persistence/integration regression test.
+
+Do not add a new version column, isolation level, retry loop, or transaction boundary without Chronicler/Clockwork ownership.
+
+## Pattern 4: Implement a Cloak Interaction Contract
+
+**Accepted Cloak requirement**:
+- while a save-owned completion mutation is pending, the completion affordance must not dispatch another completion request.
+
+Ponytail implementation behavior:
+1. find the state that owns the active mutation;
+2. bind actionable state to that existing source of truth;
+3. preserve keyboard and disabled-state behavior specified by Cloak;
+4. remove duplicate dispatch paths rather than adding timers or ad hoc flags when one owner already exists;
+5. add a focused interaction test proving one completion dispatch.
+
+Do not redesign the workflow or change server completion authority.
+
+## Pattern 5: Implement an Overseer Test Request
+
+**Overseer asks**:
+- add regression coverage for malformed configuration without expanding the suite.
+
+Ponytail implementation behavior:
+1. inspect nearby tests and fixture style;
+2. add the smallest case that reproduces the failure;
+3. invoke the same public or internal boundary used by the defect;
+4. assert the observable contract, not incidental implementation details;
+5. run the narrow test, then required repository validation.
+
+Do not add a new test framework or broad fixture hierarchy for one case.
+
+## Pattern 6: Dependency Request
+
+**Request**: add a library for a small formatting operation.
+
+Ponytail ladder:
+1. search for an existing project helper;
+2. check standard library/native APIs;
+3. check installed dependencies already used for the same purpose;
+4. only add a new dependency when the accepted requirement still cannot be met cleanly.
+
+If a dependency is added, preserve the repository package manager and lockfile, then run dependency/security/license checks required by the project.
+
+## Pattern 7: Generated Source
+
+**Situation**: an exported client contains the wrong output.
+
+Ponytail behavior:
+1. determine whether the client is generated;
+2. find the OpenAPI/schema/template/generator input;
+3. fix the canonical input or generator;
+4. run the repository-owned generation command;
+5. inspect generated diff for deterministic scope;
+6. run compile/type/test checks for both source and generated consumer surfaces.
+
+Manual patching of generated output is only acceptable when the repository explicitly treats that file as editable source.
+
+## Pattern 8: Complete Handoff Delta
+
+For material cross-domain work, the implementation handoff should be compact but complete:
+
+```text
+baseline: <approved SHA>
+head/worktree: <current identity>
+changed paths: <exact list>
+implemented contracts: <contract IDs/revisions>
+behavioral delta: <what changed>
+potential invalidations: <owners to re-enter>
+generated artifacts: <none or exact identities>
+validation executed: <exact commands/results>
+known limitations: <bounded residuals>
+```
+
+Do not claim another specialist's decision as Ponytail's own. Do not claim readiness beyond the validation actually executed.

--- a/skills/ponytail/references/go-rust.md
+++ b/skills/ponytail/references/go-rust.md
@@ -1,0 +1,149 @@
+# Go and Rust Implementation Reference
+
+## Use When
+
+Load only after repository evidence confirms Go or Rust. Follow the repository's module/workspace structure, compiler/toolchain version, formatting, linting, testing, and error-handling conventions.
+
+## Go
+
+### Core patterns
+
+Prefer small concrete APIs and explicit errors.
+
+```go
+func NormalizeName(value string) string {
+    return strings.TrimSpace(value)
+}
+```
+
+Handle errors at the point where a meaningful decision can be made:
+
+```go
+value, err := loadValue(ctx, id)
+if err != nil {
+    return Result{}, fmt.Errorf("load value %q: %w", id, err)
+}
+```
+
+Use `%w` when wrapping errors that callers may need to inspect.
+
+### Context and concurrency
+
+- Pass `context.Context` through request/cancellation boundaries when the project uses it.
+- Do not store contexts in structs unless an established API requires it.
+- Close channels from the sending/owning side.
+- Avoid goroutines whose lifecycle has no clear owner.
+- Prevent goroutine leaks by respecting cancellation and terminal conditions.
+- Use mutexes, channels, atomics, or worker pools only when the existing design or Clockwork contract establishes the concurrency model.
+
+```go
+select {
+case <-ctx.Done():
+    return ctx.Err()
+case result := <-results:
+    return result.Err
+}
+```
+
+### Resources
+
+Use `defer` for cleanup when ownership is local and the deferred operation is safe.
+
+```go
+file, err := os.Open(path)
+if err != nil {
+    return err
+}
+defer file.Close()
+```
+
+Check close/flush errors when they can affect correctness, especially writes.
+
+### Testing
+
+Use the standard `testing` package and repository helpers unless another established harness exists.
+
+```go
+func TestNormalizeName(t *testing.T) {
+    if got := NormalizeName("  Ada  "); got != "Ada" {
+        t.Fatalf("got %q", got)
+    }
+}
+```
+
+Prefer table-driven tests when multiple cases genuinely share one behavior.
+
+### Common Go mistakes
+
+Avoid:
+- ignoring returned errors;
+- starting goroutines without lifecycle/cancellation ownership;
+- copying structs containing synchronization primitives;
+- adding interfaces solely for mocking when a concrete boundary is sufficient;
+- using `panic` for recoverable request/data errors;
+- introducing global mutable state for convenience.
+
+## Rust
+
+### Ownership and borrowing
+
+Prefer APIs whose ownership reflects the real lifecycle. Borrow data when the caller retains ownership and cloning adds no value.
+
+```rust
+fn normalize_name(value: &str) -> String {
+    value.trim().to_owned()
+}
+```
+
+Return borrowed data when the lifetime is naturally tied to the input and an owned value is unnecessary.
+
+### Result and Option
+
+Use `Result` for recoverable failures and `Option` for genuine absence. Propagate errors with `?` when the current layer cannot add a meaningful decision.
+
+```rust
+fn load(path: &Path) -> io::Result<String> {
+    fs::read_to_string(path)
+}
+```
+
+Do not use `unwrap()` or `expect()` on untrusted/runtime paths unless failure is provably impossible and the repository accepts that invariant. Tests and one-time initialization may have different conventions.
+
+### Iterators
+
+Use iterators when they remain readable and ownership is clear.
+
+```rust
+let names: Vec<_> = users.iter().map(|user| user.name.as_str()).collect();
+```
+
+Avoid dense combinator chains when explicit control flow communicates error or state transitions better.
+
+### Concurrency and async
+
+Confirm the runtime before using Tokio, async-std, Rayon, or other concurrency tooling. Do not introduce a runtime or synchronization model incidentally.
+
+- Make task ownership and cancellation explicit.
+- Avoid holding mutex guards across `.await` unless the lock type and design explicitly support it.
+- Preserve `Send`/`Sync` assumptions established by the architecture.
+- Use bounded channels/queues when backpressure is an accepted requirement.
+
+### Testing
+
+Use built-in tests and the repository's integration-test organization.
+
+```rust
+#[test]
+fn normalizes_whitespace() {
+    assert_eq!(normalize_name("  Ada  "), "Ada");
+}
+```
+
+### Common Rust mistakes
+
+Avoid:
+- cloning merely to satisfy the borrow checker without understanding ownership;
+- `unwrap()` on recoverable input/I/O paths;
+- introducing `unsafe` without explicit necessity, review, and validation;
+- selecting an async runtime from generic knowledge rather than repository evidence;
+- changing public lifetime/trait bounds casually because downstream effects can be broad.

--- a/skills/ponytail/references/java-jvm.md
+++ b/skills/ponytail/references/java-jvm.md
@@ -1,0 +1,144 @@
+# Java and JVM Implementation Reference
+
+## Use When
+
+Load this reference only after repository evidence confirms Java or another JVM language. Preserve the configured JDK, Maven/Gradle wrapper, framework version, package layout, nullability conventions, and existing dependency-injection style.
+
+## Core Java
+
+Prefer clear immutable state where practical. Use interfaces and abstractions when they serve an existing boundary, not merely because Java permits them.
+
+```java
+public final class NameNormalizer {
+    public static String normalize(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    private NameNormalizer() {}
+}
+```
+
+Use `final` where it reflects stable ownership and matches project style. Do not create utility classes for behavior that already belongs to a domain/service object.
+
+## Collections and Optional Values
+
+Program against the collection behavior the project expects. Avoid returning mutable internal collections directly.
+
+Use `Optional` according to project convention, typically for return values representing absence rather than entity fields or every method parameter.
+
+```java
+public Optional<User> findById(long id) {
+    return repository.findById(id);
+}
+```
+
+Do not use `Optional.get()` without proving presence.
+
+## Exceptions
+
+- Catch exceptions only where the layer can recover, translate, or add meaningful context.
+- Preserve the cause when wrapping.
+- Do not use exceptions for ordinary control flow.
+- Respect checked/unchecked exception conventions already established by the application.
+
+```java
+try {
+    return parser.parse(input);
+} catch (ParseException ex) {
+    throw new ConfigurationException("Invalid configuration", ex);
+}
+```
+
+## Resource Management
+
+Use try-with-resources for `AutoCloseable` resources.
+
+```java
+try (var input = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
+    return input.readLine();
+}
+```
+
+Preserve transaction and connection ownership defined by the persistence layer.
+
+## Concurrency
+
+Do not add threads, executors, futures, reactive streams, or virtual-thread behavior without confirming the project's runtime and accepted architecture.
+
+When concurrency is already present:
+- identify shared mutable state;
+- preserve executor ownership;
+- propagate interruption where appropriate;
+- preserve timeout and cancellation semantics;
+- avoid holding locks across external I/O;
+- keep retryable effects idempotent.
+
+New concurrency ownership belongs to Clockwork.
+
+## Maven and Gradle
+
+Prefer repository wrappers when present:
+
+```text
+./mvnw ...
+./gradlew ...
+gradlew.bat ...
+```
+
+Do not substitute global Maven or Gradle when the wrapper is the project contract. Discover exact goals/tasks from the build file, wrapper, CI, and project docs.
+
+## Spring and Dependency Injection
+
+Confirm the framework and version before using annotations or APIs.
+
+General principles:
+- preserve constructor injection when established;
+- keep controllers/adapters thin when service boundaries already exist;
+- do not move transaction ownership without Chronicler/Clockwork agreement;
+- do not weaken method or route authorization owned by Cipher;
+- do not add a new bean abstraction for a single call site without an accepted reason.
+
+```java
+@Service
+public final class AccountService {
+    private final AccountRepository repository;
+
+    public AccountService(AccountRepository repository) {
+        this.repository = repository;
+    }
+}
+```
+
+## JPA and ORM Boundaries
+
+Chronicler owns schema and persistence semantics. Ponytail may implement an accepted persistence contract.
+
+- Respect entity identity and lifecycle rules.
+- Do not expose persistence entities as API contracts when the architecture separates DTO/domain/entity models.
+- Avoid accidental lazy-loading assumptions across closed transactions.
+- Do not add cascade, orphan-removal, fetch-mode, or transaction changes without understanding their data effects.
+- Preserve optimistic locking/version columns where present.
+
+## Testing
+
+Use the existing framework, commonly JUnit in Java repositories, and existing mocking/integration conventions.
+
+```java
+@Test
+void normalizesWhitespace() {
+    assertEquals("Ada", NameNormalizer.normalize("  Ada  "));
+}
+```
+
+Prefer repository-provided integration harnesses for persistence and framework behavior instead of mocking away the contract being tested.
+
+## Common Failure Patterns
+
+Avoid:
+- introducing interfaces with one implementation without an established boundary need;
+- field injection when the repository uses constructor injection;
+- swallowing `InterruptedException`;
+- returning ORM entities through unrelated API layers when DTO separation exists;
+- transaction annotations added as trial-and-error fixes;
+- changing Java/JDK APIs without confirming the configured target version;
+- editing generated sources instead of their generator inputs.

--- a/skills/ponytail/references/javascript-typescript.md
+++ b/skills/ponytail/references/javascript-typescript.md
@@ -1,0 +1,151 @@
+# JavaScript and TypeScript Implementation Reference
+
+## Use When
+
+Load this reference only after repository evidence confirms JavaScript or TypeScript. Preserve the project's module system, compiler target, formatter, lint rules, framework conventions, and runtime version.
+
+## Core Syntax
+
+Prefer `const`; use `let` only when reassignment is required. Avoid `var` unless maintaining legacy code that already depends on it.
+
+```ts
+export function normalizeName(value: string | null | undefined): string {
+  return value?.trim() ?? "";
+}
+```
+
+Use `===` and `!==` unless the existing code deliberately relies on coercion.
+
+Prefer nullish coalescing when `0`, `false`, or an empty string are valid values:
+
+```ts
+const retries = config.retries ?? 3;
+```
+
+Use optional chaining only for genuinely optional paths. Do not use it to hide an invariant violation that should fail.
+
+## Types
+
+- Prefer specific domain types over `any`.
+- Use `unknown` for untrusted values until narrowed.
+- Narrow unions explicitly.
+- Preserve existing exported types and public signatures unless contract change is approved.
+- Do not use a type assertion to bypass a runtime trust boundary.
+
+```ts
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+```
+
+Discriminated unions are useful for explicit state machines:
+
+```ts
+type Result =
+  | { kind: "ok"; value: string }
+  | { kind: "error"; message: string };
+```
+
+## Async Code
+
+Use `async`/`await` when the project does. Preserve cancellation and timeout behavior already established by the repository.
+
+```ts
+export async function loadJson(url: string, signal?: AbortSignal): Promise<unknown> {
+  const response = await fetch(url, { signal });
+  if (!response.ok) {
+    throw new Error(`request failed: ${response.status}`);
+  }
+  return response.json();
+}
+```
+
+Rules:
+- await promises that own required effects;
+- do not create unhandled promises;
+- use `Promise.all` only when operations are independent and concurrent execution is safe;
+- preserve ordering when side effects depend on sequence;
+- do not invent retries or concurrency limits without an accepted contract.
+
+## Collections
+
+Prefer built-ins such as `map`, `filter`, `find`, `some`, `every`, `Set`, and `Map` when they make ownership and intent clearer. Avoid compressed chains when they obscure error handling or state changes.
+
+Use `Set` for uniqueness and `Map` when keys are not naturally object properties.
+
+## Errors
+
+Throw or return errors according to the established project convention. When wrapping, retain the original cause where supported:
+
+```ts
+try {
+  await persist();
+} catch (error) {
+  throw new Error("persist failed", { cause: error });
+}
+```
+
+Do not expose raw errors to users or API clients when they may contain internal details.
+
+## Node.js
+
+- Prefer `node:` built-ins where the repository already uses them.
+- Use `path.join`/`path.resolve` rather than string-building filesystem paths.
+- Specify text encoding when reading or writing text.
+- Avoid sync filesystem APIs on latency-sensitive server request paths unless the existing design accepts them.
+- Preserve ESM/CommonJS boundaries. Do not convert module systems incidentally.
+
+```ts
+import { readFile } from "node:fs/promises";
+
+const content = await readFile(path, "utf8");
+```
+
+## React and Component Code
+
+Cloak owns UI/UX requirements; Clockwork may own state or provider architecture. Ponytail implements accepted behavior.
+
+- Keep render functions pure.
+- Derive values instead of duplicating them in state.
+- Use effects for synchronization with external systems, not ordinary derivation.
+- Clean up listeners, subscriptions, timers, and requests in effects.
+- Preserve controlled/uncontrolled component conventions already used by the project.
+- Avoid memoization unless identity or measured performance requires it.
+
+```tsx
+useEffect(() => {
+  const controller = new AbortController();
+  void loadData(controller.signal);
+  return () => controller.abort();
+}, [loadData]);
+```
+
+Do not invent dependencies to silence effect linting. Fix stale closures or unstable ownership at the correct layer.
+
+## Validation and Serialization
+
+For external data:
+- use the repository's established schema/validation library if one exists;
+- otherwise perform narrow runtime checks before trusting values;
+- distinguish absent optional fields from invalid fields;
+- preserve JSON casing, numeric precision, and date/time conventions already in use.
+
+TypeScript types disappear at runtime and do not validate network, file, environment, or user input.
+
+## Testing
+
+Use the existing framework and nearby test style. Typical patterns may include Jest, Vitest, Node test runner, Playwright, or framework-specific tools, but repository evidence decides.
+
+Prefer a test that fails for the prior bug and passes for the corrected root cause. Do not add a second test framework for one change.
+
+## Common Failure Patterns
+
+Avoid:
+- `as any` or broad assertions used to silence real type errors;
+- catching and ignoring errors;
+- mutation hidden inside getters or render logic;
+- duplicate derived state;
+- `Promise.all` across operations that must be ordered;
+- defaulting with `||` when valid falsy values exist;
+- new dependencies for standard-library tasks;
+- framework-version-specific APIs without confirming the installed version.

--- a/skills/ponytail/references/python.md
+++ b/skills/ponytail/references/python.md
@@ -1,0 +1,141 @@
+# Python Implementation Reference
+
+## Use When
+
+Load this reference only after repository evidence confirms Python. Preserve the supported Python version, formatter, linter, type checker, package manager, framework, and repository conventions.
+
+## Core Syntax
+
+Prefer straightforward functions and data structures. Use type hints where the project uses them.
+
+```python
+def normalize_name(value: str | None) -> str:
+    return value.strip() if value is not None else ""
+```
+
+Use `is None` and `is not None` for `None` checks. Do not use mutable objects as default arguments.
+
+```python
+def append_value(value: str, items: list[str] | None = None) -> list[str]:
+    result = [] if items is None else list(items)
+    result.append(value)
+    return result
+```
+
+## Data Modeling
+
+Prefer existing project models. For simple internal records, `dataclasses` may be appropriate when the repository already uses standard-library modeling.
+
+```python
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class UserRef:
+    user_id: str
+    display_name: str
+```
+
+Do not introduce Pydantic, attrs, a new ORM, or another modeling package when the repository has an established approach.
+
+## Context Management and Cleanup
+
+Use context managers for files, locks, transactions, and resources when supported.
+
+```python
+from pathlib import Path
+
+text = Path(path).read_text(encoding="utf-8")
+```
+
+```python
+with open(path, "r", encoding="utf-8") as handle:
+    content = handle.read()
+```
+
+Use `try/finally` when cleanup cannot be expressed through an existing context manager.
+
+## Exceptions
+
+Catch only exceptions you can handle meaningfully. Preserve the cause when adding context.
+
+```python
+try:
+    payload = json.loads(raw)
+except json.JSONDecodeError as exc:
+    raise ValueError("invalid configuration JSON") from exc
+```
+
+Avoid bare `except:` and broad `except Exception:` unless the boundary intentionally converts all failures and still preserves diagnostics appropriately.
+
+## Filesystem and Paths
+
+Use `pathlib.Path` when consistent with the codebase. Avoid machine-specific path strings.
+
+```python
+config_path = Path(root) / "config" / "settings.json"
+```
+
+Explicitly choose encoding for text I/O. Use temporary files/directories through `tempfile` for test or transient state.
+
+## Iteration and Collections
+
+Use comprehensions when they remain readable. Prefer generators when streaming is materially useful and does not complicate ownership.
+
+Use `set` for uniqueness and dictionaries for keyed lookup. Preserve ordering requirements explicitly rather than relying on accidental traversal behavior.
+
+## Async Code
+
+Use `asyncio` only when the project already has an asynchronous execution model or the accepted architecture requires it.
+
+```python
+async def fetch_all(client, urls: list[str]):
+    return await asyncio.gather(*(client.fetch(url) for url in urls))
+```
+
+Do not add concurrency simply to make code look faster. Confirm independent operations, cancellation semantics, resource bounds, and failure behavior first.
+
+## HTTP and Framework Code
+
+Framework-specific APIs are version-sensitive. Confirm installed versions and copy established local patterns before using Django, Flask, FastAPI, Starlette, SQLAlchemy, or similar frameworks.
+
+At external boundaries:
+- validate untrusted input;
+- do not rely on type hints as runtime validation;
+- avoid leaking raw exception details;
+- preserve authentication and authorization middleware/dependencies defined by Cipher-owned requirements.
+
+## Packaging
+
+Determine management from repository evidence such as `pyproject.toml`, `uv.lock`, `poetry.lock`, requirements files, setup metadata, or CI. Do not mix package managers casually.
+
+Prefer invocation through the active environment:
+
+```text
+python -m pytest
+python -m package_or_module
+```
+
+when that convention is supported by the repository.
+
+## Testing
+
+Use existing test conventions. Common repositories may use `pytest` or `unittest`; do not assume which one applies.
+
+```python
+def test_normalize_name_trims_value():
+    assert normalize_name("  Ada  ") == "Ada"
+```
+
+Prefer deterministic fixtures, `tmp_path` or standard temporary directories for filesystem tests, and dependency boundaries already established by the project.
+
+## Common Failure Patterns
+
+Avoid:
+- mutable default arguments;
+- broad exception swallowing;
+- changing working directory as hidden global state;
+- relying on platform-specific paths;
+- blocking I/O inside an established async request path without evaluating the existing pattern;
+- adding package-manager metadata inconsistent with the repository;
+- returning `None` for every failure when callers need to distinguish failure modes;
+- using type-ignore directives to bypass a real contract error without justification.

--- a/skills/ponytail/references/shell-powershell.md
+++ b/skills/ponytail/references/shell-powershell.md
@@ -1,0 +1,126 @@
+# Shell and PowerShell Implementation Reference
+
+## Use When
+
+Load only after repository evidence confirms shell or PowerShell scripts are part of the supported workflow. Preserve cross-platform requirements, execution-policy assumptions, quoting style, error semantics, and existing helper functions.
+
+## General Rules
+
+- Treat paths, arguments, environment values, and user input as data, not executable code.
+- Quote values according to the shell actually executing the script.
+- Avoid dynamic evaluation such as `eval`, `Invoke-Expression`, or equivalent unless explicitly required and reviewed.
+- Prefer argument arrays or native command invocation over building command strings.
+- Fail on real errors and preserve useful diagnostics.
+- Make destructive behavior explicit and separately authorized.
+- Keep scripts idempotent when they may be rerun.
+
+## POSIX Shell
+
+When Bash is confirmed, strict mode may be useful if compatible with existing script behavior:
+
+```bash
+set -euo pipefail
+```
+
+Do not add it blindly to a legacy script because it can change failure semantics.
+
+Quote parameter expansions:
+
+```bash
+config_path="$root/config/settings.json"
+python "$script_path" --config "$config_path"
+```
+
+Use arrays in Bash when passing multiple arguments:
+
+```bash
+args=(--check --format json)
+python "$script" "${args[@]}"
+```
+
+Use temporary directories through established platform tools and clean them with a trap when appropriate:
+
+```bash
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+```
+
+Destructive cleanup must remain within an explicitly created temporary path and any broader deletion requires separate authorization.
+
+## PowerShell
+
+Prefer cmdlet parameters and arrays instead of concatenated command strings.
+
+```powershell
+$path = Join-Path $Root "config\settings.json"
+& python $ScriptPath --config $path
+if ($LASTEXITCODE -ne 0) {
+    throw "Validation failed with exit code $LASTEXITCODE"
+}
+```
+
+Use `-LiteralPath` when a path should not interpret wildcard characters.
+
+```powershell
+if (Test-Path -LiteralPath $path -PathType Leaf) {
+    Get-Content -LiteralPath $path -Raw
+}
+```
+
+For native commands, check `$LASTEXITCODE`. For PowerShell cmdlets, use exceptions/`-ErrorAction Stop` where failure must stop execution.
+
+```powershell
+Copy-Item -LiteralPath $source -Destination $target -ErrorAction Stop
+```
+
+Prefer `Join-Path` and .NET path APIs over hand-built separators for portable repository tooling.
+
+## Environment Variables
+
+Read environment variables without printing secrets. Preserve existing precedence rules.
+
+PowerShell:
+
+```powershell
+$mode = $env:ORCHESTRA_MODE
+```
+
+Bash:
+
+```bash
+mode="${ORCHESTRA_MODE:-}"
+```
+
+Do not persist secret environment values into tracked config, logs, or command output.
+
+## Cross-Platform Scripts
+
+When the same workflow runs on Windows and POSIX:
+- prefer cross-platform runtimes already used by the repo, such as Python or Node, for complex shared logic;
+- keep host-specific wrappers thin;
+- do not assume `bash`, `python3`, GNU flags, Windows drive letters, or PowerShell availability without evidence;
+- normalize line endings only when the repository contract requires it;
+- test path handling and subprocess behavior on supported OS runners.
+
+## Process Execution
+
+Avoid invoking a shell when direct process execution is available. Pass arguments separately to prevent quoting/injection bugs.
+
+Python example of the preferred subprocess shape:
+
+```python
+subprocess.run(["git", "status", "--short"], check=True)
+```
+
+Do not replace this with `shell=True` merely for convenience.
+
+## Common Failure Patterns
+
+Avoid:
+- unquoted shell expansions;
+- `Invoke-Expression` or `eval` for ordinary command execution;
+- treating PowerShell cmdlet success and native-process exit codes as identical;
+- relying on Bash-only builtins in commands consumed by PowerShell hosts;
+- hardcoded machine paths;
+- recursive force deletion outside a verified temporary/sandbox path;
+- swallowing command failures and continuing to a success message.

--- a/skills/ponytail/references/shell-powershell.md
+++ b/skills/ponytail/references/shell-powershell.md
@@ -8,7 +8,7 @@ Load only after repository evidence confirms shell or PowerShell scripts are par
 
 - Treat paths, arguments, environment values, and user input as data, not executable code.
 - Quote values according to the shell actually executing the script.
-- Avoid dynamic evaluation such as `eval`, `Invoke-Expression`, or equivalent unless explicitly required and reviewed.
+- Avoid dynamic command-string evaluation. Prefer direct process invocation and argument arrays.
 - Prefer argument arrays or native command invocation over building command strings.
 - Fail on real errors and preserve useful diagnostics.
 - Make destructive behavior explicit and separately authorized.
@@ -38,12 +38,7 @@ args=(--check --format json)
 python "$script" "${args[@]}"
 ```
 
-Use temporary directories through established platform tools and clean them with a trap when appropriate:
-
-```bash
-tmp_dir="$(mktemp -d)"
-trap 'rm -rf "$tmp_dir"' EXIT
-```
+Use temporary directories through established platform or repository helpers. Register cleanup only through a bounded cleanup primitive whose target is the verified temporary directory created by the current operation. Do not place broad recursive-force deletion commands in reusable specialist guidance.
 
 Destructive cleanup must remain within an explicitly created temporary path and any broader deletion requires separate authorization.
 
@@ -118,7 +113,7 @@ Do not replace this with `shell=True` merely for convenience.
 
 Avoid:
 - unquoted shell expansions;
-- `Invoke-Expression` or `eval` for ordinary command execution;
+- dynamic command-string evaluation for ordinary command execution;
 - treating PowerShell cmdlet success and native-process exit codes as identical;
 - relying on Bash-only builtins in commands consumed by PowerShell hosts;
 - hardcoded machine paths;

--- a/skills/ponytail/references/web-runtime.md
+++ b/skills/ponytail/references/web-runtime.md
@@ -1,0 +1,119 @@
+# Web Runtime Implementation Reference
+
+## Use When
+
+Load only for accepted HTML, CSS, browser API, or frontend runtime implementation. Cloak owns UI/UX and accessibility requirements; Clockwork owns frontend architecture/state boundaries when those decisions are not already established. Ponytail implements the accepted contract.
+
+## Semantic HTML
+
+Prefer native elements that already provide the required meaning and interaction.
+
+```html
+<button type="button">Save</button>
+<nav aria-label="Primary">...</nav>
+<label for="email">Email</label>
+<input id="email" name="email" type="email" autocomplete="email">
+```
+
+Do not replace native buttons, links, inputs, headings, lists, tables, or disclosure controls with generic containers unless the accepted design genuinely requires custom behavior.
+
+ARIA supplements semantics; it does not repair an inappropriate base element automatically. Do not add ARIA roles or properties by guesswork.
+
+## Keyboard and Focus
+
+Implement the keyboard contract supplied by Cloak or established component patterns.
+
+- Interactive elements must be keyboard reachable when the interaction is intended for keyboard users.
+- Do not add positive `tabindex` values to force custom focus order.
+- Move focus only when the interaction requires it, such as accepted modal/dialog workflows or explicit error recovery.
+- Restore focus when established component behavior requires it.
+- Do not trap focus outside a component that owns a legitimate modal interaction.
+
+## Forms
+
+Use native form behavior where possible.
+
+```html
+<form>
+  <label for="quantity">Quantity</label>
+  <input id="quantity" name="quantity" type="number" min="1" required>
+  <button type="submit">Add</button>
+</form>
+```
+
+Client-side validation improves usability but does not replace server-side trust-boundary validation.
+
+Preserve disabled, pending, error, success, and retry states required by Cloak. Prevent duplicate submissions when the accepted workflow requires single ownership of a mutation.
+
+## CSS Layout
+
+Prefer normal flow, Flexbox, and Grid before JavaScript layout calculations.
+
+```css
+.toolbar {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+```
+
+```css
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+  gap: 1rem;
+}
+```
+
+Avoid arbitrary fixed dimensions when content or responsive behavior requires flexibility. Preserve project tokens and design-system variables instead of inventing local color, spacing, typography, or z-index systems.
+
+## Browser APIs
+
+Use native APIs when sufficient and supported by the project's browser target.
+
+Examples include:
+- `URL` and `URLSearchParams` for URL manipulation;
+- `AbortController` for cancellable browser requests;
+- `FormData` for form payloads;
+- `Intl` for locale-aware formatting when project requirements allow it;
+- `matchMedia` for media-query state when CSS alone cannot satisfy the runtime need.
+
+Confirm browser support and existing polyfill policy before using newer APIs.
+
+## Events
+
+- Use the event appropriate to the semantic interaction.
+- Avoid duplicate handlers that can dispatch the same mutation twice.
+- Clean up manually registered listeners.
+- Do not rely on event ordering that is not guaranteed by the project/runtime contract.
+- Preserve event propagation intentionally; do not scatter `stopPropagation()` as a symptom fix.
+
+## Network State
+
+For client requests:
+- distinguish idle, pending, success, empty, and error states when required;
+- abort superseded requests when the project pattern does so;
+- do not treat client-side authorization checks as server authorization;
+- avoid optimistic mutation unless the accepted contract defines rollback/reconciliation behavior.
+
+## Security Boundaries
+
+Cipher owns security requirements. Ponytail must preserve them while implementing frontend behavior.
+
+Do not:
+- insert untrusted HTML with `innerHTML` or framework equivalents without an accepted sanitization boundary;
+- store secrets in browser code or public environment variables;
+- rely on hidden/disabled UI controls as authorization;
+- expose raw infrastructure identifiers or sensitive error payloads unless explicitly accepted.
+
+## Common Failure Patterns
+
+Avoid:
+- generic clickable `div` elements where a button/link fits;
+- JS layout code that CSS already solves;
+- local one-off styling that bypasses the design system;
+- positive `tabindex` ordering;
+- duplicate submit/completion paths;
+- missing cleanup for listeners, timers, observers, or requests;
+- new accessibility requirements invented by Ponytail rather than sourced from Cloak or established standards already adopted by the project.


### PR DESCRIPTION
## Scope

SK1 only: strengthen Ponytail as Orchestra's implementation specialist without changing routing, authority, runtime, package, workflow, release, or other specialist ownership. The only non-Ponytail path is the repository-required `CHANGELOG.md` entry.

### Added knowledge

- repository stack discovery before selecting syntax or commands
- stronger implementation/root-cause/error/concurrency/config/dependency foundations
- JavaScript/TypeScript reference
- Python reference
- Java/JVM reference
- Go/Rust reference
- shell/PowerShell reference
- browser/web-runtime implementation reference
- build/test/generated-artifact tooling guidance
- worked cross-specialist implementation patterns
- upstream Ponytail provenance and future sync rules
- expanded implementation/validation checklist

### Context-efficiency design

- Markdown remains the specialist knowledge format for prose-heavy material.
- Knowledge is split into progressive-disclosure files rather than injected into one large default prompt.
- No JSON knowledge files are added because prose-heavy JSON would add repeated keys, punctuation, quoting, and escaping without improving specialist comprehension.
- The existing Codex exporter recursively copies Markdown support files, so portable parity remains within the current packaging contract.

### Upstream check

- `Baelfyre/ponytail` main: `14a0d79548d4de8fc2de95c1b94bb0de63a739d3`, package `4.8.4`
- upstream `DietrichGebert/ponytail` main: `2ed6c52c9d7e5e56942508591085fd45dea277d3`, package `4.9.0`
- core upstream `skills/ponytail/SKILL.md` blob at both revisions: `02c0712c86277d49d18a77da3a2b825657bf02d1`
- disposition: newer upstream work is package/host-adapter work, not a newer core Ponytail intelligence definition

### Exact baseline and validation history

- base: `0efdde29b403da725f6bc1c379ac06c174435fec`
- head 1 `e0f54bb9b0f704e2fbfda1dee13058963253b9cc`: Governance Check correctly failed on missing changelog freshness and Ponytail frontmatter role drift.
- head 2 `aeb9dd05ce76f2123733fd35e183969471342086`: strict governance passed; Governance Behavior Tests correctly rejected loss of explicit fail-closed `SPECIALIST_REROUTE_REQUIRED` plus `do not execute` wording.
- head 3 `b35f9e9713765e7f75d986495520e72fb8e5f808`: `validate`, `runtime-tests`, and Governance Check passed; macOS and Ubuntu cross-platform jobs then correctly failed because the new shell/PowerShell reference contained literal unsafe/destructive command patterns caught by the enforced runtime guardrail.
- current head 4: `5a205c7eff8fb1ab4451c96ebe3688d4c6be6b10`
  - bounded correction removes only the scanner-triggering literals from canonical and Codex shell/PowerShell guidance while preserving the safety instruction.
- all validation from heads 1 through 3 is stale for merge purposes.

### Validation gate

This PR is the exact-head validation vehicle because the current remote-development host cannot clone GitHub into its local container. No local-pass claim is made.

Before merge require fresh results on `5a205c7eff8fb1ab4451c96ebe3688d4c6be6b10` for:

- `validate`, which runs `python tests/behavior/run_tests.py`
- `runtime-tests`, which runs `python -m pytest tests/runtime --cov=orchestra_runtime --cov-report=term-missing --cov-fail-under=90`
- Governance Check
- native Windows, Ubuntu, and macOS validation
- `Analyze (actions)` and `Analyze (python)`
- exact-head branch freshness
- zero unresolved review threads
- final diff/scope review

Any further source correction invalidates prior exact-head evidence and requires the affected gates to rerun.

### Exact scope

- 26 paths under `skills/ponytail/**` and `adapters/codex/skills/ponytail/**`
- 1 repository-required `CHANGELOG.md` path
- no router, runtime, governance protocol, manifest, package, workflow, release, or other-specialist source change

### Explicit exclusions

No release/publication, deployment/production mutation, installed-integration refresh, policy activation, destructive cleanup, branch deletion, force push/history rewrite, new specialist, or orchestration/authority redesign.