### PR TITLE
feat(chronicler): add specialist persistence knowledge layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Post-v1.2.0 Specialist Knowledge Layer - SK6 Chronicler - Pending
+
+- Deepened Chronicler's persistence knowledge without changing routing, runtime architecture, schema state, or database execution authority.
+- Added engine-evidence guidance for PostgreSQL, MySQL, SQL Server, and SQLite plus ORM mapping and migration-state semantics.
+- Added progressive-disclosure guidance for transaction isolation, MVCC, locking, deadlock analysis, query-plan evidence, tenant isolation, and expand-contract zero-downtime migrations.
+- Expanded database standards and review checks for dialect/version identity, ORM/schema parity, lock and retry behavior, tenant predicates and composite integrity, plan estimates, backfill checkpoints, and compatibility windows.
+- Added a planning-only worked expand-contract migration example with bounded batches, read/write compatibility, validation, rollback boundaries, and no executable production command.
+- Kept the campaign Markdown-primary and JSON-selective: the SK6 audit found no deterministic machine-parsing need that justified a Chronicler JSON catalog.
+- Added focused regression coverage for Chronicler knowledge depth, progressive disclosure, source/Codex parity, and the no-execution boundary.
+- No schema change, migration execution, live-data access, destructive SQL, release/tag publication, deployment/production mutation, installed-integration refresh, policy activation, destructive cleanup, branch deletion, force push, or history rewrite is performed by SK6.
+
 ## Post-v1.2.0 Specialist Knowledge Layer - SK5 Dagger - Pending
 
 - Deepened Dagger's safe resilience knowledge without changing routing, runtime architecture, or execution authority.

--- a/adapters/codex/skills/chronicler/DATABASE_CHECKLIST.md
+++ b/adapters/codex/skills/chronicler/DATABASE_CHECKLIST.md
@@ -5,6 +5,7 @@
 - [ ] Database role and review objective are explicit.
 - [ ] Authoritative schema, migration, dump, or live metadata is identified.
 - [ ] Environment and mutation authority are known.
+- [ ] Engine, major version, topology, schema revision, ORM/provider, and migration tool are confirmed.
 
 ## Tables and columns
 
@@ -25,6 +26,20 @@
 - [ ] Redundant and overlapping indexes are identified.
 - [ ] Repeating groups, partial dependencies, and transitive dependencies are reviewed.
 - [ ] Denormalization has evidence and a consistency plan.
+- [ ] Query-plan evidence includes estimates versus actuals, access path, joins, sorts, spills, and representative parameters where available.
+
+## ORM and transaction semantics
+
+- [ ] ORM mapping matches schema types, nullability, keys, cascades, generated values, and concurrency controls.
+- [ ] Generated SQL avoids hidden N+1 access, unbounded materialization, accidental client evaluation, and unsafe bulk-write behavior.
+- [ ] Isolation requirements name the anomalies to prevent and account for confirmed engine behavior.
+- [ ] Lock order, transaction duration, retry ownership, idempotency, timeouts, and deadlock evidence are reviewed.
+
+## Tenant isolation
+
+- [ ] Tenant identity participates in required keys, foreign keys, uniqueness, indexes, and query predicates.
+- [ ] Cross-tenant relationships are impossible at the persistence boundary where required.
+- [ ] Row-level security, session context, and pooled-connection reset behavior are validated when applicable.
 
 ## Reference and seed data
 
@@ -37,6 +52,9 @@
 - [ ] Migration order, preconditions, data transformation, and recovery are documented.
 - [ ] Destructive operations require approval and backup or rollback planning.
 - [ ] Required actor, time, and change-history evidence is retained safely.
+- [ ] Compatibility across old and new application versions is explicit for every expand, backfill, validation, switch, and contract step.
+- [ ] Backfill batching, checkpointing, throttling, lock/replication limits, observability, and restart behavior are defined.
+- [ ] Destructive contract steps remain delayed and separately authorized.
 
 ## Reporting and integration
 

--- a/adapters/codex/skills/chronicler/DATABASE_DIALECT_ORM_GUIDE.md
+++ b/adapters/codex/skills/chronicler/DATABASE_DIALECT_ORM_GUIDE.md
@@ -1,0 +1,45 @@
+# Database Dialect and ORM Guide
+
+Use this guide only after repository evidence identifies the database engine, major version, schema revision, ORM/provider, and migration tool. A product name without a version is insufficient for syntax or operational claims.
+
+## Dialect Evidence
+
+| Surface | PostgreSQL | MySQL | SQL Server | SQLite |
+| --- | --- | --- | --- | --- |
+| Generated identity | Identity or sequence behavior is version and mapping dependent | `AUTO_INCREMENT` behavior depends on engine and mode | `IDENTITY` or sequence mapping affects insert behavior | `INTEGER PRIMARY KEY` has rowid-specific semantics |
+| Upsert | `ON CONFLICT` needs an exact conflict target | `ON DUPLICATE KEY UPDATE` may react to any matching unique key | `MERGE` has product-specific concurrency cautions; prefer evidence-backed alternatives | `ON CONFLICT` support depends on bundled version |
+| Boolean and time | Native boolean and time-zone-aware types exist | Boolean aliases, modes, and timestamp conversion require verification | `bit`, datetime families, and session settings differ | Dynamic typing and adapter conversion require explicit checks |
+| DDL behavior | Lock level and rewrite behavior vary by operation and version | Online/in-place labels do not guarantee no blocking | Online options depend on edition, operation, and version | Many alterations rebuild a table through tool-managed steps |
+
+This table is a review cue, not executable syntax. Confirm behavior in the vendor documentation for the exact version and validate on representative non-production data.
+
+## ORM Mapping Review
+
+Trace both directions:
+
+```text
+domain field -> ORM metadata -> generated SQL -> database column/constraint
+database default/generated value -> returned row -> ORM state -> domain field
+```
+
+Check:
+
+- type width, precision, collation, time zone, enum conversion, and nullability;
+- primary, alternate, and composite keys plus foreign-key column order;
+- cascade, orphan removal, eager/lazy loading, and ownership of relationship changes;
+- optimistic concurrency tokens and the affected-row behavior for stale writes;
+- server-generated identifiers/defaults and whether the ORM refreshes them;
+- query filters, soft-delete rules, and tenant predicates on every access path;
+- migrations generated from the same model/provider version that production will use.
+
+## Generated SQL Failure Modes
+
+- N+1 reads hidden by navigation access;
+- Cartesian multiplication from multiple collection joins;
+- client-side filtering after broad materialization;
+- per-row writes where a bounded set operation is intended;
+- missing concurrency predicate on update or delete;
+- schema-qualified or case-sensitive identifiers that differ by environment;
+- migration-history drift where the database, migration ledger, and ORM model disagree.
+
+Never resolve migration-history drift by deleting ledger rows or marking a migration applied without proving exact schema equivalence and obtaining mutation authority. Ponytail implements an accepted mapping change. Overseer owns executable validation. Cipher owns authorization and sensitive-data policy.

