### PR TITLE
feat(cloak): add specialist frontend knowledge layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Post-v1.2.0 Specialist Knowledge Layer - SK4 Cloak - Pending
+
+- Deepened Cloak's frontend design knowledge without changing specialist ownership, routing authority, package version, or runtime architecture.
+- Added progressive-disclosure guidance for semantic HTML, ARIA/accessibility state, keyboard and focus behavior, responsive CSS layout/overflow, forms and validation recovery, design tokens/component states, and frontend routing/component-boundary literacy.
+- Expanded four previously minimal Cloak worked examples covering responsive layout, destructive dialog interaction, navigation structure, and checkout recovery.
+- Kept the campaign Markdown-primary and JSON-selective: the SK4 audit found no concrete machine-parsing need that justified a new Cloak JSON catalog.
+- Preserved implementation ownership with Ponytail, architecture/state ownership with Clockwork, security policy with Cipher, persistence with Chronicler, readiness gates with Overseer, and diagram/documentation ownership with Weaver/Scribe.
+- Added focused regression coverage for Cloak knowledge depth and canonical/Codex support-file parity.
+- No release/publication, deployment/production mutation, installed-integration refresh, policy activation, destructive cleanup, branch deletion, force push, or history rewrite is performed by SK4.
 ## Post-v1.2.0 Specialist Knowledge Layer - SK3 Cipher - Pending
 
 - Expanded Cipher from general security/privacy review into deeper authentication, session, OAuth/OIDC, authorization, web/API, sensitive-business-flow, SSRF, secrets/cryptographic-misuse, framework-aware, and security-tooling interpretation guidance while preserving defensive-only specialist ownership.

--- a/adapters/codex/skills/cloak/ACCESSIBILITY_CHECKLIST.md
+++ b/adapters/codex/skills/cloak/ACCESSIBILITY_CHECKLIST.md
@@ -1,12 +1,23 @@
 # Accessibility Checklist
 
-- [ ] Keyboard order and visible focus follow the task.
-- [ ] Controls have accessible names and appropriate semantics.
-- [ ] Errors identify the field, correction, and recovery path.
-- [ ] Status changes are perceivable without color alone.
+- [ ] Page landmarks and heading structure match the content hierarchy.
+- [ ] DOM/source order, reading order, and keyboard order remain logical and aligned.
+- [ ] Native controls and semantic HTML are preferred before custom ARIA widgets.
+- [ ] Controls have accessible names that align with visible labels.
+- [ ] Supporting instructions and errors use an accessible description relationship when needed.
+- [ ] ARIA roles, states, and properties match the visible component state and expected interaction contract.
+- [ ] No focusable or interactive content is hidden from the accessibility tree.
+- [ ] Keyboard order and visible focus follow the task without positive-tabindex reordering.
+- [ ] Composite widgets use a recognized keyboard interaction pattern rather than an invented key model.
+- [ ] Dialogs manage initial focus, contained focus where modal, cancellation, and focus return.
+- [ ] Route or major view changes provide a predictable focus/context destination when needed.
+- [ ] Focus is not obscured by sticky, fixed, or overlay content.
+- [ ] Errors identify the field, correction, and recovery path without erasing valid input.
+- [ ] Dynamic status changes are perceivable without color alone or unnecessary focus movement.
+- [ ] Live-region behavior is limited to information users need to perceive asynchronously.
 - [ ] Contrast, text scaling, zoom, and reflow remain usable.
 - [ ] Touch and pointer targets have adequate size and spacing.
 - [ ] Images, charts, and icons have meaningful alternatives when needed.
-- [ ] Motion respects reduced-motion preferences.
-- [ ] Loading, empty, error, disabled, and success states are covered.
-- [ ] Claims distinguish inspected evidence from untested behavior.
+- [ ] Motion respects reduced-motion preferences and is not the sole state cue.
+- [ ] Loading, empty, error, disabled, read-only, success, retry, and permission states are covered when applicable.
+- [ ] Claims distinguish inspected evidence from untested rendered or assistive-technology behavior.

--- a/adapters/codex/skills/cloak/CHECKLIST.md
+++ b/adapters/codex/skills/cloak/CHECKLIST.md
@@ -127,6 +127,42 @@ Use only the sections relevant to the selected review mode. Unchecked items are 
 - [ ] State design-system constraints, form and validation expectations, and visible state coverage.
 - [ ] Name the downstream owner for implementation, security, architecture, persistence, validation, diagrams, or long-form docs when those concerns appear.
 
+## SK4 Deep-Dive Checks
+
+### Semantic HTML, ARIA, Keyboard, and Focus
+- [ ] Native semantic elements are used when they already provide the required role and keyboard behavior.
+- [ ] Accessible names align with visible labels; descriptions and errors are connected only when they add supporting information.
+- [ ] ARIA state such as expanded, current, selected, pressed, or invalid matches the visible state.
+- [ ] Composite widgets follow a recognized keyboard model and do not use positive tabindex to manufacture order.
+- [ ] Dialogs establish initial focus, contain focus while modal, support safe cancellation, and return focus appropriately.
+- [ ] Route/view changes, form failures, and dynamic updates move focus only when the context change requires it.
+- [ ] Sticky/fixed/overlay UI does not obscure the focused element.
+
+### Responsive CSS Containment
+- [ ] Flex/grid choice matches the dimensional layout need and preserves semantic source order.
+- [ ] Intrinsic sizing, long content, media, and nested containers cannot force accidental page-level horizontal overflow.
+- [ ] Overflow/clipping cannot hide actions, focus rings, errors, menus, or required content.
+- [ ] Breakpoints preserve task order under intermediate widths, zoom, text enlargement, orientation, and localization pressure.
+- [ ] Fixed/sticky surfaces account for safe areas, on-screen keyboards, and focused content.
+
+### Form, Validation, and Submission State
+- [ ] Validation timing does not punish reasonable incomplete input while authoritative constraints are still checked on submission/server response.
+- [ ] Error summaries and field errors provide an explicit recovery path and preserve valid input.
+- [ ] Failed submission has a deliberate focus target; successful state does not leave focus on removed content.
+- [ ] One authoritative submission path owns an in-flight mutation and duplicate activation is prevented.
+- [ ] Disabled, read-only, loading, and permission-restricted states remain visually and semantically distinct.
+
+### Tokens, Themes, and Component States
+- [ ] Primitive, semantic, and component token responsibilities are not mixed without evidence.
+- [ ] Default, hover, focus-visible, active, selected/current, disabled, loading, error, and success states are covered when the component can enter them.
+- [ ] Supported themes preserve semantic meaning, contrast, hierarchy, focus visibility, and chart/state legibility.
+- [ ] New variants represent a reusable product need rather than page-specific cosmetic drift.
+
+### Frontend Routes and Component Boundaries
+- [ ] Direct links, menu navigation, Back/Forward, permission, not-found, loading, and error states preserve route orientation.
+- [ ] Client-side navigation provides a predictable focus/context destination when the prior focused element disappears.
+- [ ] Permission-aware navigation is treated as UX only, not authorization enforcement.
+- [ ] Cloak limits component-boundary advice to the user-visible contract and routes state/data architecture to Clockwork.
 ## Specialist Handoff
 - [ ] Route diagram semantics and modeling to `weaver`.
 - [ ] Route database design and SQL to `chronicler`.

--- a/adapters/codex/skills/cloak/DESIGN_TOKENS_COMPONENT_STATES_GUIDE.md
+++ b/adapters/codex/skills/cloak/DESIGN_TOKENS_COMPONENT_STATES_GUIDE.md
@@ -1,0 +1,76 @@
+# Design Tokens and Component States Guide
+
+Use this guide when reviewing a design system, Figma library, theme implementation, or reusable component contract.
+
+## Token layers
+
+Distinguish the purpose of tokens before recommending new ones.
+
+- Primitive tokens hold raw design values such as a color step, spacing step, radius, or typography value.
+- Semantic tokens express intent such as surface, text, border, danger, success, focus, or interactive emphasis.
+- Component tokens are appropriate only when a reusable component needs a stable local contract that semantic tokens cannot express clearly.
+- Prefer semantic reuse over duplicating near-identical raw values across components.
+
+Cloak does not prescribe a specific token tool or file format unless the project already uses one.
+
+## Theme parity
+
+- A light-theme token and dark-theme token should preserve the same semantic purpose even when their raw values differ.
+- Contrast, hierarchy, disabled-state clarity, focus visibility, chart legibility, and error/success meaning must survive each supported theme.
+- Do not encode meaning through hue alone.
+- Avoid theme-specific exceptions that silently bypass the design-system token layer unless the exception is documented and evidence-backed.
+
+## Required state model
+
+Review the states that the component can actually enter. Typical states include:
+
+- default
+- hover when a hover-capable pointer exists
+- focus-visible
+- active or pressed
+- selected or current
+- disabled
+- read-only where applicable
+- loading or pending
+- empty where applicable
+- error or invalid
+- success or complete
+- permission-restricted where applicable
+
+Not every component needs every state. Missing states are findings only when the component can actually enter that condition.
+
+## State consistency
+
+- Visual state, accessibility state, and product state must describe the same condition.
+- Focus-visible treatment must not disappear merely because hover styling is active.
+- Disabled appearance must not be reused for read-only or permission-denied content when the user meaning differs.
+- Loading state should preserve enough layout and context to avoid confusing movement or duplicate action.
+- Error and success treatments need text or another perceivable cue in addition to color.
+
+## Variant discipline
+
+- Add a variant for a product or interaction need, not merely a one-off cosmetic preference.
+- Reuse the existing component before creating a near-duplicate component with different naming.
+- Keep variant names tied to purpose or state rather than page-specific styling.
+- If two variants behave differently, their interaction and accessibility contract must make that difference explicit.
+
+## Typography, spacing, and density
+
+- Typography tokens should preserve readable hierarchy and line spacing across responsive conditions.
+- Spacing should communicate grouping and separation consistently rather than act as arbitrary pixel tuning.
+- Dense modes must retain target size, focus visibility, readable labels, and error communication.
+- Localization and longer content must not break the component contract.
+
+## Motion tokens and transitions
+
+- Reuse established duration/easing conventions when motion serves a state transition.
+- Respect reduced-motion preferences.
+- Motion should clarify change, not become the only indication that state changed.
+
+## Evidence review
+
+For Figma or another design-system artifact, inspect available variables/tokens, component variants, properties, descriptions, annotations, and state coverage. Mark unavailable evidence as `NEEDS EVIDENCE` rather than inventing a token structure.
+
+## Handoff
+
+Cloak defines the design-system and state requirements. Ponytail owns implementation. Clockwork owns architecture or shared-state design when the component contract crosses system boundaries. Overseer owns state-matrix and visual-regression readiness evidence.

--- a/adapters/codex/skills/cloak/FORM_FOCUS_VALIDATION_GUIDE.md
+++ b/adapters/codex/skills/cloak/FORM_FOCUS_VALIDATION_GUIDE.md
@@ -1,0 +1,75 @@
+# Form, Focus, and Validation Guide
+
+Use this guide for forms, multi-step flows, authentication inputs, destructive confirmations, and other interactions where errors or state transitions can block task completion.
+
+## Field identity and grouping
+
+- Provide a persistent visible label for each field unless the control pattern has an equally clear native accessible name.
+- Group related controls with meaningful structure and instructions.
+- Distinguish required and optional fields consistently before submission.
+- Use input purpose, autocomplete, and platform-native control behavior when they reduce user effort and do not conflict with product requirements.
+- Do not use placeholder text as the only label or instruction.
+
+## Validation timing
+
+- Prevent avoidable errors before submission when the rule can be explained without interrupting normal entry.
+- Avoid aggressive validation that marks incomplete fields invalid while the user is still entering a reasonable value.
+- Revalidate authoritative constraints after submission or server response. Client-side validation improves UX but is not an enforcement boundary.
+- Async validation needs a visible pending state and must avoid racing older responses into the current field state.
+
+## Error communication
+
+A useful error tells the user what happened, where it happened, and how to recover.
+
+- Associate field-specific messages with their field.
+- Use `aria-invalid` and an accessible description relationship when appropriate to the implemented pattern.
+- Keep error text specific enough to guide correction without exposing sensitive backend or account-existence information.
+- Preserve the user's valid input after a failed submission.
+- For forms with multiple errors, provide an error summary when it materially improves navigation and recovery.
+- Do not rely on color, icon shape, or placement alone to communicate invalid state.
+
+## Focus after submission
+
+- On failed submission, move focus only when it improves recovery. Common destinations are the error summary or first invalid field according to the established product pattern.
+- Ensure the focused error target is not hidden behind sticky or fixed UI.
+- On successful submission, move or restore focus according to the resulting context. Do not leave focus on a removed control.
+- If a modal form closes, return focus to the logical invoking control when it still exists.
+
+## Submission ownership
+
+- Provide one authoritative submit path for the action.
+- Prevent accidental duplicate submission while an in-flight mutation owns completion.
+- A disabled control must still leave the reason and recovery path understandable. Do not strand users behind an unexplained disabled primary action.
+- Distinguish disabled, read-only, loading, and permission-restricted states. They have different user meanings and should not be styled as interchangeable.
+
+## Multi-step flows
+
+- Show current position and what remains when the sequence is long enough to need orientation.
+- Preserve completed valid data when users move backward or recover from errors.
+- Avoid forcing redundant entry of information already supplied unless a current safety or verification reason requires it.
+- Warn before abandoning unsaved work when loss would be meaningful, and provide a clear safe alternative.
+
+## Sensitive and destructive actions
+
+- Explain consequence before confirmation.
+- Avoid preselecting the destructive choice or using visual pressure to make cancellation harder.
+- Use additional confirmation only when the risk justifies the friction.
+- Authentication and recovery forms should not disclose whether an account exists unless product security policy explicitly allows that distinction.
+- Route security-policy decisions to Cipher and backend validation ownership to the appropriate engineering specialist.
+
+## Mobile and assistive-technology review
+
+- Verify the on-screen keyboard does not hide the active field, validation message, or primary action.
+- Verify zoom, reflow, text resizing, and orientation changes preserve labels and error relationships.
+- Verify dynamic submission status is perceivable without repeatedly stealing focus.
+- Verify touch targets and spacing support users with limited precision.
+
+## Evidence boundary
+
+Cloak defines form usability, focus, and user-visible validation requirements. Ponytail implements them, Cipher owns security policy, Clockwork owns state and architecture boundaries, and Overseer owns readiness testing.
+
+## Primary references
+
+- HTML forms: https://html.spec.whatwg.org/multipage/forms.html
+- WCAG 2.2: https://www.w3.org/TR/WCAG22/
+- WAI-ARIA Authoring Practices Guide: https://www.w3.org/WAI/ARIA/apg/

