### PR TITLE
docs(release): materialize signed v1.3.0 readiness closeout

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -7,10 +7,35 @@
 - **Stable Continuation Branch:** `main`
 - **Current Public Release:** `v1.2.0`
 - **Release Status:** `PUBLISHED_VERIFIED` on August 9, 2026
-- **Target Release:** `v1.2.0`
-- **Release-Candidate Metadata:** `1.2.0`
+- **Target Release:** `v1.3.0`
+- **Release-Candidate Metadata:** `1.3.0`
 - **v1.2.0 Release State:** `PUBLISHED_VERIFIED`
+- **v1.3.0 Preparation State:** `PREPARED_NOT_RELEASED`
+- **v1.3.0 Canonical Preparation Commit:** `32257723d6ca72847e4581d8b927c7b14c77039e`
+- **v1.3.0 Canonical Preparation Tree:** `0fdf39920a8c48a779971c8c97690985bb875d42`
 - **Policy Activation State:** `NOT_PERFORMED`
+
+## v1.3.0 Specialist Intelligence Release Preparation
+
+The SK1-SK10 Specialist Knowledge Layer campaign is `MERGED_VERIFIED`. The bounded v1.3.0 package/version preparation was reviewed through PR #255 at signed head `f63daf49add4887d7fbd1b581959ebf8654150db` and Squash-merged with an expected-head guard as canonical commit `32257723d6ca72847e4581d8b927c7b14c77039e`.
+
+Reviewed and canonical trees are exactly `0fdf39920a8c48a779971c8c97690985bb875d42`; the canonical commit has a valid GitHub signature. The exact reviewed head passed all nine observed checks: governance, validate, runtime-tests, native Windows/Ubuntu/macOS, Analyze actions/python, and CodeQL. The current runtime suite is 542 passing tests at 94.33% coverage, including deterministic `1.3.0` parity across all 11 live package/version surfaces.
+
+The first candidate PR #253 is preserved as fail-closed evidence: Stage 1 Strict Governance correctly rejected the 13-file candidate because significant package/test changes lacked a matching changelog update. The corrected tree added the focused changelog entry, restored historical wording, discarded stale validation, and reran the full exact-head matrix through PR #255.
+
+Publication remains separately gated:
+
+```text
+CURRENT_PUBLIC_RELEASE=v1.2.0
+TARGET_VERSION=1.3.0
+TARGET_TAG=v1.3.0
+V1_3_0_RELEASE_STATE=PREPARED_NOT_RELEASED
+V1_3_0_TAG_EXISTS=NO
+V1_3_0_GITHUB_RELEASE_EXISTS=NO
+V1_3_0_PUBLICATION=AWAITING_SEPARATE_AUTHORIZATION
+```
+
+See `docs/releases/v1.3.0-specialist-intelligence-release-candidate.md` and `docs/validation/V1_3_0_RELEASE_READINESS_EVIDENCE.md`.
 
 ## Canonical Capability State
 
@@ -175,6 +200,7 @@ The current bypass list is intentionally retained for repository-operational acc
 - **Pre-R8 Repository Hygiene:** README provenance/host/release state and complete conservative file/branch classifications are `MERGED_VERIFIED` through PR #234 and signed canonical Squash commit `8cca62109b10aa06abaf25fc4c9982a02160bcbf`. No tracked file or branch was deleted.
 - **Release Readiness:** Hygiene-invalidated candidate evidence has been refreshed against canonical `8cca62109b10aa06abaf25fc4c9982a02160bcbf`; behavior, 541 runtime tests at 94.31% coverage, strict governance, packaging, exact-head CI, signature/tree/base verification, and release-boundary reads are green. See `docs/validation/V1_2_0_RELEASE_READINESS_EVIDENCE.md`.
 - **Publication State:** Annotated tag `v1.2.0` and the immutable, non-draft, non-prerelease GitHub Release are `PUBLISHED_VERIFIED` at release commit `4f3c45f6d1e5f290aca108ddf5810c1b18f1dc76`. No deployment, marketplace publication, installed-integration refresh, or policy activation was performed.