--- a/adapters/codex/skills/chronicler/DATABASE_STANDARDS.md
+++ b/adapters/codex/skills/chronicler/DATABASE_STANDARDS.md
@@ -2,6 +2,12 @@
 
 Apply these standards to confirmed requirements and database evidence, not hypothetical scale.
 
+## Engine and Mapping Identity
+
+- Record the database product, major version, deployment topology, schema revision, migration tool, and ORM/provider version before engine-specific conclusions.
+- Compare ORM mappings and generated SQL with the canonical schema, including names, types, nullability, defaults, keys, cascades, concurrency tokens, and value generation.
+- Treat ORM auto-generation and schema synchronization as environment-sensitive behavior, not a substitute for reviewed migrations.
+
 ## Tables and Columns
 
 - Give each table one coherent subject and stable ownership.
@@ -33,6 +39,19 @@ Apply these standards to confirmed requirements and database evidence, not hypot
 - Tie indexes to known joins, filters, ordering, uniqueness, or measured bottlenecks.
 - Review selectivity, column order, covering needs, write cost, and overlap.
 - Avoid speculative or duplicate indexes.
+- Use actual or safely captured query plans to distinguish scans, seeks, join choices, row-estimate errors, spills, and sort or lookup cost before changing an index.
+
+## Transactions and Concurrency
+
+- Choose isolation from required anomaly prevention and confirmed engine semantics, not from a portable label alone.
+- Keep transactions bounded and define retry ownership, idempotency, lock order, timeout handling, and post-failure readback where contention is possible.
+- Diagnose deadlocks from wait and victim evidence. Do not mask deterministic lock-order defects with unbounded retries.
+
+## Tenant Isolation
+
+- Carry tenant identity through keys, unique constraints, foreign keys, indexes, and every tenant-scoped query when the data model is shared.
+- Validate database-enforced row policies against connection and pooling behavior when row-level security is used.
+- Route tenant authorization policy to Cipher while Chronicler owns persistence enforcement mechanics.
 
 ## Normalization
 
@@ -57,6 +76,8 @@ Apply these standards to confirmed requirements and database evidence, not hypot
 - Make order, prerequisites, data transformation, rollback or recovery, and deployment impact explicit.
 - Separate destructive steps and require approval.
 - Test migrations against representative data and verify constraints afterward.
+- Prefer expand, migrate, validate, contract sequencing when old and new application versions overlap.
+- Bound backfills by stable keys, make checkpoints resumable, measure lock and replication impact, and delay incompatible cleanup until all readers and writers have moved.
 
 ## Data Dictionaries and Documentation
 

--- a/adapters/codex/skills/chronicler/QUERY_PLAN_TENANT_ISOLATION_GUIDE.md
+++ b/adapters/codex/skills/chronicler/QUERY_PLAN_TENANT_ISOLATION_GUIDE.md
@@ -1,0 +1,37 @@
+# Query Plan and Tenant Isolation Guide
+
+## Query-Plan Evidence
+
+Use the engine's read-only or safely bounded plan facility appropriate to the environment. `EXPLAIN` may estimate only; `EXPLAIN ANALYZE` or equivalent can execute the statement and requires execution authority, safe parameters, and a non-production target for mutations or expensive reads.
+
+Capture:
+
+- engine/version, schema and statistics revision, representative parameter shape, and plan format;
+- estimated versus actual rows at the first material divergence;
+- access method, join type/order, filters, rows removed, sorts, memory grants, spills, loops, and elapsed/I/O metrics where available;
+- parameter-sensitive behavior and whether the captured plan is reusable or atypical;
+- the invariant and workload that an index or query change must preserve.
+
+Common evidence patterns:
+
+- severe estimate error can indicate stale statistics, correlated predicates, skew, or an expression the estimator cannot model;
+- a sequential scan is not automatically wrong, especially for small tables or low-selectivity predicates;
+- an index seek plus many lookups can cost more than a scan;
+- functions, implicit conversions, leading wildcards, or mismatched collations can make a predicate non-sargable;
+- adding an index trades read benefit for write, storage, maintenance, and lock cost.
+
+Do not claim improvement from plan shape alone. Compare result correctness and measured behavior under representative parameters.
+
+## Tenant Isolation Mechanics
+
+For shared-table models, evaluate whether tenant identity is part of:
+
+- primary or alternate identity where business identifiers are tenant-local;
+- composite foreign keys, so a child cannot reference another tenant's parent;
+- unique constraints, so uniqueness scope matches the domain;
+- leading or otherwise justified index columns for tenant-scoped access paths;
+- every read, write, aggregation, background job, export, and maintenance predicate.
+
+Database row-level security can add defense in depth, but verify policy coverage, owner/bypass roles, session-context setup, connection-pool reset, prepared statements, maintenance paths, and failure behavior. A query filter in an ORM is not by itself a database isolation guarantee.
+
+Use adversarial validation with two synthetic tenants in a non-production environment: attempt cross-tenant inserts, relationship changes, direct-key reads, aggregates, bulk operations, and pooled-connection reuse. Cipher owns the authorization policy; Chronicler owns schema, predicate, key, and row-policy mechanics; Overseer owns the acceptance evidence.

