### PR TITLE
feat(scribe): add specialist documentation knowledge layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Post-v1.2.0 Specialist Knowledge Layer - SK8 Scribe - Pending
+
+- Deepened Scribe's technical-documentation knowledge without changing routing, runtime architecture, publication state, or domain-specialist ownership.
+- Added progressive-disclosure guidance for CommonMark/GitHub-Flavored Markdown, changelog and ADR conventions, API/reference documentation, versioned documentation, deprecation/sunset records, claim freshness, and cross-link/anchor validation.
+- Expanded documentation standards and audit checks for heading/anchor stability, fenced code and tables, source revisions, effective dates, verified commands, API examples, version selectors, redirects, and broken-link reporting.
+- Added a worked source-backed API change example that separates verified current behavior, compatibility status, planned work, and release authority.
+- Kept the campaign Markdown-primary and JSON-selective: the SK8 audit found no deterministic machine-parsing need that justified a Scribe JSON catalog.
+- Added focused regression coverage for Scribe knowledge depth, progressive disclosure, source/Codex parity, link/claim discipline, and no-publication boundaries.
+- No release/tag publication, documentation-site deployment, installed-integration refresh, policy activation, destructive cleanup, branch deletion, force push, or history rewrite is performed by SK8.
+
 ## Post-v1.2.0 Specialist Knowledge Layer - SK7 Overseer - Pending
 
 - Deepened Overseer's validation-strategy knowledge without changing routing, runtime architecture, CI workflows, release gates, or test-code ownership.

--- a/adapters/codex/skills/scribe/API_VERSIONED_DOCUMENTATION_GUIDE.md
+++ b/adapters/codex/skills/scribe/API_VERSIONED_DOCUMENTATION_GUIDE.md
@@ -1,0 +1,28 @@
+# API and Versioned Documentation Guide
+
+## API Reference Source
+
+Start from the exact OpenAPI/AsyncAPI/schema revision, route definitions, generated reference artifact, or verified implementation. Record the contract revision and supported server/client version.
+
+For each operation document method/topic, path/channel, purpose, authentication reference, parameters, headers, request schema, response/status variants, error envelope, idempotency or pagination behavior, rate/size limits, and examples only when confirmed.
+
+Examples must conform to the schema and must not contain credentials or personal records. A `200` example cannot stand in for error, authorization, validation, conflict, or retry behavior.
+
+## Compatibility and Change
+
+Identify additive versus breaking changes under the repository's actual compatibility policy. Cover renamed/removed fields, requiredness, enum expansion, defaulting, precision, ordering, unknown-field behavior, and event replay where relevant. Clockwork owns interface compatibility decisions; Cipher owns auth/security requirements; Chronicler owns stored-data semantics.
+
+## Versioned Documentation
+
+Distinguish:
+
+- current documentation for the canonical supported version;
+- supported-previous documentation with explicit support status;
+- archived documentation that is read-only and clearly non-current;
+- future/draft documentation labeled as unimplemented.
+
+Define canonical URLs, version selector behavior, redirects, search indexing, cross-version links, and code-sample version alignment. Avoid silently redirecting an old incompatible API page to current behavior.
+
+## Deprecation and Sunset
+
+Record what is deprecated, first affected version, replacement, migration steps, warning channel, effective date, sunset/removal date if approved, support contact, and source authority. Do not invent dates or imply removal authority from documentation alone.

--- a/adapters/codex/skills/scribe/AUDIT_CHECKLIST.md
+++ b/adapters/codex/skills/scribe/AUDIT_CHECKLIST.md
@@ -20,6 +20,12 @@
 - [ ] Technical claims cite current artifacts.
 - [ ] Test results identify real commands or evidence.
 - [ ] Assumptions and unverified claims are marked.
+- [ ] Drift-prone claims record source revision, last-verified date, and effective date when relevant.
+
+## Markdown and Links
+- [ ] Heading hierarchy, generated anchors, reference links, images, code fences, lists, and tables render under the target Markdown engine.
+- [ ] Relative links resolve from the containing file with correct case and fragments.
+- [ ] External links identify authoritative sources and inaccessible targets are marked unverified.
 
 ## Traceability
 - [ ] Objectives map to requirements, implementation, tests, and readiness evidence.
@@ -41,6 +47,13 @@
 ## Versioning
 - [ ] Current status, version, branch, or release is identifiable when needed.
 - [ ] Stale version claims and screenshots are removed or updated.
+- [ ] Current, supported-previous, archived, deprecated, and removed content are distinguished.
+- [ ] Redirects, canonical URLs, migration guidance, and sunset/effective dates match approved evidence.
+
+## Changelog, ADR, and API Reference
+- [ ] Changelog entries describe verified user impact and do not imply an unpublished release.
+- [ ] ADR identifiers, status, context, decision, consequences, and supersession links are complete.
+- [ ] API operations, parameters, schemas, examples, errors, and authentication references match the exact documented contract revision.
 
 ## Diagrams Referenced Correctly
 - [ ] Diagram names, links, legends, scope, and current or proposed status match written claims.

