### PR TITLE
chore(release): materialize signed v1.3.0 preparation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "orchestra",
       "source": "./",
       "description": "Governance-first specialist skill framework for routed, auditable AI coding workflows.",
-      "version": "1.2.0"
+      "version": "1.3.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra",
   "description": "Governance-first specialist skill framework for routed, auditable AI coding workflows.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "update_check": {
     "update_check_enabled": true,
     "update_check_channel": "stable",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conductor",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "An installable AI workflow plugin that routes complex software tasks through focused specialist skills for architecture, UI/UX, documentation, diagrams, databases, QA, security, and gated resilience review.",
   "author": {
     "name": "Baelfyre",

--- a/adapters/cursor/package.json
+++ b/adapters/cursor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-cursor-scaffold",
   "displayName": "Orchestra Cursor Scaffold",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "description": "Scaffold-only Cursor packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/jetbrains/package.json
+++ b/adapters/jetbrains/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-jetbrains-scaffold",
   "displayName": "Orchestra JetBrains Scaffold",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "description": "Scaffold-only JetBrains packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/jetbrains/plugin.xml
+++ b/adapters/jetbrains/plugin.xml
@@ -2,7 +2,7 @@
   <id>com.baelfyre.orchestra.scaffold</id>
   <name>Orchestra JetBrains Scaffold</name>
   <vendor>Baelfyre</vendor>
-  <version>1.2.0</version>
+  <version>1.3.0</version>
   <description>Scaffold-only JetBrains packaging metadata for Orchestra runtime adapter integration.</description>
   <depends>com.intellij.modules.platform</depends>
   <extensions defaultExtensionNs="com.intellij">

--- a/adapters/neovim/package.json
+++ b/adapters/neovim/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-neovim-scaffold",
   "displayName": "Orchestra Neovim Scaffold",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "description": "Scaffold-only Neovim packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/vscode/package.json
+++ b/adapters/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-vscode-scaffold",
   "displayName": "Orchestra VS Code Scaffold",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "description": "Scaffold-only VS Code packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/windsurf/package.json
+++ b/adapters/windsurf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-windsurf-scaffold",
   "displayName": "Orchestra Windsurf Scaffold",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "description": "Scaffold-only Windsurf packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/zed/package.json
+++ b/adapters/zed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-zed-scaffold",
   "displayName": "Orchestra Zed Scaffold",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "description": "Scaffold-only Zed packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/docs/releases/v1.3.0-specialist-intelligence-release-candidate.md
+++ b/docs/releases/v1.3.0-specialist-intelligence-release-candidate.md
@@ -1,0 +1,125 @@
+# Orchestra v1.3.0: Specialist Intelligence - Release Candidate
+
+## Status
+
+`PREPARED_PENDING_EXACT_HEAD_VALIDATION`
+
+Target version: `1.3.0`
+
+Target tag: `v1.3.0`
+
+Current public release: `v1.2.0`
+
+Release classification: stable minor release candidate.
+
+Publication is not authorized by this preparation record. Tag creation and GitHub Release publication remain separate protected actions.
+
+## Release Theme
+
+Orchestra v1.3.0 packages the completed Specialist Knowledge Layer campaign. The campaign increases the depth, evidence discipline, syntax and tooling literacy, progressive-disclosure references, and worked examples available to Orchestra's existing specialists without redesigning the routing, authority, or runtime architecture by default.
+
+The release is additive. Specialist ownership and governance boundaries remain explicit: stronger knowledge does not create broader authority.
+
+## Completed Specialist Knowledge Scope
+
+### SK1 Ponytail
+
+Expanded implementation intelligence with stack discovery, language/runtime references, build and test tooling, implementation foundations, and worked cross-specialist implementation patterns while preserving minimal, reversible implementation ownership.
+
+### SK2 Clockwork
+
+Expanded architecture review across modular and distributed boundaries, concurrency ownership, caching, API compatibility/versioning, multi-tenancy, jobs, event-driven flows, outbox/inbox placement, and durable workflow patterns. Added selective machine-readable architecture-pattern metadata where deterministic parsing materially helps.
+
+### SK3 Cipher
+
+Expanded defensive security guidance for threat modeling, authentication/session/OAuth/OIDC, authorization and tenant boundaries, web/API controls, secrets and cryptographic misuse, framework-aware review, and SAST/DAST/SCA/SBOM interpretation. Added selective non-authorizing security-control metadata.
+
+### SK4 Cloak
+
+Expanded semantic HTML, ARIA, keyboard and focus behavior, responsive CSS containment, forms and validation recovery, design tokens/component states, frontend routing, and user-visible component-boundary literacy.
+
+### SK5 Dagger
+
+Expanded safe non-production resilience knowledge for workload modeling, load/stress/soak interpretation, concurrency/resource pressure, bounded fault injection, retry amplification, recovery measurement, RTO/RPO reasoning, and resilience tooling. Existing authorization and simulation-only guardrails remain intact.
+
+### SK6 Chronicler
+
+Expanded database dialect and ORM/migration semantics, transaction isolation, MVCC, locking/deadlock analysis, tenant isolation, query-plan evidence, and expand-migrate-contract zero-downtime schema-change planning.
+
+### SK7 Overseer
+
+Expanded validation strategy for unit/integration/contract/E2E boundaries, property and mutation testing, flaky-test diagnosis, deterministic isolation, coverage interpretation, CI/browser/device matrices, performance acceptance, and test-data lifecycle management.
+
+### SK8 Scribe
+
+Expanded Markdown and technical-documentation syntax, changelog/ADR conventions, API/reference documentation, versioned documentation, deprecation/sunset records, source-backed claims, and link/anchor freshness validation.
+
+### SK9 The Steward and The Governor
+
+Expanded requirements traceability, acceptance criteria, scope/change-control, and SDLC alignment for The Steward. Expanded authoritative-source acquisition, jurisdiction/effective-date verification, license/privacy/IP/compliance review frameworks, and human-escalation boundaries for The Governor while preserving the non-legal-advice boundary.
+
+### SK10 Weaver, Conductor, The Tuner, and Arbiter
+
+Added evidence-driven hardening and adversarial evaluation for modeling/source traceability, routing, ownership, contradiction/invalidation, specialist re-entry, handoff identity, continuity, and protected-action boundaries without default orchestration redesign.
+
+## Knowledge Packaging
+
+The campaign uses `MARKDOWN_PRIMARY_JSON_SELECTIVE`.
+
+Markdown remains the primary form for human-readable and LLM-consumed specialist knowledge. JSON is used only where structured parsing materially helps, such as deterministic catalogs, schemas, indexes, fixtures, and capability metadata. Prose-heavy specialist knowledge was not converted wholesale to JSON.
+
+Canonical specialist sources and Codex portable mirrors remain subject to repository parity validation.
+
+## Campaign Validation Baseline
+
+The final SK10 campaign closeout recorded:
+
+- 10 adversarial routing, coordination, invalidation, handoff, and protected-action scenarios;
+- complete authoritative behavior suite passing;
+- 541 runtime tests passing;
+- 94.31 percent runtime coverage against the 90 percent gate;
+- strict governance with 0 errors and 0 warnings;
+- prompt-load budget checks passing;
+- Codex source/export parity passing;
+- nine of nine exact-head GitHub checks passing; and
+- zero unresolved review threads.
+
+Each SK4 through SK10 source PR was Squash-merged with an expected-head guard after exact-head validation. SK1 through SK10 are recorded as `MERGED_VERIFIED` in the canonical Knowledge Base.
+
+## v1.3.0 Release-Preparation Gate
+
+Before this candidate may become publication-ready, the exact final v1.3.0 preparation head must pass the repository's current required validation matrix, including:
+
+- governance-check;
+- validate;
+- runtime-tests and coverage gate;
+- native Windows, Ubuntu, and macOS validation;
+- Analyze (actions);
+- Analyze (python);
+- CodeQL where reported for the exact head;
+- package/version-surface parity;
+- repository structure, manifest, packaging, routing, prompt-load, guardrail, and Codex export checks; and
+- zero unresolved review threads.
+
+Any source correction after validation invalidates stale evidence and requires renewed exact-head validation.
+
+## Authority and Publication Boundary
+
+This release candidate does not authorize or perform:
+
+- annotated tag creation;
+- GitHub Release publication;
+- deployment or production mutation;
+- marketplace publication;
+- installed-integration refresh;
+- policy activation;
+- destructive cleanup;
+- branch deletion;
+- force push; or
+- history rewrite.
+
+`VALIDATION_SUCCESS != RELEASE_AUTHORITY`
+
+`MERGEABILITY != PUBLICATION_AUTHORITY`
+
+The v1.3.0 preparation campaign must stop at `PREPARED_NOT_RELEASED` until tag/release publication is separately authorized.

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "name": "conductor",
   "display_name": "Orchestra",
   "description": "An installable AI workflow plugin that routes tasks through focused specialist skills. See SKILL_INDEX.md and ROUTING_MAP.md for detailed routing behavior.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "license": "MIT",
   "repository": "https://github.com/Baelfyre/Orchestra",
   "icon_path": "assets/icons/conductor.ico",

--- a/tests/runtime/test_release_version_surfaces.py
+++ b/tests/runtime/test_release_version_surfaces.py
@@ -1,0 +1,39 @@
+import json
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+EXPECTED_VERSION = "1.3.0"
+
+JSON_VERSION_SURFACES = (
+    "plugin.json",
+    ".codex-plugin/plugin.json",
+    ".claude-plugin/plugin.json",
+    "adapters/cursor/package.json",
+    "adapters/jetbrains/package.json",
+    "adapters/neovim/package.json",
+    "adapters/vscode/package.json",
+    "adapters/windsurf/package.json",
+    "adapters/zed/package.json",
+)
+
+
+def _load_json(relative_path: str) -> dict:
+    return json.loads((ROOT / relative_path).read_text(encoding="utf-8"))
+
+
+def test_release_package_versions_are_consistent() -> None:
+    observed = {
+        path: _load_json(path).get("version")
+        for path in JSON_VERSION_SURFACES
+    }
+    observed[".claude-plugin/marketplace.json"] = _load_json(
+        ".claude-plugin/marketplace.json"
+    )["plugins"][0].get("version")
+
+    plugin_xml = ET.parse(ROOT / "adapters/jetbrains/plugin.xml").getroot()
+    observed["adapters/jetbrains/plugin.xml"] = plugin_xml.findtext("version")
+
+    assert set(observed.values()) == {EXPECTED_VERSION}, observed
+    assert len(observed) == 11


### PR DESCRIPTION
Auxiliary signed-materialization PR for Orchestra v1.3.0 release preparation.

- Base: canonical campaign closeout `650b8bff00d7808bc13fd82a51c7bf0cffa7616e`
- Head: `release/v1.3.0-preparation-work`
- Exact scope: 13 files
- Purpose: materialize the already-reviewed release-preparation tree as one GitHub-generated signed Squash commit on an isolated staging branch
- This PR is not the canonical `main` merge path
- Current public release remains `v1.2.0`
- Target candidate version is `1.3.0`
- No tag creation, GitHub Release publication, deployment, production mutation, marketplace publication, installed-integration refresh, policy activation, destructive cleanup, branch deletion, force push, or history rewrite is authorized or performed