--- a/adapters/codex/skills/chronicler/SKILL.md
+++ b/adapters/codex/skills/chronicler/SKILL.md
@@ -73,6 +73,10 @@ Use `SKILL.md` first. Do not load every supporting document by default or consum
 - Load [DATABASE_STANDARDS.md](DATABASE_STANDARDS.md) and [DATABASE_CHECKLIST.md](DATABASE_CHECKLIST.md) for reviews.
 - Load [SQL_REVIEW_GUIDE.md](SQL_REVIEW_GUIDE.md) only for SQL review.
 - Load [SQL_FOUNDATIONS_GUIDE.md](SQL_FOUNDATIONS_GUIDE.md) only when the task involves SQL reasoning, query design, report generation, joins, subqueries, views, aggregation, validation queries, or business-report data logic.
+- Load [DATABASE_DIALECT_ORM_GUIDE.md](DATABASE_DIALECT_ORM_GUIDE.md) when engine/version behavior, ORM mappings, generated SQL, or migration-state tracking is material.
+- Load [TRANSACTION_ISOLATION_LOCKING_GUIDE.md](TRANSACTION_ISOLATION_LOCKING_GUIDE.md) for isolation, MVCC, concurrency anomalies, locks, deadlocks, retries, or long-running transaction review.
+- Load [QUERY_PLAN_TENANT_ISOLATION_GUIDE.md](QUERY_PLAN_TENANT_ISOLATION_GUIDE.md) for plan analysis, index evidence, row-estimate errors, tenant predicates, or database-enforced tenant isolation.
+- Load [ZERO_DOWNTIME_MIGRATION_GUIDE.md](ZERO_DOWNTIME_MIGRATION_GUIDE.md) for compatibility-window, backfill, expand-contract, online DDL, or phased schema-change planning.
 
 ## Operating principles
 
@@ -81,6 +85,8 @@ Use `SKILL.md` first. Do not load every supporting document by default or consum
 - Do not invent tables, collections, columns, constraints, indexes, relationships, query patterns, or data rules.
 - Separate confirmed facts, assumptions, and missing evidence.
 - Prefer data integrity and migration safety over complete-looking output.
+- Confirm the database engine, major version, schema revision, ORM/provider version, and migration tool before making dialect-specific claims.
+- Treat example SQL and migration patterns as planning guidance until the exact non-production environment and execution authority are confirmed.
 
 ## Supported work
 
@@ -100,6 +106,7 @@ Use `SKILL.md` first. Do not load every supporting document by default or consum
 - **No redundant comments**: Maximize signal, minimize noise.
 - Apply least-privilege awareness when permissions are in scope and use Codex Security for a security audit.
 - Do not run destructive SQL or expose credentials, production data, or sensitive records.
+- Do not present generic isolation, locking, online-DDL, ORM, or query-plan behavior as portable across engines.
 
 ## Output formats
 

--- a/adapters/codex/skills/chronicler/TRANSACTION_ISOLATION_LOCKING_GUIDE.md
+++ b/adapters/codex/skills/chronicler/TRANSACTION_ISOLATION_LOCKING_GUIDE.md
@@ -1,0 +1,34 @@
+# Transaction Isolation and Locking Guide
+
+Isolation names are not portable behavioral guarantees. Start with the invariant and anomaly, then confirm the target engine's MVCC, snapshot, and locking behavior for its exact version and configuration.
+
+## Anomaly-to-Evidence Map
+
+| Risk | Evidence to reproduce or exclude | Persistence response to evaluate |
+| --- | --- | --- |
+| Dirty read | Reader observes a value later rolled back | Minimum isolation and engine configuration |
+| Non-repeatable read | Same row changes inside one logical transaction | Row/version protection or stronger snapshot boundary |
+| Phantom or write skew | A predicate changes or two writers preserve local checks but violate a global invariant | Predicate protection, constraint redesign, serialization, or explicit locking |
+| Lost update | Two writers read one version and one update silently replaces the other | Atomic update, version predicate, lock, or conflict result |
+| Duplicate effect | Retry commits the same logical action more than once | Idempotency key and uniqueness at the persistence boundary |
+
+Do not choose `READ COMMITTED`, `REPEATABLE READ`, `SERIALIZABLE`, or snapshot isolation from the label alone. Record the invariant, concurrent schedule, observed result, engine/version, and retry behavior.
+
+## Locking Review
+
+- Identify the locked object or key range, acquisition order, duration, wait timeout, and escalation behavior.
+- Keep external calls and user think-time outside transactions.
+- Use `NOWAIT` or `SKIP LOCKED` only when the product semantics explicitly allow fail-fast or work-skipping behavior.
+- Verify queue consumers cannot starve old rows or process one logical item twice.
+- Treat long-running readers, idle transactions, DDL, and maintenance jobs as possible blockers.
+
+## Deadlock Diagnosis
+
+1. Capture the deadlock graph or equivalent victim/wait evidence.
+2. Map each statement to its transaction boundary and lock acquisition order.
+3. Reproduce with deterministic coordination, not timing-only sleeps.
+4. Prefer a consistent lock order or smaller atomic boundary.
+5. Add bounded retry only for engine-classified transient victims and only when the operation is idempotent.
+6. Verify rollback removed partial state and the retry produced one logical effect.
+
+Unbounded retries can amplify contention. A timeout without wait evidence does not prove a deadlock. Chronicler defines persistence semantics, Clockwork owns broader concurrency boundaries, Ponytail implements, and Overseer defines the concurrency validation gate.