--- a/adapters/codex/skills/scribe/CHANGELOG_ADR_GUIDE.md
+++ b/adapters/codex/skills/scribe/CHANGELOG_ADR_GUIDE.md
@@ -1,0 +1,26 @@
+# Changelog and ADR Guide
+
+## Changelog Discipline
+
+Write for users and operators. Group verified changes under Added, Changed, Deprecated, Removed, Fixed, or Security only when those categories help. Keep pending work in `Unreleased` or the repository's established pending section.
+
+Do not create a release heading, release date, comparison link, or compatibility promise until canonical release evidence exists. A merged change is not automatically published.
+
+Each entry should state the affected capability and observable impact. Link the issue, PR, migration, advisory, or documentation when it helps recovery or adoption. Avoid raw commit messages and internal-only refactors with no user impact.
+
+## Architecture Decision Records
+
+An ADR records:
+
+- stable identifier and title;
+- status such as Proposed, Accepted, Rejected, Deprecated, or Superseded;
+- decision/effective date and owners where established;
+- context and constraints;
+- the accepted decision;
+- alternatives considered and why they were not selected;
+- consequences, risks, and follow-up validation;
+- source artifacts and related ADRs.
+
+Do not rewrite an accepted ADR to make history look current. Create a new ADR, mark the old one superseded, and link both directions. A proposal remains Proposed until the authorized decision owner accepts it.
+
+Scribe records a decision supplied by Clockwork or the relevant authority; Scribe does not choose architecture or governance outcomes.

--- a/adapters/codex/skills/scribe/DOCUMENTATION_STANDARDS.md
+++ b/adapters/codex/skills/scribe/DOCUMENTATION_STANDARDS.md
@@ -6,6 +6,14 @@ Use only the sections relevant to the document. Evidence and project requirement
 - Map important claims to source evidence, specialist output, or verified project artifacts.
 - Mark unverified, draft, planned, blocked, skipped, or not-run items explicitly.
 - Do not present proposals, assumptions, or planned work as completed behavior.
+- Record source revision, last-verified date, and effective date where claims can drift.
+
+## Markdown and Rendering
+
+- Use one document title, hierarchical headings without skipped levels, fenced code blocks with language identifiers, and blank lines that render consistently under the target CommonMark/GFM implementation.
+- Prefer descriptive link text and repository-relative links for versioned local content. Keep explicit HTML rare and renderer-tested.
+- Keep tables simple, escape literal pipes, and provide a list or prose alternative when a wide table harms accessibility or narrow rendering.
+- Treat generated heading anchors as renderer-specific. Validate fragments after renaming headings.
 
 ## README
 
@@ -63,12 +71,27 @@ Use only the sections relevant to the document. Evidence and project requirement
 - Separate added, changed, fixed, deprecated, removed, and security items when useful.
 - Link changes to verified commits, issues, or release evidence.
 - Do not use the change log as a raw commit dump.
+- Keep an `Unreleased` or pending section when the repository uses one; move entries only when release evidence exists.
+- Distinguish deprecation from removal and include migration guidance when user action is required.
 
 ## Decision Log
 
 - Record context, decision, alternatives, rationale, consequences, status, and date.
 - Preserve superseded decisions and link replacements.
 - Avoid presenting an unapproved proposal as a decision.
+- Give ADRs stable identifiers and immutable accepted content; supersede with a new decision that links both directions.
+
+## API and Versioned Documentation
+
+- Derive operations, schemas, examples, errors, authentication references, and compatibility claims from the reviewed API contract and implementation evidence.
+- Label example values and redact credentials or personal data. Verify examples against the documented version where executable validation is available.
+- Keep current, previous-supported, and archived documentation visibly distinct. Define version selector, canonical URL, redirects, deprecation, migration, and sunset behavior from approved policy.
+
+## Link and Claim Validation
+
+- Check local targets, case sensitivity, fragments, reference definitions, image/media paths, redirects, and external-source authority.
+- Report inaccessible external links as unverified rather than silently replacing or deleting supported claims.
+- Revalidate commands, versions, dates, status badges, screenshots, and release claims after their source revision changes.
 
 ## Final Project or Release Submission
 