--- a/adapters/codex/skills/cloak/FRONTEND_REVIEW_GUIDE.md
+++ b/adapters/codex/skills/cloak/FRONTEND_REVIEW_GUIDE.md
@@ -1,11 +1,22 @@
 # Frontend Review Guide
 
-1. Identify the artifact sources reviewed, the target user, the primary task, the supported viewport, and the available rendered states.
-2. Inspect the smallest relevant component, style, state owner, and design-system evidence before making recommendations.
-3. Review form usability, user-facing validation messaging, and the visible loading, empty, error, success, retry, and permission states that affect the task.
-4. Report confirmed task, accessibility, containment, consistency, recovery, and design-system issues by severity. Separate confirmed evidence from assumptions and `NEEDS EVIDENCE`.
-5. Produce a frontend handoff blueprint that names semantic structure, affected components, design-system constraints, responsive or accessibility rules, and downstream routing boundaries without writing production code.
-6. Reuse native controls, current components, and existing tokens before suggesting new variants or dependencies.
-7. Verify build output and representative interaction states after implementation.
+1. Identify the artifact sources reviewed, target user, primary task, supported viewport range, themes, and available rendered states.
+2. Inspect the smallest relevant component, semantic structure, style/layout owner, current design tokens, route context, and design-system evidence before recommending changes.
+3. Review native HTML semantics, accessible names, ARIA state relationships, keyboard behavior, and focus movement when the surface contains interactive web UI.
+4. Review layout mechanics that can affect task completion: source order, flex/grid containment, intrinsic sizing, wrapping, overflow, clipping, fixed/sticky overlays, and narrow-width reflow.
+5. Review form usability, validation timing and messaging, submission ownership, focus after errors, and visible loading, empty, error, success, retry, permission, disabled, and read-only states that affect the task.
+6. Review client-side navigation at the user-visible contract level: current-location indication, deep links, Back/Forward behavior, route focus, not-found/permission states, and responsive navigation. Route internal state or architecture ownership to Clockwork.
+7. Review component-state and token consistency across supported themes. Reuse current tokens/components before proposing variants or dependencies.
+8. Report confirmed task, accessibility, containment, consistency, recovery, and design-system issues by severity. Separate confirmed evidence from assumptions and `NEEDS EVIDENCE`.
+9. Produce a frontend handoff blueprint that names semantic structure, affected components, token/state constraints, responsive rules, accessibility/focus requirements, route expectations, and downstream ownership without writing production code.
+10. Require current rendered evidence for visual correctness and route readiness testing to Overseer when the user asks for a readiness conclusion.
 
-Route implementation to `ponytail`, architecture and state ownership to `clockwork`, security policy to `cipher`, database semantics to `chronicler`, normal QA and validation gates to `overseer`, project documentation to `scribe`, system diagrams to `weaver`, and destructive guardrail pressure testing to gated `dagger`.
+Load deeper references only when the task needs them:
+
+- `SEMANTIC_HTML_ARIA_KEYBOARD_GUIDE.md`
+- `RESPONSIVE_CSS_LAYOUT_GUIDE.md`
+- `FORM_FOCUS_VALIDATION_GUIDE.md`
+- `DESIGN_TOKENS_COMPONENT_STATES_GUIDE.md`
+- `FRONTEND_ROUTING_COMPONENT_BOUNDARIES_GUIDE.md`
+
+Route implementation to `ponytail`, architecture and shared-state ownership to `clockwork`, security policy to `cipher`, database semantics to `chronicler`, normal QA and validation gates to `overseer`, project documentation to `scribe`, system diagrams to `weaver`, and destructive guardrail pressure testing to gated `dagger`.

--- a/adapters/codex/skills/cloak/FRONTEND_ROUTING_COMPONENT_BOUNDARIES_GUIDE.md
+++ b/adapters/codex/skills/cloak/FRONTEND_ROUTING_COMPONENT_BOUNDARIES_GUIDE.md
@@ -1,0 +1,76 @@
+# Frontend Routing and Component Boundary Guide
+
+Use this guide when UI structure involves client-side navigation, nested layouts, route-specific states, deep links, or reusable component boundaries. Cloak owns user-visible behavior, not application architecture.
+
+## Route experience contract
+
+For each user-visible route or screen, review:
+
+- entry path and primary user goal
+- page title and visible heading
+- active navigation indication
+- loading, empty, error, success, retry, permission, and not-found states when applicable
+- focus destination after navigation
+- back/forward behavior
+- deep-link behavior
+- responsive navigation behavior
+- unsaved-change recovery where relevant
+
+## Navigation semantics
+
+- Use one stable label for the same destination unless the contexts genuinely require different language.
+- Distinguish global, local, contextual, and utility navigation.
+- Current-location indication should be visually and programmatically perceivable.
+- A hidden navigation item is not authorization. Cipher owns access-control policy and enforcement review.
+- If a user can legitimately deep-link to a route, the direct route should provide the same understandable state and permissions as navigation through the menu.
+
+## Focus and route transitions
+
+- Route changes that replace the main view should provide a predictable context cue for keyboard and screen-reader users.
+- Preserve focus only when the same control remains the logical task continuation.
+- Do not leave focus on detached DOM content after route replacement.
+- Loading transitions should not repeatedly move focus while data resolves.
+- Error and permission states should provide a clear next action and a reachable navigation path.
+
+## History and recovery
+
+- Browser Back and Forward should not unexpectedly discard completed safe state or repeat destructive actions.
+- If unsaved user input would be lost, provide an evidence-backed warning and recovery path.
+- Redirects should not create loops or strand users on transient screens.
+- Scroll restoration should support the task rather than always forcing the same position.
+
+## Component boundary literacy
+
+Cloak may recommend a reusable visual/interaction boundary when repeated UI has the same user-visible contract.
+
+A useful component boundary usually has:
+
+- one clear user-facing responsibility
+- stable inputs and visible states
+- a consistent accessibility contract
+- predictable responsive behavior
+- reusable design-system constraints
+
+Cloak must not decide React provider architecture, query-cache ownership, service boundaries, persistence ownership, or business-rule placement. Route those decisions to Clockwork or the appropriate specialist.
+
+## Shared state warning signs
+
+Route architecture alignment to Clockwork when the UI review exposes:
+
+- duplicate sources of truth across route and component state
+- state synchronization loops
+- route guards that embed business authorization logic
+- components whose data ownership is unclear across nested routes
+- optimistic or cached state whose failure behavior changes the business contract
+- server/client rendering boundaries that affect authoritative state
+
+## Permission-aware UX
+
+- Navigation may hide unavailable actions to reduce confusion, but backend enforcement remains mandatory.
+- Permission-denied screens should explain the user-visible limitation without leaking sensitive policy details.
+- Avoid redirect behavior that makes an authorization failure look like missing data or a broken route.
+- Route policy and threat questions to Cipher.
+
+## Handoff
+
+Cloak hands off the user-visible route contract, semantic navigation structure, responsive shell behavior, focus expectations, and component-state matrix. Ponytail implements it. Clockwork owns architecture and state placement. Cipher owns authorization. Overseer owns route and state validation evidence.

--- a/adapters/codex/skills/cloak/RESPONSIVE_CSS_LAYOUT_GUIDE.md
+++ b/adapters/codex/skills/cloak/RESPONSIVE_CSS_LAYOUT_GUIDE.md
@@ -1,0 +1,71 @@
+# Responsive CSS Layout and Containment Guide
+
+Use this guide to diagnose layout risk and define implementation-ready responsive requirements without writing production CSS.
+
+## Layout model selection
+
+- Use normal document flow as the default baseline.
+- Use Flexbox for primarily one-dimensional distribution and alignment.
+- Use Grid when rows and columns need coordinated two-dimensional placement.
+- Nested layout models are valid when each level has a clear responsibility. Avoid layout mechanisms chosen only because they happen to make one screenshot align.
+- Preserve semantic DOM order even when visual layout changes across breakpoints.
+
+## Intrinsic sizing literacy
+
+Cloak should recognize common causes of unexpected overflow and compression.
+
+- Long unbroken text, intrinsic media sizes, minimum content sizes, and nested flex/grid containers can force a layout wider than its container.
+- A flex or grid child may need permission to shrink within its layout context. Diagnose the containing relationship before recommending arbitrary fixed widths.
+- Grid tracks should account for content that must shrink or wrap. Avoid layouts whose minimum track size silently preserves desktop width on narrow screens.
+- Media should respect its containing region and preserve meaningful aspect ratio unless product requirements explicitly call for cropping.
+
+## Overflow and clipping
+
+Treat overflow as a user-visible behavior decision, not merely a cosmetic property.
+
+- Horizontal scrolling on the entire page is usually a containment defect for ordinary application layouts.
+- Local horizontal scrolling can be appropriate for wide data tables, timelines, code, or other content whose two-dimensional relationship must remain intact.
+- Clipping must not hide focus indicators, validation messages, menus, tooltips, or actionable content.
+- Text truncation needs an evidence-backed reason. Critical labels, values, and error messages should remain perceivable without relying on hover-only disclosure.
+- Inspect ancestor overflow, positioning, transforms, and stacking contexts when popovers or focus rings appear cut off.
+
+## Breakpoints and reflow
+
+- Define breakpoints from content pressure and task preservation, not device-name folklore alone.
+- Preserve primary task order when columns collapse or navigation changes form.
+- Check the narrowest supported viewport, intermediate widths, landscape orientation, text enlargement, browser zoom, and long localized content.
+- A responsive design is not complete if a control is merely moved off-screen or hidden without an equivalent accessible path.
+- If container queries are already part of the project architecture, review component behavior against its actual container rather than assuming the full viewport controls every layout decision.
+
+## Fixed, sticky, and overlay UI
+
+- Fixed or sticky headers, footers, action bars, and cookie/consent surfaces must not cover focused controls or required content.
+- Account for mobile safe areas and on-screen keyboards when they can obscure form actions.
+- Verify nested scrolling does not trap keyboard or touch users inside an unexpected region.
+- Overlay layering should preserve one clear active interaction surface and predictable dismissal behavior.
+
+## Data-heavy surfaces
+
+For tables, dashboards, grids, and charts:
+
+- Preserve labels, units, legends, and critical comparisons at narrow widths.
+- Choose deliberately among column prioritization, wrapping, stacked summaries, local horizontal scroll, or alternate detail views.
+- Do not convert tabular relationships into visually convenient cards if that destroys comparisons users need to make.
+- Provide an accessible summary or data alternative when a chart alone cannot communicate the decision-relevant information.
+
+## Motion and responsive state
+
+- Layout changes should not create unnecessary motion or spatial disorientation.
+- Respect reduced-motion preferences when transitions or animated reflow are part of the experience.
+- Loading skeletons, drawers, accordions, and responsive navigation must preserve focus and state when viewport conditions change.
+
+## Review evidence
+
+A static source review may return `STATIC_UI_RISK_LOW`, `STATIC_UI_RISK_DETECTED`, or `STATIC_UI_RESULT_INCONCLUSIVE` according to Cloak's existing contract. Rendered correctness still requires current visual evidence.
+
+## Primary references
+
+- CSS Grid Layout: https://www.w3.org/TR/css-grid-2/
+- CSS Flexible Box Layout: https://www.w3.org/TR/css-flexbox-1/
+- CSS Overflow: https://www.w3.org/TR/css-overflow-3/
+- WCAG 2.2 reflow and focus requirements: https://www.w3.org/TR/WCAG22/