--- a/adapters/codex/skills/chronicler/ZERO_DOWNTIME_MIGRATION_GUIDE.md
+++ b/adapters/codex/skills/chronicler/ZERO_DOWNTIME_MIGRATION_GUIDE.md
@@ -1,0 +1,31 @@
+# Zero-Downtime Migration Guide
+
+"Zero downtime" is a target that requires observed compatibility and availability evidence. It is not guaranteed by an ORM generator, an `ONLINE` option, or an additive-looking statement.
+
+## Expand-Migrate-Contract
+
+1. **Expand:** add backward-compatible structures. Avoid new required columns without a safe default/backfill plan.
+2. **Deploy compatible writers:** write the new representation while preserving old readers. Prefer one authoritative write with a deliberate compatibility mechanism over unconstrained application dual writes.
+3. **Backfill:** process stable-key batches with checkpoints, bounded transactions, throttling, restart safety, and replica/lock telemetry.
+4. **Validate:** compare counts, nulls, duplicates, checksums or business invariants, and application readback. Record lag and error budgets.
+5. **Switch reads:** move consumers gradually while old and new representations remain compatible.
+6. **Contract:** remove old columns, constraints, triggers, or compatibility code only after all readers/writers have moved, rollback no longer depends on them, and destructive authority is separately granted.
+
+## Operation Review
+
+For each DDL or data step, confirm engine/version behavior for metadata locks, table rewrite, index build, transaction-log/WAL growth, replication lag, disk headroom, cancellation, and recovery. Online DDL can still block briefly or fall back to a heavier algorithm.
+
+Backfill evidence must include:
+
+- stable batch key and ordering;
+- checkpoint and idempotent restart rule;
+- batch size and pause/throttle controls;
+- rows attempted, changed, skipped, and failed;
+- lock waits, latency, replica lag, log growth, and remaining work;
+- invariant queries that return rows only on mismatch.
+
+## Rollback Boundaries
+
+Additive expansion is usually reversible by application rollback while compatibility remains. Once old data or structures are removed, rollback may require restore or forward repair. Mark that point explicitly and do not cross it automatically.
+
+Migration files and example SQL remain `PLANNED_UNEXECUTED` until an exact environment, backup/recovery position, command, operator, window, stop conditions, and mutation authority are recorded. Never infer production authority from a validated plan.

--- a/adapters/codex/skills/chronicler/examples/zero-downtime-schema-change-example.md
+++ b/adapters/codex/skills/chronicler/examples/zero-downtime-schema-change-example.md
@@ -1,0 +1,35 @@
+# Planning-Only Expand-Contract Example
+
+## Status
+
+`PLANNED_UNEXECUTED`. No schema or data mutation occurred.
+
+## Confirmed Inputs
+
+- Target: PostgreSQL 16 non-production clone, exact schema revision recorded in the execution packet.
+- Existing readers require `customer.display_name`.
+- Target model separates `given_name` and `family_name` while preserving the old field during compatibility.
+- Production execution, destructive cleanup, and live-data access are not authorized by this example.
+
+## Phase Plan
+
+1. Expand with nullable target columns after confirming the exact lock behavior for the reviewed DDL.
+2. Deploy a compatible writer that maintains the old representation and derives the new fields under one accepted transaction contract.
+3. Backfill by stable `customer_id` ranges using resumable checkpoints and bounded transactions.
+4. Validate mismatches, null coverage, duplicate effects, application readback, lock waits, WAL growth, and replica lag.
+5. Switch reads behind a reversible application control while monitoring both representations.
+6. Treat removal of `display_name` and compatibility code as a later destructive contract step requiring separate authority.
+
+## Stop Conditions
+
+- lock wait or request latency exceeds the approved bound;
+- replica lag, WAL growth, error rate, or disk headroom crosses its recorded threshold;
+- a validation query returns a mismatch;
+- checkpoint progress cannot resume idempotently;
+- an old reader or writer remains active before contract.
+
+## Evidence Packet
+
+Record engine/version, schema and application revisions, reviewed migration hash, batch configuration, pre-state, per-batch counts, telemetry timeline, invariant results, post-state, rollback boundary, and operator disposition.
+
+This example is guidance only. Ponytail may implement an accepted migration artifact, Overseer defines execution evidence, Clockwork owns application compatibility boundaries, Cipher reviews sensitive-data and tenant-policy concerns, and Conductor controls sequencing. No executable production command is provided.

--- a/skills/chronicler/DATABASE_CHECKLIST.md
+++ b/skills/chronicler/DATABASE_CHECKLIST.md
@@ -5,6 +5,7 @@
 - [ ] Database role and review objective are explicit.
 - [ ] Authoritative schema, migration, dump, or live metadata is identified.
 - [ ] Environment and mutation authority are known.
+- [ ] Engine, major version, topology, schema revision, ORM/provider, and migration tool are confirmed.
 
 ## Tables and columns
 
@@ -25,6 +26,20 @@
 - [ ] Redundant and overlapping indexes are identified.
 - [ ] Repeating groups, partial dependencies, and transitive dependencies are reviewed.
 - [ ] Denormalization has evidence and a consistency plan.
+- [ ] Query-plan evidence includes estimates versus actuals, access path, joins, sorts, spills, and representative parameters where available.
+
+## ORM and transaction semantics
+
+- [ ] ORM mapping matches schema types, nullability, keys, cascades, generated values, and concurrency controls.
+- [ ] Generated SQL avoids hidden N+1 access, unbounded materialization, accidental client evaluation, and unsafe bulk-write behavior.
+- [ ] Isolation requirements name the anomalies to prevent and account for confirmed engine behavior.
+- [ ] Lock order, transaction duration, retry ownership, idempotency, timeouts, and deadlock evidence are reviewed.
+
+## Tenant isolation
+
+- [ ] Tenant identity participates in required keys, foreign keys, uniqueness, indexes, and query predicates.
+- [ ] Cross-tenant relationships are impossible at the persistence boundary where required.
+- [ ] Row-level security, session context, and pooled-connection reset behavior are validated when applicable.
 
 ## Reference and seed data
 
@@ -37,6 +52,9 @@
 - [ ] Migration order, preconditions, data transformation, and recovery are documented.
 - [ ] Destructive operations require approval and backup or rollback planning.
 - [ ] Required actor, time, and change-history evidence is retained safely.
+- [ ] Compatibility across old and new application versions is explicit for every expand, backfill, validation, switch, and contract step.
+- [ ] Backfill batching, checkpointing, throttling, lock/replication limits, observability, and restart behavior are defined.
+- [ ] Destructive contract steps remain delayed and separately authorized.
 
 ## Reporting and integration
 