--- a/adapters/codex/skills/scribe/LINK_CLAIM_VALIDATION_GUIDE.md
+++ b/adapters/codex/skills/scribe/LINK_CLAIM_VALIDATION_GUIDE.md
@@ -1,0 +1,31 @@
+# Link and Claim Validation Guide
+
+## Claim Ledger
+
+For a drift-prone or consequential claim, record:
+
+```text
+claim -> source artifact -> source revision -> last verified -> effective date/status -> owner
+```
+
+Use immutable commit, tag, report, schema, issue, or authoritative URL references where appropriate. A source existing is not enough; it must directly support the claim and match the documented revision.
+
+Classify claims as `VERIFIED_CURRENT`, `VERIFIED_HISTORICAL`, `PLANNED`, `PENDING_VALIDATION`, `BLOCKED`, or `UNVERIFIED`. Never infer current status from an older report without a live reread when the fact can drift.
+
+## Local Link Validation
+
+- resolve relative paths from each containing file;
+- check exact path case, file existence, and fragment/anchor existence;
+- detect path escape, stale renamed targets, duplicate reference definitions, and orphaned images;
+- validate generated documentation links after export, not only source links;
+- distinguish a missing target from a link intentionally pointing to a future `[DRAFT]` artifact.
+
+## External Sources
+
+Prefer primary authoritative sources. Record jurisdiction, edition/version, publication/effective date, and last access when relevant. An inaccessible link becomes `UNVERIFIED` until rechecked; do not fabricate replacement evidence.
+
+## Command and Status Validation
+
+Verify commands in the documented shell, working directory, runtime, and revision. Record skipped platform variants. Re-read badges, releases, support versions, PRs, and policy state before publication because these claims are drift-prone.
+
+Any source change invalidates dependent documentation evidence. Update or explicitly mark the affected claim stale; do not leave a previously verified label attached to changed facts.

--- a/adapters/codex/skills/scribe/MARKDOWN_TECHNICAL_SYNTAX_GUIDE.md
+++ b/adapters/codex/skills/scribe/MARKDOWN_TECHNICAL_SYNTAX_GUIDE.md
@@ -1,0 +1,32 @@
+# Markdown Technical Syntax Guide
+
+Target the repository's declared renderer. CommonMark and GitHub-Flavored Markdown overlap, but tables, task lists, autolinks, footnotes, callouts, heading IDs, and raw HTML can differ.
+
+## Stable Structure
+
+- Use one H1 title and ordered heading levels. Do not use bold text as a substitute for structure.
+- Surround lists, tables, and fenced code blocks with blank lines.
+- Add a language identifier to executable or syntax examples. Keep commands and output in separate fences.
+- Use inline code for identifiers, paths, flags, and short literals, not for emphasis.
+- Use descriptive link text; avoid bare "click here" labels.
+
+## Links and Anchors
+
+Resolve a relative link from the directory of the containing Markdown file. Preserve path case for case-sensitive hosts. Percent-encode spaces only where the renderer requires it.
+
+Heading fragments can change with punctuation, duplicate headings, Unicode, or renderer rules. Validate the generated anchor rather than guessing it. Explicit HTML anchors require portability and accessibility review.
+
+## Tables and Accessibility
+
+Use tables for compact comparisons, not long prose. Escape `|` inside cells, keep headers meaningful, and avoid merged-cell HTML. Provide surrounding explanation for screen-reader and narrow-screen users.
+
+Images require useful alternative text when they convey information. Decorative images use empty alt text where the renderer supports it. Never use an image as the sole source of commands, data, or status.
+
+## Safe Technical Examples
+
+- Label placeholders such as `<host>` and never make them resemble real credentials.
+- State working directory, shell/runtime, prerequisites, and expected result when material.
+- Verify copy-paste commands against the documented revision.
+- Mark pseudocode, abbreviated output, and unexecuted examples explicitly.
+
+Rendering success does not verify the factual claim inside the document. Source-backed validation remains separate.

--- a/adapters/codex/skills/scribe/SKILL.md
+++ b/adapters/codex/skills/scribe/SKILL.md
@@ -52,6 +52,10 @@ You must select exactly one of these three documentation output modes depending 
 Use `SKILL.md` first. Do not load every supporting document by default or consume context with unused material.
 - Load [DOCUMENTATION_STANDARDS.md](DOCUMENTATION_STANDARDS.md) only when the task involves document structure, README standards, requirements documentation, architecture summaries, system readiness, testing documentation, user guides, developer guides, changelogs, decision logs, or final project/release submission.
 - Load [SOURCE_BACKED_DOCUMENTATION_GUIDE.md](SOURCE_BACKED_DOCUMENTATION_GUIDE.md) only when the task involves thesis/capstone documentation, final submission packaging, source-backed writing, claim verification, citation discipline, evidence mapping, README accuracy, technical summaries, or handoff documentation.
+- Load [MARKDOWN_TECHNICAL_SYNTAX_GUIDE.md](MARKDOWN_TECHNICAL_SYNTAX_GUIDE.md) for Markdown structure, headings, links, anchors, code fences, tables, lists, callouts, or rendering portability.
+- Load [CHANGELOG_ADR_GUIDE.md](CHANGELOG_ADR_GUIDE.md) for changelog entries, release notes, architecture decision records, supersession, or decision-history maintenance.
+- Load [API_VERSIONED_DOCUMENTATION_GUIDE.md](API_VERSIONED_DOCUMENTATION_GUIDE.md) for API/reference content, versioned documentation, compatibility, deprecation, migration, or sunset communication.
+- Load [LINK_CLAIM_VALIDATION_GUIDE.md](LINK_CLAIM_VALIDATION_GUIDE.md) for source revision, effective-date, citation, internal-link, anchor, redirect, or documentation freshness validation.
 
 ## Supported work
 