+- **v1.3.0 Preparation:** SK1-SK10 are `MERGED_VERIFIED`; package/version preparation is canonical through PR #255 at signed Squash `32257723d6ca72847e4581d8b927c7b14c77039e`, with 542 runtime tests at 94.33% coverage and all 9 observed exact-head checks passing. Publication remains `AWAITING_SEPARATE_AUTHORIZATION`.
 
 ## Local Startup Verification
 

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -4,22 +4,46 @@
 - **Canonical Branch:** `main`
 - **Base Branch:** `main`
 - **Current Public Release:** `v1.2.0`
-- **Release-Candidate Metadata:** `v1.2.0`
-- **Target Release:** `v1.2.0`
+- **Release-Candidate Metadata:** `v1.3.0`
+- **Target Release:** `v1.3.0`
 - **v1.2.0 Release State:** `PUBLISHED_VERIFIED`
+- **v1.3.0 Preparation State:** `PREPARED_NOT_RELEASED`
+- **v1.3.0 Canonical Preparation Commit:** `32257723d6ca72847e4581d8b927c7b14c77039e`
 - **Policy Activation:** `NOT_PERFORMED`
+
+## v1.3.0 Specialist Intelligence Continuity
+
+The SK1-SK10 Specialist Knowledge Layer campaign is complete and `MERGED_VERIFIED`. Release-preparation PR #255 reviewed signed head `f63daf49add4887d7fbd1b581959ebf8654150db`, passed all nine observed exact-head checks, and Squash-merged with an expected-head guard as signed canonical commit `32257723d6ca72847e4581d8b927c7b14c77039e`.
+
+Canonical preparation tree `0fdf39920a8c48a779971c8c97690985bb875d42` is exactly equal to the reviewed tree. The exact reviewed head passed 542 runtime tests at 94.33% coverage, including the deterministic version-surface parity regression for all 11 live package/version surfaces.
+
+The earlier PR #253 is intentionally retained as fail-closed evidence. It was closed unmerged after Stage 1 Strict Governance correctly detected missing changelog freshness. Its validation was not reused.
+
+Current publication boundary:
+
+```text
+CURRENT_PUBLIC_RELEASE=v1.2.0
+TARGET_VERSION=1.3.0
+TARGET_TAG=v1.3.0
+V1_3_0_RELEASE_PREPARATION=MERGED_VERIFIED
+V1_3_0_RELEASE_STATE=PREPARED_NOT_RELEASED
+V1_3_0_TAG_EXISTS=NO
+V1_3_0_GITHUB_RELEASE_EXISTS=NO
+V1_3_0_PUBLICATION=AWAITING_SEPARATE_AUTHORIZATION
+```
+
+Do not create the tag or GitHub Release without a separate explicit publication authorization. Before any future publication action, independently re-read live Orchestra `main`, this handoff, the v1.3.0 candidate, and `docs/validation/V1_3_0_RELEASE_READINESS_EVIDENCE.md`, then detect drift.
 
 ## Active README Governance Reconciliation
 
 Canonical Orchestra `main` currently contains accepted README refinement commit `807bda608d65cb10bf65cdf313916d9d0fd62320`. The change is README-only and exact local validation is green, including 541 runtime tests at 94.31% coverage and strict governance with 0 errors and 0 warnings.
 
-The canonical commit is unsigned and the transition occurred directly on `main`, so it is not governance-complete. Preserve the current history and remediate forward-only through a normal exact-head validated PR and signed Squash result.
+The canonical commit is unsigned and the transition occurred directly on `main` rather than through the repository's required pull-request path, so it is not governance-complete. Preserve the current history and remediate forward-only through a normal exact-head validated PR and signed Squash result.
 
 ```text
 PRESERVE_CURRENT_CANONICAL_HISTORY=true
 HISTORY_REWRITE=false
 FORCE_PUSH=false
-KB_SYNC=HELD_UNTIL_ORCHESTRA_REMEDIATION_MERGED_VERIFIED
 ```
 
 Evidence: `docs/validation/README_DIRECT_MAIN_GOVERNANCE_RECONCILIATION_2026_08_10.md`.