--- a/skills/chronicler/DATABASE_DIALECT_ORM_GUIDE.md
+++ b/skills/chronicler/DATABASE_DIALECT_ORM_GUIDE.md
@@ -1,0 +1,45 @@
+# Database Dialect and ORM Guide
+
+Use this guide only after repository evidence identifies the database engine, major version, schema revision, ORM/provider, and migration tool. A product name without a version is insufficient for syntax or operational claims.
+
+## Dialect Evidence
+
+| Surface | PostgreSQL | MySQL | SQL Server | SQLite |
+| --- | --- | --- | --- | --- |
+| Generated identity | Identity or sequence behavior is version and mapping dependent | `AUTO_INCREMENT` behavior depends on engine and mode | `IDENTITY` or sequence mapping affects insert behavior | `INTEGER PRIMARY KEY` has rowid-specific semantics |
+| Upsert | `ON CONFLICT` needs an exact conflict target | `ON DUPLICATE KEY UPDATE` may react to any matching unique key | `MERGE` has product-specific concurrency cautions; prefer evidence-backed alternatives | `ON CONFLICT` support depends on bundled version |
+| Boolean and time | Native boolean and time-zone-aware types exist | Boolean aliases, modes, and timestamp conversion require verification | `bit`, datetime families, and session settings differ | Dynamic typing and adapter conversion require explicit checks |
+| DDL behavior | Lock level and rewrite behavior vary by operation and version | Online/in-place labels do not guarantee no blocking | Online options depend on edition, operation, and version | Many alterations rebuild a table through tool-managed steps |
+
+This table is a review cue, not executable syntax. Confirm behavior in the vendor documentation for the exact version and validate on representative non-production data.
+
+## ORM Mapping Review
+
+Trace both directions:
+
+```text
+domain field -> ORM metadata -> generated SQL -> database column/constraint
+database default/generated value -> returned row -> ORM state -> domain field
+```
+
+Check:
+
+- type width, precision, collation, time zone, enum conversion, and nullability;
+- primary, alternate, and composite keys plus foreign-key column order;
+- cascade, orphan removal, eager/lazy loading, and ownership of relationship changes;
+- optimistic concurrency tokens and the affected-row behavior for stale writes;
+- server-generated identifiers/defaults and whether the ORM refreshes them;
+- query filters, soft-delete rules, and tenant predicates on every access path;
+- migrations generated from the same model/provider version that production will use.
+
+## Generated SQL Failure Modes
+
+- N+1 reads hidden by navigation access;
+- Cartesian multiplication from multiple collection joins;
+- client-side filtering after broad materialization;
+- per-row writes where a bounded set operation is intended;
+- missing concurrency predicate on update or delete;
+- schema-qualified or case-sensitive identifiers that differ by environment;
+- migration-history drift where the database, migration ledger, and ORM model disagree.
+
+Never resolve migration-history drift by deleting ledger rows or marking a migration applied without proving exact schema equivalence and obtaining mutation authority. Ponytail implements an accepted mapping change. Overseer owns executable validation. Cipher owns authorization and sensitive-data policy.

--- a/skills/chronicler/DATABASE_STANDARDS.md
+++ b/skills/chronicler/DATABASE_STANDARDS.md
@@ -2,6 +2,12 @@
 
 Apply these standards to confirmed requirements and database evidence, not hypothetical scale.
 
+## Engine and Mapping Identity
+
+- Record the database product, major version, deployment topology, schema revision, migration tool, and ORM/provider version before engine-specific conclusions.
+- Compare ORM mappings and generated SQL with the canonical schema, including names, types, nullability, defaults, keys, cascades, concurrency tokens, and value generation.
+- Treat ORM auto-generation and schema synchronization as environment-sensitive behavior, not a substitute for reviewed migrations.
+
 ## Tables and Columns
 
 - Give each table one coherent subject and stable ownership.
@@ -33,6 +39,19 @@ Apply these standards to confirmed requirements and database evidence, not hypot
 - Tie indexes to known joins, filters, ordering, uniqueness, or measured bottlenecks.
 - Review selectivity, column order, covering needs, write cost, and overlap.
 - Avoid speculative or duplicate indexes.
+- Use actual or safely captured query plans to distinguish scans, seeks, join choices, row-estimate errors, spills, and sort or lookup cost before changing an index.
+
+## Transactions and Concurrency
+
+- Choose isolation from required anomaly prevention and confirmed engine semantics, not from a portable label alone.
+- Keep transactions bounded and define retry ownership, idempotency, lock order, timeout handling, and post-failure readback where contention is possible.
+- Diagnose deadlocks from wait and victim evidence. Do not mask deterministic lock-order defects with unbounded retries.
+
+## Tenant Isolation
+
+- Carry tenant identity through keys, unique constraints, foreign keys, indexes, and every tenant-scoped query when the data model is shared.
+- Validate database-enforced row policies against connection and pooling behavior when row-level security is used.
+- Route tenant authorization policy to Cipher while Chronicler owns persistence enforcement mechanics.
 
 ## Normalization
 
@@ -57,6 +76,8 @@ Apply these standards to confirmed requirements and database evidence, not hypot
 - Make order, prerequisites, data transformation, rollback or recovery, and deployment impact explicit.
 - Separate destructive steps and require approval.
 - Test migrations against representative data and verify constraints afterward.
+- Prefer expand, migrate, validate, contract sequencing when old and new application versions overlap.
+- Bound backfills by stable keys, make checkpoints resumable, measure lock and replication impact, and delay incompatible cleanup until all readers and writers have moved.
 
 ## Data Dictionaries and Documentation
 