@@ -112,6 +116,8 @@ Act as a specialist routed by `conductor`.
 
 - Base documentation claims on source-backed prose inputs, verified artifacts, specialist-provided facts, validated results, links, changelog entries, and documentation diffs that actually exist.
 - Keep documentation claims traceable to the reviewed file, command result, screenshot, specialist output, or repository evidence that supports them.
+- Record the exact source revision and last-verified date when a claim, command, API, compatibility statement, or external rule can drift.
+- Validate local links and generated heading anchors under the target renderer instead of assuming that a visible label proves the target exists.
 - Use explicit placeholder labels only under the allowed operating modes and never present placeholders as confirmed facts.
 - If downstream specialists provide the source facts, keep Scribe validation claims limited to transcription accuracy, traceability, and reviewed evidence rather than re-owning their decisions.
 

--- a/adapters/codex/skills/scribe/examples/source-backed-api-change-example.md
+++ b/adapters/codex/skills/scribe/examples/source-backed-api-change-example.md
@@ -1,0 +1,32 @@
+# Source-Backed API Change Example
+
+## Status
+
+`DOCUMENTATION_PLANNED`; no release or documentation-site publication occurred.
+
+## Evidence Identity
+
+- API contract: `api/openapi.yaml` at fictional reviewed commit `abc1234`
+- Implementation evidence: fictional PR #42 exact head `def5678`
+- Validation: contract test report `report-2026-08-12`, `PASS` for the same head
+- Release evidence: `NOT_FOUND`; change must remain under `Unreleased`
+
+## Documented Change
+
+`POST /orders` accepts an optional idempotency-key header in the reviewed contract. The reference update must document header syntax, repeated-request response, conflict/error behavior, and one schema-valid redacted example. It must not claim production availability or a release version.
+
+## Compatibility and Migration
+
+Existing clients that omit the optional header remain supported according to the reviewed contract. Any future requirement to make the header mandatory is `PLANNED` and requires a separately accepted compatibility decision, deprecation notice, migration guide, and effective date.
+
+## Link Checks
+
+- operation anchor exists under the target renderer;
+- schema links resolve with exact case;
+- error-envelope and authentication references target the same API version;
+- changelog link remains in the pending section;
+- no link claims a release, tag, or deployed endpoint.
+
+## Ownership
+
+Clockwork supplies compatibility facts, Cipher supplies authentication/security facts, Overseer supplies validation evidence, and Scribe transcribes them. Scribe does not publish the docs or create release authority.

--- a/skills/scribe/API_VERSIONED_DOCUMENTATION_GUIDE.md
+++ b/skills/scribe/API_VERSIONED_DOCUMENTATION_GUIDE.md
@@ -1,0 +1,28 @@
+# API and Versioned Documentation Guide
+
+## API Reference Source
+
+Start from the exact OpenAPI/AsyncAPI/schema revision, route definitions, generated reference artifact, or verified implementation. Record the contract revision and supported server/client version.
+
+For each operation document method/topic, path/channel, purpose, authentication reference, parameters, headers, request schema, response/status variants, error envelope, idempotency or pagination behavior, rate/size limits, and examples only when confirmed.
+
+Examples must conform to the schema and must not contain credentials or personal records. A `200` example cannot stand in for error, authorization, validation, conflict, or retry behavior.
+
+## Compatibility and Change
+
+Identify additive versus breaking changes under the repository's actual compatibility policy. Cover renamed/removed fields, requiredness, enum expansion, defaulting, precision, ordering, unknown-field behavior, and event replay where relevant. Clockwork owns interface compatibility decisions; Cipher owns auth/security requirements; Chronicler owns stored-data semantics.
+
+## Versioned Documentation
+
+Distinguish:
+
+- current documentation for the canonical supported version;
+- supported-previous documentation with explicit support status;
+- archived documentation that is read-only and clearly non-current;
+- future/draft documentation labeled as unimplemented.
+
+Define canonical URLs, version selector behavior, redirects, search indexing, cross-version links, and code-sample version alignment. Avoid silently redirecting an old incompatible API page to current behavior.
+
+## Deprecation and Sunset
+
+Record what is deprecated, first affected version, replacement, migration steps, warning channel, effective date, sunset/removal date if approved, support contact, and source authority. Do not invent dates or imply removal authority from documentation alone.

