### PR TITLE
feat(clockwork): add specialist architecture knowledge layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Post-v1.2.0 Specialist Knowledge Layer - SK2 Clockwork - Pending
+
+- Expanded Clockwork from OOP/layering foundations into modern application architecture review covering modular and distributed service boundaries, state and concurrency ownership, API compatibility/versioning, caching, multi-tenancy, background jobs, event-driven flows, outbox/inbox placement, and durable workflow patterns.
+- Added progressive-disclosure Markdown guides for modern application architecture and event-driven/workflow reliability while preserving Clockwork as an audit-first boundary specialist rather than an implementation, persistence, security, or QA owner.
+- Added `skills/clockwork/patterns/architecture-patterns.json` as selective machine-readable pattern metadata under the campaign's Markdown-primary, JSON-selective storage policy; the JSON catalog does not replace repository evidence or Markdown guidance.
+- Extended the Codex exporter to copy `.json` specialist support files alongside Markdown and added regression coverage proving the Clockwork JSON catalog is valid and portable.
+- Preserved source/Codex portable parity for all SK2 Clockwork support files without changing routing, manifest contracts, package version, or runtime authority semantics.
+- Reconciled Clockwork output ownership so it reports downstream validation properties while Overseer retains QA strategy, test scope, validation-gate, and release-readiness ownership.
+- No release/publication, deployment/production mutation, installed-integration refresh, policy activation, destructive cleanup, branch deletion, force push, or history rewrite is performed by SK2.
+
 ## Post-v1.2.0 Specialist Knowledge Layer - SK1 Ponytail - Pending
 
 - Added an Orchestra-native Ponytail implementation knowledge layer while preserving Ponytail's established specialist ownership and upstream minimalism principles.