--- a/adapters/codex/skills/cloak/SEMANTIC_HTML_ARIA_KEYBOARD_GUIDE.md
+++ b/adapters/codex/skills/cloak/SEMANTIC_HTML_ARIA_KEYBOARD_GUIDE.md
@@ -1,0 +1,86 @@
+# Semantic HTML, ARIA, and Keyboard Interaction Guide
+
+Use this guide when a web UI review requires more depth than the base accessibility checklist. Cloak defines user-visible requirements and review criteria. Ponytail owns implementation code.
+
+## Native semantics first
+
+- Prefer native HTML elements whose built-in role and keyboard behavior match the interaction.
+- Treat ARIA as a semantic supplement, not a replacement for native behavior.
+- A custom role creates an interaction contract. If a component uses an ARIA widget role, its keyboard behavior, focus behavior, states, and accessible name must match that role.
+- Do not add redundant roles to native elements when the native semantics already express the requirement.
+- Do not place `aria-hidden="true"` on an element that contains focusable or interactive content.
+
+## Landmarks and document structure
+
+Review the page structure before individual widgets.
+
+- Require one clear main content region for the page task.
+- Use landmarks such as header, nav, main, aside, and footer when they represent the actual region purpose.
+- Preserve a logical heading hierarchy that communicates document structure rather than visual size alone.
+- Use section or article only when the content has a meaningful structural identity.
+- Keep DOM/source order aligned with reading order and keyboard order. Visual reordering must not create a different interaction sequence.
+
+## Accessible names and descriptions
+
+Every interactive control needs a stable accessible name.
+
+- Prefer visible text or an associated `label` for form controls.
+- Use `aria-labelledby` when another visible element already provides the correct name.
+- Use `aria-describedby` for supporting instructions, constraints, or error details that are useful in addition to the name.
+- Keep the visible label and accessible name aligned so voice-input and screen-reader users receive the same control identity.
+- Icon-only controls require an accessible name that communicates the action, not the icon shape.
+- Placeholder text is not a substitute for a persistent label.
+
+## ARIA state literacy
+
+Cloak should recognize common state relationships and verify that user-visible state and accessibility state do not diverge.
+
+- `aria-expanded` should reflect whether a controlled disclosure, menu, or region is currently expanded.
+- `aria-controls` may express a relationship when it materially helps identify the controlled region, but it does not create behavior by itself.
+- `aria-current` identifies the current item in a set such as navigation or a step sequence.
+- `aria-selected` represents selection in widgets whose role defines selectable items.
+- `aria-pressed` represents the state of a toggle button, not a generic selected style.
+- `aria-invalid` identifies a form value that is currently invalid and should be paired with useful correction guidance.
+- Live-region techniques such as `aria-live` should be reserved for dynamic information users need to perceive without moving focus. Avoid repeated or noisy announcements.
+
+## Keyboard interaction review
+
+- All interactive functionality must be reachable and operable without a pointer.
+- Preserve predictable Tab and Shift+Tab movement between components.
+- Avoid positive `tabindex` values used to manually reorder focus. Prefer a logical DOM order.
+- Native buttons activate with their platform/browser keyboard behavior. A custom button-like control must provide equivalent behavior if a native button cannot be used.
+- Composite widgets such as tabs, menus, listboxes, and grids require their pattern-specific keyboard model. Do not invent a novel arrow-key model when a recognized platform pattern applies.
+- Keyboard shortcuts must not conflict with text entry or create inaccessible single-character traps.
+
+## Focus management
+
+Focus should move only when doing so helps users understand a real context change.
+
+- When a modal dialog opens, move focus into the dialog and contain keyboard focus while it is modal.
+- Initial dialog focus should support comprehension and safe action. Do not automatically focus a destructive primary action merely because it is visually prominent.
+- When a dialog closes, return focus to the invoking control when that control still exists and remains the logical continuation point.
+- After client-side route or major view changes, provide a predictable focus destination such as the page heading or main content start when users otherwise lose context.
+- After failed form submission, focus an error summary or the first invalid field according to the product pattern, while preserving entered values.
+- Do not move focus for passive status messages that can be communicated through a live region.
+- Ensure sticky headers, overlays, and fixed controls do not visually obscure the focused element.
+
+## Dialog and disclosure review
+
+For dialogs, disclosures, tabs, menus, and other rich patterns:
+
+1. Confirm a native element or simpler pattern cannot meet the need first.
+2. Identify the expected role, state, accessible name, and keyboard model.
+3. Verify visible state and accessibility state stay synchronized.
+4. Verify initial focus, contained focus where required, Escape/cancel behavior when safe, and focus return.
+5. Verify the component remains understandable under zoom, reflow, high contrast, and reduced-motion conditions.
+
+## Evidence boundary
+
+A source-level review can identify probable semantic and focus defects, but it is not a rendered accessibility pass. Cloak must state what was inspected and route browser, assistive-technology, or formal conformance testing to Overseer when readiness evidence is required.
+
+## Primary references
+
+- WCAG 2.2: https://www.w3.org/TR/WCAG22/
+- WAI-ARIA Authoring Practices Guide: https://www.w3.org/WAI/ARIA/apg/
+- APG keyboard interface practice: https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/
+- HTML Living Standard: https://html.spec.whatwg.org/

--- a/adapters/codex/skills/cloak/SKILL.md
+++ b/adapters/codex/skills/cloak/SKILL.md
@@ -45,6 +45,11 @@ Do not apply `QUICK_UI_HANDOFF` or `FORMAL_UI_AUDIT` fields to Markdown document
 Use `SKILL.md` first. Do not load every supporting document by default or consume context with unused material.
 - Load `OUTPUT_FORMATS.md` only when generating the final response.
 - Load `UI_UX_FOUNDATIONS_GUIDE.md` only when the task involves UI/UX review, frontend experience, visual hierarchy, accessibility, forms, responsive layout, interaction design, secure UX, privacy-aware display, role-aware UI, validation messaging, sensitive action flows, or frontend behavior boundaries.
+- Load `SEMANTIC_HTML_ARIA_KEYBOARD_GUIDE.md` only for semantic HTML, accessible-name, ARIA state, keyboard-pattern, dialog, or focus-management depth.
+- Load `RESPONSIVE_CSS_LAYOUT_GUIDE.md` only for flex/grid containment, intrinsic sizing, overflow, clipping, breakpoints, sticky/fixed UI, or responsive data-heavy surfaces.
+- Load `FORM_FOCUS_VALIDATION_GUIDE.md` only for form labels, validation timing, errors, focus recovery, duplicate submission, multi-step flows, or destructive confirmations.
+- Load `DESIGN_TOKENS_COMPONENT_STATES_GUIDE.md` only for design-system tokens, variants, theme parity, component state matrices, or reusable state semantics.
+- Load `FRONTEND_ROUTING_COMPONENT_BOUNDARIES_GUIDE.md` only for user-visible route behavior, deep links, route focus, browser history, responsive navigation, or component-boundary review.
 - Load `templates/<template-name>.md` only when the user explicitly requests a specific aesthetic (e.g., `bryl-minimal`). Do not load templates by default.
 
 ## Artifact Evidence Review
@@ -130,6 +135,17 @@ Required rules:
 
 Cloak provides semantic structure requirements and review criteria. Ponytail owns the implementation code.
 
+## Deep Frontend Knowledge References
+
+Load only the smallest reference needed for the active UI problem:
+
+- `SEMANTIC_HTML_ARIA_KEYBOARD_GUIDE.md`: native semantics, accessible names/descriptions, ARIA state literacy, keyboard conventions, dialog/focus behavior.
+- `RESPONSIVE_CSS_LAYOUT_GUIDE.md`: flex/grid review, intrinsic sizing, overflow/clipping, responsive reflow, sticky/fixed surfaces, data-heavy layouts.
+- `FORM_FOCUS_VALIDATION_GUIDE.md`: field identity, validation timing, error recovery, focus after submission, duplicate-submission prevention, multi-step/destructive flows.
+- `DESIGN_TOKENS_COMPONENT_STATES_GUIDE.md`: token layers, theme parity, component states, variant discipline, density, and motion conventions.
+- `FRONTEND_ROUTING_COMPONENT_BOUNDARIES_GUIDE.md`: route experience, deep links, history, focus transitions, responsive navigation, permission-aware UX, and user-visible component boundaries.
+
+These are review and handoff references. They do not transfer implementation, architecture, security-policy, persistence, or readiness ownership to Cloak.
 ## Backend Alignment Trigger
 
 When a frontend design decision affects data flow, authentication, authorization, persistence, API shape, backend validation, audit logging, security, privacy, payments, integrations, or compliance-sensitive workflows, Cloak must not decide those backend-sensitive details independently.

--- a/adapters/codex/skills/cloak/UI_UX_FOUNDATIONS_GUIDE.md
+++ b/adapters/codex/skills/cloak/UI_UX_FOUNDATIONS_GUIDE.md
@@ -57,6 +57,17 @@
 - **Secure Onboarding/Recovery**: Provide safe, clear flows for login, onboarding, and password recovery.
 - **Audit Clarity**: Ensure actions that generate an audit log are clear to the user if relevant.
 
+## Deep Reference Loading
+
+Use the base guide for broad UI review, then load only the specialized reference needed by the evidence:
+
+- `SEMANTIC_HTML_ARIA_KEYBOARD_GUIDE.md` for semantic structure, accessible names/descriptions, ARIA states, keyboard patterns, dialogs, or focus movement.
+- `RESPONSIVE_CSS_LAYOUT_GUIDE.md` for flex/grid containment, intrinsic sizing, overflow/clipping, responsive reflow, fixed/sticky UI, or data-heavy surfaces.
+- `FORM_FOCUS_VALIDATION_GUIDE.md` for field identity, validation timing, error recovery, focus after submission, duplicate submission, multi-step forms, or destructive confirmations.
+- `DESIGN_TOKENS_COMPONENT_STATES_GUIDE.md` for tokens, themes, reusable component variants, and state matrices.
+- `FRONTEND_ROUTING_COMPONENT_BOUNDARIES_GUIDE.md` for route orientation, deep links, focus transitions, history/recovery, responsive navigation, or component-boundary review.
+
+Do not load all five by default. Progressive disclosure remains the context-efficiency rule.
 ## Handoff Blueprint Requirements
 - **Blueprint over Code**: Cloak hands off semantic structure, component intent, visible state expectations, and review findings, not production code.
 - **Design-System Constraints**: Name the token, component, and variant constraints that the implementation should preserve.

--- a/adapters/codex/skills/cloak/examples/frontend-layout-review-example.md
+++ b/adapters/codex/skills/cloak/examples/frontend-layout-review-example.md
@@ -1,14 +1,47 @@
 # Cloak Frontend-Layout Review
 
 ## Scope Reviewed
-- Artifact: Responsive account dashboard layout
-- User goal: Scan account status and reach primary actions
+- Artifact: Responsive account dashboard source and current desktop/mobile screenshots
+- User goal: Scan account status, understand alerts, and reach the primary account action
+- Evidence: DOM/source order, layout containers, current design tokens, 1440 px and 390 px screenshots
 
-## Confirmed Finding
-At narrow widths, the primary action moves below low-priority activity content.
+## Confirmed Findings
 
-## Recommendation
-Preserve task priority by placing the primary action after account status and before activity. Reuse the existing responsive layout primitives.
+### High - Task order diverges during narrow reflow
+The desktop grid presents account status, the primary action, and recent activity in that task order. At narrow widths the visual order places the complete activity feed before the primary action while the DOM order still places the action earlier. The user has to traverse a large secondary region visually before reaching the primary action.
+
+### Medium - Activity region can force horizontal overflow
+A nested grid keeps a minimum content width large enough that long transaction labels push the dashboard wider than the viewport. The screenshot shows clipping at the right edge, and the source contains no local overflow strategy for the activity region.
+
+### Medium - Sticky action bar can obscure focus
+The mobile action bar is fixed to the bottom edge. Current evidence does not show additional scroll padding or spacing that would keep the last focusable activity control visible above it.
+
+## Recommendations
+
+1. Preserve the primary task hierarchy when the grid collapses: account status, primary action, then secondary activity.
+2. Keep DOM order and keyboard order logical. Do not solve visual order by creating a different keyboard sequence.
+3. Let the activity container shrink within the grid and choose a deliberate local overflow/wrapping strategy for content that cannot fit.
+4. Reserve enough mobile scroll space that the fixed action bar cannot obscure a focused control or validation message.
+5. Reuse current layout primitives and spacing tokens rather than adding page-specific fixed widths.
+
+## Responsive Verification Matrix
+
+| Condition | Expected result |
+|---|---|
+| Narrow supported viewport | No page-level horizontal scrolling; primary action remains before secondary activity. |
+| 200% text zoom | Labels wrap without clipping controls or hiding status. |
+| Long localized account name | Header and action remain contained without overlap. |
+| Keyboard navigation | Focus order follows the logical task and focused controls remain visible. |
+| Reduced motion | Responsive changes do not depend on animated movement for comprehension. |
+
+## Handoff
+
+- Cloak: layout hierarchy, containment, focus-visibility requirements
+- Ponytail: implementation changes
+- Overseer: current rendered viewport, zoom, keyboard, and regression evidence
 
 ## Missing Evidence