--- a/skills/scribe/AUDIT_CHECKLIST.md
+++ b/skills/scribe/AUDIT_CHECKLIST.md
@@ -20,6 +20,12 @@
 - [ ] Technical claims cite current artifacts.
 - [ ] Test results identify real commands or evidence.
 - [ ] Assumptions and unverified claims are marked.
+- [ ] Drift-prone claims record source revision, last-verified date, and effective date when relevant.
+
+## Markdown and Links
+- [ ] Heading hierarchy, generated anchors, reference links, images, code fences, lists, and tables render under the target Markdown engine.
+- [ ] Relative links resolve from the containing file with correct case and fragments.
+- [ ] External links identify authoritative sources and inaccessible targets are marked unverified.
 
 ## Traceability
 - [ ] Objectives map to requirements, implementation, tests, and readiness evidence.
@@ -41,6 +47,13 @@
 ## Versioning
 - [ ] Current status, version, branch, or release is identifiable when needed.
 - [ ] Stale version claims and screenshots are removed or updated.
+- [ ] Current, supported-previous, archived, deprecated, and removed content are distinguished.
+- [ ] Redirects, canonical URLs, migration guidance, and sunset/effective dates match approved evidence.
+
+## Changelog, ADR, and API Reference
+- [ ] Changelog entries describe verified user impact and do not imply an unpublished release.
+- [ ] ADR identifiers, status, context, decision, consequences, and supersession links are complete.
+- [ ] API operations, parameters, schemas, examples, errors, and authentication references match the exact documented contract revision.
 
 ## Diagrams Referenced Correctly
 - [ ] Diagram names, links, legends, scope, and current or proposed status match written claims.

--- a/skills/scribe/CHANGELOG_ADR_GUIDE.md
+++ b/skills/scribe/CHANGELOG_ADR_GUIDE.md
@@ -1,0 +1,26 @@
+# Changelog and ADR Guide
+
+## Changelog Discipline
+
+Write for users and operators. Group verified changes under Added, Changed, Deprecated, Removed, Fixed, or Security only when those categories help. Keep pending work in `Unreleased` or the repository's established pending section.
+
+Do not create a release heading, release date, comparison link, or compatibility promise until canonical release evidence exists. A merged change is not automatically published.
+
+Each entry should state the affected capability and observable impact. Link the issue, PR, migration, advisory, or documentation when it helps recovery or adoption. Avoid raw commit messages and internal-only refactors with no user impact.
+
+## Architecture Decision Records
+
+An ADR records:
+
+- stable identifier and title;
+- status such as Proposed, Accepted, Rejected, Deprecated, or Superseded;
+- decision/effective date and owners where established;
+- context and constraints;
+- the accepted decision;
+- alternatives considered and why they were not selected;
+- consequences, risks, and follow-up validation;
+- source artifacts and related ADRs.
+
+Do not rewrite an accepted ADR to make history look current. Create a new ADR, mark the old one superseded, and link both directions. A proposal remains Proposed until the authorized decision owner accepts it.
+
+Scribe records a decision supplied by Clockwork or the relevant authority; Scribe does not choose architecture or governance outcomes.

--- a/skills/scribe/DOCUMENTATION_STANDARDS.md
+++ b/skills/scribe/DOCUMENTATION_STANDARDS.md
@@ -6,6 +6,14 @@ Use only the sections relevant to the document. Evidence and project requirement
 - Map important claims to source evidence, specialist output, or verified project artifacts.
 - Mark unverified, draft, planned, blocked, skipped, or not-run items explicitly.
 - Do not present proposals, assumptions, or planned work as completed behavior.
+- Record source revision, last-verified date, and effective date where claims can drift.
+
+## Markdown and Rendering
+
+- Use one document title, hierarchical headings without skipped levels, fenced code blocks with language identifiers, and blank lines that render consistently under the target CommonMark/GFM implementation.
+- Prefer descriptive link text and repository-relative links for versioned local content. Keep explicit HTML rare and renderer-tested.
+- Keep tables simple, escape literal pipes, and provide a list or prose alternative when a wide table harms accessibility or narrow rendering.
+- Treat generated heading anchors as renderer-specific. Validate fragments after renaming headings.
 
 ## README
 
@@ -63,12 +71,27 @@ Use only the sections relevant to the document. Evidence and project requirement
 - Separate added, changed, fixed, deprecated, removed, and security items when useful.
 - Link changes to verified commits, issues, or release evidence.
 - Do not use the change log as a raw commit dump.
+- Keep an `Unreleased` or pending section when the repository uses one; move entries only when release evidence exists.
+- Distinguish deprecation from removal and include migration guidance when user action is required.
 
 ## Decision Log
 
 - Record context, decision, alternatives, rationale, consequences, status, and date.
 - Preserve superseded decisions and link replacements.
 - Avoid presenting an unapproved proposal as a decision.