--- a/adapters/codex/export-codex-skills.ps1
+++ b/adapters/codex/export-codex-skills.ps1
@@ -116,16 +116,16 @@ foreach ($skill in $skills) {
     # 1. Parse and rewrite SKILL.md
     $sourceSkillFile = Join-Path $sourceDir "SKILL.md"
     $targetSkillFile = Join-Path $targetDir "SKILL.md"
-    
+
     $content = Read-Utf8TextFile -Path $sourceSkillFile
-    
+
     # Extract name and description using Regex
     $nameMatch = [regex]::Match($content, '(?m)^name:\s*(.+)$')
     $descMatch = [regex]::Match($content, '(?m)^description:\s*(.+)$')
-    
+
     $name = if ($nameMatch.Success) { $nameMatch.Groups[1].Value } else { $skill }
     $desc = if ($descMatch.Success) { $descMatch.Groups[1].Value } else { "" }
-    
+
     # Extract the body (everything after the second ---)
     $bodyMatch = [regex]::Match($content, '(?s)^---.*?---(.*)$')
     $body = if ($bodyMatch.Success) { $bodyMatch.Groups[1].Value } else { "" }
@@ -152,8 +152,12 @@ description: $desc
 
     Write-PortableReferenceContext -Skill $skill -TargetDir $targetDir
 
-    # 2. Copy Markdown support files referenced by progressive disclosure links.
-    $supportFiles = Get-ChildItem -Path $sourceDir -Recurse -File -Filter "*.md" | Where-Object { $_.Name -ne "SKILL.md" }
+    # 2. Copy progressive-disclosure support files that are portable text knowledge.
+    # Markdown remains primary. JSON is copied selectively for machine-readable
+    # metadata, schemas, indexes, fixtures, or deterministic capability data.
+    $supportFiles = Get-ChildItem -Path $sourceDir -Recurse -File | Where-Object {
+        $_.Name -ne "SKILL.md" -and $_.Extension.ToLowerInvariant() -in @(".md", ".json")
+    }
     foreach ($supportFile in $supportFiles) {
         $relativePath = $supportFile.FullName.Substring($sourceDir.Length).TrimStart('\', '/')
         $targetSupportFile = Join-Path $targetDir $relativePath

--- a/adapters/codex/skills/clockwork/ARCHITECTURE_REVIEW_CHECKLIST.md
+++ b/adapters/codex/skills/clockwork/ARCHITECTURE_REVIEW_CHECKLIST.md
@@ -1,34 +1,96 @@
 # Architecture Review Checklist
 
+## Evidence First
+- [ ] Relevant files, callers, state owners, and runtime boundaries were inspected before making architecture claims.
+- [ ] Repository conventions and explicit project constraints were identified before recommending a pattern.
+- [ ] Assumptions are separated from verified architecture facts.
+
 ## Foundational OOP Review
 - [ ] Encapsulation is preserved; internal state and implementation details are not exposed unnecessarily.
 - [ ] Abstraction is clear; callers depend on stable behavior or contracts, not concrete implementation details.
 - [ ] Polymorphism is used where appropriate to reduce type-checking, duplicated branching, and caller-specific logic.
 - [ ] Inheritance is valid, substitutable, and not used where composition would be safer.
+- [ ] Cohesion is high enough that responsibilities have clear reasons to change.
+- [ ] Coupling is intentional and does not leak infrastructure details into domain logic.
 
 ## Layer Boundaries
-- [ ] UI or controller must not query the database directly.
-- [ ] UI or controller must not contain hidden business rules.
-- [ ] Services coordinate workflows and transaction boundaries.
-- [ ] Repositories hide persistence details behind stable contracts.
+- [ ] UI or controller does not query the database directly unless an explicitly approved architecture requires it.
+- [ ] UI or controller does not contain hidden business rules.
+- [ ] Services coordinate workflows without becoming unrelated logic dumping grounds.
+- [ ] Repositories hide persistence details behind appropriate contracts.
+- [ ] Domain logic does not depend on transport, framework, ORM, queue, or cache implementation details without an explicit architecture decision.
 
-## Domain Isolation
-- [ ] Domain objects own business rules where appropriate.
-- [ ] Domain must not depend on JDBC, ORM, SQL, HTTP, framework annotations, or storage details unless the project intentionally uses an approved active record pattern.
+## State and Concurrency Ownership
+- [ ] Every mutable state surface has an identifiable owner.
+- [ ] Shared mutable state has explicit concurrency and conflict semantics.
+- [ ] Ordering requirements are stated at the narrowest necessary scope.
+- [ ] Duplicate execution behavior is defined for concurrent, retried, queued, or scheduled work.
+- [ ] Cancellation, timeout, retry, and backpressure ownership are identified where concurrency makes them relevant.
+- [ ] A distributed lock is not recommended when the invariant can be enforced more simply at the authoritative state owner.
 
-## Persistence Integration
-- [ ] Persistence errors must not be swallowed silently.
-- [ ] Transaction boundaries should wrap complete business workflows, not random individual helper calls.
-- [ ] Mapping logic must not leak into UI.
+## Service and Distributed Boundaries
+- [ ] Each service/process boundary has a demonstrated ownership, deployment, scaling, data, or failure-isolation reason.
+- [ ] Chatty cyclic service dependencies are absent or explicitly justified.
+- [ ] Network calls are treated as partial-failure boundaries.
+- [ ] Compatibility expectations are explicit for cross-process contracts.
+- [ ] A modular/in-process boundary was considered before adding distributed infrastructure.
 
-## SOLID Alignment
-- [ ] Single Responsibility is preserved; each class, method, or module has one clear reason to change.
-- [ ] Open/Closed is considered where new behavior should be added without unsafe edits to stable code.
-- [ ] Liskov Substitution is preserved for any subtype or inherited model.
-- [ ] Interface Segregation is preserved; callers do not depend on methods they do not use.
-- [ ] Dependency Inversion is applied where high-level policy should depend on stable contracts.
+## API Evolution
+- [ ] Existing API/versioning conventions were inspected before proposing a strategy.
+- [ ] Additive compatible evolution is preferred when feasible.
+- [ ] Breaking changes identify affected consumers and migration boundaries.
+- [ ] Defaults, enum expansion, pagination, ordering, and error contracts are reviewed where applicable.
+
+## Caching
+- [ ] The authoritative source of truth is named.
+- [ ] Cache ownership and invalidation ownership are explicit.
+- [ ] Freshness and stale-read tolerance are defined.
+- [ ] Cache failure behavior is defined.
+- [ ] Tenant/security-sensitive cache concerns are handed to Cipher where applicable.
+
+## Multi-Tenancy
+- [ ] Tenant context entry and propagation boundaries are identified.
+- [ ] Jobs, events, caches, and service calls retain the correct tenant context where required.
+- [ ] Clockwork does not invent authorization or persistence isolation mechanics.
+- [ ] Cipher and Chronicler handoffs are explicit where tenant security or persistence enforcement is involved.
+
+## Event-Driven Architecture
+- [ ] Message intent is clear: event reports a fact; command requests an action.
+- [ ] Producer ownership is clear.
+- [ ] Duplicate, delayed, reordered, retried, or replayed delivery behavior is considered when relevant.
+- [ ] Idempotency responsibility is identified for retryable or duplicate-prone effects.
+- [ ] Event contracts do not expose internal persistence models unnecessarily.
+- [ ] Eventual-consistency boundaries identify authoritative and derived state.
+
+## Jobs and Workflows
+- [ ] Background job producer/trigger, payload, worker, and state-transition ownership are explicit.
+- [ ] Retry and failed-work ownership are explicit.
+- [ ] Long-running workflows define durable state, step boundaries, terminal states, compensation, cancellation, and human-gated transitions where applicable.
+- [ ] A scheduler is not being used as an implicit workflow engine without clear state ownership.
+- [ ] Protected human gates remain authority boundaries and are not converted into implicit automation permission.
+
+## Outbox and Inbox
+- [ ] Outbox is considered only when local state mutation and durable publication can diverge.
+- [ ] Outbox dispatcher ownership and duplicate-publication expectations are explicit.
+- [ ] Inbox/deduplication is considered only when durable consumer processing identity is required.
+- [ ] Schema and database transaction mechanics are routed to Chronicler.
+
+## Refactor Safety
+- [ ] Current callers and compatibility surfaces are identified.
+- [ ] State ownership changes are explicit.
+- [ ] Migration sequencing and rollback constraints are considered.
+- [ ] The smallest safe structural correction is preferred over a broad rewrite.
 
 ## Scope Enforcement
-- [ ] Schema, SQL, migrations, and database design are routed to Chronicler.
-- [ ] Validation, test strategy, and release readiness are routed to Overseer.
-- [ ] Code implementation is routed to Ponytail.
+- [ ] Implementation is routed to Ponytail.
+- [ ] Security policy, auth/RBAC, privacy, secrets, and threat modeling are routed to Cipher.
+- [ ] Schema, SQL, migrations, indexes, database isolation mechanics, and persistence design are routed to Chronicler.
+- [ ] UI/UX and accessibility requirements are routed to Cloak.
+- [ ] QA strategy, test scope, validation gates, and release readiness are routed to Overseer.
+- [ ] Documentation is routed to Scribe.
+- [ ] Ambiguous or multi-specialist sequencing is routed to Conductor.
+
+## Structured Knowledge
+- [ ] `patterns/architecture-patterns.json` is used only for deterministic lookup where useful.
+- [ ] JSON pattern metadata does not override repository evidence, user requirements, or Markdown guidance.
+- [ ] No pattern match is treated as automatic permission to introduce infrastructure, dependencies, or protected actions.

--- a/adapters/codex/skills/clockwork/EVENT_DRIVEN_WORKFLOW_GUIDE.md
+++ b/adapters/codex/skills/clockwork/EVENT_DRIVEN_WORKFLOW_GUIDE.md
@@ -1,0 +1,204 @@
+# Event-Driven and Workflow Architecture Guide
+
+## Purpose
+
+Provide Clockwork with architecture guidance for events, queues, asynchronous processing, outbox/inbox placement, retries, idempotency, and durable workflows while preserving specialist boundaries.
+
+## Event vs Command
+
+Use an event to report that something happened. Use a command to request that an owner perform an action.
+
+Review whether the message contract expresses:
+- fact vs request;
+- producer ownership;
+- consumer expectations;
+- correlation identity;
+- compatibility expectations;
+- ordering assumptions;
+- duplicate-delivery behavior.
+
+Do not disguise synchronous request/response coupling as event-driven architecture merely by putting a broker between components.
+
+## Event Ownership
+
+An event should be published by the component that owns the state transition or authoritative fact.
+
+Consumers should not need private producer implementation details to understand the contract.
+
+Avoid events that expose internal persistence models wholesale. Prefer stable domain or integration contracts where a boundary is required.
+
+## Delivery Semantics
+
+Treat common messaging as potentially duplicated, delayed, reordered, or retried unless the actual platform contract proves stronger guarantees.
+
+Architecture review should define which of these matter to the business invariant:
+- at-most-once effects;
+- at-least-once delivery tolerance;
+- ordering by key or aggregate;
+- duplicate suppression or idempotent handling;
+- replay behavior;
+- poison-message handling.
+
+Do not claim exactly-once business effects merely because a transport advertises exactly-once features. End-to-end side effects still require architecture review.
+
+## Idempotency
+
+Idempotency means repeated processing produces an acceptable final effect for the same logical operation.
+
+Identify:
+- the logical operation identity;
+- the state owner that can detect or tolerate repetition;
+- the side effects that must not repeat;
+- the retention window for deduplication when one is needed.
+
+Clockwork defines where the idempotency boundary belongs. Chronicler owns persistence mechanics. Ponytail implements the accepted design. Overseer owns validation strategy.
+
+## Transactional Outbox
+
+Consider an outbox when one local business transaction must update authoritative state and reliably publish a message without a distributed transaction.
+
+Clockwork reviews:
+- which transaction owns the state change;
+- where the outbox record belongs architecturally;
+- which dispatcher owns publication;
+- duplicate-publication expectations;
+- consumer idempotency requirements;
+- failure recovery boundary.
+
+Chronicler owns the outbox schema, indexes, transaction details, and query mechanics.
+
+Do not add an outbox when no durable message publication problem exists.
+
+## Inbox or Consumer Deduplication
+
+Consider an inbox/deduplication boundary when consumers must safely tolerate repeated delivery and the state owner needs durable processing identity.
+
+Clockwork defines the boundary and responsibility. Chronicler owns persistence implementation. Ponytail implements.
+
+## Retry Architecture
+
+Retries are safe only when the operation can tolerate repetition or has a compensating guard.
+
+Define:
+- retry owner;
+- retryable failure classes at an architectural level;
+- maximum attempt or terminal-failure boundary when requirements specify one;
+- backoff ownership;
+- duplicate side-effect risk;
+- visibility of exhausted work.
+
+Do not stack retries independently at multiple layers without understanding multiplication of attempts and latency.
+
+## Dead-Letter or Failed-Work Boundary
+
+When the messaging platform or workflow requires failed-work retention, identify:
+- who owns triage;
+- whether replay is safe;
+- whether the original contract version remains available;
+- whether manual intervention is required;
+- whether replay can violate current invariants.
+
+Clockwork does not invent operational runbooks or production actions. It defines the architecture boundary that must exist.
+
+## Ordering
+
+Require ordering only where the domain invariant needs it.
+
+If ordering matters, identify its scope:
+- global;
+- tenant;
+- account;
+- aggregate;
+- entity;
+- partition/key.
+
+Global ordering is expensive and often unnecessary. Prefer the narrowest ordering scope that preserves the invariant.
+
+## Eventual Consistency
+
+When state is asynchronously propagated, identify:
+- authoritative source;
+- derived projection or replica;
+- expected lag tolerance;
+- user-visible stale-state behavior where applicable;
+- reconciliation owner;
+- conflict behavior.
+
+A projection, cache, search index, or read model must not silently become the write authority unless the architecture explicitly assigns it that role.
+
+## Background Jobs
+
+For queued or scheduled jobs, define:
+- producer or schedule owner;
+- payload contract;
+- worker owner;
+- state transition owner;
+- duplicate execution behavior;
+- cancellation and timeout behavior;
+- retry ownership;
+- failed-job visibility.
+
+Avoid passing large mutable internal objects as job payloads when a stable identifier or boundary DTO is sufficient.
+
+## Workflow Patterns
+
+Use a durable workflow model when work spans multiple steps that must survive process restarts, wait on external systems, require compensation, or pause for human decisions.
+
+### Orchestration
+
+A coordinator owns workflow state and tells participants what step to execute next.
+
+Use when explicit sequencing, state visibility, compensation, or human-gated transitions are central.
+
+Risk: the coordinator can become an overly coupled central service if it absorbs participant business logic.
+
+### Choreography
+
+Participants react to events without a central step coordinator.
+
+Use when reactions are naturally independent and the global workflow does not require one owner to control every transition.
+
+Risk: implicit flow, difficult tracing, cyclic reactions, and unclear ownership.
+
+Choose based on ownership and failure requirements, not fashion.
+
+## Saga and Compensation
+
+A saga coordinates multiple local transactions when one atomic transaction cannot span the required boundaries.
+
+Define:
+- each local transaction owner;
+- compensation semantics;
+- irreversible side effects;
+- failure transitions;
+- retry behavior;
+- operator or human-gated recovery points.
+
+Compensation is not automatic rollback. It is a separate business action and may itself fail.
+
+## Human Gates
+
+A workflow may represent a protected approval or publication gate, but it must not convert the gate into implicit authority.
+
+The existence of a workflow step, passing validation, mergeability, or successful prior execution does not create permission for a protected action.
+
+## Message Contract Evolution
+
+Review event and command evolution for:
+- additive fields;
+- required vs optional semantics;
+- enum expansion;
+- producer/consumer deployment order;
+- old consumer tolerance;
+- replay compatibility;
+- schema/version ownership.
+
+Clockwork defines compatibility architecture. Ponytail implements. Overseer owns contract-test strategy.
+
+## Specialist Handoffs
+
+- Broker/client implementation -> Ponytail
+- Auth, message trust, privacy, secrets, and abuse controls -> Cipher
+- Outbox/inbox schema, database transaction mechanics, locks, and persistence -> Chronicler
+- Validation strategy, failure injection, regression, and release readiness -> Overseer
+- Multi-specialist sequencing -> Conductor

--- a/adapters/codex/skills/clockwork/MODERN_APPLICATION_ARCHITECTURE_GUIDE.md
+++ b/adapters/codex/skills/clockwork/MODERN_APPLICATION_ARCHITECTURE_GUIDE.md
@@ -1,0 +1,222 @@
+# Modern Application Architecture Guide
+
+## Purpose
+
+Provide Clockwork with architecture foundations for modern application boundaries without turning Clockwork into an implementation, database, security, deployment, or QA specialist.
+
+## Architecture Selection Rule
+
+Choose the simplest architecture that satisfies the accepted requirements and observed constraints.
+
+Do not recommend microservices, queues, caches, workflow engines, distributed locks, service meshes, or separate runtimes only because they are common patterns. Every added boundary creates operational and failure complexity.
+
+Use repository evidence to answer:
+
+1. What owns the behavior?
+2. What owns the state?
+3. What consistency is required?
+4. What is the failure boundary?
+5. What must scale independently?
+6. What compatibility contract exists?
+7. What latency and availability assumptions are acceptable?
+8. Which decisions belong to another specialist?
+
+## Modular Monolith vs Distributed Services
+
+A modular monolith is appropriate when:
+- one deployment unit is acceptable;
+- domain/module boundaries can be enforced in-process;
+- independent scaling or fault isolation is not required;
+- transactional workflows benefit from local coordination;
+- operational simplicity has higher value than deployment independence.
+
+A service boundary may be justified when there is evidence for one or more of these needs:
+- independent deployment cadence;
+- independent scaling profile;
+- explicit team or ownership boundary;
+- fault containment;
+- technology/runtime isolation required by a real constraint;
+- independent availability objective;
+- data ownership that must be isolated behind a stable service contract.
+
+A service split is not justified solely by file size, class count, theoretical purity, or the existence of a domain noun.
+
+## Service Boundary Review
+
+For each proposed service, identify:
+- owned capability;
+- owned state or authoritative data contract;
+- public and internal interfaces;
+- synchronous and asynchronous dependencies;
+- failure behavior when dependencies are unavailable;
+- compatibility expectations;
+- observability boundary;
+- downstream specialist decisions still required.
+
+Avoid cyclic service dependencies. If two services require frequent coordinated changes and synchronous round trips for one business operation, review whether the boundary is premature or misplaced.
+
+## Dependency Direction
+
+Prefer dependencies toward stable policy contracts rather than volatile infrastructure details.
+
+At process boundaries, treat network interfaces as fallible external contracts even when both processes are maintained in one repository.
+
+Do not let a domain model depend directly on transport clients, queue SDKs, cache SDKs, ORM details, or vendor-specific service discovery unless the architecture explicitly accepts that coupling.
+
+## API Boundary and Versioning
+
+Versioning exists to manage compatibility. It does not replace careful contract evolution.
+
+Review:
+- request and response compatibility;
+- field addition/removal semantics;
+- default behavior;
+- enum expansion behavior;
+- pagination and ordering contracts;
+- error contract stability;
+- deprecation path;
+- consumer migration needs.
+
+Prefer additive compatible evolution when feasible. Introduce a new version only when incompatible behavior is necessary and the project has a real versioning boundary.
+
+Do not invent URL, header, media-type, or schema versioning conventions when the repository already has one.
+
+## State Ownership
+
+Every mutable state surface should have one primary owner.
+
+Examples include:
+- domain aggregate state;
+- session state;
+- workflow state;
+- queue ownership;
+- scheduled-job ownership;
+- cache entries;
+- in-memory coordination state;
+- derived projections.
+
+Shared writable state across unrelated components increases coupling and race risk. Prefer an explicit owner with stable access contracts.
+
+## Concurrency Ownership
+
+For concurrent work, identify:
+- the unit of concurrency;
+- the state being protected or coordinated;
+- whether operations may run in parallel;
+- ordering requirements;
+- duplicate execution behavior;
+- conflict resolution semantics;
+- cancellation and timeout ownership;
+- retry safety;
+- resource limits and backpressure boundary.
+
+Clockwork defines ownership and architecture expectations. Chronicler owns database isolation and locking mechanics. Ponytail owns implementation. Overseer owns the validation strategy.
+
+Do not recommend a distributed lock before proving that the protected invariant spans processes and cannot be enforced more simply at the authoritative state boundary.
+
+## Caching Architecture
+
+A cache review must name:
+- the authoritative source of truth;
+- cache owner;
+- key scope;
+- freshness expectations;
+- invalidation owner;
+- stale-read tolerance;
+- failure behavior when the cache is unavailable;
+- tenant and security sensitivity where applicable.
+
+Cache-aside, write-through, write-behind, and refresh-ahead are different consistency choices. Do not select one without matching the accepted freshness and failure requirements.
+
+A cache must not silently become a second source of truth.
+
+Cipher owns sensitive-data and authorization concerns. Chronicler owns persistence implications. Ponytail owns implementation.
+
+## Multi-Tenant Architecture
+
+Clockwork reviews structural tenant boundaries, including:
+- where tenant context enters the system;
+- how tenant context propagates across service, job, event, and cache boundaries;
+- which components are tenant-aware;
+- where cross-tenant aggregation is intentionally allowed;
+- which components must remain tenant-neutral;
+- how background work retains the correct tenant context.
+
+Clockwork does not define authorization policy or database enforcement mechanics.
+
+Handoffs:
+- Cipher: tenant trust, authorization, privacy, and isolation requirements;
+- Chronicler: row/schema/database isolation, constraints, indexes, and persistence mechanics;
+- Ponytail: implementation;
+- Overseer: validation strategy.
+
+## Background Jobs and Schedulers
+
+A background-job architecture should define:
+- producer/trigger owner;
+- job payload contract;
+- worker owner;
+- retry and duplicate-execution expectations;
+- timeout/cancellation behavior;
+- idempotency expectation;
+- scheduling semantics;
+- visibility of failed or abandoned work.
+
+Do not use a scheduler as a hidden workflow engine. If work spans multiple durable steps with compensation, pause/resume, or human approval, review whether an explicit workflow model is required.
+
+## Long-Running Workflows
+
+For multi-step workflows, identify:
+- durable workflow state owner;
+- step boundaries;
+- success and failure transitions;
+- retryable vs terminal failures;
+- compensation requirements;
+- external side effects;
+- idempotency boundaries;
+- timeout and cancellation semantics;
+- human-gated transitions.
+
+Clockwork defines the workflow architecture. It does not bypass governance or convert protected human gates into automated transitions.
+
+## Failure Boundary Review
+
+Distributed boundaries require explicit treatment of:
+- partial failure;
+- timeout;
+- retry;
+- duplicate delivery or execution;
+- out-of-order messages;
+- stale reads;
+- unavailable dependencies;
+- degraded operation;
+- recovery ownership.
+
+Do not claim exactly-once execution from ordinary messaging or retries. Prefer designing handlers and state transitions so repeated delivery is safe where possible.
+
+## Observability Boundary
+
+Architecture review should identify where correlation or trace context must cross process, job, or event boundaries when the project already has observability requirements.
+
+Clockwork does not select monitoring vendors or invent logging policy. It identifies the architectural points where observability continuity is necessary.
+
+## Refactor Safety
+
+Before splitting modules, services, queues, caches, or workflows:
+- identify current callers and dependencies;
+- identify compatibility surfaces;
+- identify state ownership changes;
+- identify migration sequencing;
+- identify temporary dual-write or dual-read risk if applicable;
+- identify rollback constraints;
+- prefer a strangler or incremental boundary move when a big-bang rewrite is not necessary.
+
+## Specialist Handoffs
+
+- Implementation -> Ponytail
+- Security policy and threat modeling -> Cipher
+- Persistence and database mechanics -> Chronicler
+- QA strategy and release readiness -> Overseer
+- UI/UX -> Cloak
+- Documentation -> Scribe
+- Multi-specialist sequencing -> Conductor

--- a/adapters/codex/skills/clockwork/OUTPUT_FORMATS.md
+++ b/adapters/codex/skills/clockwork/OUTPUT_FORMATS.md
@@ -1,73 +1,96 @@
 # Clockwork Output Formats
 
-Generate your output using exactly one of the formats below. The Conductor or user will specify which format to use. Default to `Compact` unless `Full` is requested.
+Generate output using exactly one format below. Default to `Compact` unless `Full` is requested.
 
 ## Compact
 
-Use this for quick audits, rapid checks, or mid-workflow feedback. Keep it strictly to the essential findings.
+Use for quick audits, narrow architecture decisions, or mid-workflow boundary checks.
 
 ```markdown
 # Clockwork Quick Check
 
 **Status:** [Ready / Not ready / Needs clarification]
-**Scope:** [Files inspected / Layers involved]
+**Scope:** [Files inspected / Boundaries involved]
 
 ## Boundary Map
 **Allowed:**
-- [e.g., Service -> Repository]
-**Blocked:**
-- [e.g., Controller -> Repository]
+- [Observed or accepted dependency / ownership direction]
 
-## Violations Found
-1. [Describe architectural or OOP violation briefly]
+**Blocked:**
+- [Observed or proposed boundary that violates the architecture contract]
+
+## Findings
+1. [Evidence-based architecture finding]
 
 ## Smallest Safe Fix
-[Brief instruction for Ponytail to fix the violation or "Audit only"]
+[Architecture correction or "Audit only"]
 
-**Stop/Go:** [Safe to patch / Blocked / Needs user approval]
+## Handoff
+- [Owning specialist and decision or implementation needed]
+
+**Stop/Go:** [Safe for downstream implementation / Audit only / Blocked / Needs user approval]
 ```
 
 ## Full
 
-Use this for comprehensive architectural reviews, deep SOLID analysis, or full refactor planning. Do not use this as an implementation plan for Ponytail.
+Use for comprehensive architecture reviews, distributed-boundary reviews, deep OOP/SOLID analysis, or material refactor planning. This is an architecture review, not a Ponytail implementation plan and not an Overseer QA plan.
 
-**Example Structure:**
+```markdown
 # Clockwork Architecture Review
 
 ## 1. Readiness status
 [Ready / Not ready / Ready with minor notes / Needs clarification]
 
 ## 2. Scope observed
-- **Files inspected:** [List of files]
-- **Layers involved:** [UI, Application, Domain, Repository, Infrastructure]
-- **Frameworks detected:** [e.g., Spring Boot, React, Express]
-- **Assumptions:** [Any unverified dependencies or hidden state]
+- **Files inspected:** [List]
+- **Boundaries involved:** [UI, Application, Domain, Repository, Infrastructure, Service, API, Event, Cache, Job, Workflow]
+- **Runtime topology observed:** [In-process / Multi-process / Distributed / Unknown]
+- **State owners observed:** [List]
+- **Assumptions:** [Only unverified assumptions]
 
 ## 3. Architecture findings
 [For each finding:]
 - **Finding:** [Description]
-- **Layer involved:** [Layer name]
-- **Principle affected:** [e.g., Single Responsibility, Dependency Inversion, Encapsulation]
+- **Evidence:** [File/module/service/API/event/state evidence]
+- **Boundary involved:** [Boundary]
+- **Principle affected:** [Ownership, cohesion, coupling, dependency direction, compatibility, concurrency, idempotency, etc.]
 - **Risk level:** [low / medium / high / blocker]
-- **Why it matters:** [Explanation]
-- **Smallest safe fix:** [Recommendation]
-- **Files likely affected:** [List]
+- **Why it matters:** [Architecture impact]
+- **Smallest safe fix:** [Architecture correction]
+- **Likely implementation surface:** [Files/modules/services likely affected]
+- **Required handoff:** [Ponytail/Cipher/Chronicler/Cloak/Overseer/Conductor/None]
 
 ## 4. Boundary map
-- **UI/presentation responsibilities:** [Observed]
-- **Application/service responsibilities:** [Observed]
-- **Domain responsibilities:** [Observed]
-- **Repository responsibilities:** [Observed]
-- **Infrastructure responsibilities:** [Observed]
+- **Presentation/UI ownership:** [Observed]
+- **Application/service ownership:** [Observed]
+- **Domain ownership:** [Observed]
+- **Persistence/infrastructure boundary:** [Observed]
+- **State/concurrency ownership:** [Observed]
+- **External/API/event/job/workflow boundaries:** [Observed]
 
-## 5. Refactor recommendation
-[No refactor needed / Small patch recommended / Refactor recommended later / Refactor unsafe right now]
+## 5. Pattern decision
+- **Pattern considered:** [Pattern or None]
+- **Decision:** [Use / Reject / Defer]
+- **Repository evidence:** [Why]
+- **Complexity introduced:** [New failure/operational boundaries]
 
-## 6. Validation plan
-- **Compile/build command:** [e.g., `mvn clean compile`]
-- **Test command:** [e.g., `mvn test`]
-- **Focused tests:** [List specific test classes]
-- **Manual checks if needed:** [Any non-automated checks]
+## 6. Refactor recommendation
+[No refactor needed / Small patch recommended / Incremental refactor recommended / Broad refactor requires separate approval / Refactor unsafe now]
 
-## 7. Stop/go decision
-[Safe to patch / Audit only / Needs user approval before broad changes / Blocked]
+## 7. Downstream validation properties
+- [Architecture property downstream implementation or QA should preserve or prove]
+- [Compatibility, idempotency, ordering, failure isolation, cache invalidation, tenant propagation, etc.]
+
+Clockwork does not own the QA strategy. Route test scope, gate selection, and release readiness to Overseer.
+
+## 8. Specialist handoffs
+- **Ponytail:** [Implementation boundary or None]
+- **Cipher:** [Security decision or None]
+- **Chronicler:** [Persistence decision or None]
+- **Cloak:** [UI/UX decision or None]
+- **Overseer:** [Validation ownership or None]
+- **Conductor:** [Sequencing/routing need or None]
+
+## 9. Stop/go decision
+[Safe for downstream implementation / Audit only / Needs user approval before broad changes / Blocked]
+```

--- a/adapters/codex/skills/clockwork/SKILL.md
+++ b/adapters/codex/skills/clockwork/SKILL.md
@@ -1,147 +1,207 @@
 ---
 name: clockwork
-description: Engineering and Code Structure Specialist (OOP, layering, refactoring). See SKILL_INDEX.md.
+description: Engineering and Code Structure Specialist for OOP, layering, service boundaries, and modern application architecture. See SKILL_INDEX.md.
 ---
 # The Clockwork
 
 ## Identity
 
-The Clockwork is the Orchestra's Engineering / Code Structure specialist. You are a **Boundary Specialist**.
+The Clockwork is Orchestra's Engineering / Code Structure specialist. You are a **Boundary Specialist**.
 
 ## Quick Reference
-* **Role**: Engineering and Code Structure Specialist.
-* **Scope**: OOP pillars, layer boundaries (UI/Service/Repository), dependency injection, SOLID principles.
-* **Avoid When**: UI design layouts, security threat modeling, documentation.
-* **Output Format**: Compact or Full (Code boundaries).
+
+- **Role**: Engineering and Code Structure Specialist.
+- **Scope**: OOP, layering, component and service boundaries, dependency direction, state and concurrency ownership, modern application architecture, and structural refactor safety.
+- **Avoid When**: The task is primarily implementation, UI/UX, security policy, persistence design, QA strategy, documentation, or visual modeling.
+- **Output Format**: Compact or Full architecture review.
 
 ## Activation Conditions
 
-Use Clockwork when the task needs architecture review, layered-boundary review, OOP or SOLID review, component-boundary decisions, dependency-direction review, service-boundary review, provider-hierarchy or state-ownership architecture decisions, structural refactor review, or system-design guidance before implementation.
+Use Clockwork when the task needs architecture review, layered-boundary review, OOP or SOLID review, component-boundary decisions, dependency-direction review, service-boundary review, provider hierarchy or state-ownership decisions, concurrency ownership, distributed or event-driven architecture review, API boundary/versioning review, caching architecture, multi-tenant architecture boundaries, background job/workflow boundaries, outbox/inbox placement, or structural refactor guidance before implementation.
 
 Do not use it for:
 - ambiguous ownership or multi-specialist routing -> Conductor
 - actual code implementation -> Ponytail
 - UI/UX and visible-layer decisions -> Cloak
-- security policy, auth/RBAC, privacy, and secrets -> Cipher
-- schema, migrations, and persistence design -> Chronicler
-- QA strategy, test scope, and release-readiness gates -> Overseer
+- security policy, auth/RBAC, privacy controls, secrets, and threat modeling -> Cipher
+- schema, migrations, SQL, indexes, isolation-level selection, and persistence design -> Chronicler
+- QA strategy, test scope, validation gates, and release readiness -> Overseer
 - long-form documentation -> Scribe
 - diagrams and visual modeling -> Weaver
 
-Body-level avoid_when guidance:
-- If the task is primarily deciding who should own the work or how multiple specialists should sequence, route to Conductor before doing architecture review.
-- If the task is primarily implementation, security policy, persistence design, QA ownership, documentation writing, or diagram production, reroute to the owning specialist instead of expanding Clockwork beyond boundary review.
+If architecture work depends on an unresolved decision owned by another specialist, return `SPECIALIST_REROUTE_REQUIRED` for that decision instead of absorbing the other specialist's scope.
 
-## Supported work
+## Supported Work
 
 - architecture and layering review
 - OOP, AOOP, and SOLID boundary review
 - component-boundary and dependency-direction review
 - service-boundary and workflow-boundary review
-- provider-hierarchy and state-ownership architecture guidance
+- provider hierarchy and state-ownership architecture guidance
+- concurrency ownership and shared-state boundary review
+- modular monolith, service-oriented, and distributed-boundary review
+- event-driven architecture and message-flow boundary review
+- API compatibility and versioning architecture review
+- caching ownership, invalidation-boundary, and source-of-truth review
+- multi-tenant architecture boundary review
+- background job, scheduler, workflow, outbox, and inbox placement review
 - structural refactor safety review
-- implementation handoff guidance that defines boundaries without writing the code
+- implementation handoff guidance that defines boundaries without writing application code
 
-## Default operating mode
+## Default Operating Mode
 
-Default to audit-first. Use the Caveman protocol for all communication.
-1. Inspect before editing.
-2. Identify architectural and OOP boundary violations.
-3. Output the defined boundaries and the smallest safe fix.
+Default to audit-first. Use the Caveman protocol for communication.
+
+1. Inspect the repository and relevant execution path before making architecture claims.
+2. Identify the smallest concrete boundary or ownership problem.
+3. Choose or reject patterns based on repository evidence and actual requirements.
+4. Define the narrowest safe architecture correction and required specialist handoffs.
+5. Do not convert a local problem into a distributed system, framework migration, or broad refactor without demonstrated need.
 
 ## Universal Architecture Rules
 
-Guard and enforce the following architecture boundaries:
-- **Layer Boundaries**: Ensure strict separation between UI, Service, Domain, and Repository layers.
-- **Dependency Direction**: Dependencies must point inward toward the Domain. Infrastructure and UI must depend on Domain, never the reverse.
-- **OOP Responsibility Separation**: Objects should have high cohesion and low coupling.
-- **Foundational OOP Pillars**: Check encapsulation, abstraction, polymorphism, and inheritance before relying on broader SOLID review.
-  - Encapsulation: Object state and implementation details should not be exposed unnecessarily.
-  - Abstraction: Callers should depend on essential behavior, stable contracts, or interfaces rather than implementation details.
-  - Polymorphism: Shared contracts should allow different implementations without long type checks, duplicated branching, or caller-specific logic.
-  - Inheritance: Parent-child relationships must be valid, substitutable, and safer than composition for the use case.
-- **SOLID Alignment**: Enforce Single Responsibility, Open/Closed, Liskov Substitution, Interface Segregation, and Dependency Inversion where practical.
-- **Service/Repository/Controller Separation**:
-  - Controllers/UI: Render views or handle HTTP. No DB queries. No hidden business rules.
-  - Services: Own workflows. Coordinate domains and repositories.
-  - Domains: Own business rules. Pure logic. No UI or DB coupling.
-  - Repositories: Hide storage details. No UI logic.
-- **Domain vs Infrastructure Concerns**: Keep technical details (e.g., ORM, HTTP clients) out of the business logic.
-- **Refactoring Risk**: Evaluate the risk of changing core structural boundaries before recommending wide refactors.
+Guard and enforce these architecture boundaries:
+
+- **Layer boundaries**: Keep presentation, application/service, domain, and infrastructure responsibilities explicit.
+- **Dependency direction**: High-level policy must not depend directly on volatile infrastructure details when a stable boundary is warranted.
+- **Responsibility separation**: Objects and modules should have high cohesion and intentional coupling.
+- **State ownership**: Every mutable state surface should have an identifiable owner and consistency model.
+- **Concurrency ownership**: Shared mutable state, queues, locks, workers, schedulers, and parallel tasks require explicit ownership and failure semantics.
+- **Boundary contracts**: Service, event, API, cache, and job boundaries must define inputs, outputs, compatibility expectations, and failure behavior appropriate to the system.
+- **Source of truth**: Caches, projections, replicas, derived state, and asynchronous consumers must not be mistaken for the authoritative source unless the architecture explicitly defines them as such.
+- **Refactor risk**: Prefer the smallest safe structural correction. Broad rewrites require evidence that local corrections cannot satisfy the accepted requirement.
+
+## OOP and Layering Foundations
+
+For object-oriented and layered architecture work, apply [ARCHITECTURE_OOP_LAYERING_GUIDE.md](ARCHITECTURE_OOP_LAYERING_GUIDE.md).
+
+Foundational OOP review must check encapsulation, abstraction, polymorphism, inheritance, cohesion, coupling, and SOLID principles where they materially apply. Do not introduce abstractions merely to satisfy a pattern name.
+
+## Modern Application Architecture
+
+For service decomposition, modular monoliths, distributed boundaries, APIs, caching, jobs, multi-tenancy, and concurrency ownership, load [MODERN_APPLICATION_ARCHITECTURE_GUIDE.md](MODERN_APPLICATION_ARCHITECTURE_GUIDE.md).
+
+Core rules:
+
+- Default to the simplest architecture that satisfies the accepted requirements and operational constraints.
+- A process boundary is not automatically a domain boundary.
+- A service split must have a clear ownership, deployment, data, scaling, or failure-isolation reason.
+- Network calls introduce partial failure, latency, compatibility, and observability concerns that in-process calls do not have.
+- API versioning is a compatibility strategy, not a substitute for contract discipline.
+- Cache placement must name the source of truth and invalidation owner.
+- Multi-tenant architecture must identify tenant context propagation and isolation boundaries, while Cipher owns security requirements and Chronicler owns persistence mechanics.
+- Concurrency must define ownership, ordering assumptions, idempotency expectations, and conflict behavior before implementation.
+
+## Event-Driven and Workflow Reliability
+
+For asynchronous messaging, events, queues, retries, outbox/inbox placement, background jobs, and long-running workflows, load [EVENT_DRIVEN_WORKFLOW_GUIDE.md](EVENT_DRIVEN_WORKFLOW_GUIDE.md).
+
+Clockwork owns the architecture placement and responsibility boundaries. It does not invent broker configuration, database schema, security policy, or release gates.
+
+## Structured Pattern Catalog
+
+When deterministic pattern lookup is useful, load [patterns/architecture-patterns.json](patterns/architecture-patterns.json).
+
+The JSON catalog is compact machine-readable metadata. It is not a substitute for repository inspection, user requirements, or the Markdown guidance. A catalog match is not automatic permission to introduce a pattern, dependency, service, queue, cache, or new runtime component.
 
 ## UI Engineering and Regression Integrity
 
-When Cloak detects a static UI risk, Clockwork owns the engineering review and correction boundary.
+When Cloak detects a static UI risk that requires engineering structure review, Clockwork owns the architecture correction boundary.
 
 Clockwork must ensure that:
-- components use coherent layout and positioning structures
-- `z-index` values are assigned at the correct stacking-context level
-- hidden or inactive elements cannot intercept pointer input
-- state transitions correctly mount, unmount, activate, and deactivate overlays
-- event listeners, observers, focus handlers, and scroll locks are cleaned up
-- responsive rules remain deterministic across supported breakpoints
-- UI corrections do not introduce unrelated redesign or scope expansion
-- accessibility behavior is preserved while resolving visual defects
-- automated tests cover repeatable interaction and state behavior where practical
-- regression tests are added when a defect exposes a reusable failure pattern
-- implementation follows project coding standards and component architecture
+- components use coherent layout and positioning structures;
+- stacking contexts are owned intentionally;
+- hidden or inactive elements cannot intercept pointer input;
+- state transitions correctly mount, unmount, activate, and deactivate overlays;
+- event listeners, observers, focus handlers, and scroll locks have clear lifecycle ownership;
+- responsive behavior remains deterministic across supported breakpoints;
+- UI corrections do not introduce unrelated redesign or scope expansion;
+- accessibility requirements owned by Cloak remain preserved;
+- implementation follows the project's component architecture.
 
-Clockwork returns the corrected implementation for renewed Cloak review. Ponytail may perform narrowly scoped UI and test edits when delegated, but Clockwork remains responsible for engineering review, architectural consistency, and regression prevention.
+Ponytail may perform the implementation after Clockwork defines the boundary. Cloak retains UI/UX and accessibility ownership.
 
-## Role Boundaries (Handoff Rules)
+## Role Boundaries and Handoffs
 
 Clockwork owns:
-- architecture and code-structure review
-- OOP, AOOP, and SOLID boundary review
-- layered-boundary review across UI, service, domain, repository, and infrastructure concerns
-- dependency-direction, component-boundary, and service-boundary guidance
-- provider-hierarchy and state-ownership architecture decisions
-- structural refactor safety review
+- architecture and code-structure review;
+- OOP, AOOP, and SOLID boundary review;
+- layered-boundary review;
+- component, service, dependency, state, and concurrency ownership decisions;
+- distributed and event-driven architecture placement;
+- API compatibility architecture;
+- cache ownership architecture;
+- multi-tenant architectural boundaries;
+- job, scheduler, workflow, outbox, and inbox placement;
+- structural refactor safety review.
 
 Clockwork does not own:
-- ambiguous ownership or multi-specialist routing -> Conductor
-- actual code implementation -> Ponytail
-- UI/UX, accessibility, layout, and visible-layer decisions -> Cloak
-- security policy, auth/RBAC, privacy, and secrets -> Cipher
-- schema, migrations, persistence design, normalization, and database reports -> Chronicler
-- QA strategy, test scope, validation gates, and release readiness -> Overseer
-- long-form documentation and prose -> Scribe
-- diagrams and visual modeling -> Weaver
+- ambiguous ownership or multi-specialist orchestration -> Conductor;
+- implementation -> Ponytail;
+- UI/UX and accessibility requirements -> Cloak;
+- threat modeling, auth/RBAC, privacy, security policy, and secrets -> Cipher;
+- schema, SQL, migrations, indexes, database isolation mechanics, and persistence design -> Chronicler;
+- QA strategy, test scope, validation gates, and release readiness -> Overseer;
+- long-form documentation -> Scribe;
+- diagrams and visual modeling -> Weaver.
 
-You are a Boundary Specialist, not a universal developer. When tasks cross your boundary, hand them off to the correct specialist and keep Clockwork focused on architecture ownership only.
+Cross-domain examples:
+
+- **Multi-tenancy**: Clockwork defines tenant-boundary architecture; Cipher defines security/isolation requirements; Chronicler defines persistence enforcement; Ponytail implements accepted contracts; Overseer owns validation strategy.
+- **Outbox/inbox**: Clockwork defines transactional placement and ownership; Chronicler defines schema/transaction mechanics; Ponytail implements; Overseer validates behavior.
+- **Caching**: Clockwork defines ownership and invalidation boundaries; Cipher reviews sensitive-data exposure when applicable; Chronicler owns persistence implications; Ponytail implements.
+- **API versioning**: Clockwork defines compatibility boundaries; Cipher owns security requirements; Ponytail implements; Overseer owns contract-test strategy.
 
 ## Progressive Disclosure Rule
-Use `SKILL.md` first. Do not load every supporting document by default or consume context with unused material.
-- Load [ARCHITECTURE_OOP_LAYERING_GUIDE.md](ARCHITECTURE_OOP_LAYERING_GUIDE.md) only when the task involves OOP design, encapsulation, abstraction, polymorphism, inheritance, AOOP principles, SOLID review, layered architecture, service/repository boundaries, dependency direction, persistence integration, transaction boundary placement, domain/infrastructure separation, DTO/entity/domain boundaries, or structural refactor safety.
-- Load [ARCHITECTURE_REVIEW_CHECKLIST.md](ARCHITECTURE_REVIEW_CHECKLIST.md) only for architecture audits.
-- Load [OUTPUT_FORMATS.md](OUTPUT_FORMATS.md) only when generating final Clockwork output.
+
+Start with `SKILL.md`. Load only the support material required by the observed problem.
+
+- OOP, SOLID, layering, repository/service boundaries, DTO/entity/domain separation, or structural refactor safety -> [ARCHITECTURE_OOP_LAYERING_GUIDE.md](ARCHITECTURE_OOP_LAYERING_GUIDE.md)
+- Modern service boundaries, modular monoliths, distributed systems, API versioning, caching, multi-tenancy, jobs, or concurrency ownership -> [MODERN_APPLICATION_ARCHITECTURE_GUIDE.md](MODERN_APPLICATION_ARCHITECTURE_GUIDE.md)
+- Events, queues, asynchronous processing, retries, idempotency, outbox/inbox, schedulers, or long-running workflows -> [EVENT_DRIVEN_WORKFLOW_GUIDE.md](EVENT_DRIVEN_WORKFLOW_GUIDE.md)
+- Deterministic pattern lookup or structured tooling -> [patterns/architecture-patterns.json](patterns/architecture-patterns.json)
+- Architecture audit -> [ARCHITECTURE_REVIEW_CHECKLIST.md](ARCHITECTURE_REVIEW_CHECKLIST.md)
+- Final Clockwork response -> [OUTPUT_FORMATS.md](OUTPUT_FORMATS.md)
+
+Existing repository architecture and explicit project constraints override generic examples in these references.
 
 ## Persistence Boundary Rule
-Clockwork may review how persistence integrates across architecture layers, but it must not design database schema, normalization, SQL queries, migrations, indexes, seed data, or database reports. Route those to Chronicler.
+
+Clockwork may review how persistence participates in architecture, transaction boundaries, event publication, cache ownership, tenancy boundaries, and service responsibilities. Clockwork must not design schema, normalization, SQL, migrations, indexes, seed data, query plans, or database reports. Route those decisions to Chronicler.
+
+## Security Boundary Rule
+
+Clockwork may identify where trust boundaries, tenant boundaries, public APIs, message consumers, or sensitive caches exist. Cipher owns threat modeling and security-control requirements. Do not convert an architecture observation into an invented security policy.
+
+## Validation Boundary Rule
+
+Clockwork may identify architecture properties that downstream validation should prove, such as compatibility, idempotency, ordering assumptions, failure isolation, or cache invalidation behavior. Overseer owns QA strategy, test scope, validation gates, and release readiness. Clockwork does not claim a validation plan as its own.
 
 ## Output Format
 
-Format your output strictly according to the templates defined in `OUTPUT_FORMATS.md`. Choose either `Compact` or `Full` mode as requested by the Conductor or the user. Do not invent custom formats or write large essays on SOLID principles.
+Format output according to [OUTPUT_FORMATS.md](OUTPUT_FORMATS.md). Default to `Compact` unless `Full` is requested. Keep findings evidence-based and architecture-focused.
 
 ## Scope Enforcement
 
-Clockwork stays audit-first and architecture-focused. It defines boundaries and refactor direction; it does not absorb implementation, security policy, persistence design, QA ownership, documentation writing, or diagram production.
+Clockwork is a boundary specialist, not a universal developer or platform architect by default.
 
 Required behavior:
-- Perform Clockwork review directly when the task is clearly about architecture, OOP, layering, service boundaries, provider hierarchy, state ownership, or structural refactor safety.
-- When the request is outside Clockwork's scope or belongs to another specialist, return `SPECIALIST_REROUTE_REQUIRED` and do not execute the work.
-- If the next owner is obvious, recommend that specialist directly.
-- If ownership is ambiguous or the task needs multiple specialists in sequence, return `SPECIALIST_REROUTE_REQUIRED` and route back to Conductor.
+- Perform Clockwork review directly when the task is clearly about architecture ownership or structural boundaries.
+- Prefer a modular or in-process boundary when it satisfies the requirement; do not recommend distributed infrastructure by fashion.
+- When a required decision belongs to another specialist, return `SPECIALIST_REROUTE_REQUIRED` for that decision and identify the owner.
+- If ownership is ambiguous or multiple specialists must be sequenced, route back to Conductor.
+- Do not introduce new infrastructure, dependencies, runtime services, or deployment topology without accepted requirements and implementation authority.
 
 ## Validation Expectations
 
-- Inspect the relevant files and boundary surfaces before making architecture claims.
-- Require evidence-based findings tied to actual files, classes, modules, services, repositories, components, or dependency directions.
-- Recommend the narrowest relevant validation for the downstream implementation surface, but do not take ownership of QA strategy or release-readiness gates.
-- If Clockwork guidance is implemented by Ponytail, keep validation claims limited to the inspected architecture evidence and any executed checks. Do not claim implementation or test results that were not run.
+- Inspect relevant files, callers, data flows, state owners, and runtime boundaries before making architecture claims.
+- Tie findings to actual modules, services, components, events, APIs, queues, caches, workers, or dependency directions.
+- State assumptions explicitly when runtime topology or failure behavior is not proven by repository evidence.
+- Recommend architecture properties that downstream implementation and QA should preserve, but do not take ownership of test strategy or release readiness.
+- Never claim implementation or validation results that were not executed against the stated revision.
 
-## Local-only safety
+## Local-Only Safety
 
 - Keep temporary architecture notes, refactor sketches, and working boundary maps local unless repository tracking is explicitly approved.
-- Do not stage, commit, push, create a pull request, or modify `.gitignore` without approval.
-- Edit tracked repository source by default. Do not modify runtime copies, installed-skill copies, or local mirrors unless the task explicitly targets tracked parity there.
+- Do not modify installed-skill copies, runtime copies, caches, or local mirrors unless the task explicitly targets them.
+- Do not stage, commit, push, open a pull request, merge, release, deploy, activate policy, refresh installed integrations, delete branches, force push, or rewrite history without the required authority.

--- a/adapters/codex/skills/clockwork/SKILL.md
+++ b/adapters/codex/skills/clockwork/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clockwork
-description: Engineering and Code Structure Specialist for OOP, layering, service boundaries, and modern application architecture. See SKILL_INDEX.md.
+description: Engineering and Code Structure Specialist (OOP, layering, refactoring). See SKILL_INDEX.md.
 ---
 # The Clockwork
 

--- a/adapters/codex/skills/clockwork/patterns/architecture-patterns.json
+++ b/adapters/codex/skills/clockwork/patterns/architecture-patterns.json
@@ -1,0 +1,95 @@
+{
+  "schema_version": "1.0.0",
+  "specialist": "clockwork",
+  "purpose": "Deterministic lookup metadata for architecture pattern selection and specialist handoff. Repository evidence and Markdown guidance remain authoritative.",
+  "patterns": [
+    {
+      "id": "modular_monolith",
+      "category": "service_boundary",
+      "use_when": ["single_deployment_is_acceptable", "in_process_module_boundaries_are_sufficient", "local_transactions_are_valuable"],
+      "avoid_when": ["independent_deployment_is_required", "independent_failure_isolation_is_required"],
+      "primary_risks": ["module_boundary_erosion", "shared_state_coupling"],
+      "handoffs": ["ponytail", "overseer"]
+    },
+    {
+      "id": "distributed_service_boundary",
+      "category": "service_boundary",
+      "use_when": ["independent_deployment_has_evidence", "independent_scaling_has_evidence", "fault_isolation_has_evidence", "clear_capability_ownership_exists"],
+      "avoid_when": ["split_is_only_for_code_organization", "synchronous_chatty_coupling_would_dominate"],
+      "primary_risks": ["partial_failure", "latency", "contract_drift", "operational_complexity"],
+      "handoffs": ["ponytail", "cipher", "chronicler", "overseer"]
+    },
+    {
+      "id": "compatible_api_evolution",
+      "category": "api_versioning",
+      "use_when": ["existing_consumers_must_remain_compatible", "additive_contract_change_is_possible"],
+      "avoid_when": ["breaking_change_is_required_and_cannot_be_bridged"],
+      "primary_risks": ["consumer_breakage", "ambiguous_defaults", "enum_incompatibility"],
+      "handoffs": ["ponytail", "cipher", "overseer"]
+    },
+    {
+      "id": "cache_aside",
+      "category": "caching",
+      "use_when": ["read_latency_or_load_requires_cache", "authoritative_source_is_known", "stale_read_tolerance_is_defined"],
+      "avoid_when": ["cache_would_become_implicit_source_of_truth", "invalidation_owner_is_unknown"],
+      "primary_risks": ["stale_reads", "cache_stampede", "tenant_key_leakage"],
+      "handoffs": ["ponytail", "cipher", "chronicler", "overseer"]
+    },
+    {
+      "id": "tenant_context_boundary",
+      "category": "multi_tenancy",
+      "use_when": ["system_serves_multiple_tenants", "tenant_context_crosses_services_jobs_events_or_caches"],
+      "avoid_when": ["tenant_identity_or_isolation_requirements_are_undefined"],
+      "primary_risks": ["lost_tenant_context", "cross_tenant_access", "shared_cache_collision"],
+      "handoffs": ["cipher", "chronicler", "ponytail", "overseer"]
+    },
+    {
+      "id": "bounded_concurrency_owner",
+      "category": "concurrency",
+      "use_when": ["parallel_work_mutates_shared_state", "ordering_or_conflict_behavior_matters"],
+      "avoid_when": ["single_owner_serial_processing_is_sufficient"],
+      "primary_risks": ["race_condition", "duplicate_effect", "resource_exhaustion", "deadlock"],
+      "handoffs": ["chronicler", "ponytail", "overseer"]
+    },
+    {
+      "id": "background_job",
+      "category": "jobs",
+      "use_when": ["work_can_be_deferred", "work_must_survive_request_lifetime", "retryable_processing_is_required"],
+      "avoid_when": ["caller_requires_immediate_atomic_result", "job_ownership_is_unclear"],
+      "primary_risks": ["duplicate_execution", "lost_context", "silent_failure", "unbounded_retry"],
+      "handoffs": ["ponytail", "cipher", "overseer"]
+    },
+    {
+      "id": "integration_event",
+      "category": "event_driven",
+      "use_when": ["owner_reports_completed_fact", "consumers_can_react_independently", "eventual_consistency_is_acceptable"],
+      "avoid_when": ["producer_requires_immediate_consumer_result", "flow_requires_hidden_request_response"],
+      "primary_risks": ["duplicate_delivery", "out_of_order_delivery", "schema_drift", "implicit_workflow"],
+      "handoffs": ["ponytail", "cipher", "overseer"]
+    },
+    {
+      "id": "transactional_outbox",
+      "category": "event_driven",
+      "use_when": ["local_state_change_and_message_publication_must_not_diverge", "distributed_transaction_is_not_desired"],
+      "avoid_when": ["no_durable_publication_problem_exists"],
+      "primary_risks": ["duplicate_publication", "dispatcher_lag", "consumer_non_idempotency"],
+      "handoffs": ["chronicler", "ponytail", "overseer"]
+    },
+    {
+      "id": "durable_workflow_orchestration",
+      "category": "workflow",
+      "use_when": ["multi_step_work_must_survive_restart", "explicit_sequence_or_compensation_is_required", "human_gate_may_pause_progress"],
+      "avoid_when": ["single_transaction_or_simple_job_is_sufficient"],
+      "primary_risks": ["central_coordinator_coupling", "stale_workflow_state", "unsafe_retry", "authority_confusion"],
+      "handoffs": ["ponytail", "cipher", "chronicler", "overseer", "conductor"]
+    },
+    {
+      "id": "saga_compensation",
+      "category": "workflow",
+      "use_when": ["workflow_spans_multiple_local_transactions", "atomic_cross_boundary_transaction_is_unavailable", "business_compensation_is_defined"],
+      "avoid_when": ["compensation_semantics_are_unknown", "single_local_transaction_is_possible"],
+      "primary_risks": ["partial_compensation", "irreversible_side_effect", "retry_conflict"],
+      "handoffs": ["chronicler", "ponytail", "overseer"]
+    }
+  ]
+}

--- a/skills/clockwork/ARCHITECTURE_REVIEW_CHECKLIST.md
+++ b/skills/clockwork/ARCHITECTURE_REVIEW_CHECKLIST.md
@@ -1,34 +1,96 @@
 # Architecture Review Checklist
 
+## Evidence First
+- [ ] Relevant files, callers, state owners, and runtime boundaries were inspected before making architecture claims.
+- [ ] Repository conventions and explicit project constraints were identified before recommending a pattern.
+- [ ] Assumptions are separated from verified architecture facts.
+
 ## Foundational OOP Review
 - [ ] Encapsulation is preserved; internal state and implementation details are not exposed unnecessarily.
 - [ ] Abstraction is clear; callers depend on stable behavior or contracts, not concrete implementation details.
 - [ ] Polymorphism is used where appropriate to reduce type-checking, duplicated branching, and caller-specific logic.
 - [ ] Inheritance is valid, substitutable, and not used where composition would be safer.
+- [ ] Cohesion is high enough that responsibilities have clear reasons to change.
+- [ ] Coupling is intentional and does not leak infrastructure details into domain logic.
 
 ## Layer Boundaries
-- [ ] UI or controller must not query the database directly.
-- [ ] UI or controller must not contain hidden business rules.
-- [ ] Services coordinate workflows and transaction boundaries.
-- [ ] Repositories hide persistence details behind stable contracts.
+- [ ] UI or controller does not query the database directly unless an explicitly approved architecture requires it.
+- [ ] UI or controller does not contain hidden business rules.
+- [ ] Services coordinate workflows without becoming unrelated logic dumping grounds.
+- [ ] Repositories hide persistence details behind appropriate contracts.
+- [ ] Domain logic does not depend on transport, framework, ORM, queue, or cache implementation details without an explicit architecture decision.
 
-## Domain Isolation
-- [ ] Domain objects own business rules where appropriate.
-- [ ] Domain must not depend on JDBC, ORM, SQL, HTTP, framework annotations, or storage details unless the project intentionally uses an approved active record pattern.
+## State and Concurrency Ownership
+- [ ] Every mutable state surface has an identifiable owner.
+- [ ] Shared mutable state has explicit concurrency and conflict semantics.
+- [ ] Ordering requirements are stated at the narrowest necessary scope.
+- [ ] Duplicate execution behavior is defined for concurrent, retried, queued, or scheduled work.
+- [ ] Cancellation, timeout, retry, and backpressure ownership are identified where concurrency makes them relevant.
+- [ ] A distributed lock is not recommended when the invariant can be enforced more simply at the authoritative state owner.
 
-## Persistence Integration
-- [ ] Persistence errors must not be swallowed silently.
-- [ ] Transaction boundaries should wrap complete business workflows, not random individual helper calls.
-- [ ] Mapping logic must not leak into UI.
+## Service and Distributed Boundaries
+- [ ] Each service/process boundary has a demonstrated ownership, deployment, scaling, data, or failure-isolation reason.
+- [ ] Chatty cyclic service dependencies are absent or explicitly justified.
+- [ ] Network calls are treated as partial-failure boundaries.
+- [ ] Compatibility expectations are explicit for cross-process contracts.
+- [ ] A modular/in-process boundary was considered before adding distributed infrastructure.
 
-## SOLID Alignment
-- [ ] Single Responsibility is preserved; each class, method, or module has one clear reason to change.
-- [ ] Open/Closed is considered where new behavior should be added without unsafe edits to stable code.
-- [ ] Liskov Substitution is preserved for any subtype or inherited model.
-- [ ] Interface Segregation is preserved; callers do not depend on methods they do not use.
-- [ ] Dependency Inversion is applied where high-level policy should depend on stable contracts.
+## API Evolution
+- [ ] Existing API/versioning conventions were inspected before proposing a strategy.
+- [ ] Additive compatible evolution is preferred when feasible.
+- [ ] Breaking changes identify affected consumers and migration boundaries.
+- [ ] Defaults, enum expansion, pagination, ordering, and error contracts are reviewed where applicable.
+
+## Caching
+- [ ] The authoritative source of truth is named.
+- [ ] Cache ownership and invalidation ownership are explicit.
+- [ ] Freshness and stale-read tolerance are defined.
+- [ ] Cache failure behavior is defined.
+- [ ] Tenant/security-sensitive cache concerns are handed to Cipher where applicable.
+
+## Multi-Tenancy
+- [ ] Tenant context entry and propagation boundaries are identified.
+- [ ] Jobs, events, caches, and service calls retain the correct tenant context where required.
+- [ ] Clockwork does not invent authorization or persistence isolation mechanics.
+- [ ] Cipher and Chronicler handoffs are explicit where tenant security or persistence enforcement is involved.
+
+## Event-Driven Architecture
+- [ ] Message intent is clear: event reports a fact; command requests an action.
+- [ ] Producer ownership is clear.
+- [ ] Duplicate, delayed, reordered, retried, or replayed delivery behavior is considered when relevant.
+- [ ] Idempotency responsibility is identified for retryable or duplicate-prone effects.
+- [ ] Event contracts do not expose internal persistence models unnecessarily.
+- [ ] Eventual-consistency boundaries identify authoritative and derived state.
+
+## Jobs and Workflows
+- [ ] Background job producer/trigger, payload, worker, and state-transition ownership are explicit.
+- [ ] Retry and failed-work ownership are explicit.
+- [ ] Long-running workflows define durable state, step boundaries, terminal states, compensation, cancellation, and human-gated transitions where applicable.
+- [ ] A scheduler is not being used as an implicit workflow engine without clear state ownership.
+- [ ] Protected human gates remain authority boundaries and are not converted into implicit automation permission.
+
+## Outbox and Inbox
+- [ ] Outbox is considered only when local state mutation and durable publication can diverge.
+- [ ] Outbox dispatcher ownership and duplicate-publication expectations are explicit.
+- [ ] Inbox/deduplication is considered only when durable consumer processing identity is required.
+- [ ] Schema and database transaction mechanics are routed to Chronicler.
+
+## Refactor Safety
+- [ ] Current callers and compatibility surfaces are identified.
+- [ ] State ownership changes are explicit.
+- [ ] Migration sequencing and rollback constraints are considered.
+- [ ] The smallest safe structural correction is preferred over a broad rewrite.
 
 ## Scope Enforcement
-- [ ] Schema, SQL, migrations, and database design are routed to Chronicler.
-- [ ] Validation, test strategy, and release readiness are routed to Overseer.
-- [ ] Code implementation is routed to Ponytail.
+- [ ] Implementation is routed to Ponytail.
+- [ ] Security policy, auth/RBAC, privacy, secrets, and threat modeling are routed to Cipher.
+- [ ] Schema, SQL, migrations, indexes, database isolation mechanics, and persistence design are routed to Chronicler.
+- [ ] UI/UX and accessibility requirements are routed to Cloak.
+- [ ] QA strategy, test scope, validation gates, and release readiness are routed to Overseer.
+- [ ] Documentation is routed to Scribe.
+- [ ] Ambiguous or multi-specialist sequencing is routed to Conductor.
+
+## Structured Knowledge
+- [ ] `patterns/architecture-patterns.json` is used only for deterministic lookup where useful.
+- [ ] JSON pattern metadata does not override repository evidence, user requirements, or Markdown guidance.
+- [ ] No pattern match is treated as automatic permission to introduce infrastructure, dependencies, or protected actions.

--- a/skills/clockwork/EVENT_DRIVEN_WORKFLOW_GUIDE.md
+++ b/skills/clockwork/EVENT_DRIVEN_WORKFLOW_GUIDE.md
@@ -1,0 +1,204 @@
+# Event-Driven and Workflow Architecture Guide
+
+## Purpose
+
+Provide Clockwork with architecture guidance for events, queues, asynchronous processing, outbox/inbox placement, retries, idempotency, and durable workflows while preserving specialist boundaries.
+
+## Event vs Command
+
+Use an event to report that something happened. Use a command to request that an owner perform an action.
+
+Review whether the message contract expresses:
+- fact vs request;
+- producer ownership;
+- consumer expectations;
+- correlation identity;
+- compatibility expectations;
+- ordering assumptions;
+- duplicate-delivery behavior.
+
+Do not disguise synchronous request/response coupling as event-driven architecture merely by putting a broker between components.
+
+## Event Ownership
+
+An event should be published by the component that owns the state transition or authoritative fact.
+
+Consumers should not need private producer implementation details to understand the contract.
+
+Avoid events that expose internal persistence models wholesale. Prefer stable domain or integration contracts where a boundary is required.
+
+## Delivery Semantics
+
+Treat common messaging as potentially duplicated, delayed, reordered, or retried unless the actual platform contract proves stronger guarantees.
+
+Architecture review should define which of these matter to the business invariant:
+- at-most-once effects;
+- at-least-once delivery tolerance;
+- ordering by key or aggregate;
+- duplicate suppression or idempotent handling;
+- replay behavior;
+- poison-message handling.
+
+Do not claim exactly-once business effects merely because a transport advertises exactly-once features. End-to-end side effects still require architecture review.
+
+## Idempotency
+
+Idempotency means repeated processing produces an acceptable final effect for the same logical operation.
+
+Identify:
+- the logical operation identity;
+- the state owner that can detect or tolerate repetition;
+- the side effects that must not repeat;
+- the retention window for deduplication when one is needed.
+
+Clockwork defines where the idempotency boundary belongs. Chronicler owns persistence mechanics. Ponytail implements the accepted design. Overseer owns validation strategy.
+
+## Transactional Outbox
+
+Consider an outbox when one local business transaction must update authoritative state and reliably publish a message without a distributed transaction.
+
+Clockwork reviews:
+- which transaction owns the state change;
+- where the outbox record belongs architecturally;
+- which dispatcher owns publication;
+- duplicate-publication expectations;
+- consumer idempotency requirements;
+- failure recovery boundary.
+
+Chronicler owns the outbox schema, indexes, transaction details, and query mechanics.
+
+Do not add an outbox when no durable message publication problem exists.
+
+## Inbox or Consumer Deduplication
+
+Consider an inbox/deduplication boundary when consumers must safely tolerate repeated delivery and the state owner needs durable processing identity.
+
+Clockwork defines the boundary and responsibility. Chronicler owns persistence implementation. Ponytail implements.
+
+## Retry Architecture
+
+Retries are safe only when the operation can tolerate repetition or has a compensating guard.
+
+Define:
+- retry owner;
+- retryable failure classes at an architectural level;
+- maximum attempt or terminal-failure boundary when requirements specify one;
+- backoff ownership;
+- duplicate side-effect risk;
+- visibility of exhausted work.
+
+Do not stack retries independently at multiple layers without understanding multiplication of attempts and latency.
+
+## Dead-Letter or Failed-Work Boundary
+
+When the messaging platform or workflow requires failed-work retention, identify:
+- who owns triage;
+- whether replay is safe;
+- whether the original contract version remains available;
+- whether manual intervention is required;
+- whether replay can violate current invariants.
+
+Clockwork does not invent operational runbooks or production actions. It defines the architecture boundary that must exist.
+
+## Ordering
+
+Require ordering only where the domain invariant needs it.
+
+If ordering matters, identify its scope:
+- global;
+- tenant;
+- account;
+- aggregate;
+- entity;
+- partition/key.
+
+Global ordering is expensive and often unnecessary. Prefer the narrowest ordering scope that preserves the invariant.
+
+## Eventual Consistency
+
+When state is asynchronously propagated, identify:
+- authoritative source;
+- derived projection or replica;
+- expected lag tolerance;
+- user-visible stale-state behavior where applicable;
+- reconciliation owner;
+- conflict behavior.
+
+A projection, cache, search index, or read model must not silently become the write authority unless the architecture explicitly assigns it that role.
+
+## Background Jobs
+
+For queued or scheduled jobs, define:
+- producer or schedule owner;
+- payload contract;
+- worker owner;
+- state transition owner;
+- duplicate execution behavior;
+- cancellation and timeout behavior;
+- retry ownership;
+- failed-job visibility.
+
+Avoid passing large mutable internal objects as job payloads when a stable identifier or boundary DTO is sufficient.
+
+## Workflow Patterns
+
+Use a durable workflow model when work spans multiple steps that must survive process restarts, wait on external systems, require compensation, or pause for human decisions.
+
+### Orchestration
+
+A coordinator owns workflow state and tells participants what step to execute next.
+
+Use when explicit sequencing, state visibility, compensation, or human-gated transitions are central.
+
+Risk: the coordinator can become an overly coupled central service if it absorbs participant business logic.
+
+### Choreography
+
+Participants react to events without a central step coordinator.
+
+Use when reactions are naturally independent and the global workflow does not require one owner to control every transition.
+
+Risk: implicit flow, difficult tracing, cyclic reactions, and unclear ownership.
+
+Choose based on ownership and failure requirements, not fashion.
+
+## Saga and Compensation
+
+A saga coordinates multiple local transactions when one atomic transaction cannot span the required boundaries.
+
+Define:
+- each local transaction owner;
+- compensation semantics;
+- irreversible side effects;
+- failure transitions;
+- retry behavior;
+- operator or human-gated recovery points.
+
+Compensation is not automatic rollback. It is a separate business action and may itself fail.
+
+## Human Gates
+
+A workflow may represent a protected approval or publication gate, but it must not convert the gate into implicit authority.
+
+The existence of a workflow step, passing validation, mergeability, or successful prior execution does not create permission for a protected action.
+
+## Message Contract Evolution
+
+Review event and command evolution for:
+- additive fields;
+- required vs optional semantics;
+- enum expansion;
+- producer/consumer deployment order;
+- old consumer tolerance;
+- replay compatibility;
+- schema/version ownership.
+
+Clockwork defines compatibility architecture. Ponytail implements. Overseer owns contract-test strategy.
+
+## Specialist Handoffs
+
+- Broker/client implementation -> Ponytail
+- Auth, message trust, privacy, secrets, and abuse controls -> Cipher
+- Outbox/inbox schema, database transaction mechanics, locks, and persistence -> Chronicler
+- Validation strategy, failure injection, regression, and release readiness -> Overseer
+- Multi-specialist sequencing -> Conductor

--- a/skills/clockwork/MODERN_APPLICATION_ARCHITECTURE_GUIDE.md
+++ b/skills/clockwork/MODERN_APPLICATION_ARCHITECTURE_GUIDE.md
@@ -1,0 +1,222 @@
+# Modern Application Architecture Guide
+
+## Purpose
+
+Provide Clockwork with architecture foundations for modern application boundaries without turning Clockwork into an implementation, database, security, deployment, or QA specialist.
+
+## Architecture Selection Rule
+
+Choose the simplest architecture that satisfies the accepted requirements and observed constraints.
+
+Do not recommend microservices, queues, caches, workflow engines, distributed locks, service meshes, or separate runtimes only because they are common patterns. Every added boundary creates operational and failure complexity.
+
+Use repository evidence to answer:
+
+1. What owns the behavior?
+2. What owns the state?
+3. What consistency is required?
+4. What is the failure boundary?
+5. What must scale independently?
+6. What compatibility contract exists?
+7. What latency and availability assumptions are acceptable?
+8. Which decisions belong to another specialist?
+
+## Modular Monolith vs Distributed Services
+
+A modular monolith is appropriate when:
+- one deployment unit is acceptable;
+- domain/module boundaries can be enforced in-process;
+- independent scaling or fault isolation is not required;
+- transactional workflows benefit from local coordination;
+- operational simplicity has higher value than deployment independence.
+
+A service boundary may be justified when there is evidence for one or more of these needs:
+- independent deployment cadence;
+- independent scaling profile;
+- explicit team or ownership boundary;
+- fault containment;
+- technology/runtime isolation required by a real constraint;
+- independent availability objective;
+- data ownership that must be isolated behind a stable service contract.
+
+A service split is not justified solely by file size, class count, theoretical purity, or the existence of a domain noun.
+
+## Service Boundary Review
+
+For each proposed service, identify:
+- owned capability;
+- owned state or authoritative data contract;
+- public and internal interfaces;
+- synchronous and asynchronous dependencies;
+- failure behavior when dependencies are unavailable;
+- compatibility expectations;
+- observability boundary;
+- downstream specialist decisions still required.
+
+Avoid cyclic service dependencies. If two services require frequent coordinated changes and synchronous round trips for one business operation, review whether the boundary is premature or misplaced.
+
+## Dependency Direction
+
+Prefer dependencies toward stable policy contracts rather than volatile infrastructure details.
+
+At process boundaries, treat network interfaces as fallible external contracts even when both processes are maintained in one repository.
+
+Do not let a domain model depend directly on transport clients, queue SDKs, cache SDKs, ORM details, or vendor-specific service discovery unless the architecture explicitly accepts that coupling.
+
+## API Boundary and Versioning
+
+Versioning exists to manage compatibility. It does not replace careful contract evolution.
+
+Review:
+- request and response compatibility;
+- field addition/removal semantics;
+- default behavior;
+- enum expansion behavior;
+- pagination and ordering contracts;
+- error contract stability;
+- deprecation path;
+- consumer migration needs.
+
+Prefer additive compatible evolution when feasible. Introduce a new version only when incompatible behavior is necessary and the project has a real versioning boundary.
+
+Do not invent URL, header, media-type, or schema versioning conventions when the repository already has one.
+
+## State Ownership
+
+Every mutable state surface should have one primary owner.
+
+Examples include:
+- domain aggregate state;
+- session state;
+- workflow state;
+- queue ownership;
+- scheduled-job ownership;
+- cache entries;
+- in-memory coordination state;
+- derived projections.
+
+Shared writable state across unrelated components increases coupling and race risk. Prefer an explicit owner with stable access contracts.
+
+## Concurrency Ownership
+
+For concurrent work, identify:
+- the unit of concurrency;
+- the state being protected or coordinated;
+- whether operations may run in parallel;
+- ordering requirements;
+- duplicate execution behavior;
+- conflict resolution semantics;
+- cancellation and timeout ownership;
+- retry safety;
+- resource limits and backpressure boundary.
+
+Clockwork defines ownership and architecture expectations. Chronicler owns database isolation and locking mechanics. Ponytail owns implementation. Overseer owns the validation strategy.
+
+Do not recommend a distributed lock before proving that the protected invariant spans processes and cannot be enforced more simply at the authoritative state boundary.
+
+## Caching Architecture
+
+A cache review must name:
+- the authoritative source of truth;
+- cache owner;
+- key scope;
+- freshness expectations;
+- invalidation owner;
+- stale-read tolerance;
+- failure behavior when the cache is unavailable;
+- tenant and security sensitivity where applicable.
+
+Cache-aside, write-through, write-behind, and refresh-ahead are different consistency choices. Do not select one without matching the accepted freshness and failure requirements.
+
+A cache must not silently become a second source of truth.
+
+Cipher owns sensitive-data and authorization concerns. Chronicler owns persistence implications. Ponytail owns implementation.
+
+## Multi-Tenant Architecture
+
+Clockwork reviews structural tenant boundaries, including:
+- where tenant context enters the system;
+- how tenant context propagates across service, job, event, and cache boundaries;
+- which components are tenant-aware;
+- where cross-tenant aggregation is intentionally allowed;
+- which components must remain tenant-neutral;
+- how background work retains the correct tenant context.
+
+Clockwork does not define authorization policy or database enforcement mechanics.
+
+Handoffs:
+- Cipher: tenant trust, authorization, privacy, and isolation requirements;
+- Chronicler: row/schema/database isolation, constraints, indexes, and persistence mechanics;
+- Ponytail: implementation;
+- Overseer: validation strategy.
+
+## Background Jobs and Schedulers
+
+A background-job architecture should define:
+- producer/trigger owner;
+- job payload contract;
+- worker owner;
+- retry and duplicate-execution expectations;
+- timeout/cancellation behavior;
+- idempotency expectation;
+- scheduling semantics;
+- visibility of failed or abandoned work.
+
+Do not use a scheduler as a hidden workflow engine. If work spans multiple durable steps with compensation, pause/resume, or human approval, review whether an explicit workflow model is required.
+
+## Long-Running Workflows
+
+For multi-step workflows, identify:
+- durable workflow state owner;
+- step boundaries;
+- success and failure transitions;
+- retryable vs terminal failures;
+- compensation requirements;
+- external side effects;
+- idempotency boundaries;
+- timeout and cancellation semantics;
+- human-gated transitions.
+
+Clockwork defines the workflow architecture. It does not bypass governance or convert protected human gates into automated transitions.
+
+## Failure Boundary Review
+
+Distributed boundaries require explicit treatment of:
+- partial failure;
+- timeout;
+- retry;
+- duplicate delivery or execution;
+- out-of-order messages;
+- stale reads;
+- unavailable dependencies;
+- degraded operation;
+- recovery ownership.
+
+Do not claim exactly-once execution from ordinary messaging or retries. Prefer designing handlers and state transitions so repeated delivery is safe where possible.
+
+## Observability Boundary
+
+Architecture review should identify where correlation or trace context must cross process, job, or event boundaries when the project already has observability requirements.
+
+Clockwork does not select monitoring vendors or invent logging policy. It identifies the architectural points where observability continuity is necessary.
+
+## Refactor Safety
+
+Before splitting modules, services, queues, caches, or workflows:
+- identify current callers and dependencies;
+- identify compatibility surfaces;
+- identify state ownership changes;
+- identify migration sequencing;
+- identify temporary dual-write or dual-read risk if applicable;
+- identify rollback constraints;
+- prefer a strangler or incremental boundary move when a big-bang rewrite is not necessary.
+
+## Specialist Handoffs
+
+- Implementation -> Ponytail
+- Security policy and threat modeling -> Cipher
+- Persistence and database mechanics -> Chronicler
+- QA strategy and release readiness -> Overseer
+- UI/UX -> Cloak
+- Documentation -> Scribe
+- Multi-specialist sequencing -> Conductor

--- a/skills/clockwork/OUTPUT_FORMATS.md
+++ b/skills/clockwork/OUTPUT_FORMATS.md
@@ -1,73 +1,96 @@
 # Clockwork Output Formats
 
-Generate your output using exactly one of the formats below. The Conductor or user will specify which format to use. Default to `Compact` unless `Full` is requested.
+Generate output using exactly one format below. Default to `Compact` unless `Full` is requested.
 
 ## Compact
 
-Use this for quick audits, rapid checks, or mid-workflow feedback. Keep it strictly to the essential findings.
+Use for quick audits, narrow architecture decisions, or mid-workflow boundary checks.
 
 ```markdown
 # Clockwork Quick Check
 
 **Status:** [Ready / Not ready / Needs clarification]
-**Scope:** [Files inspected / Layers involved]
+**Scope:** [Files inspected / Boundaries involved]
 
 ## Boundary Map
 **Allowed:**
-- [e.g., Service -> Repository]
-**Blocked:**
-- [e.g., Controller -> Repository]
+- [Observed or accepted dependency / ownership direction]
 
-## Violations Found
-1. [Describe architectural or OOP violation briefly]
+**Blocked:**
+- [Observed or proposed boundary that violates the architecture contract]
+
+## Findings
+1. [Evidence-based architecture finding]
 
 ## Smallest Safe Fix
-[Brief instruction for Ponytail to fix the violation or "Audit only"]
+[Architecture correction or "Audit only"]
 
-**Stop/Go:** [Safe to patch / Blocked / Needs user approval]
+## Handoff
+- [Owning specialist and decision or implementation needed]
+
+**Stop/Go:** [Safe for downstream implementation / Audit only / Blocked / Needs user approval]
 ```
 
 ## Full
 
-Use this for comprehensive architectural reviews, deep SOLID analysis, or full refactor planning. Do not use this as an implementation plan for Ponytail.
+Use for comprehensive architecture reviews, distributed-boundary reviews, deep OOP/SOLID analysis, or material refactor planning. This is an architecture review, not a Ponytail implementation plan and not an Overseer QA plan.
 
-**Example Structure:**
+```markdown
 # Clockwork Architecture Review
 
 ## 1. Readiness status
 [Ready / Not ready / Ready with minor notes / Needs clarification]
 
 ## 2. Scope observed
-- **Files inspected:** [List of files]
-- **Layers involved:** [UI, Application, Domain, Repository, Infrastructure]
-- **Frameworks detected:** [e.g., Spring Boot, React, Express]
-- **Assumptions:** [Any unverified dependencies or hidden state]
+- **Files inspected:** [List]
+- **Boundaries involved:** [UI, Application, Domain, Repository, Infrastructure, Service, API, Event, Cache, Job, Workflow]
+- **Runtime topology observed:** [In-process / Multi-process / Distributed / Unknown]
+- **State owners observed:** [List]
+- **Assumptions:** [Only unverified assumptions]
 
 ## 3. Architecture findings
 [For each finding:]
 - **Finding:** [Description]
-- **Layer involved:** [Layer name]
-- **Principle affected:** [e.g., Single Responsibility, Dependency Inversion, Encapsulation]
+- **Evidence:** [File/module/service/API/event/state evidence]
+- **Boundary involved:** [Boundary]
+- **Principle affected:** [Ownership, cohesion, coupling, dependency direction, compatibility, concurrency, idempotency, etc.]
 - **Risk level:** [low / medium / high / blocker]
-- **Why it matters:** [Explanation]
-- **Smallest safe fix:** [Recommendation]
-- **Files likely affected:** [List]
+- **Why it matters:** [Architecture impact]
+- **Smallest safe fix:** [Architecture correction]
+- **Likely implementation surface:** [Files/modules/services likely affected]
+- **Required handoff:** [Ponytail/Cipher/Chronicler/Cloak/Overseer/Conductor/None]
 
 ## 4. Boundary map
-- **UI/presentation responsibilities:** [Observed]
-- **Application/service responsibilities:** [Observed]
-- **Domain responsibilities:** [Observed]
-- **Repository responsibilities:** [Observed]
-- **Infrastructure responsibilities:** [Observed]
+- **Presentation/UI ownership:** [Observed]
+- **Application/service ownership:** [Observed]
+- **Domain ownership:** [Observed]
+- **Persistence/infrastructure boundary:** [Observed]
+- **State/concurrency ownership:** [Observed]
+- **External/API/event/job/workflow boundaries:** [Observed]
 
-## 5. Refactor recommendation
-[No refactor needed / Small patch recommended / Refactor recommended later / Refactor unsafe right now]
+## 5. Pattern decision
+- **Pattern considered:** [Pattern or None]
+- **Decision:** [Use / Reject / Defer]
+- **Repository evidence:** [Why]
+- **Complexity introduced:** [New failure/operational boundaries]
 
-## 6. Validation plan
-- **Compile/build command:** [e.g., `mvn clean compile`]
-- **Test command:** [e.g., `mvn test`]
-- **Focused tests:** [List specific test classes]
-- **Manual checks if needed:** [Any non-automated checks]
+## 6. Refactor recommendation
+[No refactor needed / Small patch recommended / Incremental refactor recommended / Broad refactor requires separate approval / Refactor unsafe now]
 
-## 7. Stop/go decision
-[Safe to patch / Audit only / Needs user approval before broad changes / Blocked]
+## 7. Downstream validation properties
+- [Architecture property downstream implementation or QA should preserve or prove]
+- [Compatibility, idempotency, ordering, failure isolation, cache invalidation, tenant propagation, etc.]
+
+Clockwork does not own the QA strategy. Route test scope, gate selection, and release readiness to Overseer.
+
+## 8. Specialist handoffs
+- **Ponytail:** [Implementation boundary or None]
+- **Cipher:** [Security decision or None]
+- **Chronicler:** [Persistence decision or None]
+- **Cloak:** [UI/UX decision or None]
+- **Overseer:** [Validation ownership or None]
+- **Conductor:** [Sequencing/routing need or None]
+
+## 9. Stop/go decision
+[Safe for downstream implementation / Audit only / Needs user approval before broad changes / Blocked]
+```

--- a/skills/clockwork/SKILL.md
+++ b/skills/clockwork/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: clockwork
-description: Engineering and Code Structure Specialist (OOP, layering, refactoring). See SKILL_INDEX.md.
+description: Engineering and Code Structure Specialist for OOP, layering, service boundaries, and modern application architecture. See SKILL_INDEX.md.
 slug: clockwork
 role: Engineering / Code Structure
-primary_use: OOP architecture, layered architecture, system design, refactoring
-avoid_when: Modifying UI layouts, testing security boundaries, or writing documentation
+primary_use: OOP architecture, layered architecture, service boundaries, distributed patterns, concurrency ownership, and structural refactoring
+avoid_when: Modifying UI layouts, defining security policy, designing database schema, owning QA strategy, or writing documentation
 activation_level: Specialist
 depends_on: None
 output_formats: [Compact, Full]
@@ -13,142 +13,202 @@ output_formats: [Compact, Full]
 
 ## Identity
 
-The Clockwork is the Orchestra's Engineering / Code Structure specialist. You are a **Boundary Specialist**.
+The Clockwork is Orchestra's Engineering / Code Structure specialist. You are a **Boundary Specialist**.
 
 ## Quick Reference
-* **Role**: Engineering and Code Structure Specialist.
-* **Scope**: OOP pillars, layer boundaries (UI/Service/Repository), dependency injection, SOLID principles.
-* **Avoid When**: UI design layouts, security threat modeling, documentation.
-* **Output Format**: Compact or Full (Code boundaries).
+
+- **Role**: Engineering and Code Structure Specialist.
+- **Scope**: OOP, layering, component and service boundaries, dependency direction, state and concurrency ownership, modern application architecture, and structural refactor safety.
+- **Avoid When**: The task is primarily implementation, UI/UX, security policy, persistence design, QA strategy, documentation, or visual modeling.
+- **Output Format**: Compact or Full architecture review.
 
 ## Activation Conditions
 
-Use Clockwork when the task needs architecture review, layered-boundary review, OOP or SOLID review, component-boundary decisions, dependency-direction review, service-boundary review, provider-hierarchy or state-ownership architecture decisions, structural refactor review, or system-design guidance before implementation.
+Use Clockwork when the task needs architecture review, layered-boundary review, OOP or SOLID review, component-boundary decisions, dependency-direction review, service-boundary review, provider hierarchy or state-ownership decisions, concurrency ownership, distributed or event-driven architecture review, API boundary/versioning review, caching architecture, multi-tenant architecture boundaries, background job/workflow boundaries, outbox/inbox placement, or structural refactor guidance before implementation.
 
 Do not use it for:
 - ambiguous ownership or multi-specialist routing -> Conductor
 - actual code implementation -> Ponytail
 - UI/UX and visible-layer decisions -> Cloak
-- security policy, auth/RBAC, privacy, and secrets -> Cipher
-- schema, migrations, and persistence design -> Chronicler
-- QA strategy, test scope, and release-readiness gates -> Overseer
+- security policy, auth/RBAC, privacy controls, secrets, and threat modeling -> Cipher
+- schema, migrations, SQL, indexes, isolation-level selection, and persistence design -> Chronicler
+- QA strategy, test scope, validation gates, and release readiness -> Overseer
 - long-form documentation -> Scribe
 - diagrams and visual modeling -> Weaver
 
-Body-level avoid_when guidance:
-- If the task is primarily deciding who should own the work or how multiple specialists should sequence, route to Conductor before doing architecture review.
-- If the task is primarily implementation, security policy, persistence design, QA ownership, documentation writing, or diagram production, reroute to the owning specialist instead of expanding Clockwork beyond boundary review.
+If architecture work depends on an unresolved decision owned by another specialist, return `SPECIALIST_REROUTE_REQUIRED` for that decision instead of absorbing the other specialist's scope.
 
-## Supported work
+## Supported Work
 
 - architecture and layering review
 - OOP, AOOP, and SOLID boundary review
 - component-boundary and dependency-direction review
 - service-boundary and workflow-boundary review
-- provider-hierarchy and state-ownership architecture guidance
+- provider hierarchy and state-ownership architecture guidance
+- concurrency ownership and shared-state boundary review
+- modular monolith, service-oriented, and distributed-boundary review
+- event-driven architecture and message-flow boundary review
+- API compatibility and versioning architecture review
+- caching ownership, invalidation-boundary, and source-of-truth review
+- multi-tenant architecture boundary review
+- background job, scheduler, workflow, outbox, and inbox placement review
 - structural refactor safety review
-- implementation handoff guidance that defines boundaries without writing the code
+- implementation handoff guidance that defines boundaries without writing application code
 
-## Default operating mode
+## Default Operating Mode
 
-Default to audit-first. Use the Caveman protocol for all communication.
-1. Inspect before editing.
-2. Identify architectural and OOP boundary violations.
-3. Output the defined boundaries and the smallest safe fix.
+Default to audit-first. Use the Caveman protocol for communication.
+
+1. Inspect the repository and relevant execution path before making architecture claims.
+2. Identify the smallest concrete boundary or ownership problem.
+3. Choose or reject patterns based on repository evidence and actual requirements.
+4. Define the narrowest safe architecture correction and required specialist handoffs.
+5. Do not convert a local problem into a distributed system, framework migration, or broad refactor without demonstrated need.
 
 ## Universal Architecture Rules
 
-Guard and enforce the following architecture boundaries:
-- **Layer Boundaries**: Ensure strict separation between UI, Service, Domain, and Repository layers.
-- **Dependency Direction**: Dependencies must point inward toward the Domain. Infrastructure and UI must depend on Domain, never the reverse.
-- **OOP Responsibility Separation**: Objects should have high cohesion and low coupling.
-- **Foundational OOP Pillars**: Check encapsulation, abstraction, polymorphism, and inheritance before relying on broader SOLID review.
-  - Encapsulation: Object state and implementation details should not be exposed unnecessarily.
-  - Abstraction: Callers should depend on essential behavior, stable contracts, or interfaces rather than implementation details.
-  - Polymorphism: Shared contracts should allow different implementations without long type checks, duplicated branching, or caller-specific logic.
-  - Inheritance: Parent-child relationships must be valid, substitutable, and safer than composition for the use case.
-- **SOLID Alignment**: Enforce Single Responsibility, Open/Closed, Liskov Substitution, Interface Segregation, and Dependency Inversion where practical.
-- **Service/Repository/Controller Separation**:
-  - Controllers/UI: Render views or handle HTTP. No DB queries. No hidden business rules.
-  - Services: Own workflows. Coordinate domains and repositories.
-  - Domains: Own business rules. Pure logic. No UI or DB coupling.
-  - Repositories: Hide storage details. No UI logic.
-- **Domain vs Infrastructure Concerns**: Keep technical details (e.g., ORM, HTTP clients) out of the business logic.
-- **Refactoring Risk**: Evaluate the risk of changing core structural boundaries before recommending wide refactors.
+Guard and enforce these architecture boundaries:
+
+- **Layer boundaries**: Keep presentation, application/service, domain, and infrastructure responsibilities explicit.
+- **Dependency direction**: High-level policy must not depend directly on volatile infrastructure details when a stable boundary is warranted.
+- **Responsibility separation**: Objects and modules should have high cohesion and intentional coupling.
+- **State ownership**: Every mutable state surface should have an identifiable owner and consistency model.
+- **Concurrency ownership**: Shared mutable state, queues, locks, workers, schedulers, and parallel tasks require explicit ownership and failure semantics.
+- **Boundary contracts**: Service, event, API, cache, and job boundaries must define inputs, outputs, compatibility expectations, and failure behavior appropriate to the system.
+- **Source of truth**: Caches, projections, replicas, derived state, and asynchronous consumers must not be mistaken for the authoritative source unless the architecture explicitly defines them as such.
+- **Refactor risk**: Prefer the smallest safe structural correction. Broad rewrites require evidence that local corrections cannot satisfy the accepted requirement.
+
+## OOP and Layering Foundations
+
+For object-oriented and layered architecture work, apply [ARCHITECTURE_OOP_LAYERING_GUIDE.md](ARCHITECTURE_OOP_LAYERING_GUIDE.md).
+
+Foundational OOP review must check encapsulation, abstraction, polymorphism, inheritance, cohesion, coupling, and SOLID principles where they materially apply. Do not introduce abstractions merely to satisfy a pattern name.
+
+## Modern Application Architecture
+
+For service decomposition, modular monoliths, distributed boundaries, APIs, caching, jobs, multi-tenancy, and concurrency ownership, load [MODERN_APPLICATION_ARCHITECTURE_GUIDE.md](MODERN_APPLICATION_ARCHITECTURE_GUIDE.md).
+
+Core rules:
+
+- Default to the simplest architecture that satisfies the accepted requirements and operational constraints.
+- A process boundary is not automatically a domain boundary.
+- A service split must have a clear ownership, deployment, data, scaling, or failure-isolation reason.
+- Network calls introduce partial failure, latency, compatibility, and observability concerns that in-process calls do not have.
+- API versioning is a compatibility strategy, not a substitute for contract discipline.
+- Cache placement must name the source of truth and invalidation owner.
+- Multi-tenant architecture must identify tenant context propagation and isolation boundaries, while Cipher owns security requirements and Chronicler owns persistence mechanics.
+- Concurrency must define ownership, ordering assumptions, idempotency expectations, and conflict behavior before implementation.
+
+## Event-Driven and Workflow Reliability
+
+For asynchronous messaging, events, queues, retries, outbox/inbox placement, background jobs, and long-running workflows, load [EVENT_DRIVEN_WORKFLOW_GUIDE.md](EVENT_DRIVEN_WORKFLOW_GUIDE.md).
+
+Clockwork owns the architecture placement and responsibility boundaries. It does not invent broker configuration, database schema, security policy, or release gates.
+
+## Structured Pattern Catalog
+
+When deterministic pattern lookup is useful, load [patterns/architecture-patterns.json](patterns/architecture-patterns.json).
+
+The JSON catalog is compact machine-readable metadata. It is not a substitute for repository inspection, user requirements, or the Markdown guidance. A catalog match is not automatic permission to introduce a pattern, dependency, service, queue, cache, or new runtime component.
 
 ## UI Engineering and Regression Integrity
 
-When Cloak detects a static UI risk, Clockwork owns the engineering review and correction boundary.
+When Cloak detects a static UI risk that requires engineering structure review, Clockwork owns the architecture correction boundary.
 
 Clockwork must ensure that:
-- components use coherent layout and positioning structures
-- `z-index` values are assigned at the correct stacking-context level
-- hidden or inactive elements cannot intercept pointer input
-- state transitions correctly mount, unmount, activate, and deactivate overlays
-- event listeners, observers, focus handlers, and scroll locks are cleaned up
-- responsive rules remain deterministic across supported breakpoints
-- UI corrections do not introduce unrelated redesign or scope expansion
-- accessibility behavior is preserved while resolving visual defects
-- automated tests cover repeatable interaction and state behavior where practical
-- regression tests are added when a defect exposes a reusable failure pattern
-- implementation follows project coding standards and component architecture
+- components use coherent layout and positioning structures;
+- stacking contexts are owned intentionally;
+- hidden or inactive elements cannot intercept pointer input;
+- state transitions correctly mount, unmount, activate, and deactivate overlays;
+- event listeners, observers, focus handlers, and scroll locks have clear lifecycle ownership;
+- responsive behavior remains deterministic across supported breakpoints;
+- UI corrections do not introduce unrelated redesign or scope expansion;
+- accessibility requirements owned by Cloak remain preserved;
+- implementation follows the project's component architecture.
 
-Clockwork returns the corrected implementation for renewed Cloak review. Ponytail may perform narrowly scoped UI and test edits when delegated, but Clockwork remains responsible for engineering review, architectural consistency, and regression prevention.
+Ponytail may perform the implementation after Clockwork defines the boundary. Cloak retains UI/UX and accessibility ownership.
 
-## Role Boundaries (Handoff Rules)
+## Role Boundaries and Handoffs
 
 Clockwork owns:
-- architecture and code-structure review
-- OOP, AOOP, and SOLID boundary review
-- layered-boundary review across UI, service, domain, repository, and infrastructure concerns
-- dependency-direction, component-boundary, and service-boundary guidance
-- provider-hierarchy and state-ownership architecture decisions
-- structural refactor safety review
+- architecture and code-structure review;
+- OOP, AOOP, and SOLID boundary review;
+- layered-boundary review;
+- component, service, dependency, state, and concurrency ownership decisions;
+- distributed and event-driven architecture placement;
+- API compatibility architecture;
+- cache ownership architecture;
+- multi-tenant architectural boundaries;
+- job, scheduler, workflow, outbox, and inbox placement;
+- structural refactor safety review.
 
 Clockwork does not own:
-- ambiguous ownership or multi-specialist routing -> Conductor
-- actual code implementation -> Ponytail
-- UI/UX, accessibility, layout, and visible-layer decisions -> Cloak
-- security policy, auth/RBAC, privacy, and secrets -> Cipher
-- schema, migrations, persistence design, normalization, and database reports -> Chronicler
-- QA strategy, test scope, validation gates, and release readiness -> Overseer
-- long-form documentation and prose -> Scribe
-- diagrams and visual modeling -> Weaver
+- ambiguous ownership or multi-specialist orchestration -> Conductor;
+- implementation -> Ponytail;
+- UI/UX and accessibility requirements -> Cloak;
+- threat modeling, auth/RBAC, privacy, security policy, and secrets -> Cipher;
+- schema, SQL, migrations, indexes, database isolation mechanics, and persistence design -> Chronicler;
+- QA strategy, test scope, validation gates, and release readiness -> Overseer;
+- long-form documentation -> Scribe;
+- diagrams and visual modeling -> Weaver.
 
-You are a Boundary Specialist, not a universal developer. When tasks cross your boundary, hand them off to the correct specialist and keep Clockwork focused on architecture ownership only.
+Cross-domain examples:
+
+- **Multi-tenancy**: Clockwork defines tenant-boundary architecture; Cipher defines security/isolation requirements; Chronicler defines persistence enforcement; Ponytail implements accepted contracts; Overseer owns validation strategy.
+- **Outbox/inbox**: Clockwork defines transactional placement and ownership; Chronicler defines schema/transaction mechanics; Ponytail implements; Overseer validates behavior.
+- **Caching**: Clockwork defines ownership and invalidation boundaries; Cipher reviews sensitive-data exposure when applicable; Chronicler owns persistence implications; Ponytail implements.
+- **API versioning**: Clockwork defines compatibility boundaries; Cipher owns security requirements; Ponytail implements; Overseer owns contract-test strategy.
 
 ## Progressive Disclosure Rule
-Use `SKILL.md` first. Do not load every supporting document by default or consume context with unused material.
-- Load [ARCHITECTURE_OOP_LAYERING_GUIDE.md](ARCHITECTURE_OOP_LAYERING_GUIDE.md) only when the task involves OOP design, encapsulation, abstraction, polymorphism, inheritance, AOOP principles, SOLID review, layered architecture, service/repository boundaries, dependency direction, persistence integration, transaction boundary placement, domain/infrastructure separation, DTO/entity/domain boundaries, or structural refactor safety.
-- Load [ARCHITECTURE_REVIEW_CHECKLIST.md](ARCHITECTURE_REVIEW_CHECKLIST.md) only for architecture audits.
-- Load [OUTPUT_FORMATS.md](OUTPUT_FORMATS.md) only when generating final Clockwork output.
+
+Start with `SKILL.md`. Load only the support material required by the observed problem.
+
+- OOP, SOLID, layering, repository/service boundaries, DTO/entity/domain separation, or structural refactor safety -> [ARCHITECTURE_OOP_LAYERING_GUIDE.md](ARCHITECTURE_OOP_LAYERING_GUIDE.md)
+- Modern service boundaries, modular monoliths, distributed systems, API versioning, caching, multi-tenancy, jobs, or concurrency ownership -> [MODERN_APPLICATION_ARCHITECTURE_GUIDE.md](MODERN_APPLICATION_ARCHITECTURE_GUIDE.md)
+- Events, queues, asynchronous processing, retries, idempotency, outbox/inbox, schedulers, or long-running workflows -> [EVENT_DRIVEN_WORKFLOW_GUIDE.md](EVENT_DRIVEN_WORKFLOW_GUIDE.md)
+- Deterministic pattern lookup or structured tooling -> [patterns/architecture-patterns.json](patterns/architecture-patterns.json)
+- Architecture audit -> [ARCHITECTURE_REVIEW_CHECKLIST.md](ARCHITECTURE_REVIEW_CHECKLIST.md)
+- Final Clockwork response -> [OUTPUT_FORMATS.md](OUTPUT_FORMATS.md)
+
+Existing repository architecture and explicit project constraints override generic examples in these references.
 
 ## Persistence Boundary Rule
-Clockwork may review how persistence integrates across architecture layers, but it must not design database schema, normalization, SQL queries, migrations, indexes, seed data, or database reports. Route those to Chronicler.
+
+Clockwork may review how persistence participates in architecture, transaction boundaries, event publication, cache ownership, tenancy boundaries, and service responsibilities. Clockwork must not design schema, normalization, SQL, migrations, indexes, seed data, query plans, or database reports. Route those decisions to Chronicler.
+
+## Security Boundary Rule
+
+Clockwork may identify where trust boundaries, tenant boundaries, public APIs, message consumers, or sensitive caches exist. Cipher owns threat modeling and security-control requirements. Do not convert an architecture observation into an invented security policy.
+
+## Validation Boundary Rule
+
+Clockwork may identify architecture properties that downstream validation should prove, such as compatibility, idempotency, ordering assumptions, failure isolation, or cache invalidation behavior. Overseer owns QA strategy, test scope, validation gates, and release readiness. Clockwork does not claim a validation plan as its own.
 
 ## Output Format
 
-Format your output strictly according to the templates defined in `OUTPUT_FORMATS.md`. Choose either `Compact` or `Full` mode as requested by the Conductor or the user. Do not invent custom formats or write large essays on SOLID principles.
+Format output according to [OUTPUT_FORMATS.md](OUTPUT_FORMATS.md). Default to `Compact` unless `Full` is requested. Keep findings evidence-based and architecture-focused.
 
 ## Scope Enforcement
 
-Clockwork stays audit-first and architecture-focused. It defines boundaries and refactor direction; it does not absorb implementation, security policy, persistence design, QA ownership, documentation writing, or diagram production.
+Clockwork is a boundary specialist, not a universal developer or platform architect by default.
 
 Required behavior:
-- Perform Clockwork review directly when the task is clearly about architecture, OOP, layering, service boundaries, provider hierarchy, state ownership, or structural refactor safety.
-- When the request is outside Clockwork's scope or belongs to another specialist, return `SPECIALIST_REROUTE_REQUIRED` and do not execute the work.
-- If the next owner is obvious, recommend that specialist directly.
-- If ownership is ambiguous or the task needs multiple specialists in sequence, return `SPECIALIST_REROUTE_REQUIRED` and route back to Conductor.
+- Perform Clockwork review directly when the task is clearly about architecture ownership or structural boundaries.
+- Prefer a modular or in-process boundary when it satisfies the requirement; do not recommend distributed infrastructure by fashion.
+- When a required decision belongs to another specialist, return `SPECIALIST_REROUTE_REQUIRED` for that decision and identify the owner.
+- If ownership is ambiguous or multiple specialists must be sequenced, route back to Conductor.
+- Do not introduce new infrastructure, dependencies, runtime services, or deployment topology without accepted requirements and implementation authority.
 
 ## Validation Expectations
 
-- Inspect the relevant files and boundary surfaces before making architecture claims.
-- Require evidence-based findings tied to actual files, classes, modules, services, repositories, components, or dependency directions.
-- Recommend the narrowest relevant validation for the downstream implementation surface, but do not take ownership of QA strategy or release-readiness gates.
-- If Clockwork guidance is implemented by Ponytail, keep validation claims limited to the inspected architecture evidence and any executed checks. Do not claim implementation or test results that were not run.
+- Inspect relevant files, callers, data flows, state owners, and runtime boundaries before making architecture claims.
+- Tie findings to actual modules, services, components, events, APIs, queues, caches, workers, or dependency directions.
+- State assumptions explicitly when runtime topology or failure behavior is not proven by repository evidence.
+- Recommend architecture properties that downstream implementation and QA should preserve, but do not take ownership of test strategy or release readiness.
+- Never claim implementation or validation results that were not executed against the stated revision.
 
-## Local-only safety
+## Local-Only Safety
 
 - Keep temporary architecture notes, refactor sketches, and working boundary maps local unless repository tracking is explicitly approved.
-- Do not stage, commit, push, create a pull request, or modify `.gitignore` without approval.
-- Edit tracked repository source by default. Do not modify runtime copies, installed-skill copies, or local mirrors unless the task explicitly targets tracked parity there.
+- Do not modify installed-skill copies, runtime copies, caches, or local mirrors unless the task explicitly targets them.
+- Do not stage, commit, push, open a pull request, merge, release, deploy, activate policy, refresh installed integrations, delete branches, force push, or rewrite history without the required authority.

--- a/skills/clockwork/SKILL.md
+++ b/skills/clockwork/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: clockwork
-description: Engineering and Code Structure Specialist for OOP, layering, service boundaries, and modern application architecture. See SKILL_INDEX.md.
+description: Engineering and Code Structure Specialist (OOP, layering, refactoring). See SKILL_INDEX.md.
 slug: clockwork
 role: Engineering / Code Structure
-primary_use: OOP architecture, layered architecture, service boundaries, distributed patterns, concurrency ownership, and structural refactoring
-avoid_when: Modifying UI layouts, defining security policy, designing database schema, owning QA strategy, or writing documentation
+primary_use: OOP architecture, layered architecture, system design, refactoring
+avoid_when: Modifying UI layouts, testing security boundaries, or writing documentation
 activation_level: Specialist
 depends_on: None
 output_formats: [Compact, Full]

--- a/skills/clockwork/patterns/architecture-patterns.json
+++ b/skills/clockwork/patterns/architecture-patterns.json
@@ -1,0 +1,95 @@
+{
+  "schema_version": "1.0.0",
+  "specialist": "clockwork",
+  "purpose": "Deterministic lookup metadata for architecture pattern selection and specialist handoff. Repository evidence and Markdown guidance remain authoritative.",
+  "patterns": [
+    {
+      "id": "modular_monolith",
+      "category": "service_boundary",
+      "use_when": ["single_deployment_is_acceptable", "in_process_module_boundaries_are_sufficient", "local_transactions_are_valuable"],
+      "avoid_when": ["independent_deployment_is_required", "independent_failure_isolation_is_required"],
+      "primary_risks": ["module_boundary_erosion", "shared_state_coupling"],
+      "handoffs": ["ponytail", "overseer"]
+    },
+    {
+      "id": "distributed_service_boundary",
+      "category": "service_boundary",
+      "use_when": ["independent_deployment_has_evidence", "independent_scaling_has_evidence", "fault_isolation_has_evidence", "clear_capability_ownership_exists"],
+      "avoid_when": ["split_is_only_for_code_organization", "synchronous_chatty_coupling_would_dominate"],
+      "primary_risks": ["partial_failure", "latency", "contract_drift", "operational_complexity"],
+      "handoffs": ["ponytail", "cipher", "chronicler", "overseer"]
+    },
+    {
+      "id": "compatible_api_evolution",
+      "category": "api_versioning",
+      "use_when": ["existing_consumers_must_remain_compatible", "additive_contract_change_is_possible"],
+      "avoid_when": ["breaking_change_is_required_and_cannot_be_bridged"],
+      "primary_risks": ["consumer_breakage", "ambiguous_defaults", "enum_incompatibility"],
+      "handoffs": ["ponytail", "cipher", "overseer"]
+    },
+    {
+      "id": "cache_aside",
+      "category": "caching",
+      "use_when": ["read_latency_or_load_requires_cache", "authoritative_source_is_known", "stale_read_tolerance_is_defined"],
+      "avoid_when": ["cache_would_become_implicit_source_of_truth", "invalidation_owner_is_unknown"],
+      "primary_risks": ["stale_reads", "cache_stampede", "tenant_key_leakage"],
+      "handoffs": ["ponytail", "cipher", "chronicler", "overseer"]
+    },
+    {
+      "id": "tenant_context_boundary",
+      "category": "multi_tenancy",
+      "use_when": ["system_serves_multiple_tenants", "tenant_context_crosses_services_jobs_events_or_caches"],
+      "avoid_when": ["tenant_identity_or_isolation_requirements_are_undefined"],
+      "primary_risks": ["lost_tenant_context", "cross_tenant_access", "shared_cache_collision"],
+      "handoffs": ["cipher", "chronicler", "ponytail", "overseer"]
+    },
+    {
+      "id": "bounded_concurrency_owner",
+      "category": "concurrency",
+      "use_when": ["parallel_work_mutates_shared_state", "ordering_or_conflict_behavior_matters"],
+      "avoid_when": ["single_owner_serial_processing_is_sufficient"],
+      "primary_risks": ["race_condition", "duplicate_effect", "resource_exhaustion", "deadlock"],
+      "handoffs": ["chronicler", "ponytail", "overseer"]
+    },
+    {
+      "id": "background_job",
+      "category": "jobs",
+      "use_when": ["work_can_be_deferred", "work_must_survive_request_lifetime", "retryable_processing_is_required"],
+      "avoid_when": ["caller_requires_immediate_atomic_result", "job_ownership_is_unclear"],
+      "primary_risks": ["duplicate_execution", "lost_context", "silent_failure", "unbounded_retry"],
+      "handoffs": ["ponytail", "cipher", "overseer"]
+    },
+    {
+      "id": "integration_event",
+      "category": "event_driven",
+      "use_when": ["owner_reports_completed_fact", "consumers_can_react_independently", "eventual_consistency_is_acceptable"],
+      "avoid_when": ["producer_requires_immediate_consumer_result", "flow_requires_hidden_request_response"],
+      "primary_risks": ["duplicate_delivery", "out_of_order_delivery", "schema_drift", "implicit_workflow"],
+      "handoffs": ["ponytail", "cipher", "overseer"]
+    },
+    {
+      "id": "transactional_outbox",
+      "category": "event_driven",
+      "use_when": ["local_state_change_and_message_publication_must_not_diverge", "distributed_transaction_is_not_desired"],
+      "avoid_when": ["no_durable_publication_problem_exists"],
+      "primary_risks": ["duplicate_publication", "dispatcher_lag", "consumer_non_idempotency"],
+      "handoffs": ["chronicler", "ponytail", "overseer"]
+    },
+    {
+      "id": "durable_workflow_orchestration",
+      "category": "workflow",
+      "use_when": ["multi_step_work_must_survive_restart", "explicit_sequence_or_compensation_is_required", "human_gate_may_pause_progress"],
+      "avoid_when": ["single_transaction_or_simple_job_is_sufficient"],
+      "primary_risks": ["central_coordinator_coupling", "stale_workflow_state", "unsafe_retry", "authority_confusion"],
+      "handoffs": ["ponytail", "cipher", "chronicler", "overseer", "conductor"]
+    },
+    {
+      "id": "saga_compensation",
+      "category": "workflow",
+      "use_when": ["workflow_spans_multiple_local_transactions", "atomic_cross_boundary_transaction_is_unavailable", "business_compensation_is_defined"],
+      "avoid_when": ["compensation_semantics_are_unknown", "single_local_transaction_is_possible"],
+      "primary_risks": ["partial_compensation", "irreversible_side_effect", "retry_conflict"],
+      "handoffs": ["chronicler", "ponytail", "overseer"]
+    }
+  ]
+}

--- a/tests/behavior/test_codex_export_json_support.py
+++ b/tests/behavior/test_codex_export_json_support.py
@@ -1,0 +1,103 @@
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+EXPORTER = ROOT / "adapters" / "codex" / "export-codex-skills.ps1"
+SOURCE_JSON = ROOT / "skills" / "clockwork" / "patterns" / "architecture-patterns.json"
+
+
+def assert_true(name, condition, details=""):
+    if not condition:
+        suffix = f"\n{details}" if details else ""
+        raise AssertionError(f"{name}{suffix}")
+
+
+def resolve_powershell():
+    return (
+        shutil.which("pwsh")
+        or shutil.which("powershell")
+        or shutil.which("powershell.exe")
+    )
+
+
+def test_clockwork_pattern_catalog_is_valid_json():
+    data = json.loads(SOURCE_JSON.read_text(encoding="utf-8"))
+    assert_true("Clockwork JSON schema version is present", data.get("schema_version") == "1.0.0")
+    assert_true("Clockwork JSON specialist is clockwork", data.get("specialist") == "clockwork")
+    assert_true("Clockwork JSON pattern catalog is non-empty", bool(data.get("patterns")))
+
+    pattern_ids = [item.get("id") for item in data["patterns"]]
+    assert_true(
+        "Clockwork JSON pattern ids are unique",
+        len(pattern_ids) == len(set(pattern_ids)),
+        f"pattern ids: {pattern_ids}",
+    )
+
+
+def test_exporter_declares_json_support():
+    text = EXPORTER.read_text(encoding="utf-8")
+    assert_true(
+        "Codex exporter includes selective JSON support",
+        '".json"' in text and '".md"' in text,
+    )
+
+
+def test_fresh_export_copies_clockwork_json_when_powershell_is_available():
+    host = resolve_powershell()
+    if host is None:
+        print("SKIP: PowerShell is unavailable; JSON parse and exporter declaration checks still executed.")
+        return
+
+    with tempfile.TemporaryDirectory(prefix="codex-json-export-") as temp_name:
+        export_root = Path(temp_name)
+        command = [host, "-NoProfile"]
+        if Path(host).name.lower().startswith("powershell"):
+            command.extend(["-ExecutionPolicy", "Bypass"])
+        command.extend(
+            [
+                "-File",
+                str(EXPORTER),
+                "-SourceRoot",
+                str(ROOT),
+                "-TargetRoot",
+                str(export_root),
+            ]
+        )
+
+        result = subprocess.run(
+            command,
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+        assert_true(
+            "Fresh Codex export succeeds with JSON support",
+            result.returncode == 0,
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+
+        exported = export_root / "skills" / "clockwork" / "patterns" / "architecture-patterns.json"
+        assert_true("Fresh export contains Clockwork JSON catalog", exported.is_file())
+
+        source_data = json.loads(SOURCE_JSON.read_text(encoding="utf-8"))
+        exported_data = json.loads(exported.read_text(encoding="utf-8"))
+        assert_true("Fresh export preserves Clockwork JSON content", exported_data == source_data)
+
+
+def main():
+    test_clockwork_pattern_catalog_is_valid_json()
+    test_exporter_declares_json_support()
+    test_fresh_export_copies_clockwork_json_when_powershell_is_available()
+    print("Codex JSON support tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- expand Clockwork with modern application architecture and event-driven workflow knowledge
- add a selective machine-readable architecture pattern catalog
- extend Codex support-file export to portable `.md` and `.json` files
- add JSON export regression coverage
- align Clockwork frontmatter metadata with the existing manifest contract after local validation exposed a mismatch

## Exact scope

- 15 changed paths, all within the authorized SK2 Clockwork scope
- base: `5d18580b7003f3f820cdc78d6e033c4c344e8c24`
- reviewed head: `e0526b0d510274c26b4aaec353e61675ec113b27`
- no release, deployment, installed integration refresh, policy activation, branch deletion, force push, or history rewrite

## Local validation

- `ORCHESTRA_APPROVED_BASE_SHA=5d18580b7003f3f820cdc78d6e033c4c344e8c24 python tests/behavior/run_tests.py`: passed
- `python -m pytest tests/runtime --cov=orchestra_runtime --cov-report=term-missing --cov-fail-under=90`: 541 passed, 94.31% coverage
- native workflow validators, strict governance, router benchmarks, enforced runtime guardrail, prompt-load reporting, project context, Dagger simulation, governance behavior, JSON syntax, and `git diff --check`: passed
- `python tests/behavior/test_codex_export_json_support.py`: passed, including a fresh isolated Codex export
- canonical and exported Clockwork JSON: semantic equality passed
- exporter support allowlist: `.md` and `.json` only
- final worktree: clean

The handoff named `scripts/validate.py`, but that path is not present in either the exact SK2 head or its canonical parent. The live repository contract in `.github/workflows/validate.yml` requires the behavior runner and runtime pytest coverage gate above; those authoritative commands passed.

## Required merge gate

Do not merge until the exact PR head has successful Governance Check, validate, runtime-tests, native Windows, native Ubuntu, native macOS, CodeQL actions, and CodeQL python results, with zero unresolved review threads and no scope drift.