-- Smallest supported viewport, text scaling, and keyboard order
+- Smallest formally supported viewport
+- Landscape mobile state
+- Virtual-keyboard interaction with the fixed action bar
+- Current browser matrix

--- a/adapters/codex/skills/cloak/examples/interaction-flow-review-example.md
+++ b/adapters/codex/skills/cloak/examples/interaction-flow-review-example.md
@@ -1,14 +1,50 @@
 # Cloak Interaction-Flow Review
 
 ## Scope Reviewed
-- Artifact: Account-deletion confirmation interaction
-- User goal: Understand consequences and cancel or confirm safely
+- Artifact: Account-deletion modal interaction and destructive-action copy
+- User goal: Understand consequences, cancel safely, or deliberately confirm deletion
+- Evidence: Dialog markup, focus order, button states, confirmation copy, and supplied keyboard recording
 
-## Confirmed Finding
-The destructive action receives initial keyboard focus while Cancel is visually secondary.
+## Confirmed Findings
 
-## Recommendation
-Focus the dialog heading or safe action, state the irreversible consequence, and require a deliberate confirmation without dark patterns.
+### Critical - Initial focus favors the destructive action
+When the modal opens, focus is placed directly on Delete account. The destructive action is also the strongest visual button. This makes an irreversible action the default keyboard continuation instead of prioritizing comprehension and safe cancellation.
+
+### High - Dialog description is not connected to the interaction
+The consequence text is visually present but is not included in the dialog's accessible description relationship. A screen-reader user can reach the controls without receiving the same consequence context.
+
+### Medium - Focus return is undefined
+The supplied flow closes the modal after Cancel, but the evidence does not establish where focus returns. Losing focus context after cancellation would make the interaction harder to recover from.
+
+## Recommendations
+
+1. Give the dialog a stable accessible name and connect the consequence text as supporting description.
+2. Place initial focus on a comprehension target or safe action according to the established product pattern, not automatically on the destructive action.
+3. Keep Tab and Shift+Tab inside the modal while it is active and provide a safe cancel path, including Escape when product requirements permit it.
+4. Return focus to the invoking Delete account control after cancellation when it still exists.
+5. Keep the irreversible consequence explicit and avoid styling or wording that pressures the user toward confirmation.
+6. After confirmed deletion, move focus to the resulting stable context rather than attempting to restore focus to removed account controls.
+
+## Keyboard and State Matrix
+
+| Event | Expected user-visible behavior |
+|---|---|
+| Open dialog | Focus enters the modal and consequence context is available. |
+| Tab / Shift+Tab | Focus remains within the active modal. |
+| Cancel | Dialog closes and focus returns to the logical invoker. |
+| Confirm while pending | One authoritative submission path owns completion; duplicate activation is blocked. |
+| Failure | Dialog remains recoverable with a clear error and safe retry/cancel path. |
+| Success | User is taken to a stable post-deletion context. |
+
+## Handoff
+
+- Cloak: dialog semantics, focus, hierarchy, destructive UX requirements
+- Cipher: security/re-authentication policy if deletion requires identity confirmation
+- Ponytail: implementation
+- Overseer: keyboard, screen-reader, and current rendered evidence
 
 ## Missing Evidence
-- Screen-reader announcement and post-confirmation state
+- Assistive-technology announcement of the current dialog
+- Re-authentication policy
+- Post-confirmation destination
+- Failure/retry behavior

--- a/adapters/codex/skills/cloak/examples/navigation-structure-review-example.md
+++ b/adapters/codex/skills/cloak/examples/navigation-structure-review-example.md
@@ -1,14 +1,50 @@
 # Cloak Navigation-Structure Review
 
 ## Scope Reviewed
-- Artifact: Analytics dashboard navigation map
-- User goal: Move between overview, reports, and saved views
+- Artifact: Analytics dashboard navigation map and route inventory
+- User goal: Move between Overview, Reports, and Saved views while retaining orientation
+- Evidence: Desktop navigation, mobile drawer, route labels, direct-link behavior, and permission-state screenshots
 
-## Confirmed Finding
-Saved views appear under both Reports and Settings with different labels.
+## Confirmed Findings
 
-## Recommendation
-Choose one task-based location, preserve a single label, and provide a shortcut from Reports only if usage evidence supports it.
+### High - Saved views has two competing navigation homes
+Saved views appears under Reports and Settings with different labels. Both entries navigate to the same destination, so users cannot build a stable mental model of where saved analysis belongs.
+
+### High - Direct route loses orientation
+Opening a saved-view deep link renders the content but does not mark a current navigation item or provide a route heading that names Saved views. The screen is usable but lacks location context.
+
+### Medium - Mobile navigation omits the current-state cue
+The desktop sidebar highlights the active section, while the mobile drawer only closes after navigation. The current destination is not identified when the drawer is reopened.
+
+## Recommendations
+
+1. Choose one task-based primary home for Saved views and use one stable label.
+2. If Reports needs a shortcut, present it as a contextual shortcut rather than a second primary navigation location.
+3. Ensure direct links render the same page title/heading, current-location cue, permission state, and recovery options as menu navigation.
+4. Preserve current-location indication in both desktop and mobile navigation.
+5. After a client-side route change, provide a predictable focus/context target such as the new page heading when focus would otherwise remain on a removed navigation control.
+6. Keep permission-based hiding as a usability rule only. Route authorization enforcement to Cipher.
+
+## Route Experience Matrix
+
+| Route condition | Expected result |
+|---|---|
+| Normal navigation | One active location and one visible page heading. |
+| Direct deep link | Same orientation and permission behavior as menu entry. |
+| Back / Forward | History returns to the prior logical view without duplicate navigation state. |
+| Permission denied | Clear limitation and safe next action without exposing sensitive policy detail. |
+| Not found | Distinct not-found state, not an ambiguous permission or empty-data screen. |
+| Mobile drawer | Current destination remains perceivable when navigation reopens. |
+
+## Handoff
+
+- Cloak: information architecture, route labels, current-location and focus requirements
+- Clockwork: client-side route/state architecture when ownership is unclear
+- Cipher: authorization policy
+- Ponytail: implementation
+- Overseer: direct-link, history, mobile, focus, and permission-state validation
 
 ## Missing Evidence
-- Search behavior, permissions, and mobile navigation
+- Search behavior across saved views
+- Unsaved-change handling
+- Browser history behavior after report filters

--- a/adapters/codex/skills/cloak/examples/user-flow-review-example.md
+++ b/adapters/codex/skills/cloak/examples/user-flow-review-example.md
@@ -1,15 +1,51 @@
 # Cloak User-Flow Review
 
 ## Scope Reviewed
-- Artifact: Checkout user-flow diagram
-- User goal: Review an order and complete payment
-- Evidence: User-facing steps and error branches
+- Artifact: Checkout user-flow diagram plus supplied payment error screens
+- User goal: Review an order, complete payment, and recover without re-entering valid information
+- Evidence: User-facing steps, validation branches, payment failure state, and success destination
 
-## Confirmed Finding
-The payment-failure branch returns to cart and discards the user's delivery selection.
+## Confirmed Findings
 
-## Recommendation
-Return to payment with prior valid selections preserved and a clear recoverable error. Route system sequence or service-message modeling to `weaver`.
+### Critical - Payment failure discards completed delivery work
+The payment-failure branch returns the user to Cart and clears the previously valid delivery selection. The user must repeat an unrelated completed step even though the failure occurred during payment.
+
+### High - Failure state does not identify ownership of retry
+The error screen shows both Retry payment and Return to cart with equal visual weight. It does not explain whether the existing payment attempt is still pending or safe to retry.
+
+### Medium - Focus destination after failure is unspecified
+The diagram shows the failed state but does not define where keyboard focus moves when the payment screen changes to the error state.
+
+## Recommendations
+
+1. Return the user to the payment step with prior valid delivery and order-review selections preserved unless the backend explicitly invalidated them.
+2. Provide one authoritative retry path and expose pending/completed state clearly enough to prevent duplicate payment actions.
+3. Put the actionable error and safe retry guidance near the payment task. Avoid generic failure text that forces users to infer what happened.
+4. Move focus to an error heading/summary when the failure replaces the current payment content and users would otherwise lose context.
+5. Keep Return to cart available as a secondary user-controlled exit without making it the only recovery route.
+6. Route payment-state idempotency, backend mutation ownership, and persistence semantics to Clockwork/Cipher/Chronicler as appropriate. Cloak owns only the user-visible recovery contract.
+
+## State Continuity Matrix
+
+| State | Preserve | Primary user action |
+|---|---|---|
+| Payment pending | Delivery choice, cart, order summary | Wait or cancel only when supported. |
+| Recoverable failure | Valid prior selections and entered non-sensitive data | Retry payment once. |
+| Payment declined | Order context | Choose another allowed payment method or exit safely. |
+| Session/permission failure | Only data policy permits retaining | Re-authenticate or follow the provided safe recovery path. |
+| Success | Final order summary | Continue to receipt/order status. |
+
+## Handoff
+
+- Cloak: user-visible state continuity, hierarchy, focus, and recovery path
+- Clockwork: payment-state and client/server ownership
+- Cipher: payment/authentication security policy
+- Chronicler: persistence semantics if state retention depends on stored records
+- Ponytail: implementation
+- Overseer: retry, duplicate-action, keyboard, and current rendered evidence
 
 ## Missing Evidence
-- Running error state and persistence behavior
+- Current idempotency/retry contract
+- Running focus behavior
+- Exact retention policy for sensitive payment fields
+- Persistence behavior across session expiry

--- a/skills/cloak/ACCESSIBILITY_CHECKLIST.md
+++ b/skills/cloak/ACCESSIBILITY_CHECKLIST.md
@@ -1,12 +1,23 @@
 # Accessibility Checklist
 
-- [ ] Keyboard order and visible focus follow the task.
-- [ ] Controls have accessible names and appropriate semantics.
-- [ ] Errors identify the field, correction, and recovery path.
-- [ ] Status changes are perceivable without color alone.
+- [ ] Page landmarks and heading structure match the content hierarchy.
+- [ ] DOM/source order, reading order, and keyboard order remain logical and aligned.
+- [ ] Native controls and semantic HTML are preferred before custom ARIA widgets.
+- [ ] Controls have accessible names that align with visible labels.
+- [ ] Supporting instructions and errors use an accessible description relationship when needed.
+- [ ] ARIA roles, states, and properties match the visible component state and expected interaction contract.
+- [ ] No focusable or interactive content is hidden from the accessibility tree.
+- [ ] Keyboard order and visible focus follow the task without positive-tabindex reordering.
+- [ ] Composite widgets use a recognized keyboard interaction pattern rather than an invented key model.
+- [ ] Dialogs manage initial focus, contained focus where modal, cancellation, and focus return.
+- [ ] Route or major view changes provide a predictable focus/context destination when needed.
+- [ ] Focus is not obscured by sticky, fixed, or overlay content.
+- [ ] Errors identify the field, correction, and recovery path without erasing valid input.
+- [ ] Dynamic status changes are perceivable without color alone or unnecessary focus movement.
+- [ ] Live-region behavior is limited to information users need to perceive asynchronously.
 - [ ] Contrast, text scaling, zoom, and reflow remain usable.
 - [ ] Touch and pointer targets have adequate size and spacing.
 - [ ] Images, charts, and icons have meaningful alternatives when needed.
-- [ ] Motion respects reduced-motion preferences.
-- [ ] Loading, empty, error, disabled, and success states are covered.
-- [ ] Claims distinguish inspected evidence from untested behavior.
+- [ ] Motion respects reduced-motion preferences and is not the sole state cue.
+- [ ] Loading, empty, error, disabled, read-only, success, retry, and permission states are covered when applicable.
+- [ ] Claims distinguish inspected evidence from untested rendered or assistive-technology behavior.

--- a/skills/cloak/CHECKLIST.md
+++ b/skills/cloak/CHECKLIST.md
@@ -127,6 +127,42 @@ Use only the sections relevant to the selected review mode. Unchecked items are 
 - [ ] State design-system constraints, form and validation expectations, and visible state coverage.
 - [ ] Name the downstream owner for implementation, security, architecture, persistence, validation, diagrams, or long-form docs when those concerns appear.
 