+- Give ADRs stable identifiers and immutable accepted content; supersede with a new decision that links both directions.
+
+## API and Versioned Documentation
+
+- Derive operations, schemas, examples, errors, authentication references, and compatibility claims from the reviewed API contract and implementation evidence.
+- Label example values and redact credentials or personal data. Verify examples against the documented version where executable validation is available.
+- Keep current, previous-supported, and archived documentation visibly distinct. Define version selector, canonical URL, redirects, deprecation, migration, and sunset behavior from approved policy.
+
+## Link and Claim Validation
+
+- Check local targets, case sensitivity, fragments, reference definitions, image/media paths, redirects, and external-source authority.
+- Report inaccessible external links as unverified rather than silently replacing or deleting supported claims.
+- Revalidate commands, versions, dates, status badges, screenshots, and release claims after their source revision changes.
 
 ## Final Project or Release Submission
 

--- a/skills/scribe/LINK_CLAIM_VALIDATION_GUIDE.md
+++ b/skills/scribe/LINK_CLAIM_VALIDATION_GUIDE.md
@@ -1,0 +1,31 @@
+# Link and Claim Validation Guide
+
+## Claim Ledger
+
+For a drift-prone or consequential claim, record:
+
+```text
+claim -> source artifact -> source revision -> last verified -> effective date/status -> owner
+```
+
+Use immutable commit, tag, report, schema, issue, or authoritative URL references where appropriate. A source existing is not enough; it must directly support the claim and match the documented revision.
+
+Classify claims as `VERIFIED_CURRENT`, `VERIFIED_HISTORICAL`, `PLANNED`, `PENDING_VALIDATION`, `BLOCKED`, or `UNVERIFIED`. Never infer current status from an older report without a live reread when the fact can drift.
+
+## Local Link Validation
+
+- resolve relative paths from each containing file;
+- check exact path case, file existence, and fragment/anchor existence;
+- detect path escape, stale renamed targets, duplicate reference definitions, and orphaned images;
+- validate generated documentation links after export, not only source links;
+- distinguish a missing target from a link intentionally pointing to a future `[DRAFT]` artifact.
+
+## External Sources
+
+Prefer primary authoritative sources. Record jurisdiction, edition/version, publication/effective date, and last access when relevant. An inaccessible link becomes `UNVERIFIED` until rechecked; do not fabricate replacement evidence.
+
+## Command and Status Validation
+
+Verify commands in the documented shell, working directory, runtime, and revision. Record skipped platform variants. Re-read badges, releases, support versions, PRs, and policy state before publication because these claims are drift-prone.
+
+Any source change invalidates dependent documentation evidence. Update or explicitly mark the affected claim stale; do not leave a previously verified label attached to changed facts.

--- a/skills/scribe/MARKDOWN_TECHNICAL_SYNTAX_GUIDE.md
+++ b/skills/scribe/MARKDOWN_TECHNICAL_SYNTAX_GUIDE.md
@@ -1,0 +1,32 @@
+# Markdown Technical Syntax Guide
+
+Target the repository's declared renderer. CommonMark and GitHub-Flavored Markdown overlap, but tables, task lists, autolinks, footnotes, callouts, heading IDs, and raw HTML can differ.
+
+## Stable Structure
+
+- Use one H1 title and ordered heading levels. Do not use bold text as a substitute for structure.
+- Surround lists, tables, and fenced code blocks with blank lines.
+- Add a language identifier to executable or syntax examples. Keep commands and output in separate fences.
+- Use inline code for identifiers, paths, flags, and short literals, not for emphasis.
+- Use descriptive link text; avoid bare "click here" labels.
+
+## Links and Anchors
+
+Resolve a relative link from the directory of the containing Markdown file. Preserve path case for case-sensitive hosts. Percent-encode spaces only where the renderer requires it.
+
+Heading fragments can change with punctuation, duplicate headings, Unicode, or renderer rules. Validate the generated anchor rather than guessing it. Explicit HTML anchors require portability and accessibility review.
+
+## Tables and Accessibility
+
+Use tables for compact comparisons, not long prose. Escape `|` inside cells, keep headers meaningful, and avoid merged-cell HTML. Provide surrounding explanation for screen-reader and narrow-screen users.
+
+Images require useful alternative text when they convey information. Decorative images use empty alt text where the renderer supports it. Never use an image as the sole source of commands, data, or status.
+
+## Safe Technical Examples
+
+- Label placeholders such as `<host>` and never make them resemble real credentials.
+- State working directory, shell/runtime, prerequisites, and expected result when material.
+- Verify copy-paste commands against the documented revision.
+- Mark pseudocode, abbreviated output, and unexecuted examples explicitly.
+
+Rendering success does not verify the factual claim inside the document. Source-backed validation remains separate.