@@ -52,15 +76,15 @@ The clean replay then completed R1 through R5B:
 
 ## Historical R6 Release-Candidate Preparation
 
-R6 normalized repository release-candidate metadata to `1.2.0`, consolidated README/setup/current-state/release notes, and prepared exact-head release-readiness evidence. This section records the pre-publication checkpoint; it is not the current release state.
+R6 normalized repository release-candidate metadata to `1.2.0`, consolidated README/setup/current-state/release notes, and prepared exact-head release-readiness evidence. This section records the pre-publication checkpoint; it is not the current release-candidate state.
 
 Historical R6 and current publication state:
 
 ```text
-RELEASE_CANDIDATE_VERSION=1.2.0
+HISTORICAL_RELEASE_CANDIDATE_VERSION=1.2.0
 HISTORICAL_R6_RELEASE_STATE=PREPARED_NOT_RELEASED
 CURRENT_PUBLIC_RELEASE=v1.2.0
-RELEASE_STATE=PUBLISHED_VERIFIED
+V1_2_0_RELEASE_STATE=PUBLISHED_VERIFIED
 POLICY_ACTIVATION=NOT_PERFORMED
 LIVE_INSTALLED_HOST_VALIDATION=VERIFIED_RECONCILED_LOCALLY
 ```
@@ -73,7 +97,7 @@ R7 live-host validation and repository reconciliation are `MERGED_VERIFIED`. PR 
 
 ## Governed Autonomy Modes
 
-GA-0 concluded `NO_DUPLICATE_AUTHORITY_MODEL`. GA-1 through GA-7 are `MERGED_VERIFIED` through PR #232 and signed Squash commit `900f88d7a3ed480ae8b910e6ba204008a72d2784`. Exact-head checks and canonical release-readiness validation are green. Runtime authority, plugin manifests, versions, the R7 fixture/validator, and installed integrations remain unchanged.
+GA-0 concluded `NO_DUPLICATE_AUTHORITY_MODEL`. GA-1 through GA-7 are `MERGED_VERIFIED` through PR #232 and signed Squash commit `900f88d7a3ed480ae8b910e6ba204008a72d2784`. Exact-head checks and canonical release-readiness validation are green. Runtime authority and installed integrations remain unchanged.
 
 ## Historical Pre-R8 Repository Hygiene and Publication
 
@@ -101,14 +125,10 @@ git pull --ff-only origin main
 ## Remaining Sequence
 
 ```text
-R5   merged - autonomous merge-readiness hardening
-R5B  merged - delegated-governance state reconciliation
-R6   v1.2.0 release-candidate repository preparation
-R7   live installed Codex/Antigravity/Claude compatibility evidence - merged verified
-R7R  signed Squash-aware merge-governance remediation - merged verified
-GA-0..GA-7  governed autonomy profiles - merged verified
-R7H  pre-R8 repository hygiene - merged verified; release evidence refreshed
-R8   annotated tag and GitHub Release - published verified
+SK1..SK10  specialist knowledge campaign - merged verified
+V1.3-PREP   package/version preparation and exact-head validation - merged verified
+V1.3-READY  revision-bound readiness and continuity reconciliation - current closeout
+V1.3-PUBLISH  annotated tag and GitHub Release - awaiting separate authorization
 ```
 