+## SK4 Deep-Dive Checks
+
+### Semantic HTML, ARIA, Keyboard, and Focus
+- [ ] Native semantic elements are used when they already provide the required role and keyboard behavior.
+- [ ] Accessible names align with visible labels; descriptions and errors are connected only when they add supporting information.
+- [ ] ARIA state such as expanded, current, selected, pressed, or invalid matches the visible state.
+- [ ] Composite widgets follow a recognized keyboard model and do not use positive tabindex to manufacture order.
+- [ ] Dialogs establish initial focus, contain focus while modal, support safe cancellation, and return focus appropriately.
+- [ ] Route/view changes, form failures, and dynamic updates move focus only when the context change requires it.
+- [ ] Sticky/fixed/overlay UI does not obscure the focused element.
+
+### Responsive CSS Containment
+- [ ] Flex/grid choice matches the dimensional layout need and preserves semantic source order.
+- [ ] Intrinsic sizing, long content, media, and nested containers cannot force accidental page-level horizontal overflow.
+- [ ] Overflow/clipping cannot hide actions, focus rings, errors, menus, or required content.
+- [ ] Breakpoints preserve task order under intermediate widths, zoom, text enlargement, orientation, and localization pressure.
+- [ ] Fixed/sticky surfaces account for safe areas, on-screen keyboards, and focused content.
+
+### Form, Validation, and Submission State
+- [ ] Validation timing does not punish reasonable incomplete input while authoritative constraints are still checked on submission/server response.
+- [ ] Error summaries and field errors provide an explicit recovery path and preserve valid input.
+- [ ] Failed submission has a deliberate focus target; successful state does not leave focus on removed content.
+- [ ] One authoritative submission path owns an in-flight mutation and duplicate activation is prevented.
+- [ ] Disabled, read-only, loading, and permission-restricted states remain visually and semantically distinct.
+
+### Tokens, Themes, and Component States
+- [ ] Primitive, semantic, and component token responsibilities are not mixed without evidence.
+- [ ] Default, hover, focus-visible, active, selected/current, disabled, loading, error, and success states are covered when the component can enter them.
+- [ ] Supported themes preserve semantic meaning, contrast, hierarchy, focus visibility, and chart/state legibility.
+- [ ] New variants represent a reusable product need rather than page-specific cosmetic drift.
+
+### Frontend Routes and Component Boundaries
+- [ ] Direct links, menu navigation, Back/Forward, permission, not-found, loading, and error states preserve route orientation.
+- [ ] Client-side navigation provides a predictable focus/context destination when the prior focused element disappears.
+- [ ] Permission-aware navigation is treated as UX only, not authorization enforcement.
+- [ ] Cloak limits component-boundary advice to the user-visible contract and routes state/data architecture to Clockwork.
 ## Specialist Handoff
 - [ ] Route diagram semantics and modeling to `weaver`.
 - [ ] Route database design and SQL to `chronicler`.

--- a/skills/cloak/DESIGN_TOKENS_COMPONENT_STATES_GUIDE.md
+++ b/skills/cloak/DESIGN_TOKENS_COMPONENT_STATES_GUIDE.md
@@ -1,0 +1,76 @@
+# Design Tokens and Component States Guide
+
+Use this guide when reviewing a design system, Figma library, theme implementation, or reusable component contract.
+
+## Token layers
+
+Distinguish the purpose of tokens before recommending new ones.
+
+- Primitive tokens hold raw design values such as a color step, spacing step, radius, or typography value.
+- Semantic tokens express intent such as surface, text, border, danger, success, focus, or interactive emphasis.
+- Component tokens are appropriate only when a reusable component needs a stable local contract that semantic tokens cannot express clearly.
+- Prefer semantic reuse over duplicating near-identical raw values across components.
+
+Cloak does not prescribe a specific token tool or file format unless the project already uses one.
+
+## Theme parity
+
+- A light-theme token and dark-theme token should preserve the same semantic purpose even when their raw values differ.
+- Contrast, hierarchy, disabled-state clarity, focus visibility, chart legibility, and error/success meaning must survive each supported theme.
+- Do not encode meaning through hue alone.
+- Avoid theme-specific exceptions that silently bypass the design-system token layer unless the exception is documented and evidence-backed.
+
+## Required state model
+
+Review the states that the component can actually enter. Typical states include:
+
+- default
+- hover when a hover-capable pointer exists
+- focus-visible
+- active or pressed
+- selected or current
+- disabled
+- read-only where applicable
+- loading or pending
+- empty where applicable
+- error or invalid
+- success or complete
+- permission-restricted where applicable
+
+Not every component needs every state. Missing states are findings only when the component can actually enter that condition.
+
+## State consistency
+
+- Visual state, accessibility state, and product state must describe the same condition.
+- Focus-visible treatment must not disappear merely because hover styling is active.
+- Disabled appearance must not be reused for read-only or permission-denied content when the user meaning differs.
+- Loading state should preserve enough layout and context to avoid confusing movement or duplicate action.
+- Error and success treatments need text or another perceivable cue in addition to color.
+
+## Variant discipline
+
+- Add a variant for a product or interaction need, not merely a one-off cosmetic preference.
+- Reuse the existing component before creating a near-duplicate component with different naming.
+- Keep variant names tied to purpose or state rather than page-specific styling.
+- If two variants behave differently, their interaction and accessibility contract must make that difference explicit.
+
+## Typography, spacing, and density
+
+- Typography tokens should preserve readable hierarchy and line spacing across responsive conditions.
+- Spacing should communicate grouping and separation consistently rather than act as arbitrary pixel tuning.
+- Dense modes must retain target size, focus visibility, readable labels, and error communication.
+- Localization and longer content must not break the component contract.
+
+## Motion tokens and transitions
+
+- Reuse established duration/easing conventions when motion serves a state transition.
+- Respect reduced-motion preferences.
+- Motion should clarify change, not become the only indication that state changed.
+
+## Evidence review
+
+For Figma or another design-system artifact, inspect available variables/tokens, component variants, properties, descriptions, annotations, and state coverage. Mark unavailable evidence as `NEEDS EVIDENCE` rather than inventing a token structure.
+
+## Handoff
+
+Cloak defines the design-system and state requirements. Ponytail owns implementation. Clockwork owns architecture or shared-state design when the component contract crosses system boundaries. Overseer owns state-matrix and visual-regression readiness evidence.

--- a/skills/cloak/FORM_FOCUS_VALIDATION_GUIDE.md
+++ b/skills/cloak/FORM_FOCUS_VALIDATION_GUIDE.md
@@ -1,0 +1,75 @@
+# Form, Focus, and Validation Guide
+
+Use this guide for forms, multi-step flows, authentication inputs, destructive confirmations, and other interactions where errors or state transitions can block task completion.
+
+## Field identity and grouping
+
+- Provide a persistent visible label for each field unless the control pattern has an equally clear native accessible name.
+- Group related controls with meaningful structure and instructions.
+- Distinguish required and optional fields consistently before submission.
+- Use input purpose, autocomplete, and platform-native control behavior when they reduce user effort and do not conflict with product requirements.
+- Do not use placeholder text as the only label or instruction.
+
+## Validation timing
+
+- Prevent avoidable errors before submission when the rule can be explained without interrupting normal entry.
+- Avoid aggressive validation that marks incomplete fields invalid while the user is still entering a reasonable value.
+- Revalidate authoritative constraints after submission or server response. Client-side validation improves UX but is not an enforcement boundary.
+- Async validation needs a visible pending state and must avoid racing older responses into the current field state.
+
+## Error communication
+
+A useful error tells the user what happened, where it happened, and how to recover.
+
+- Associate field-specific messages with their field.
+- Use `aria-invalid` and an accessible description relationship when appropriate to the implemented pattern.
+- Keep error text specific enough to guide correction without exposing sensitive backend or account-existence information.
+- Preserve the user's valid input after a failed submission.
+- For forms with multiple errors, provide an error summary when it materially improves navigation and recovery.
+- Do not rely on color, icon shape, or placement alone to communicate invalid state.
+
+## Focus after submission
+
+- On failed submission, move focus only when it improves recovery. Common destinations are the error summary or first invalid field according to the established product pattern.
+- Ensure the focused error target is not hidden behind sticky or fixed UI.
+- On successful submission, move or restore focus according to the resulting context. Do not leave focus on a removed control.
+- If a modal form closes, return focus to the logical invoking control when it still exists.
+
+## Submission ownership
+
+- Provide one authoritative submit path for the action.
+- Prevent accidental duplicate submission while an in-flight mutation owns completion.
+- A disabled control must still leave the reason and recovery path understandable. Do not strand users behind an unexplained disabled primary action.
+- Distinguish disabled, read-only, loading, and permission-restricted states. They have different user meanings and should not be styled as interchangeable.
+
+## Multi-step flows
+
+- Show current position and what remains when the sequence is long enough to need orientation.
+- Preserve completed valid data when users move backward or recover from errors.
+- Avoid forcing redundant entry of information already supplied unless a current safety or verification reason requires it.
+- Warn before abandoning unsaved work when loss would be meaningful, and provide a clear safe alternative.
+
+## Sensitive and destructive actions
+
+- Explain consequence before confirmation.
+- Avoid preselecting the destructive choice or using visual pressure to make cancellation harder.
+- Use additional confirmation only when the risk justifies the friction.
+- Authentication and recovery forms should not disclose whether an account exists unless product security policy explicitly allows that distinction.
+- Route security-policy decisions to Cipher and backend validation ownership to the appropriate engineering specialist.
+
+## Mobile and assistive-technology review
+
+- Verify the on-screen keyboard does not hide the active field, validation message, or primary action.
+- Verify zoom, reflow, text resizing, and orientation changes preserve labels and error relationships.
+- Verify dynamic submission status is perceivable without repeatedly stealing focus.
+- Verify touch targets and spacing support users with limited precision.
+
+## Evidence boundary
+
+Cloak defines form usability, focus, and user-visible validation requirements. Ponytail implements them, Cipher owns security policy, Clockwork owns state and architecture boundaries, and Overseer owns readiness testing.
+
+## Primary references
+
+- HTML forms: https://html.spec.whatwg.org/multipage/forms.html
+- WCAG 2.2: https://www.w3.org/TR/WCAG22/
+- WAI-ARIA Authoring Practices Guide: https://www.w3.org/WAI/ARIA/apg/

--- a/skills/cloak/FRONTEND_REVIEW_GUIDE.md
+++ b/skills/cloak/FRONTEND_REVIEW_GUIDE.md
@@ -1,11 +1,22 @@
 # Frontend Review Guide
 
-1. Identify the artifact sources reviewed, the target user, the primary task, the supported viewport, and the available rendered states.
-2. Inspect the smallest relevant component, style, state owner, and design-system evidence before making recommendations.
-3. Review form usability, user-facing validation messaging, and the visible loading, empty, error, success, retry, and permission states that affect the task.
-4. Report confirmed task, accessibility, containment, consistency, recovery, and design-system issues by severity. Separate confirmed evidence from assumptions and `NEEDS EVIDENCE`.
-5. Produce a frontend handoff blueprint that names semantic structure, affected components, design-system constraints, responsive or accessibility rules, and downstream routing boundaries without writing production code.
-6. Reuse native controls, current components, and existing tokens before suggesting new variants or dependencies.
-7. Verify build output and representative interaction states after implementation.
+1. Identify the artifact sources reviewed, target user, primary task, supported viewport range, themes, and available rendered states.
+2. Inspect the smallest relevant component, semantic structure, style/layout owner, current design tokens, route context, and design-system evidence before recommending changes.
+3. Review native HTML semantics, accessible names, ARIA state relationships, keyboard behavior, and focus movement when the surface contains interactive web UI.
+4. Review layout mechanics that can affect task completion: source order, flex/grid containment, intrinsic sizing, wrapping, overflow, clipping, fixed/sticky overlays, and narrow-width reflow.
+5. Review form usability, validation timing and messaging, submission ownership, focus after errors, and visible loading, empty, error, success, retry, permission, disabled, and read-only states that affect the task.
+6. Review client-side navigation at the user-visible contract level: current-location indication, deep links, Back/Forward behavior, route focus, not-found/permission states, and responsive navigation. Route internal state or architecture ownership to Clockwork.
+7. Review component-state and token consistency across supported themes. Reuse current tokens/components before proposing variants or dependencies.
+8. Report confirmed task, accessibility, containment, consistency, recovery, and design-system issues by severity. Separate confirmed evidence from assumptions and `NEEDS EVIDENCE`.
+9. Produce a frontend handoff blueprint that names semantic structure, affected components, token/state constraints, responsive rules, accessibility/focus requirements, route expectations, and downstream ownership without writing production code.
+10. Require current rendered evidence for visual correctness and route readiness testing to Overseer when the user asks for a readiness conclusion.
 