--- a/skills/chronicler/QUERY_PLAN_TENANT_ISOLATION_GUIDE.md
+++ b/skills/chronicler/QUERY_PLAN_TENANT_ISOLATION_GUIDE.md
@@ -1,0 +1,37 @@
+# Query Plan and Tenant Isolation Guide
+
+## Query-Plan Evidence
+
+Use the engine's read-only or safely bounded plan facility appropriate to the environment. `EXPLAIN` may estimate only; `EXPLAIN ANALYZE` or equivalent can execute the statement and requires execution authority, safe parameters, and a non-production target for mutations or expensive reads.
+
+Capture:
+
+- engine/version, schema and statistics revision, representative parameter shape, and plan format;
+- estimated versus actual rows at the first material divergence;
+- access method, join type/order, filters, rows removed, sorts, memory grants, spills, loops, and elapsed/I/O metrics where available;
+- parameter-sensitive behavior and whether the captured plan is reusable or atypical;
+- the invariant and workload that an index or query change must preserve.
+
+Common evidence patterns:
+
+- severe estimate error can indicate stale statistics, correlated predicates, skew, or an expression the estimator cannot model;
+- a sequential scan is not automatically wrong, especially for small tables or low-selectivity predicates;
+- an index seek plus many lookups can cost more than a scan;
+- functions, implicit conversions, leading wildcards, or mismatched collations can make a predicate non-sargable;
+- adding an index trades read benefit for write, storage, maintenance, and lock cost.
+
+Do not claim improvement from plan shape alone. Compare result correctness and measured behavior under representative parameters.
+
+## Tenant Isolation Mechanics
+
+For shared-table models, evaluate whether tenant identity is part of:
+
+- primary or alternate identity where business identifiers are tenant-local;
+- composite foreign keys, so a child cannot reference another tenant's parent;
+- unique constraints, so uniqueness scope matches the domain;
+- leading or otherwise justified index columns for tenant-scoped access paths;
+- every read, write, aggregation, background job, export, and maintenance predicate.
+
+Database row-level security can add defense in depth, but verify policy coverage, owner/bypass roles, session-context setup, connection-pool reset, prepared statements, maintenance paths, and failure behavior. A query filter in an ORM is not by itself a database isolation guarantee.
+
+Use adversarial validation with two synthetic tenants in a non-production environment: attempt cross-tenant inserts, relationship changes, direct-key reads, aggregates, bulk operations, and pooled-connection reuse. Cipher owns the authorization policy; Chronicler owns schema, predicate, key, and row-policy mechanics; Overseer owns the acceptance evidence.

--- a/skills/chronicler/SKILL.md
+++ b/skills/chronicler/SKILL.md
@@ -80,6 +80,10 @@ Use `SKILL.md` first. Do not load every supporting document by default or consum
 - Load [DATABASE_STANDARDS.md](DATABASE_STANDARDS.md) and [DATABASE_CHECKLIST.md](DATABASE_CHECKLIST.md) for reviews.
 - Load [SQL_REVIEW_GUIDE.md](SQL_REVIEW_GUIDE.md) only for SQL review.
 - Load [SQL_FOUNDATIONS_GUIDE.md](SQL_FOUNDATIONS_GUIDE.md) only when the task involves SQL reasoning, query design, report generation, joins, subqueries, views, aggregation, validation queries, or business-report data logic.
+- Load [DATABASE_DIALECT_ORM_GUIDE.md](DATABASE_DIALECT_ORM_GUIDE.md) when engine/version behavior, ORM mappings, generated SQL, or migration-state tracking is material.
+- Load [TRANSACTION_ISOLATION_LOCKING_GUIDE.md](TRANSACTION_ISOLATION_LOCKING_GUIDE.md) for isolation, MVCC, concurrency anomalies, locks, deadlocks, retries, or long-running transaction review.
+- Load [QUERY_PLAN_TENANT_ISOLATION_GUIDE.md](QUERY_PLAN_TENANT_ISOLATION_GUIDE.md) for plan analysis, index evidence, row-estimate errors, tenant predicates, or database-enforced tenant isolation.
+- Load [ZERO_DOWNTIME_MIGRATION_GUIDE.md](ZERO_DOWNTIME_MIGRATION_GUIDE.md) for compatibility-window, backfill, expand-contract, online DDL, or phased schema-change planning.
 
 ## Operating principles
 
@@ -88,6 +92,8 @@ Use `SKILL.md` first. Do not load every supporting document by default or consum
 - Do not invent tables, collections, columns, constraints, indexes, relationships, query patterns, or data rules.
 - Separate confirmed facts, assumptions, and missing evidence.
 - Prefer data integrity and migration safety over complete-looking output.
+- Confirm the database engine, major version, schema revision, ORM/provider version, and migration tool before making dialect-specific claims.
+- Treat example SQL and migration patterns as planning guidance until the exact non-production environment and execution authority are confirmed.
 
 ## Supported work
 
@@ -107,6 +113,7 @@ Use `SKILL.md` first. Do not load every supporting document by default or consum
 - **No redundant comments**: Maximize signal, minimize noise.
 - Apply least-privilege awareness when permissions are in scope and use Codex Security for a security audit.
 - Do not run destructive SQL or expose credentials, production data, or sensitive records.
+- Do not present generic isolation, locking, online-DDL, ORM, or query-plan behavior as portable across engines.
 
 ## Output formats
 

--- a/skills/chronicler/TRANSACTION_ISOLATION_LOCKING_GUIDE.md
+++ b/skills/chronicler/TRANSACTION_ISOLATION_LOCKING_GUIDE.md
@@ -1,0 +1,34 @@
+# Transaction Isolation and Locking Guide
+
+Isolation names are not portable behavioral guarantees. Start with the invariant and anomaly, then confirm the target engine's MVCC, snapshot, and locking behavior for its exact version and configuration.
+
+## Anomaly-to-Evidence Map
+
+| Risk | Evidence to reproduce or exclude | Persistence response to evaluate |
+| --- | --- | --- |
+| Dirty read | Reader observes a value later rolled back | Minimum isolation and engine configuration |
+| Non-repeatable read | Same row changes inside one logical transaction | Row/version protection or stronger snapshot boundary |
+| Phantom or write skew | A predicate changes or two writers preserve local checks but violate a global invariant | Predicate protection, constraint redesign, serialization, or explicit locking |
+| Lost update | Two writers read one version and one update silently replaces the other | Atomic update, version predicate, lock, or conflict result |
+| Duplicate effect | Retry commits the same logical action more than once | Idempotency key and uniqueness at the persistence boundary |
+
+Do not choose `READ COMMITTED`, `REPEATABLE READ`, `SERIALIZABLE`, or snapshot isolation from the label alone. Record the invariant, concurrent schedule, observed result, engine/version, and retry behavior.
+
+## Locking Review
+
+- Identify the locked object or key range, acquisition order, duration, wait timeout, and escalation behavior.
+- Keep external calls and user think-time outside transactions.
+- Use `NOWAIT` or `SKIP LOCKED` only when the product semantics explicitly allow fail-fast or work-skipping behavior.
+- Verify queue consumers cannot starve old rows or process one logical item twice.
+- Treat long-running readers, idle transactions, DDL, and maintenance jobs as possible blockers.
+
+## Deadlock Diagnosis
+
+1. Capture the deadlock graph or equivalent victim/wait evidence.
+2. Map each statement to its transaction boundary and lock acquisition order.
+3. Reproduce with deterministic coordination, not timing-only sleeps.
+4. Prefer a consistent lock order or smaller atomic boundary.
+5. Add bounded retry only for engine-classified transient victims and only when the operation is idempotent.
+6. Verify rollback removed partial state and the retry produced one logical effect.
+
+Unbounded retries can amplify contention. A timeout without wait evidence does not prove a deadlock. Chronicler defines persistence semantics, Clockwork owns broader concurrency boundaries, Ponytail implements, and Overseer defines the concurrency validation gate.