--- a/skills/scribe/SKILL.md
+++ b/skills/scribe/SKILL.md
@@ -59,6 +59,10 @@ You must select exactly one of these three documentation output modes depending 
 Use `SKILL.md` first. Do not load every supporting document by default or consume context with unused material.
 - Load [DOCUMENTATION_STANDARDS.md](DOCUMENTATION_STANDARDS.md) only when the task involves document structure, README standards, requirements documentation, architecture summaries, system readiness, testing documentation, user guides, developer guides, changelogs, decision logs, or final project/release submission.
 - Load [SOURCE_BACKED_DOCUMENTATION_GUIDE.md](SOURCE_BACKED_DOCUMENTATION_GUIDE.md) only when the task involves thesis/capstone documentation, final submission packaging, source-backed writing, claim verification, citation discipline, evidence mapping, README accuracy, technical summaries, or handoff documentation.
+- Load [MARKDOWN_TECHNICAL_SYNTAX_GUIDE.md](MARKDOWN_TECHNICAL_SYNTAX_GUIDE.md) for Markdown structure, headings, links, anchors, code fences, tables, lists, callouts, or rendering portability.
+- Load [CHANGELOG_ADR_GUIDE.md](CHANGELOG_ADR_GUIDE.md) for changelog entries, release notes, architecture decision records, supersession, or decision-history maintenance.
+- Load [API_VERSIONED_DOCUMENTATION_GUIDE.md](API_VERSIONED_DOCUMENTATION_GUIDE.md) for API/reference content, versioned documentation, compatibility, deprecation, migration, or sunset communication.
+- Load [LINK_CLAIM_VALIDATION_GUIDE.md](LINK_CLAIM_VALIDATION_GUIDE.md) for source revision, effective-date, citation, internal-link, anchor, redirect, or documentation freshness validation.
 
 ## Supported work
 
@@ -119,6 +123,8 @@ Act as a specialist routed by `conductor`.
 
 - Base documentation claims on source-backed prose inputs, verified artifacts, specialist-provided facts, validated results, links, changelog entries, and documentation diffs that actually exist.
 - Keep documentation claims traceable to the reviewed file, command result, screenshot, specialist output, or repository evidence that supports them.
+- Record the exact source revision and last-verified date when a claim, command, API, compatibility statement, or external rule can drift.
+- Validate local links and generated heading anchors under the target renderer instead of assuming that a visible label proves the target exists.
 - Use explicit placeholder labels only under the allowed operating modes and never present placeholders as confirmed facts.
 - If downstream specialists provide the source facts, keep Scribe validation claims limited to transcription accuracy, traceability, and reviewed evidence rather than re-owning their decisions.
 

--- a/skills/scribe/examples/source-backed-api-change-example.md
+++ b/skills/scribe/examples/source-backed-api-change-example.md
@@ -1,0 +1,32 @@
+# Source-Backed API Change Example
+
+## Status
+
+`DOCUMENTATION_PLANNED`; no release or documentation-site publication occurred.
+
+## Evidence Identity
+
+- API contract: `api/openapi.yaml` at fictional reviewed commit `abc1234`
+- Implementation evidence: fictional PR #42 exact head `def5678`
+- Validation: contract test report `report-2026-08-12`, `PASS` for the same head
+- Release evidence: `NOT_FOUND`; change must remain under `Unreleased`
+
+## Documented Change
+
+`POST /orders` accepts an optional idempotency-key header in the reviewed contract. The reference update must document header syntax, repeated-request response, conflict/error behavior, and one schema-valid redacted example. It must not claim production availability or a release version.
+
+## Compatibility and Migration
+
+Existing clients that omit the optional header remain supported according to the reviewed contract. Any future requirement to make the header mandatory is `PLANNED` and requires a separately accepted compatibility decision, deprecation notice, migration guide, and effective date.
+
+## Link Checks
+
+- operation anchor exists under the target renderer;
+- schema links resolve with exact case;
+- error-envelope and authentication references target the same API version;
+- changelog link remains in the pending section;
+- no link claims a release, tag, or deployed endpoint.
+
+## Ownership
+
+Clockwork supplies compatibility facts, Cipher supplies authentication/security facts, Overseer supplies validation evidence, and Scribe transcribes them. Scribe does not publish the docs or create release authority.

--- a/tests/behavior/run_tests.py
+++ b/tests/behavior/run_tests.py
@@ -110,6 +110,7 @@ def main():
         {"Name": "test_dagger_specialist_knowledge.py", "Path": "tests/behavior/test_dagger_specialist_knowledge.py"},
         {"Name": "test_chronicler_specialist_knowledge.py", "Path": "tests/behavior/test_chronicler_specialist_knowledge.py"},
         {"Name": "test_overseer_specialist_knowledge.py", "Path": "tests/behavior/test_overseer_specialist_knowledge.py"},