-Route implementation to `ponytail`, architecture and state ownership to `clockwork`, security policy to `cipher`, database semantics to `chronicler`, normal QA and validation gates to `overseer`, project documentation to `scribe`, system diagrams to `weaver`, and destructive guardrail pressure testing to gated `dagger`.
+Load deeper references only when the task needs them:
+
+- `SEMANTIC_HTML_ARIA_KEYBOARD_GUIDE.md`
+- `RESPONSIVE_CSS_LAYOUT_GUIDE.md`
+- `FORM_FOCUS_VALIDATION_GUIDE.md`
+- `DESIGN_TOKENS_COMPONENT_STATES_GUIDE.md`
+- `FRONTEND_ROUTING_COMPONENT_BOUNDARIES_GUIDE.md`
+
+Route implementation to `ponytail`, architecture and shared-state ownership to `clockwork`, security policy to `cipher`, database semantics to `chronicler`, normal QA and validation gates to `overseer`, project documentation to `scribe`, system diagrams to `weaver`, and destructive guardrail pressure testing to gated `dagger`.

--- a/skills/cloak/FRONTEND_ROUTING_COMPONENT_BOUNDARIES_GUIDE.md
+++ b/skills/cloak/FRONTEND_ROUTING_COMPONENT_BOUNDARIES_GUIDE.md
@@ -1,0 +1,76 @@
+# Frontend Routing and Component Boundary Guide
+
+Use this guide when UI structure involves client-side navigation, nested layouts, route-specific states, deep links, or reusable component boundaries. Cloak owns user-visible behavior, not application architecture.
+
+## Route experience contract
+
+For each user-visible route or screen, review:
+
+- entry path and primary user goal
+- page title and visible heading
+- active navigation indication
+- loading, empty, error, success, retry, permission, and not-found states when applicable
+- focus destination after navigation
+- back/forward behavior
+- deep-link behavior
+- responsive navigation behavior
+- unsaved-change recovery where relevant
+
+## Navigation semantics
+
+- Use one stable label for the same destination unless the contexts genuinely require different language.
+- Distinguish global, local, contextual, and utility navigation.
+- Current-location indication should be visually and programmatically perceivable.
+- A hidden navigation item is not authorization. Cipher owns access-control policy and enforcement review.
+- If a user can legitimately deep-link to a route, the direct route should provide the same understandable state and permissions as navigation through the menu.
+
+## Focus and route transitions
+
+- Route changes that replace the main view should provide a predictable context cue for keyboard and screen-reader users.
+- Preserve focus only when the same control remains the logical task continuation.
+- Do not leave focus on detached DOM content after route replacement.
+- Loading transitions should not repeatedly move focus while data resolves.
+- Error and permission states should provide a clear next action and a reachable navigation path.
+
+## History and recovery
+
+- Browser Back and Forward should not unexpectedly discard completed safe state or repeat destructive actions.
+- If unsaved user input would be lost, provide an evidence-backed warning and recovery path.
+- Redirects should not create loops or strand users on transient screens.
+- Scroll restoration should support the task rather than always forcing the same position.
+
+## Component boundary literacy
+
+Cloak may recommend a reusable visual/interaction boundary when repeated UI has the same user-visible contract.
+
+A useful component boundary usually has:
+
+- one clear user-facing responsibility
+- stable inputs and visible states
+- a consistent accessibility contract
+- predictable responsive behavior
+- reusable design-system constraints
+
+Cloak must not decide React provider architecture, query-cache ownership, service boundaries, persistence ownership, or business-rule placement. Route those decisions to Clockwork or the appropriate specialist.
+
+## Shared state warning signs
+
+Route architecture alignment to Clockwork when the UI review exposes:
+
+- duplicate sources of truth across route and component state
+- state synchronization loops
+- route guards that embed business authorization logic
+- components whose data ownership is unclear across nested routes
+- optimistic or cached state whose failure behavior changes the business contract
+- server/client rendering boundaries that affect authoritative state
+
+## Permission-aware UX
+
+- Navigation may hide unavailable actions to reduce confusion, but backend enforcement remains mandatory.
+- Permission-denied screens should explain the user-visible limitation without leaking sensitive policy details.
+- Avoid redirect behavior that makes an authorization failure look like missing data or a broken route.
+- Route policy and threat questions to Cipher.
+
+## Handoff
+
+Cloak hands off the user-visible route contract, semantic navigation structure, responsive shell behavior, focus expectations, and component-state matrix. Ponytail implements it. Clockwork owns architecture and state placement. Cipher owns authorization. Overseer owns route and state validation evidence.

--- a/skills/cloak/RESPONSIVE_CSS_LAYOUT_GUIDE.md
+++ b/skills/cloak/RESPONSIVE_CSS_LAYOUT_GUIDE.md
@@ -1,0 +1,71 @@
+# Responsive CSS Layout and Containment Guide
+
+Use this guide to diagnose layout risk and define implementation-ready responsive requirements without writing production CSS.
+
+## Layout model selection
+
+- Use normal document flow as the default baseline.
+- Use Flexbox for primarily one-dimensional distribution and alignment.
+- Use Grid when rows and columns need coordinated two-dimensional placement.
+- Nested layout models are valid when each level has a clear responsibility. Avoid layout mechanisms chosen only because they happen to make one screenshot align.
+- Preserve semantic DOM order even when visual layout changes across breakpoints.
+
+## Intrinsic sizing literacy
+
+Cloak should recognize common causes of unexpected overflow and compression.
+
+- Long unbroken text, intrinsic media sizes, minimum content sizes, and nested flex/grid containers can force a layout wider than its container.
+- A flex or grid child may need permission to shrink within its layout context. Diagnose the containing relationship before recommending arbitrary fixed widths.
+- Grid tracks should account for content that must shrink or wrap. Avoid layouts whose minimum track size silently preserves desktop width on narrow screens.
+- Media should respect its containing region and preserve meaningful aspect ratio unless product requirements explicitly call for cropping.
+
+## Overflow and clipping
+
+Treat overflow as a user-visible behavior decision, not merely a cosmetic property.
+
+- Horizontal scrolling on the entire page is usually a containment defect for ordinary application layouts.
+- Local horizontal scrolling can be appropriate for wide data tables, timelines, code, or other content whose two-dimensional relationship must remain intact.
+- Clipping must not hide focus indicators, validation messages, menus, tooltips, or actionable content.
+- Text truncation needs an evidence-backed reason. Critical labels, values, and error messages should remain perceivable without relying on hover-only disclosure.
+- Inspect ancestor overflow, positioning, transforms, and stacking contexts when popovers or focus rings appear cut off.
+
+## Breakpoints and reflow
+
+- Define breakpoints from content pressure and task preservation, not device-name folklore alone.
+- Preserve primary task order when columns collapse or navigation changes form.
+- Check the narrowest supported viewport, intermediate widths, landscape orientation, text enlargement, browser zoom, and long localized content.
+- A responsive design is not complete if a control is merely moved off-screen or hidden without an equivalent accessible path.
+- If container queries are already part of the project architecture, review component behavior against its actual container rather than assuming the full viewport controls every layout decision.
+
+## Fixed, sticky, and overlay UI
+
+- Fixed or sticky headers, footers, action bars, and cookie/consent surfaces must not cover focused controls or required content.
+- Account for mobile safe areas and on-screen keyboards when they can obscure form actions.
+- Verify nested scrolling does not trap keyboard or touch users inside an unexpected region.
+- Overlay layering should preserve one clear active interaction surface and predictable dismissal behavior.
+
+## Data-heavy surfaces
+
+For tables, dashboards, grids, and charts:
+
+- Preserve labels, units, legends, and critical comparisons at narrow widths.
+- Choose deliberately among column prioritization, wrapping, stacked summaries, local horizontal scroll, or alternate detail views.
+- Do not convert tabular relationships into visually convenient cards if that destroys comparisons users need to make.
+- Provide an accessible summary or data alternative when a chart alone cannot communicate the decision-relevant information.
+
+## Motion and responsive state
+
+- Layout changes should not create unnecessary motion or spatial disorientation.
+- Respect reduced-motion preferences when transitions or animated reflow are part of the experience.
+- Loading skeletons, drawers, accordions, and responsive navigation must preserve focus and state when viewport conditions change.
+
+## Review evidence
+
+A static source review may return `STATIC_UI_RISK_LOW`, `STATIC_UI_RISK_DETECTED`, or `STATIC_UI_RESULT_INCONCLUSIVE` according to Cloak's existing contract. Rendered correctness still requires current visual evidence.
+
+## Primary references
+
+- CSS Grid Layout: https://www.w3.org/TR/css-grid-2/
+- CSS Flexible Box Layout: https://www.w3.org/TR/css-flexbox-1/
+- CSS Overflow: https://www.w3.org/TR/css-overflow-3/
+- WCAG 2.2 reflow and focus requirements: https://www.w3.org/TR/WCAG22/

--- a/skills/cloak/SEMANTIC_HTML_ARIA_KEYBOARD_GUIDE.md
+++ b/skills/cloak/SEMANTIC_HTML_ARIA_KEYBOARD_GUIDE.md
@@ -1,0 +1,86 @@
+# Semantic HTML, ARIA, and Keyboard Interaction Guide
+
+Use this guide when a web UI review requires more depth than the base accessibility checklist. Cloak defines user-visible requirements and review criteria. Ponytail owns implementation code.
+
+## Native semantics first
+
+- Prefer native HTML elements whose built-in role and keyboard behavior match the interaction.
+- Treat ARIA as a semantic supplement, not a replacement for native behavior.
+- A custom role creates an interaction contract. If a component uses an ARIA widget role, its keyboard behavior, focus behavior, states, and accessible name must match that role.
+- Do not add redundant roles to native elements when the native semantics already express the requirement.
+- Do not place `aria-hidden="true"` on an element that contains focusable or interactive content.
+
+## Landmarks and document structure
+
+Review the page structure before individual widgets.
+
+- Require one clear main content region for the page task.
+- Use landmarks such as header, nav, main, aside, and footer when they represent the actual region purpose.
+- Preserve a logical heading hierarchy that communicates document structure rather than visual size alone.
+- Use section or article only when the content has a meaningful structural identity.
+- Keep DOM/source order aligned with reading order and keyboard order. Visual reordering must not create a different interaction sequence.
+
+## Accessible names and descriptions
+
+Every interactive control needs a stable accessible name.
+
+- Prefer visible text or an associated `label` for form controls.
+- Use `aria-labelledby` when another visible element already provides the correct name.
+- Use `aria-describedby` for supporting instructions, constraints, or error details that are useful in addition to the name.
+- Keep the visible label and accessible name aligned so voice-input and screen-reader users receive the same control identity.
+- Icon-only controls require an accessible name that communicates the action, not the icon shape.
+- Placeholder text is not a substitute for a persistent label.
+
+## ARIA state literacy
+
+Cloak should recognize common state relationships and verify that user-visible state and accessibility state do not diverge.
+
+- `aria-expanded` should reflect whether a controlled disclosure, menu, or region is currently expanded.
+- `aria-controls` may express a relationship when it materially helps identify the controlled region, but it does not create behavior by itself.
+- `aria-current` identifies the current item in a set such as navigation or a step sequence.
+- `aria-selected` represents selection in widgets whose role defines selectable items.
+- `aria-pressed` represents the state of a toggle button, not a generic selected style.
+- `aria-invalid` identifies a form value that is currently invalid and should be paired with useful correction guidance.
+- Live-region techniques such as `aria-live` should be reserved for dynamic information users need to perceive without moving focus. Avoid repeated or noisy announcements.
+
+## Keyboard interaction review
+
+- All interactive functionality must be reachable and operable without a pointer.
+- Preserve predictable Tab and Shift+Tab movement between components.
+- Avoid positive `tabindex` values used to manually reorder focus. Prefer a logical DOM order.
+- Native buttons activate with their platform/browser keyboard behavior. A custom button-like control must provide equivalent behavior if a native button cannot be used.
+- Composite widgets such as tabs, menus, listboxes, and grids require their pattern-specific keyboard model. Do not invent a novel arrow-key model when a recognized platform pattern applies.
+- Keyboard shortcuts must not conflict with text entry or create inaccessible single-character traps.
+
+## Focus management
+
+Focus should move only when doing so helps users understand a real context change.
+
+- When a modal dialog opens, move focus into the dialog and contain keyboard focus while it is modal.
+- Initial dialog focus should support comprehension and safe action. Do not automatically focus a destructive primary action merely because it is visually prominent.
+- When a dialog closes, return focus to the invoking control when that control still exists and remains the logical continuation point.
+- After client-side route or major view changes, provide a predictable focus destination such as the page heading or main content start when users otherwise lose context.
+- After failed form submission, focus an error summary or the first invalid field according to the product pattern, while preserving entered values.
+- Do not move focus for passive status messages that can be communicated through a live region.
+- Ensure sticky headers, overlays, and fixed controls do not visually obscure the focused element.
+
+## Dialog and disclosure review
+
+For dialogs, disclosures, tabs, menus, and other rich patterns:
+
+1. Confirm a native element or simpler pattern cannot meet the need first.
+2. Identify the expected role, state, accessible name, and keyboard model.
+3. Verify visible state and accessibility state stay synchronized.
+4. Verify initial focus, contained focus where required, Escape/cancel behavior when safe, and focus return.
+5. Verify the component remains understandable under zoom, reflow, high contrast, and reduced-motion conditions.
+
+## Evidence boundary
+
+A source-level review can identify probable semantic and focus defects, but it is not a rendered accessibility pass. Cloak must state what was inspected and route browser, assistive-technology, or formal conformance testing to Overseer when readiness evidence is required.
+
+## Primary references
+
+- WCAG 2.2: https://www.w3.org/TR/WCAG22/
+- WAI-ARIA Authoring Practices Guide: https://www.w3.org/WAI/ARIA/apg/
+- APG keyboard interface practice: https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/
+- HTML Living Standard: https://html.spec.whatwg.org/