--- a/skills/chronicler/ZERO_DOWNTIME_MIGRATION_GUIDE.md
+++ b/skills/chronicler/ZERO_DOWNTIME_MIGRATION_GUIDE.md
@@ -1,0 +1,31 @@
+# Zero-Downtime Migration Guide
+
+"Zero downtime" is a target that requires observed compatibility and availability evidence. It is not guaranteed by an ORM generator, an `ONLINE` option, or an additive-looking statement.
+
+## Expand-Migrate-Contract
+
+1. **Expand:** add backward-compatible structures. Avoid new required columns without a safe default/backfill plan.
+2. **Deploy compatible writers:** write the new representation while preserving old readers. Prefer one authoritative write with a deliberate compatibility mechanism over unconstrained application dual writes.
+3. **Backfill:** process stable-key batches with checkpoints, bounded transactions, throttling, restart safety, and replica/lock telemetry.
+4. **Validate:** compare counts, nulls, duplicates, checksums or business invariants, and application readback. Record lag and error budgets.
+5. **Switch reads:** move consumers gradually while old and new representations remain compatible.
+6. **Contract:** remove old columns, constraints, triggers, or compatibility code only after all readers/writers have moved, rollback no longer depends on them, and destructive authority is separately granted.
+
+## Operation Review
+
+For each DDL or data step, confirm engine/version behavior for metadata locks, table rewrite, index build, transaction-log/WAL growth, replication lag, disk headroom, cancellation, and recovery. Online DDL can still block briefly or fall back to a heavier algorithm.
+
+Backfill evidence must include:
+
+- stable batch key and ordering;
+- checkpoint and idempotent restart rule;
+- batch size and pause/throttle controls;
+- rows attempted, changed, skipped, and failed;
+- lock waits, latency, replica lag, log growth, and remaining work;
+- invariant queries that return rows only on mismatch.
+
+## Rollback Boundaries
+
+Additive expansion is usually reversible by application rollback while compatibility remains. Once old data or structures are removed, rollback may require restore or forward repair. Mark that point explicitly and do not cross it automatically.
+
+Migration files and example SQL remain `PLANNED_UNEXECUTED` until an exact environment, backup/recovery position, command, operator, window, stop conditions, and mutation authority are recorded. Never infer production authority from a validated plan.

--- a/skills/chronicler/examples/zero-downtime-schema-change-example.md
+++ b/skills/chronicler/examples/zero-downtime-schema-change-example.md
@@ -1,0 +1,35 @@
+# Planning-Only Expand-Contract Example
+
+## Status
+
+`PLANNED_UNEXECUTED`. No schema or data mutation occurred.
+
+## Confirmed Inputs
+
+- Target: PostgreSQL 16 non-production clone, exact schema revision recorded in the execution packet.
+- Existing readers require `customer.display_name`.
+- Target model separates `given_name` and `family_name` while preserving the old field during compatibility.
+- Production execution, destructive cleanup, and live-data access are not authorized by this example.
+
+## Phase Plan
+
+1. Expand with nullable target columns after confirming the exact lock behavior for the reviewed DDL.
+2. Deploy a compatible writer that maintains the old representation and derives the new fields under one accepted transaction contract.
+3. Backfill by stable `customer_id` ranges using resumable checkpoints and bounded transactions.
+4. Validate mismatches, null coverage, duplicate effects, application readback, lock waits, WAL growth, and replica lag.
+5. Switch reads behind a reversible application control while monitoring both representations.
+6. Treat removal of `display_name` and compatibility code as a later destructive contract step requiring separate authority.
+
+## Stop Conditions
+
+- lock wait or request latency exceeds the approved bound;
+- replica lag, WAL growth, error rate, or disk headroom crosses its recorded threshold;
+- a validation query returns a mismatch;
+- checkpoint progress cannot resume idempotently;
+- an old reader or writer remains active before contract.
+
+## Evidence Packet
+
+Record engine/version, schema and application revisions, reviewed migration hash, batch configuration, pre-state, per-batch counts, telemetry timeline, invariant results, post-state, rollback boundary, and operator disposition.
+
+This example is guidance only. Ponytail may implement an accepted migration artifact, Overseer defines execution evidence, Clockwork owns application compatibility boundaries, Cipher reviews sensitive-data and tenant-policy concerns, and Conductor controls sequencing. No executable production command is provided.

--- a/tests/behavior/run_tests.py
+++ b/tests/behavior/run_tests.py
@@ -108,6 +108,7 @@ def main():
         {"Name": "test_codex_export_portable_references.py", "Path": "tests/behavior/test_codex_export_portable_references.py"},
         {"Name": "test_cloak_specialist_knowledge.py", "Path": "tests/behavior/test_cloak_specialist_knowledge.py"},
         {"Name": "test_dagger_specialist_knowledge.py", "Path": "tests/behavior/test_dagger_specialist_knowledge.py"},
+        {"Name": "test_chronicler_specialist_knowledge.py", "Path": "tests/behavior/test_chronicler_specialist_knowledge.py"},
         {"Name": "validate_tuner_collaboration_contract.py", "Path": "scripts/validate_tuner_collaboration_contract.py"},
         {"Name": "test_tuner_collaboration_contract.py", "Path": "tests/behavior/test_tuner_collaboration_contract.py"},
         {"Name": "validate_cross_layer_synchronicity_contract.py", "Path": "scripts/validate_cross_layer_synchronicity_contract.py"},