+        {"Name": "test_scribe_specialist_knowledge.py", "Path": "tests/behavior/test_scribe_specialist_knowledge.py"},
         {"Name": "validate_tuner_collaboration_contract.py", "Path": "scripts/validate_tuner_collaboration_contract.py"},
         {"Name": "test_tuner_collaboration_contract.py", "Path": "tests/behavior/test_tuner_collaboration_contract.py"},
         {"Name": "validate_cross_layer_synchronicity_contract.py", "Path": "scripts/validate_cross_layer_synchronicity_contract.py"},

--- a/tests/behavior/test_scribe_specialist_knowledge.py
+++ b/tests/behavior/test_scribe_specialist_knowledge.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE = ROOT / "skills" / "scribe"
+CODEX = ROOT / "adapters" / "codex" / "skills" / "scribe"
+
+REQUIRED_SUPPORT = [
+    "AUDIT_CHECKLIST.md",
+    "DOCUMENTATION_STANDARDS.md",
+    "OUTPUT_FORMATS.md",
+    "OUTPUT_TEMPLATES.md",
+    "SOURCE_BACKED_DOCUMENTATION_GUIDE.md",
+    "MARKDOWN_TECHNICAL_SYNTAX_GUIDE.md",
+    "CHANGELOG_ADR_GUIDE.md",
+    "API_VERSIONED_DOCUMENTATION_GUIDE.md",
+    "LINK_CLAIM_VALIDATION_GUIDE.md",
+    "examples/final-submission-readiness-example.md",
+    "examples/project-documentation-audit-example.md",
+    "examples/readme-audit-example.md",
+    "examples/system-readiness-doc-example.md",
+    "examples/source-backed-api-change-example.md",
+]
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def require(text: str, *needles: str) -> None:
+    missing = [needle for needle in needles if needle not in text]
+    if missing:
+        raise AssertionError(f"Missing required Scribe knowledge markers: {missing}")
+
+
+def main() -> None:
+    for relative in REQUIRED_SUPPORT:
+        source = SOURCE / relative
+        mirror = CODEX / relative
+        if not source.is_file() or not mirror.is_file():
+            raise AssertionError(f"Missing Scribe support or mirror: {relative}")
+        if source.read_bytes() != mirror.read_bytes():
+            raise AssertionError(f"Scribe source/Codex support parity failed: {relative}")
+
+    skill = read(SOURCE / "SKILL.md")
+    for filename in [
+        "MARKDOWN_TECHNICAL_SYNTAX_GUIDE.md",
+        "CHANGELOG_ADR_GUIDE.md",
+        "API_VERSIONED_DOCUMENTATION_GUIDE.md",
+        "LINK_CLAIM_VALIDATION_GUIDE.md",
+    ]:
+        if filename not in skill:
+            raise AssertionError(f"Scribe progressive disclosure misses {filename}")
+    require(skill, "source revision and last-verified date", "generated heading anchors")
+
+    markdown = read(SOURCE / "MARKDOWN_TECHNICAL_SYNTAX_GUIDE.md")
+    require(markdown, "CommonMark", "GitHub-Flavored Markdown", "Heading fragments", "language identifier", "alternative text")
+
+    decisions = read(SOURCE / "CHANGELOG_ADR_GUIDE.md")
+    require(decisions, "Unreleased", "merged change is not automatically published", "Superseded", "link both directions")
+
+    api = read(SOURCE / "API_VERSIONED_DOCUMENTATION_GUIDE.md")
+    require(api, "OpenAPI/AsyncAPI", "error envelope", "supported-previous", "canonical URLs", "sunset/removal date")
+
+    claims = read(SOURCE / "LINK_CLAIM_VALIDATION_GUIDE.md")
+    require(claims, "Claim Ledger", "VERIFIED_CURRENT", "fragment/anchor existence", "authoritative sources", "invalidates dependent documentation evidence")
+
+    example = read(SOURCE / "examples" / "source-backed-api-change-example.md")
+    require(example, "`DOCUMENTATION_PLANNED`", "Release evidence: `NOT_FOUND`", "must remain under `Unreleased`", "no release or documentation-site publication occurred")
+
+    if (SOURCE / "patterns").exists():
+        raise AssertionError("SK8 audit selected Markdown-only depth; unexpected Scribe patterns directory")
+
+    print(f"Scribe specialist knowledge regression passed for {len(REQUIRED_SUPPORT)} mirrored support files without publication.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Result
Completes bounded SK8 Scribe knowledge expansion without changing routing, runtime architecture, publication state, or domain ownership.

Adds Markdown syntax/rendering, changelog/ADR, API/versioned docs, link/claim freshness, and a source-backed API change example. Exact 19 paths, Markdown-primary, no JSON catalog.

Validation: focused Scribe regression across 14 mirrors, Codex export/parity, complete behavior suite, 541 runtime tests at 94.31%, strict governance 0/0, router/guardrails, exact scope, diff, stale-reference, and secret gates all pass. Exporter residue outside scope was rejected. No publication or protected action occurred.