--- a/skills/cloak/SKILL.md
+++ b/skills/cloak/SKILL.md
@@ -52,6 +52,11 @@ Do not apply `QUICK_UI_HANDOFF` or `FORMAL_UI_AUDIT` fields to Markdown document
 Use `SKILL.md` first. Do not load every supporting document by default or consume context with unused material.
 - Load `OUTPUT_FORMATS.md` only when generating the final response.
 - Load `UI_UX_FOUNDATIONS_GUIDE.md` only when the task involves UI/UX review, frontend experience, visual hierarchy, accessibility, forms, responsive layout, interaction design, secure UX, privacy-aware display, role-aware UI, validation messaging, sensitive action flows, or frontend behavior boundaries.
+- Load `SEMANTIC_HTML_ARIA_KEYBOARD_GUIDE.md` only for semantic HTML, accessible-name, ARIA state, keyboard-pattern, dialog, or focus-management depth.
+- Load `RESPONSIVE_CSS_LAYOUT_GUIDE.md` only for flex/grid containment, intrinsic sizing, overflow, clipping, breakpoints, sticky/fixed UI, or responsive data-heavy surfaces.
+- Load `FORM_FOCUS_VALIDATION_GUIDE.md` only for form labels, validation timing, errors, focus recovery, duplicate submission, multi-step flows, or destructive confirmations.
+- Load `DESIGN_TOKENS_COMPONENT_STATES_GUIDE.md` only for design-system tokens, variants, theme parity, component state matrices, or reusable state semantics.
+- Load `FRONTEND_ROUTING_COMPONENT_BOUNDARIES_GUIDE.md` only for user-visible route behavior, deep links, route focus, browser history, responsive navigation, or component-boundary review.
 - Load `templates/<template-name>.md` only when the user explicitly requests a specific aesthetic (e.g., `bryl-minimal`). Do not load templates by default.
 
 ## Artifact Evidence Review
@@ -137,6 +142,17 @@ Required rules:
 
 Cloak provides semantic structure requirements and review criteria. Ponytail owns the implementation code.
 
+## Deep Frontend Knowledge References
+
+Load only the smallest reference needed for the active UI problem:
+
+- `SEMANTIC_HTML_ARIA_KEYBOARD_GUIDE.md`: native semantics, accessible names/descriptions, ARIA state literacy, keyboard conventions, dialog/focus behavior.
+- `RESPONSIVE_CSS_LAYOUT_GUIDE.md`: flex/grid review, intrinsic sizing, overflow/clipping, responsive reflow, sticky/fixed surfaces, data-heavy layouts.
+- `FORM_FOCUS_VALIDATION_GUIDE.md`: field identity, validation timing, error recovery, focus after submission, duplicate-submission prevention, multi-step/destructive flows.
+- `DESIGN_TOKENS_COMPONENT_STATES_GUIDE.md`: token layers, theme parity, component states, variant discipline, density, and motion conventions.
+- `FRONTEND_ROUTING_COMPONENT_BOUNDARIES_GUIDE.md`: route experience, deep links, history, focus transitions, responsive navigation, permission-aware UX, and user-visible component boundaries.
+
+These are review and handoff references. They do not transfer implementation, architecture, security-policy, persistence, or readiness ownership to Cloak.
 ## Backend Alignment Trigger
 
 When a frontend design decision affects data flow, authentication, authorization, persistence, API shape, backend validation, audit logging, security, privacy, payments, integrations, or compliance-sensitive workflows, Cloak must not decide those backend-sensitive details independently.

--- a/skills/cloak/UI_UX_FOUNDATIONS_GUIDE.md
+++ b/skills/cloak/UI_UX_FOUNDATIONS_GUIDE.md
@@ -57,6 +57,17 @@
 - **Secure Onboarding/Recovery**: Provide safe, clear flows for login, onboarding, and password recovery.
 - **Audit Clarity**: Ensure actions that generate an audit log are clear to the user if relevant.
 
+## Deep Reference Loading
+
+Use the base guide for broad UI review, then load only the specialized reference needed by the evidence:
+
+- `SEMANTIC_HTML_ARIA_KEYBOARD_GUIDE.md` for semantic structure, accessible names/descriptions, ARIA states, keyboard patterns, dialogs, or focus movement.
+- `RESPONSIVE_CSS_LAYOUT_GUIDE.md` for flex/grid containment, intrinsic sizing, overflow/clipping, responsive reflow, fixed/sticky UI, or data-heavy surfaces.
+- `FORM_FOCUS_VALIDATION_GUIDE.md` for field identity, validation timing, error recovery, focus after submission, duplicate submission, multi-step forms, or destructive confirmations.
+- `DESIGN_TOKENS_COMPONENT_STATES_GUIDE.md` for tokens, themes, reusable component variants, and state matrices.
+- `FRONTEND_ROUTING_COMPONENT_BOUNDARIES_GUIDE.md` for route orientation, deep links, focus transitions, history/recovery, responsive navigation, or component-boundary review.
+
+Do not load all five by default. Progressive disclosure remains the context-efficiency rule.
 ## Handoff Blueprint Requirements
 - **Blueprint over Code**: Cloak hands off semantic structure, component intent, visible state expectations, and review findings, not production code.
 - **Design-System Constraints**: Name the token, component, and variant constraints that the implementation should preserve.

--- a/skills/cloak/examples/frontend-layout-review-example.md
+++ b/skills/cloak/examples/frontend-layout-review-example.md
@@ -1,14 +1,47 @@
 # Cloak Frontend-Layout Review
 
 ## Scope Reviewed
-- Artifact: Responsive account dashboard layout
-- User goal: Scan account status and reach primary actions
+- Artifact: Responsive account dashboard source and current desktop/mobile screenshots
+- User goal: Scan account status, understand alerts, and reach the primary account action
+- Evidence: DOM/source order, layout containers, current design tokens, 1440 px and 390 px screenshots
 
-## Confirmed Finding
-At narrow widths, the primary action moves below low-priority activity content.
+## Confirmed Findings
 
-## Recommendation
-Preserve task priority by placing the primary action after account status and before activity. Reuse the existing responsive layout primitives.
+### High - Task order diverges during narrow reflow
+The desktop grid presents account status, the primary action, and recent activity in that task order. At narrow widths the visual order places the complete activity feed before the primary action while the DOM order still places the action earlier. The user has to traverse a large secondary region visually before reaching the primary action.
+
+### Medium - Activity region can force horizontal overflow
+A nested grid keeps a minimum content width large enough that long transaction labels push the dashboard wider than the viewport. The screenshot shows clipping at the right edge, and the source contains no local overflow strategy for the activity region.
+
+### Medium - Sticky action bar can obscure focus
+The mobile action bar is fixed to the bottom edge. Current evidence does not show additional scroll padding or spacing that would keep the last focusable activity control visible above it.
+
+## Recommendations
+
+1. Preserve the primary task hierarchy when the grid collapses: account status, primary action, then secondary activity.
+2. Keep DOM order and keyboard order logical. Do not solve visual order by creating a different keyboard sequence.
+3. Let the activity container shrink within the grid and choose a deliberate local overflow/wrapping strategy for content that cannot fit.
+4. Reserve enough mobile scroll space that the fixed action bar cannot obscure a focused control or validation message.
+5. Reuse current layout primitives and spacing tokens rather than adding page-specific fixed widths.
+
+## Responsive Verification Matrix
+
+| Condition | Expected result |
+|---|---|
+| Narrow supported viewport | No page-level horizontal scrolling; primary action remains before secondary activity. |
+| 200% text zoom | Labels wrap without clipping controls or hiding status. |
+| Long localized account name | Header and action remain contained without overlap. |
+| Keyboard navigation | Focus order follows the logical task and focused controls remain visible. |
+| Reduced motion | Responsive changes do not depend on animated movement for comprehension. |
+
+## Handoff
+
+- Cloak: layout hierarchy, containment, focus-visibility requirements
+- Ponytail: implementation changes
+- Overseer: current rendered viewport, zoom, keyboard, and regression evidence
 
 ## Missing Evidence
-- Smallest supported viewport, text scaling, and keyboard order
+- Smallest formally supported viewport
+- Landscape mobile state
+- Virtual-keyboard interaction with the fixed action bar
+- Current browser matrix

--- a/skills/cloak/examples/interaction-flow-review-example.md
+++ b/skills/cloak/examples/interaction-flow-review-example.md
@@ -1,14 +1,50 @@
 # Cloak Interaction-Flow Review
 
 ## Scope Reviewed
-- Artifact: Account-deletion confirmation interaction
-- User goal: Understand consequences and cancel or confirm safely
+- Artifact: Account-deletion modal interaction and destructive-action copy
+- User goal: Understand consequences, cancel safely, or deliberately confirm deletion
+- Evidence: Dialog markup, focus order, button states, confirmation copy, and supplied keyboard recording
 
-## Confirmed Finding
-The destructive action receives initial keyboard focus while Cancel is visually secondary.
+## Confirmed Findings
 
-## Recommendation
-Focus the dialog heading or safe action, state the irreversible consequence, and require a deliberate confirmation without dark patterns.
+### Critical - Initial focus favors the destructive action
+When the modal opens, focus is placed directly on Delete account. The destructive action is also the strongest visual button. This makes an irreversible action the default keyboard continuation instead of prioritizing comprehension and safe cancellation.
+
+### High - Dialog description is not connected to the interaction
+The consequence text is visually present but is not included in the dialog's accessible description relationship. A screen-reader user can reach the controls without receiving the same consequence context.
+
+### Medium - Focus return is undefined
+The supplied flow closes the modal after Cancel, but the evidence does not establish where focus returns. Losing focus context after cancellation would make the interaction harder to recover from.
+
+## Recommendations
+
+1. Give the dialog a stable accessible name and connect the consequence text as supporting description.
+2. Place initial focus on a comprehension target or safe action according to the established product pattern, not automatically on the destructive action.
+3. Keep Tab and Shift+Tab inside the modal while it is active and provide a safe cancel path, including Escape when product requirements permit it.
+4. Return focus to the invoking Delete account control after cancellation when it still exists.
+5. Keep the irreversible consequence explicit and avoid styling or wording that pressures the user toward confirmation.
+6. After confirmed deletion, move focus to the resulting stable context rather than attempting to restore focus to removed account controls.
+
+## Keyboard and State Matrix
+
+| Event | Expected user-visible behavior |
+|---|---|
+| Open dialog | Focus enters the modal and consequence context is available. |
+| Tab / Shift+Tab | Focus remains within the active modal. |
+| Cancel | Dialog closes and focus returns to the logical invoker. |
+| Confirm while pending | One authoritative submission path owns completion; duplicate activation is blocked. |
+| Failure | Dialog remains recoverable with a clear error and safe retry/cancel path. |
+| Success | User is taken to a stable post-deletion context. |
+
+## Handoff
+
+- Cloak: dialog semantics, focus, hierarchy, destructive UX requirements
+- Cipher: security/re-authentication policy if deletion requires identity confirmation
+- Ponytail: implementation
+- Overseer: keyboard, screen-reader, and current rendered evidence
 
 ## Missing Evidence
-- Screen-reader announcement and post-confirmation state
+- Assistive-technology announcement of the current dialog
+- Re-authentication policy
+- Post-confirmation destination
+- Failure/retry behavior

--- a/skills/cloak/examples/navigation-structure-review-example.md
+++ b/skills/cloak/examples/navigation-structure-review-example.md
@@ -1,14 +1,50 @@
 # Cloak Navigation-Structure Review
 
 ## Scope Reviewed
-- Artifact: Analytics dashboard navigation map
-- User goal: Move between overview, reports, and saved views
+- Artifact: Analytics dashboard navigation map and route inventory
+- User goal: Move between Overview, Reports, and Saved views while retaining orientation
+- Evidence: Desktop navigation, mobile drawer, route labels, direct-link behavior, and permission-state screenshots
 