--- a/tests/behavior/test_chronicler_specialist_knowledge.py
+++ b/tests/behavior/test_chronicler_specialist_knowledge.py
@@ -1,0 +1,126 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE = ROOT / "skills" / "chronicler"
+CODEX = ROOT / "adapters" / "codex" / "skills" / "chronicler"
+
+REQUIRED_SUPPORT = [
+    "DATABASE_CHECKLIST.md",
+    "DATABASE_STANDARDS.md",
+    "DB_DOCUMENTATION_TEMPLATES.md",
+    "OUTPUT_FORMATS.md",
+    "SQL_FOUNDATIONS_GUIDE.md",
+    "SQL_REVIEW_GUIDE.md",
+    "DATABASE_DIALECT_ORM_GUIDE.md",
+    "TRANSACTION_ISOLATION_LOCKING_GUIDE.md",
+    "QUERY_PLAN_TENANT_ISOLATION_GUIDE.md",
+    "ZERO_DOWNTIME_MIGRATION_GUIDE.md",
+    "examples/constraints-review-example.md",
+    "examples/database-documentation-example.md",
+    "examples/erd-database-review-example.md",
+    "examples/schema-review-example.md",
+    "examples/seed-data-review-example.md",
+    "examples/zero-downtime-schema-change-example.md",
+]
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def require(text: str, *needles: str) -> None:
+    missing = [needle for needle in needles if needle not in text]
+    if missing:
+        raise AssertionError(f"Missing required Chronicler knowledge markers: {missing}")
+
+
+def main() -> None:
+    for relative in REQUIRED_SUPPORT:
+        source = SOURCE / relative
+        mirror = CODEX / relative
+        if not source.is_file():
+            raise AssertionError(f"Missing canonical Chronicler support file: {relative}")
+        if not mirror.is_file():
+            raise AssertionError(f"Missing Codex Chronicler support file: {relative}")
+        if source.read_bytes() != mirror.read_bytes():
+            raise AssertionError(f"Chronicler source/Codex support parity failed: {relative}")
+
+    skill = read(SOURCE / "SKILL.md")
+    for filename in [
+        "DATABASE_DIALECT_ORM_GUIDE.md",
+        "TRANSACTION_ISOLATION_LOCKING_GUIDE.md",
+        "QUERY_PLAN_TENANT_ISOLATION_GUIDE.md",
+        "ZERO_DOWNTIME_MIGRATION_GUIDE.md",
+    ]:
+        if filename not in skill:
+            raise AssertionError(f"Chronicler progressive disclosure does not reference {filename}")
+    require(skill, "engine, major version", "example SQL and migration patterns as planning guidance")
+
+    dialect = read(SOURCE / "DATABASE_DIALECT_ORM_GUIDE.md")
+    require(
+        dialect,
+        "PostgreSQL",
+        "MySQL",
+        "SQL Server",
+        "SQLite",
+        "generated SQL",
+        "optimistic concurrency tokens",
+        "migration-history drift",
+    )
+
+    transactions = read(SOURCE / "TRANSACTION_ISOLATION_LOCKING_GUIDE.md")
+    require(
+        transactions,
+        "READ COMMITTED",
+        "REPEATABLE READ",
+        "SERIALIZABLE",
+        "snapshot isolation",
+        "write skew",
+        "deadlock graph",
+        "bounded retry",
+    )
+
+    plans = read(SOURCE / "QUERY_PLAN_TENANT_ISOLATION_GUIDE.md")
+    require(
+        plans,
+        "EXPLAIN ANALYZE",
+        "estimated versus actual rows",
+        "non-sargable",
+        "composite foreign keys",
+        "connection-pool reset",
+        "two synthetic tenants",
+    )
+
+    migration = read(SOURCE / "ZERO_DOWNTIME_MIGRATION_GUIDE.md")
+    require(
+        migration,
+        "Expand-Migrate-Contract",
+        "stable-key batches",
+        "replication lag",
+        "Rollback Boundaries",
+        "`PLANNED_UNEXECUTED`",
+        "Never infer production authority",
+    )
+
+    example = read(SOURCE / "examples" / "zero-downtime-schema-change-example.md")
+    require(
+        example,
+        "`PLANNED_UNEXECUTED`",
+        "No schema or data mutation occurred",
+        "PostgreSQL 16 non-production clone",
+        "Stop Conditions",
+        "No executable production command is provided",
+    )
+
+    if (SOURCE / "patterns").exists():
+        raise AssertionError("SK6 audit selected Markdown-only depth; unexpected Chronicler patterns directory was added")
+
+    print(
+        "Chronicler specialist knowledge regression passed for "
+        f"{len(REQUIRED_SUPPORT)} mirrored support files with no database execution."
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Result

Completes the bounded SK6 Chronicler knowledge expansion for the Specialist Knowledge Layer campaign without changing routing, runtime architecture, schema state, or database execution authority.

## Knowledge added

- engine/version and ORM mapping semantics for PostgreSQL, MySQL, SQL Server, and SQLite
- transaction isolation, MVCC, locking, deadlock, retry, and idempotency review
- query-plan evidence and tenant-isolation persistence mechanics
- expand-migrate-contract zero-downtime schema-change planning
- planning-only worked migration example with explicit stop and rollback boundaries
- expanded database standards and checklist

## Exact scope

19 paths: 8 canonical Chronicler paths, their 8 Codex paths, `CHANGELOG.md`, the behavior runner, and one focused regression.

Markdown remains primary. No JSON catalog was added because the audit found no deterministic parsing need.

## Validation

- focused Chronicler regression: PASS, 16 mirrored support files
- Codex portable-reference and export validation: PASS
- complete behavior suite: PASS
- runtime: 541 passed, 94.31% coverage, 90% gate
- strict governance: PASS, 0 errors, 0 warnings
- manifest/stale-reference/router benchmark/negative fixture checks: PASS
- enforced runtime guardrail and pre-commit hook: PASS
- exact scope, source/Codex parity, diff, secret, and em-dash checks: PASS

The prompt-load report retains pre-existing advisory soft-limit breaches for Group B and grand total; SK6 does not modify those prompt groups and the checker exits green by policy.

## Safety and protected actions

No schema change, migration execution, SQL execution, live-data access, destructive operation, release/tag publication, deployment/production mutation, installed-integration refresh, policy activation, branch deletion, force push, or history rewrite was performed.