-Historical first-run failures remain preserved as audit evidence in the KB and archive branch. They must not be silently rewritten or deleted during cleanup.
+Historical first-run failures remain preserved as audit evidence. They must not be silently rewritten or deleted during cleanup.

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -67,6 +67,21 @@ Phases 6B-A through 6C are complete and merged through PR #183. Phase 6D produce
 - [x] Refresh every release-readiness artifact invalidated by R7R or GA implementation and independently verify the final candidate; canonical evidence is recorded in `docs/validation/V1_2_0_RELEASE_READINESS_EVIDENCE.md`.
 - [x] R8: annotated `v1.2.0` tag and immutable [GitHub Release](https://github.com/Baelfyre/Orchestra/releases/tag/v1.2.0) published and independently verified at release commit `4f3c45f6d1e5f290aca108ddf5810c1b18f1dc76`.
 
+## v1.3.0 Specialist Intelligence - Prepared, Publication Gated
+
+- [x] Complete the SK1-SK10 Specialist Knowledge Layer campaign and independently record every phase as `MERGED_VERIFIED`.
+- [x] Select `1.3.0` as the stable minor version for the additive Specialist Intelligence release theme.
+- [x] Normalize all 11 live package/version surfaces to `1.3.0` without changing host maturity or installed integrations.
+- [x] Add deterministic runtime validation for cross-package `1.3.0` version parity.
+- [x] Add source-backed v1.3.0 release-candidate notes covering SK1-SK10 and preserving `MARKDOWN_PRIMARY_JSON_SELECTIVE`.
+- [x] Fail closed on the first signed candidate when Strict Governance detects missing changelog freshness; preserve PR #253 as unmerged evidence and discard its stale validation.
+- [x] Correct changelog freshness without rewriting historical release evidence and rematerialize the exact tree as a signed commit.
+- [x] Validate corrected PR #255 on its exact signed head with governance, behavior, 542 runtime tests at 94.33% coverage, native Windows/Ubuntu/macOS, Analyze actions/python, and CodeQL all passing.
+- [x] Squash-merge PR #255 with expected-head guard and independently verify canonical signed commit `32257723d6ca72847e4581d8b927c7b14c77039e`, parent `650b8bff00d7808bc13fd82a51c7bf0cffa7616e`, and exact reviewed/canonical tree `0fdf39920a8c48a779971c8c97690985bb875d42`.
+- [x] Independently verify that no `v1.3.0` tag or GitHub Release exists after package preparation and that `v1.2.0` remains the public release.
+- [x] Prepare revision-bound release-readiness evidence and stable continuity surfaces.
+- [ ] Publication gate: after separate explicit authorization, reverify live canonical state, create the annotated `v1.3.0` tag, publish `Orchestra v1.3.0: Specialist Intelligence`, and independently verify publication. This item is not authorized by release preparation alone.
+
 ### Current `Protect main` Development Baseline
 
 The current repository policy is a solo-maintainer ruleset with zero required approvals, conversation resolution, Squash-only merge, signed commits, linear history, branch-up-to-date enforcement, restricted deletion, blocked force pushes, and these eight required check contexts:

--- a/docs/releases/v1.3.0-specialist-intelligence-release-candidate.md
+++ b/docs/releases/v1.3.0-specialist-intelligence-release-candidate.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-`PREPARED_PENDING_EXACT_HEAD_VALIDATION`
+`PREPARED_NOT_RELEASED`
 
 Target version: `1.3.0`
 
@@ -11,6 +11,10 @@ Target tag: `v1.3.0`
 Current public release: `v1.2.0`
 
 Release classification: stable minor release candidate.
+
+Canonical preparation commit: `32257723d6ca72847e4581d8b927c7b14c77039e`
+
+Canonical preparation tree: `0fdf39920a8c48a779971c8c97690985bb875d42`
 
 Publication is not authorized by this preparation record. Tag creation and GitHub Release publication remain separate protected actions.
 
@@ -86,22 +90,47 @@ The final SK10 campaign closeout recorded:
 
 Each SK4 through SK10 source PR was Squash-merged with an expected-head guard after exact-head validation. SK1 through SK10 are recorded as `MERGED_VERIFIED` in the canonical Knowledge Base.
 
-## v1.3.0 Release-Preparation Gate
+## v1.3.0 Release-Preparation Evidence
 
-Before this candidate may become publication-ready, the exact final v1.3.0 preparation head must pass the repository's current required validation matrix, including:
+The first signed preparation candidate, PR #253 at head `5238abe2c41782e8fe411e178a75b3ec8d7e323b`, was correctly blocked by Stage 1 Strict Governance because significant package and runtime-test changes lacked a matching changelog update. It was closed unmerged and preserved as failure evidence.
 
-- governance-check;
-- validate;
-- runtime-tests and coverage gate;
-- native Windows, Ubuntu, and macOS validation;
-- Analyze (actions);
-- Analyze (python);
-- CodeQL where reported for the exact head;
-- package/version-surface parity;
-- repository structure, manifest, packaging, routing, prompt-load, guardrail, and Codex export checks; and
+The corrected release-preparation tree added only the required focused changelog entry, restored untouched historical changelog wording, and was rematerialized as signed head `f63daf49add4887d7fbd1b581959ebf8654150db` for PR #255.
+
+PR #255 passed all nine exact-head checks:
+
+- `governance-check`;
+- `validate`;
+- `runtime-tests`;
+- `native-windows-latest`;
+- `native-ubuntu-latest`;
+- `native-macos-latest`;
+- `Analyze (actions)`;
+- `Analyze (python)`; and
+- `CodeQL`.
+
+The exact reviewed head also recorded:
+
+- 542 runtime tests passing;
+- 94.33 percent runtime coverage against the 90 percent gate;
+- the new package/version-surface regression passing for all 11 live package surfaces;
+- Stage 1 Strict Governance passing after remediation;
+- prompt-load, Dagger guardrail, governance behavior, repository behavior, manifest, packaging, and Codex-related validation passing; and
 - zero unresolved review threads.
 
-Any source correction after validation invalidates stale evidence and requires renewed exact-head validation.
+PR #255 was Squash-merged using expected-head guard `f63daf49add4887d7fbd1b581959ebf8654150db`.
+
+Independent canonical verification established:
+
+- canonical commit `32257723d6ca72847e4581d8b927c7b14c77039e`;
+- canonical parent `650b8bff00d7808bc13fd82a51c7bf0cffa7616e`;
+- canonical tree `0fdf39920a8c48a779971c8c97690985bb875d42`;
+- reviewed and canonical tree equality;
+- valid GitHub signature on the canonical commit; and
+- all 11 live package/version surfaces at `1.3.0`.
+
+As of this preparation closeout, GitHub has no `v1.3.0` tag and no GitHub Release for `v1.3.0`. The current public release remains `v1.2.0`.
+
+Detailed revision-bound evidence is recorded in `docs/validation/V1_3_0_RELEASE_READINESS_EVIDENCE.md`.
 
 ## Authority and Publication Boundary
 
@@ -122,4 +151,4 @@ This release candidate does not authorize or perform:
 
 `MERGEABILITY != PUBLICATION_AUTHORITY`
 
-The v1.3.0 preparation campaign must stop at `PREPARED_NOT_RELEASED` until tag/release publication is separately authorized.
+The v1.3.0 preparation campaign stops at `PREPARED_NOT_RELEASED` until tag/release publication is separately authorized.

--- a/docs/validation/V1_3_0_RELEASE_READINESS_EVIDENCE.md
+++ b/docs/validation/V1_3_0_RELEASE_READINESS_EVIDENCE.md
@@ -1,0 +1,200 @@
+# Orchestra v1.3.0 Release Readiness Evidence
+
+## Verdict
+
+`V1_3_0_RELEASE_PREPARATION=MERGED_VERIFIED`
+
+`V1_3_0_RELEASE_STATE=PREPARED_NOT_RELEASED`
+
+`CURRENT_PUBLIC_RELEASE=v1.2.0`
+
+`TARGET_VERSION=1.3.0`
+
+`TARGET_TAG=v1.3.0`
+
+This record is revision-bound release-preparation evidence. It does not authorize tag creation or GitHub Release publication.
+
+## Canonical Preparation Identity
+
+- Pre-preparation Orchestra `main`: `650b8bff00d7808bc13fd82a51c7bf0cffa7616e`
+- Reviewed signed preparation head: `f63daf49add4887d7fbd1b581959ebf8654150db`
+- Reviewed tree: `0fdf39920a8c48a779971c8c97690985bb875d42`
+- Canonical preparation PR: #255
+- Canonical Squash: `32257723d6ca72847e4581d8b927c7b14c77039e`
+- Canonical parent: `650b8bff00d7808bc13fd82a51c7bf0cffa7616e`
+- Canonical tree: `0fdf39920a8c48a779971c8c97690985bb875d42`
+- Reviewed/canonical tree equivalence: `EXACT`
+- Canonical GitHub signature: `VERIFIED_VALID`
+- Expected-head merge guard: `USED`
+- Branch deletion: `NOT_PERFORMED`
+- Force push/history rewrite: `NOT_PERFORMED`
+
+The signed reviewed head and the canonical Squash have the same tree. Squash rewrote commit identity as expected, but not reviewed content.
+
+## Superseded Candidate Evidence
+
+The first 13-file signed candidate was materialized as `5238abe2c41782e8fe411e178a75b3ec8d7e323b` and opened as PR #253.
+
+PR #253 failed closed at Stage 1 Strict Governance because significant package/test changes had no matching `CHANGELOG.md` update. The finding was:
+
+```text
+Significant changes were detected without a matching CHANGELOG.md update.
+Significant paths: plugin.json, tests/runtime/test_release_version_surfaces.py
+```
+
+PR #253 was closed unmerged. Its validation was invalidated and not reused.
+
+The corrected work tree added a focused v1.3.0 preparation changelog entry and restored an accidentally touched historical changelog phrase before signed rematerialization. The final canonical compare shows the release-preparation changelog change as additive only.
+
+## Exact PR #255 Scope
+
+The canonical preparation changed exactly 14 files:
+
+1. `.claude-plugin/marketplace.json`
+2. `.claude-plugin/plugin.json`
+3. `.codex-plugin/plugin.json`
+4. `CHANGELOG.md`
+5. `adapters/cursor/package.json`
+6. `adapters/jetbrains/package.json`
+7. `adapters/jetbrains/plugin.xml`
+8. `adapters/neovim/package.json`
+9. `adapters/vscode/package.json`
+10. `adapters/windsurf/package.json`
+11. `adapters/zed/package.json`
+12. `docs/releases/v1.3.0-specialist-intelligence-release-candidate.md`
+13. `plugin.json`
+14. `tests/runtime/test_release_version_surfaces.py`
+
+The package/version change is additive release preparation. It does not graduate any scaffold-only host, change runtime authority, activate policy, deploy software, or publish an integration.
+
+## Package Version Surface
+
+The new deterministic runtime regression validates these 11 live package/version surfaces as `1.3.0`:
+
+- `plugin.json`
+- `.codex-plugin/plugin.json`
+- `.claude-plugin/plugin.json`
+- `.claude-plugin/marketplace.json` plugin entry
+- `adapters/cursor/package.json`
+- `adapters/jetbrains/package.json`
+- `adapters/jetbrains/plugin.xml`
+- `adapters/neovim/package.json`
+- `adapters/vscode/package.json`
+- `adapters/windsurf/package.json`
+- `adapters/zed/package.json`
+
+The test `tests/runtime/test_release_version_surfaces.py` passed on the exact reviewed head.
+
+## Exact-Head GitHub Checks
+
+Exact reviewed head: `f63daf49add4887d7fbd1b581959ebf8654150db`
+
+All nine observed checks completed successfully:
+
+| Check | Result |
+|---|---|
+| `governance-check` | PASS |
+| `validate` | PASS |
+| `runtime-tests` | PASS |
+| `native-windows-latest` | PASS |
+| `native-ubuntu-latest` | PASS |
+| `native-macos-latest` | PASS |
+| `Analyze (actions)` | PASS |
+| `Analyze (python)` | PASS |
+| `CodeQL` | PASS |
+
+CodeQL reported no new alerts in code changed by PR #255.
+
+PR #255 had zero unresolved review threads and was mergeable on the exact reviewed head immediately before the expected-head Squash merge.
+
+## Runtime and Repository Validation
+
+The exact reviewed release-preparation head recorded:
+
+```text
+542 passed
+Required coverage: 90%
+Observed coverage: 94.33%
+```
+
+The new v1.3.0 version-parity regression was included in those 542 runtime tests and passed.
+
+The exact-head workflows also passed:
+
+- behavior validation;
+- repository structure validation;
+- manifest validation;
+- IDE/scaffold packaging validation;
+- prompt-load measurement and thresholds;
+- project context validation;
+- Stage 1 Strict Governance after changelog remediation;
+- Dagger guardrail simulation;
+- governance behavior tests;
+- general behavior tests;
+- native Windows/Ubuntu/macOS validation;
+- action and Python static analysis; and
+- CodeQL.
+
+The Stage 1 remediation demonstrates that stale or incomplete release evidence was not accepted merely because earlier package tests were green.
+
+## Specialist Campaign Basis
+
+v1.3.0 packages the completed SK1-SK10 Specialist Knowledge Layer campaign. Before release preparation began, canonical campaign closeout recorded all phases as `MERGED_VERIFIED` and the final SK10 assurance included:
+
+- 10 adversarial routing, coordination, invalidation, handoff, and protected-action scenarios;
+- complete authoritative behavior validation;
+- 541 runtime tests at 94.31 percent coverage;
+- strict governance at 0 errors and 0 warnings;
+- prompt-load budgets passing;
+- Codex source/export parity passing;
+- nine of nine exact-head checks passing; and
+- zero unresolved review threads.
+
+The release-preparation regression raises the current runtime-suite count to 542 and current coverage to 94.33 percent.
+
+## Public Release Boundary
+
+After canonical package preparation, independent GitHub reads established:
+
+```text
+CURRENT_PUBLIC_RELEASE=v1.2.0
+V1_3_0_TAG_EXISTS=NO
+V1_3_0_GITHUB_RELEASE_EXISTS=NO
+```
+
+GitHub returned `404 Not Found` for both the `refs/tags/v1.3.0` reference and the release-by-tag `v1.3.0` endpoint at this checkpoint.
+
+The existing `v1.2.0` release/tag history is not modified by v1.3.0 preparation.
+
+## Protected Actions
+
+The following were not performed and remain separately gated:
+
+- annotated tag creation;
+- GitHub Release publication;
+- deployment or production mutation;
+- marketplace publication;
+- installed-integration refresh;
+- policy activation;
+- destructive cleanup;
+- branch deletion;
+- force push; and
+- history rewrite.
+
+```text
+VALIDATION_SUCCESS != RELEASE_AUTHORITY
+MERGEABILITY != PUBLICATION_AUTHORITY
+PACKAGE_VERSION_1_3_0 != PUBLIC_RELEASE_V1_3_0
+```
+
+## Publication Gate
+
+The repository may be described as **prepared for v1.3.0 publication**, not as already released.
+
+Required next authority state:
+
+```text
+V1_3_0_PUBLICATION=AWAITING_SEPARATE_AUTHORIZATION
+```
+
+A future publication action must independently re-read live Orchestra `main`, verify this readiness state has not drifted, verify no newer release/version conflict exists, and then follow the separately authorized tag/release publication procedure. Validation or this evidence file alone does not grant that authority.


### PR DESCRIPTION
Auxiliary signed-materialization PR for the bounded v1.3.0 readiness/continuity tree.

- Base: canonical package-preparation commit `32257723d6ca72847e4581d8b927c7b14c77039e`
- Head: `release/v1.3.0-readiness-work`
- Exact scope: 5 documentation/continuity files
- Purpose: materialize revision-bound readiness evidence and current-state continuity as one GitHub-verified signed Squash commit on an isolated staging branch
- This PR does not target canonical `main`
- No tag/release publication or other protected action is performed