-## Confirmed Finding
-Saved views appear under both Reports and Settings with different labels.
+## Confirmed Findings
 
-## Recommendation
-Choose one task-based location, preserve a single label, and provide a shortcut from Reports only if usage evidence supports it.
+### High - Saved views has two competing navigation homes
+Saved views appears under Reports and Settings with different labels. Both entries navigate to the same destination, so users cannot build a stable mental model of where saved analysis belongs.
+
+### High - Direct route loses orientation
+Opening a saved-view deep link renders the content but does not mark a current navigation item or provide a route heading that names Saved views. The screen is usable but lacks location context.
+
+### Medium - Mobile navigation omits the current-state cue
+The desktop sidebar highlights the active section, while the mobile drawer only closes after navigation. The current destination is not identified when the drawer is reopened.
+
+## Recommendations
+
+1. Choose one task-based primary home for Saved views and use one stable label.
+2. If Reports needs a shortcut, present it as a contextual shortcut rather than a second primary navigation location.
+3. Ensure direct links render the same page title/heading, current-location cue, permission state, and recovery options as menu navigation.
+4. Preserve current-location indication in both desktop and mobile navigation.
+5. After a client-side route change, provide a predictable focus/context target such as the new page heading when focus would otherwise remain on a removed navigation control.
+6. Keep permission-based hiding as a usability rule only. Route authorization enforcement to Cipher.
+
+## Route Experience Matrix
+
+| Route condition | Expected result |
+|---|---|
+| Normal navigation | One active location and one visible page heading. |
+| Direct deep link | Same orientation and permission behavior as menu entry. |
+| Back / Forward | History returns to the prior logical view without duplicate navigation state. |
+| Permission denied | Clear limitation and safe next action without exposing sensitive policy detail. |
+| Not found | Distinct not-found state, not an ambiguous permission or empty-data screen. |
+| Mobile drawer | Current destination remains perceivable when navigation reopens. |
+
+## Handoff
+
+- Cloak: information architecture, route labels, current-location and focus requirements
+- Clockwork: client-side route/state architecture when ownership is unclear
+- Cipher: authorization policy
+- Ponytail: implementation
+- Overseer: direct-link, history, mobile, focus, and permission-state validation
 
 ## Missing Evidence
-- Search behavior, permissions, and mobile navigation
+- Search behavior across saved views
+- Unsaved-change handling
+- Browser history behavior after report filters

--- a/skills/cloak/examples/user-flow-review-example.md
+++ b/skills/cloak/examples/user-flow-review-example.md
@@ -1,15 +1,51 @@
 # Cloak User-Flow Review
 
 ## Scope Reviewed
-- Artifact: Checkout user-flow diagram
-- User goal: Review an order and complete payment
-- Evidence: User-facing steps and error branches
+- Artifact: Checkout user-flow diagram plus supplied payment error screens
+- User goal: Review an order, complete payment, and recover without re-entering valid information
+- Evidence: User-facing steps, validation branches, payment failure state, and success destination
 
-## Confirmed Finding
-The payment-failure branch returns to cart and discards the user's delivery selection.
+## Confirmed Findings
 
-## Recommendation
-Return to payment with prior valid selections preserved and a clear recoverable error. Route system sequence or service-message modeling to `weaver`.
+### Critical - Payment failure discards completed delivery work
+The payment-failure branch returns the user to Cart and clears the previously valid delivery selection. The user must repeat an unrelated completed step even though the failure occurred during payment.
+
+### High - Failure state does not identify ownership of retry
+The error screen shows both Retry payment and Return to cart with equal visual weight. It does not explain whether the existing payment attempt is still pending or safe to retry.
+
+### Medium - Focus destination after failure is unspecified
+The diagram shows the failed state but does not define where keyboard focus moves when the payment screen changes to the error state.
+
+## Recommendations
+
+1. Return the user to the payment step with prior valid delivery and order-review selections preserved unless the backend explicitly invalidated them.
+2. Provide one authoritative retry path and expose pending/completed state clearly enough to prevent duplicate payment actions.
+3. Put the actionable error and safe retry guidance near the payment task. Avoid generic failure text that forces users to infer what happened.
+4. Move focus to an error heading/summary when the failure replaces the current payment content and users would otherwise lose context.
+5. Keep Return to cart available as a secondary user-controlled exit without making it the only recovery route.
+6. Route payment-state idempotency, backend mutation ownership, and persistence semantics to Clockwork/Cipher/Chronicler as appropriate. Cloak owns only the user-visible recovery contract.
+
+## State Continuity Matrix
+
+| State | Preserve | Primary user action |
+|---|---|---|
+| Payment pending | Delivery choice, cart, order summary | Wait or cancel only when supported. |
+| Recoverable failure | Valid prior selections and entered non-sensitive data | Retry payment once. |
+| Payment declined | Order context | Choose another allowed payment method or exit safely. |
+| Session/permission failure | Only data policy permits retaining | Re-authenticate or follow the provided safe recovery path. |
+| Success | Final order summary | Continue to receipt/order status. |
+
+## Handoff
+
+- Cloak: user-visible state continuity, hierarchy, focus, and recovery path
+- Clockwork: payment-state and client/server ownership
+- Cipher: payment/authentication security policy
+- Chronicler: persistence semantics if state retention depends on stored records
+- Ponytail: implementation
+- Overseer: retry, duplicate-action, keyboard, and current rendered evidence
 
 ## Missing Evidence
-- Running error state and persistence behavior
+- Current idempotency/retry contract
+- Running focus behavior
+- Exact retention policy for sensitive payment fields
+- Persistence behavior across session expiry

--- a/tests/behavior/run_tests.py
+++ b/tests/behavior/run_tests.py
@@ -106,6 +106,7 @@ def main():
         {"Name": "test_governance_protocol_consistency.py", "Path": "tests/behavior/test_governance_protocol_consistency.py"},
         {"Name": "test_router_contracts.py", "Path": "tests/behavior/test_router_contracts.py"},
         {"Name": "test_codex_export_portable_references.py", "Path": "tests/behavior/test_codex_export_portable_references.py"},
+        {"Name": "test_cloak_specialist_knowledge.py", "Path": "tests/behavior/test_cloak_specialist_knowledge.py"},
         {"Name": "validate_tuner_collaboration_contract.py", "Path": "scripts/validate_tuner_collaboration_contract.py"},
         {"Name": "test_tuner_collaboration_contract.py", "Path": "tests/behavior/test_tuner_collaboration_contract.py"},
         {"Name": "validate_cross_layer_synchronicity_contract.py", "Path": "scripts/validate_cross_layer_synchronicity_contract.py"},

--- a/tests/behavior/test_cloak_specialist_knowledge.py
+++ b/tests/behavior/test_cloak_specialist_knowledge.py
@@ -1,0 +1,136 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE = ROOT / "skills" / "cloak"
+CODEX = ROOT / "adapters" / "codex" / "skills" / "cloak"
+
+REQUIRED_SUPPORT = [
+    "ACCESSIBILITY_CHECKLIST.md",
+    "CHECKLIST.md",
+    "FRONTEND_REVIEW_GUIDE.md",
+    "UI_UX_FOUNDATIONS_GUIDE.md",
+    "SEMANTIC_HTML_ARIA_KEYBOARD_GUIDE.md",
+    "RESPONSIVE_CSS_LAYOUT_GUIDE.md",
+    "FORM_FOCUS_VALIDATION_GUIDE.md",
+    "DESIGN_TOKENS_COMPONENT_STATES_GUIDE.md",
+    "FRONTEND_ROUTING_COMPONENT_BOUNDARIES_GUIDE.md",
+    "examples/frontend-layout-review-example.md",
+    "examples/interaction-flow-review-example.md",
+    "examples/navigation-structure-review-example.md",
+    "examples/user-flow-review-example.md",
+]
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def require(text: str, *needles: str) -> None:
+    missing = [needle for needle in needles if needle not in text]
+    if missing:
+        raise AssertionError(f"Missing required Cloak knowledge markers: {missing}")
+
+
+def main() -> None:
+    for relative in REQUIRED_SUPPORT:
+        source = SOURCE / relative
+        mirror = CODEX / relative
+        if not source.is_file():
+            raise AssertionError(f"Missing canonical Cloak support file: {relative}")
+        if not mirror.is_file():
+            raise AssertionError(f"Missing Codex Cloak support file: {relative}")
+        if source.read_bytes() != mirror.read_bytes():
+            raise AssertionError(f"Cloak source/Codex support parity failed: {relative}")
+
+    semantic = read(SOURCE / "SEMANTIC_HTML_ARIA_KEYBOARD_GUIDE.md")
+    require(
+        semantic,
+        "Native semantics first",
+        "aria-labelledby",
+        "aria-describedby",
+        "aria-expanded",
+        "aria-current",
+        "aria-invalid",
+        "aria-live",
+        "Focus management",
+        "WAI-ARIA Authoring Practices Guide",
+    )
+
+    responsive = read(SOURCE / "RESPONSIVE_CSS_LAYOUT_GUIDE.md")
+    require(
+        responsive,
+        "Flexbox",
+        "Grid",
+        "Intrinsic sizing literacy",
+        "Overflow and clipping",
+        "Breakpoints and reflow",
+        "Fixed, sticky, and overlay UI",
+        "Data-heavy surfaces",
+    )
+
+    forms = read(SOURCE / "FORM_FOCUS_VALIDATION_GUIDE.md")
+    require(
+        forms,
+        "Validation timing",
+        "aria-invalid",
+        "Focus after submission",
+        "duplicate submission",
+        "Multi-step flows",
+        "Sensitive and destructive actions",
+    )
+
+    tokens = read(SOURCE / "DESIGN_TOKENS_COMPONENT_STATES_GUIDE.md")
+    require(
+        tokens,
+        "Primitive tokens",
+        "Semantic tokens",
+        "Theme parity",
+        "focus-visible",
+        "disabled",
+        "read-only",
+        "loading",
+        "Variant discipline",
+    )
+
+    routing = read(SOURCE / "FRONTEND_ROUTING_COMPONENT_BOUNDARIES_GUIDE.md")
+    require(
+        routing,
+        "Route experience contract",
+        "deep-link",
+        "Back and Forward",
+        "Component boundary literacy",
+        "Permission-aware UX",
+        "Clockwork",
+        "Cipher",
+    )
+
+    skill = read(SOURCE / "SKILL.md")
+    for filename in [
+        "SEMANTIC_HTML_ARIA_KEYBOARD_GUIDE.md",
+        "RESPONSIVE_CSS_LAYOUT_GUIDE.md",
+        "FORM_FOCUS_VALIDATION_GUIDE.md",
+        "DESIGN_TOKENS_COMPONENT_STATES_GUIDE.md",
+        "FRONTEND_ROUTING_COMPONENT_BOUNDARIES_GUIDE.md",
+    ]:
+        if filename not in skill:
+            raise AssertionError(f"Cloak progressive disclosure does not reference {filename}")
+
+    for example in [
+        "frontend-layout-review-example.md",
+        "interaction-flow-review-example.md",
+        "navigation-structure-review-example.md",
+        "user-flow-review-example.md",
+    ]:
+        text = read(SOURCE / "examples" / example)
+        if len(text) < 1500:
+            raise AssertionError(f"Worked example is still too shallow: {example}")
+        require(text, "## Scope Reviewed", "## Confirmed Findings", "## Recommendations", "## Handoff", "## Missing Evidence")
+
+    if (SOURCE / "patterns").exists():
+        raise AssertionError("SK4 audit selected Markdown-only depth; unexpected Cloak patterns directory was added")
+
+    print(f"Cloak specialist knowledge regression passed for {len(REQUIRED_SUPPORT)} mirrored support files.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Expands Cloak's specialist frontend knowledge while preserving existing routing, authority, and ownership boundaries.

## Scope

- exact 31-path SK4 delta
- deeper semantic HTML, ARIA, keyboard, and focus guidance
- responsive CSS layout and containment guidance
- form, validation, focus-recovery, and submission-state guidance
- design token, theme, variant, and component-state guidance
- frontend route, deep-link, history, and user-visible component-boundary guidance
- four expanded worked examples
- canonical/Codex mirror parity and focused regression coverage
- no new Cloak JSON catalog because the SK4 audit found no concrete machine-readable need

## Validation

- focused Cloak knowledge regression: PASS
- Codex export validation: PASS
- authoritative behavior suite: PASS
- runtime suite: 541 passed
- runtime coverage: 94.31% (90% required)
- exact post-validation scope: 31 paths
- staged diff check: PASS
- signed implementation commit: `6bf83ae011248d80ea437ce9515e6aebb668765f`
- parent: `bbff41dd93413d09049c11c9b97ab5ec461e645e`
- GitHub commit verification: valid

## Boundaries

No release/publication, deployment or production mutation, installed-integration refresh, policy activation, destructive cleanup, branch deletion, force push, or history rewrite is included.