### PR TITLE
docs: record v1.3.0 publication closeout

### DIFF
--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -10,7 +10,7 @@ A governance-first specialist skill framework that routes complex AI-assisted so
 Open-source developer tooling and AI orchestration framework
 
 ## Current Stage
-Published release `v1.2.0` (`PUBLISHED_VERIFIED`) from annotated tag `v1.2.0` at exact release commit `4f3c45f6d1e5f290aca108ddf5810c1b18f1dc76`. Canonical release history includes R7/R7R, Governed Autonomy Modes, pre-R8 repository hygiene through PR #234, and final release-readiness refresh through PR #235. GA-0 concluded `NO_DUPLICATE_AUTHORITY_MODEL`; GA-1 through GA-7 and the source-pinned README/hygiene reconciliation are `MERGED_VERIFIED`. Publication performed no deployment, installed-integration refresh, branch deletion, marketplace publication, or policy activation.
+Published release `v1.3.0` (`PUBLISHED_VERIFIED`) from annotated tag `v1.3.0` at exact release commit `3c6155c111981632649a3c3207fac8ac1edcea74`. The release packages the completed SK1-SK10 Specialist Intelligence campaign, 11 aligned package/version surfaces at `1.3.0`, 542 runtime tests at 94.33% coverage, revision-bound release-readiness evidence, and the README-alignment gate through PR #259. The GitHub Release is non-draft, non-prerelease, and immutable. Publication performed no deployment, installed-integration refresh, branch deletion, marketplace publication, or policy activation.
 
 ## Primary Users
 Developers and maintainers who install Orchestra as a plugin, skill set, or runtime package inside a supported or scaffold-only IDE or coding host (Claude Code, Codex, Antigravity, Cursor, Windsurf, JetBrains, Zed, Neovim)
@@ -56,7 +56,7 @@ Guidance used for this classification:
 - `tests/behavior/run-tests.ps1` is intentionally maintained in parallel with `run_tests.py` as the primary validation path for Windows environments, per `docs/MATURITY.md`.
 - Direct pushes to `main` are not part of the normal workflow; changes go through a branch and pull request except for documented maintainer bypass recovery cases.
 - Installed Codex and Antigravity parity, host context-reset behavior, and Windows filesystem-specific behavior require host-local evidence in addition to repository CI.
-- `v1.2.0` metadata in the repository is release-candidate state, not evidence of a published tag or GitHub Release.
+- Repository package metadata is `1.3.0`, and public release `v1.3.0` is independently verified. Later `main` commits may contain post-release documentation or future unreleased work and do not move the `v1.3.0` tag.
 
 ## Known Non-Goals
 - Orchestra does not store, process, or transmit end-user or client data itself.
@@ -72,4 +72,4 @@ Guidance used for this classification:
 Not yet decided. No project-specific maintainer preferences beyond `docs/CONTRIBUTING.md` are currently documented for this field.
 
 ## Last Reviewed
-2026-08-09
+2026-08-13

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -5,37 +5,48 @@
 - **Canonical Branch:** `main`
 - **Base Branch:** `main`
 - **Stable Continuation Branch:** `main`
-- **Current Public Release:** `v1.2.0`
-- **Release Status:** `PUBLISHED_VERIFIED` on August 9, 2026
+- **Current Public Release:** `v1.3.0`
+- **Release Status:** `PUBLISHED_VERIFIED` on August 12, 2026 UTC / August 13, 2026 Asia/Manila
 - **Target Release:** `v1.3.0`
 - **Release-Candidate Metadata:** `1.3.0`
 - **v1.2.0 Release State:** `PUBLISHED_VERIFIED`
-- **v1.3.0 Preparation State:** `PREPARED_NOT_RELEASED`
-- **v1.3.0 Canonical Preparation Commit:** `32257723d6ca72847e4581d8b927c7b14c77039e`
-- **v1.3.0 Canonical Preparation Tree:** `0fdf39920a8c48a779971c8c97690985bb875d42`
+- **v1.3.0 Release State:** `PUBLISHED_VERIFIED`
+- **v1.3.0 Release Commit:** `3c6155c111981632649a3c3207fac8ac1edcea74`
+- **v1.3.0 Release Tree:** `5ae72f6ab9ddf5284afdc3d8675f67fc23c24281`
+- **v1.3.0 Annotated Tag Object:** `c66afec49990036d9deb2f07e3363cd664e2dcb1` (`UNSIGNED`, exact target verified)
+- **v1.3.0 GitHub Release:** `PUBLISHED_VERIFIED`, immutable, non-draft, non-prerelease
 - **Policy Activation State:** `NOT_PERFORMED`
 
-## v1.3.0 Specialist Intelligence Release Preparation
+## v1.3.0 Specialist Intelligence Publication
 
 The SK1-SK10 Specialist Knowledge Layer campaign is `MERGED_VERIFIED`. The bounded v1.3.0 package/version preparation was reviewed through PR #255 at signed head `f63daf49add4887d7fbd1b581959ebf8654150db` and Squash-merged with an expected-head guard as canonical commit `32257723d6ca72847e4581d8b927c7b14c77039e`.
 
-Reviewed and canonical trees are exactly `0fdf39920a8c48a779971c8c97690985bb875d42`; the canonical commit has a valid GitHub signature. The exact reviewed head passed all nine observed checks: governance, validate, runtime-tests, native Windows/Ubuntu/macOS, Analyze actions/python, and CodeQL. The current runtime suite is 542 passing tests at 94.33% coverage, including deterministic `1.3.0` parity across all 11 live package/version surfaces.
+Revision-bound readiness was reviewed through PR #257 and merged as signed canonical commit `db351796684789987eb5bce85e641ce31c91993b`. README alignment was then reviewed through PR #259 at signed head `b7b8bfeced7c0719558eb95c0797f0685f0c98f2`, passed all nine exact-head checks, and Squash-merged with an expected-head guard as exact release commit `3c6155c111981632649a3c3207fac8ac1edcea74` with tree `5ae72f6ab9ddf5284afdc3d8675f67fc23c24281`.
+
+The current runtime suite is 542 passing tests at 94.33% coverage, including deterministic `1.3.0` parity across all 11 live package/version surfaces.
 
 The first candidate PR #253 is preserved as fail-closed evidence: Stage 1 Strict Governance correctly rejected the 13-file candidate because significant package/test changes lacked a matching changelog update. The corrected tree added the focused changelog entry, restored historical wording, discarded stale validation, and reran the full exact-head matrix through PR #255.
 
-Publication remains separately gated:
+Publication completed under separate explicit maintainer authority:
 
 ```text
-CURRENT_PUBLIC_RELEASE=v1.2.0
+CURRENT_PUBLIC_RELEASE=v1.3.0
 TARGET_VERSION=1.3.0
 TARGET_TAG=v1.3.0
-V1_3_0_RELEASE_STATE=PREPARED_NOT_RELEASED
-V1_3_0_TAG_EXISTS=NO
-V1_3_0_GITHUB_RELEASE_EXISTS=NO
-V1_3_0_PUBLICATION=AWAITING_SEPARATE_AUTHORIZATION
+V1_3_0_RELEASE_STATE=PUBLISHED_VERIFIED
+V1_3_0_TAG_OBJECT=c66afec49990036d9deb2f07e3363cd664e2dcb1
+V1_3_0_TAG_TARGET=3c6155c111981632649a3c3207fac8ac1edcea74
+V1_3_0_TAG_OBJECT_SIGNATURE=UNSIGNED
+V1_3_0_RELEASE_COMMIT_SIGNATURE=VERIFIED_VALID
+V1_3_0_GITHUB_RELEASE_IMMUTABLE=true
+V1_3_0_PUBLICATION=COMPLETE_VERIFIED
 ```
 
-See `docs/releases/v1.3.0-specialist-intelligence-release-candidate.md` and `docs/validation/V1_3_0_RELEASE_READINESS_EVIDENCE.md`.
+The unsigned annotated-tag-object state is recorded accurately and is consistent with the prior v1.2.0 annotated tag pattern. Trust remains anchored to the exact tag target and the GitHub-verified signed release commit.
+
+No deployment, marketplace publication, installed-integration refresh, policy activation, destructive cleanup, branch deletion, force push, or history rewrite was performed.
+
+See `docs/releases/v1.3.0-specialist-intelligence-release-candidate.md`, `docs/validation/V1_3_0_RELEASE_READINESS_EVIDENCE.md`, and `docs/validation/V1_3_0_PUBLICATION_CLOSEOUT.md`.
 
 ## Canonical Capability State
 
@@ -148,7 +159,7 @@ Autonomous merges follow `docs/governance/AUTONOMOUS_MERGE_READINESS_PROTOCOL.md
 - **GA-6:** Deterministic adversarial fixtures and focused validator/runtime regressions.
 - **GA-7:** Governance, routing, adapter, project-state, README, roadmap, and release-candidate documentation reconciliation.
 
-No profile creates authority. Claude Code remains `SCAFFOLD_ONLY`; runtime authority, plugin manifests, versions, host fixtures, and installed integrations are unchanged.
+No profile creates authority. Claude Code remains `SCAFFOLD_ONLY`; runtime authority, plugin manifests, versions, host fixtures, and installed integrations are unchanged by the autonomy-profile implementation itself.
 
 ## Current `Protect main` Ruleset
 
@@ -193,14 +204,14 @@ The current bypass list is intentionally retained for repository-operational acc
 - **Ruleset Rule:** Live ruleset drift, non-Squash merge selection, unresolved review threads, or unauthorized bypass use blocks ordinary autonomous merge.
 - **Baseline Rule:** A new phase must not begin from a red canonical `main`.
 - **Post-Merge Rule:** An API response is not completion evidence. For Squash, canonical parent/tree/content/signature evidence and a canonical remote read are required before state advances.
-- **Issue #215:** `CLOSED_VERIFIED` after the published release, Orchestra post-publication PR #236, KB publication-closeout PR #32, and the evidence-backed completion comment were independently verified.
+- **Issue #215:** `CLOSED_VERIFIED` after the published v1.2.0 release, Orchestra post-publication PR #236, KB publication-closeout PR #32, and the evidence-backed completion comment were independently verified.
 - **R6 Repository State:** Release-candidate preparation completed with version surfaces normalized to `1.2.0`.
 - **R7 State:** R7 and R7R are `MERGED_VERIFIED`; PR #230 incident history is preserved forward-only and PR #231 is the signed Squash trust anchor.
 - **Governed Autonomy Modes:** GA-0 through GA-7 are `MERGED_VERIFIED` through PR #232 and signed canonical Squash commit `900f88d7a3ed480ae8b910e6ba204008a72d2784`.
 - **Pre-R8 Repository Hygiene:** README provenance/host/release state and complete conservative file/branch classifications are `MERGED_VERIFIED` through PR #234 and signed canonical Squash commit `8cca62109b10aa06abaf25fc4c9982a02160bcbf`. No tracked file or branch was deleted.
-- **Release Readiness:** Hygiene-invalidated candidate evidence has been refreshed against canonical `8cca62109b10aa06abaf25fc4c9982a02160bcbf`; behavior, 541 runtime tests at 94.31% coverage, strict governance, packaging, exact-head CI, signature/tree/base verification, and release-boundary reads are green. See `docs/validation/V1_2_0_RELEASE_READINESS_EVIDENCE.md`.
-- **Publication State:** Annotated tag `v1.2.0` and the immutable, non-draft, non-prerelease GitHub Release are `PUBLISHED_VERIFIED` at release commit `4f3c45f6d1e5f290aca108ddf5810c1b18f1dc76`. No deployment, marketplace publication, installed-integration refresh, or policy activation was performed.
-- **v1.3.0 Preparation:** SK1-SK10 are `MERGED_VERIFIED`; package/version preparation is canonical through PR #255 at signed Squash `32257723d6ca72847e4581d8b927c7b14c77039e`, with 542 runtime tests at 94.33% coverage and all 9 observed exact-head checks passing. Publication remains `AWAITING_SEPARATE_AUTHORIZATION`.
+- **v1.2.0 Publication State:** Annotated tag `v1.2.0` and the immutable, non-draft, non-prerelease GitHub Release are historical `PUBLISHED_VERIFIED` evidence at release commit `4f3c45f6d1e5f290aca108ddf5810c1b18f1dc76`.
+- **v1.3.0 Preparation:** SK1-SK10 are `MERGED_VERIFIED`; package/version preparation is canonical through PR #255 at signed Squash `32257723d6ca72847e4581d8b927c7b14c77039e`, with 542 runtime tests at 94.33% coverage and all 9 observed exact-head checks passing.
+- **v1.3.0 Publication State:** Annotated tag `v1.3.0` targets exact signed release commit `3c6155c111981632649a3c3207fac8ac1edcea74`; the immutable, non-draft, non-prerelease GitHub Release `Orchestra v1.3.0: Specialist Intelligence` is `PUBLISHED_VERIFIED`. No deployment, marketplace publication, installed-integration refresh, or policy activation was performed.
 
 ## Local Startup Verification
 

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -3,12 +3,14 @@
 - **Canonical Repo:** `Baelfyre/Orchestra`
 - **Canonical Branch:** `main`
 - **Base Branch:** `main`
-- **Current Public Release:** `v1.2.0`
+- **Current Public Release:** `v1.3.0`
 - **Release-Candidate Metadata:** `v1.3.0`
 - **Target Release:** `v1.3.0`
 - **v1.2.0 Release State:** `PUBLISHED_VERIFIED`
-- **v1.3.0 Preparation State:** `PREPARED_NOT_RELEASED`
-- **v1.3.0 Canonical Preparation Commit:** `32257723d6ca72847e4581d8b927c7b14c77039e`
+- **v1.3.0 Release State:** `PUBLISHED_VERIFIED`
+- **v1.3.0 Release Commit:** `3c6155c111981632649a3c3207fac8ac1edcea74`
+- **v1.3.0 Release Tree:** `5ae72f6ab9ddf5284afdc3d8675f67fc23c24281`
+- **v1.3.0 Tag Object:** `c66afec49990036d9deb2f07e3363cd664e2dcb1` (`UNSIGNED`, exact target verified)
 - **Policy Activation:** `NOT_PERFORMED`
 
 ## v1.3.0 Specialist Intelligence Continuity
@@ -19,26 +21,35 @@ Canonical preparation tree `0fdf39920a8c48a779971c8c97690985bb875d42` is exactly
 
 The earlier PR #253 is intentionally retained as fail-closed evidence. It was closed unmerged after Stage 1 Strict Governance correctly detected missing changelog freshness. Its validation was not reused.
 
-Current publication boundary:
+Revision-bound readiness was merged through PR #257 at signed canonical commit `db351796684789987eb5bce85e641ce31c91993b`. README alignment was then reviewed through PR #259 at signed head `b7b8bfeced7c0719558eb95c0797f0685f0c98f2`, passed all nine exact-head checks with zero review threads, and Squash-merged with an expected-head guard as signed release commit `3c6155c111981632649a3c3207fac8ac1edcea74`.
+
+Current publication state:
 
 ```text
-CURRENT_PUBLIC_RELEASE=v1.2.0
+CURRENT_PUBLIC_RELEASE=v1.3.0
 TARGET_VERSION=1.3.0
 TARGET_TAG=v1.3.0
 V1_3_0_RELEASE_PREPARATION=MERGED_VERIFIED
-V1_3_0_RELEASE_STATE=PREPARED_NOT_RELEASED
-V1_3_0_TAG_EXISTS=NO
-V1_3_0_GITHUB_RELEASE_EXISTS=NO
-V1_3_0_PUBLICATION=AWAITING_SEPARATE_AUTHORIZATION
+V1_3_0_RELEASE_STATE=PUBLISHED_VERIFIED
+V1_3_0_TAG_OBJECT=c66afec49990036d9deb2f07e3363cd664e2dcb1
+V1_3_0_TAG_TARGET=3c6155c111981632649a3c3207fac8ac1edcea74
+V1_3_0_TAG_OBJECT_SIGNATURE=UNSIGNED
+V1_3_0_RELEASE_COMMIT_SIGNATURE=VERIFIED_VALID
+V1_3_0_GITHUB_RELEASE_IMMUTABLE=true
+V1_3_0_PUBLICATION=COMPLETE_VERIFIED
 ```
 
-Do not create the tag or GitHub Release without a separate explicit publication authorization. Before any future publication action, independently re-read live Orchestra `main`, this handoff, the v1.3.0 candidate, and `docs/validation/V1_3_0_RELEASE_READINESS_EVIDENCE.md`, then detect drift.
+The GitHub Release is non-draft, non-prerelease, immutable, and the latest public release. The annotated tag object is unsigned, as was the prior v1.2.0 annotated tag object; the exact target is verified and the release commit itself is GitHub-verified and valid.
 
-## Active README Governance Reconciliation
+No deployment, production mutation, marketplace publication, installed-integration refresh, policy activation, destructive cleanup, branch deletion, force push, or history rewrite was performed.
 
-Canonical Orchestra `main` currently contains accepted README refinement commit `807bda608d65cb10bf65cdf313916d9d0fd62320`. The change is README-only and exact local validation is green, including 541 runtime tests at 94.31% coverage and strict governance with 0 errors and 0 warnings.
+Evidence: `docs/validation/V1_3_0_PUBLICATION_CLOSEOUT.md`.
 
-The canonical commit is unsigned and the transition occurred directly on `main` rather than through the repository's required pull-request path, so it is not governance-complete. Preserve the current history and remediate forward-only through a normal exact-head validated PR and signed Squash result.
+## Historical README Governance Reconciliation
+
+Canonical Orchestra history contains accepted README refinement commit `807bda608d65cb10bf65cdf313916d9d0fd62320`. The change was README-only and exact local validation was green, including 541 runtime tests at 94.31% coverage and strict governance with 0 errors and 0 warnings.
+
+The canonical commit was unsigned and the transition occurred directly on `main` rather than through the repository's required pull-request path. The incident was remediated forward-only through later normal PR/Squash governance; history was preserved without force push or rewrite.
 
 ```text
 PRESERVE_CURRENT_CANONICAL_HISTORY=true
@@ -67,7 +78,7 @@ backup/main-pre-v1.2-autonomous-2026-08-07
 
 The clean replay then completed R1 through R5B:
 
-- **R1 / PR #223:** Spec Kitty Phase 3 and roadmap reconciliation.
+- **R1 / PR #223:** Spec Kitty Phase 3 and roadmap closeout.
 - **R2 / PR #224:** additive backend-persistence and cross-module logical-flow integrity.
 - **R3 / PR #225:** delegated Phase C repository host-reliability contract after bounded fixture remediation and a fully fresh validation matrix.
 - **R4 / PR #226:** delegated Phase D runtime-overlap reconciliation with `NO_DUPLICATE_RUNTIME_EXTENSION_REQUIRED` for v1.2.0.
@@ -83,8 +94,9 @@ Historical R6 and current publication state:
 ```text
 HISTORICAL_RELEASE_CANDIDATE_VERSION=1.2.0
 HISTORICAL_R6_RELEASE_STATE=PREPARED_NOT_RELEASED
-CURRENT_PUBLIC_RELEASE=v1.2.0
+CURRENT_PUBLIC_RELEASE=v1.3.0
 V1_2_0_RELEASE_STATE=PUBLISHED_VERIFIED
+V1_3_0_RELEASE_STATE=PUBLISHED_VERIFIED
 POLICY_ACTIVATION=NOT_PERFORMED
 LIVE_INSTALLED_HOST_VALIDATION=VERIFIED_RECONCILED_LOCALLY
 ```
@@ -122,13 +134,15 @@ git switch main
 git pull --ff-only origin main
 ```
 
-## Remaining Sequence
+## Completed Sequence
 
 ```text
-SK1..SK10  specialist knowledge campaign - merged verified
-V1.3-PREP   package/version preparation and exact-head validation - merged verified
-V1.3-READY  revision-bound readiness and continuity reconciliation - current closeout
-V1.3-PUBLISH  annotated tag and GitHub Release - awaiting separate authorization
+SK1..SK10    specialist knowledge campaign - merged verified
+V1.3-PREP    package/version preparation and exact-head validation - merged verified
+V1.3-READY   revision-bound readiness and continuity reconciliation - merged verified
+V1.3-README  pre-publication README alignment - merged verified
+V1.3-PUBLISH annotated tag and immutable GitHub Release - complete verified
+V1.3-CLOSE   post-publication repository and KB continuity - current closeout
 ```
 
 Historical first-run failures remain preserved as audit evidence. They must not be silently rewritten or deleted during cleanup.

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -63,11 +63,11 @@ Phases 6B-A through 6C are complete and merged through PR #183. Phase 6D produce
 - [x] GA-4: Profile-aware transition integration through Squash-aware post-merge verification.
 - [x] GA-5: Audit, provenance, interruption recovery, delegation inheritance, and portable-resume preservation.
 - [x] GA-6: Adversarial fixture validation for authority, profile, policy, evidence, bypass, merge-method, signature, scope, and continuity boundaries.
-- [x] GA-7: Governance, routing, Conductor/Codex parity, project-state, README, roadmap, and release-candidate documentation.
+- [x] GA-7: Governance, routing, Conductor/Codex parity, project-state, README, roadmap, and release-candidate documentation reconciliation.
 - [x] Refresh every release-readiness artifact invalidated by R7R or GA implementation and independently verify the final candidate; canonical evidence is recorded in `docs/validation/V1_2_0_RELEASE_READINESS_EVIDENCE.md`.
 - [x] R8: annotated `v1.2.0` tag and immutable [GitHub Release](https://github.com/Baelfyre/Orchestra/releases/tag/v1.2.0) published and independently verified at release commit `4f3c45f6d1e5f290aca108ddf5810c1b18f1dc76`.
 
-## v1.3.0 Specialist Intelligence - Prepared, Publication Gated
+## v1.3.0 Specialist Intelligence - Published Verified
 
 - [x] Complete the SK1-SK10 Specialist Knowledge Layer campaign and independently record every phase as `MERGED_VERIFIED`.
 - [x] Select `1.3.0` as the stable minor version for the additive Specialist Intelligence release theme.
@@ -78,9 +78,15 @@ Phases 6B-A through 6C are complete and merged through PR #183. Phase 6D produce
 - [x] Correct changelog freshness without rewriting historical release evidence and rematerialize the exact tree as a signed commit.
 - [x] Validate corrected PR #255 on its exact signed head with governance, behavior, 542 runtime tests at 94.33% coverage, native Windows/Ubuntu/macOS, Analyze actions/python, and CodeQL all passing.
 - [x] Squash-merge PR #255 with expected-head guard and independently verify canonical signed commit `32257723d6ca72847e4581d8b927c7b14c77039e`, parent `650b8bff00d7808bc13fd82a51c7bf0cffa7616e`, and exact reviewed/canonical tree `0fdf39920a8c48a779971c8c97690985bb875d42`.
-- [x] Independently verify that no `v1.3.0` tag or GitHub Release exists after package preparation and that `v1.2.0` remains the public release.
-- [x] Prepare revision-bound release-readiness evidence and stable continuity surfaces.
-- [ ] Publication gate: after separate explicit authorization, reverify live canonical state, create the annotated `v1.3.0` tag, publish `Orchestra v1.3.0: Specialist Intelligence`, and independently verify publication. This item is not authorized by release preparation alone.
+- [x] Independently verify that no `v1.3.0` tag or GitHub Release existed after package preparation and that `v1.2.0` remained the public release at that checkpoint.
+- [x] Prepare revision-bound release-readiness evidence and stable continuity surfaces through PR #257.
+- [x] Align README public-facing scope with the completed Specialist Intelligence campaign through PR #259, pass all nine exact-head checks, and merge exact signed release commit `3c6155c111981632649a3c3207fac8ac1edcea74`.
+- [x] Under separate explicit publication authority, create annotated tag `v1.3.0` targeting exact release commit `3c6155c111981632649a3c3207fac8ac1edcea74`.
+- [x] Publish `Orchestra v1.3.0: Specialist Intelligence` as a non-draft, non-prerelease, immutable GitHub Release and independently verify it as the latest public release.
+- [x] Record the annotated tag object as unsigned while preserving the GitHub-verified signed release commit as the release trust anchor, consistent with the v1.2.0 tag pattern.
+- [x] Confirm publication performed no deployment, marketplace publication, installed-integration refresh, policy activation, destructive cleanup, branch deletion, force push, or history rewrite.
+
+Publication closeout evidence is recorded in `docs/validation/V1_3_0_PUBLICATION_CLOSEOUT.md`.
 
 ### Current `Protect main` Development Baseline
 
@@ -122,3 +128,4 @@ The existing bypass list remains operationally available. Orchestra governance m
 - [ ] Improve adapters as tool capabilities change.
 - [ ] Expand fictional, project-agnostic examples.
 - [x] Publish `v1.2.0` after R7R, GA-0 through GA-7, refreshed release evidence, independent final verification, and the separate R8 publication gate completed.
+- [x] Publish `v1.3.0` after the SK1-SK10 Specialist Intelligence campaign, release preparation, revision-bound readiness, README alignment, and separate publication authority completed.

--- a/docs/setup/COMPATIBILITY.md
+++ b/docs/setup/COMPATIBILITY.md
@@ -1,6 +1,8 @@
 # Compatibility
 
-The current public GitHub Release is Orchestra `v1.2.0`, published from annotated tag `v1.2.0` at release commit `4f3c45f6d1e5f290aca108ddf5810c1b18f1dc76`. Publication did not graduate scaffold-only hosts or perform marketplace publication.
+The current public GitHub Release is Orchestra `v1.3.0: Specialist Intelligence`, published from annotated tag `v1.3.0` at exact release commit `3c6155c111981632649a3c3207fac8ac1edcea74`. The release is non-draft, non-prerelease, and immutable. Publication did not graduate scaffold-only hosts or perform marketplace publication.
+
+The annotated `v1.3.0` tag object is unsigned and targets the GitHub-verified signed release commit above. This is consistent with the prior v1.2.0 annotated-tag pattern and is not represented as a signed tag.
 
 Scaffold-only hosts are not full support claims. Promotion requirements and graduation order live in `docs/project/SCAFFOLD_ADAPTER_GRADUATION_CRITERIA.md`.
 

--- a/docs/setup/INSTALLATION.md
+++ b/docs/setup/INSTALLATION.md
@@ -4,9 +4,11 @@ Orchestra can be installed in several ways depending on your AI host or IDE.
 
 ## Release Status
 
-The current public GitHub Release is `v1.2.0`, published August 9, 2026 from annotated tag `v1.2.0` at release commit `4f3c45f6d1e5f290aca108ddf5810c1b18f1dc76`. Repository manifests and the published release are normalized to version `1.2.0`.
+The current public GitHub Release is `v1.3.0: Specialist Intelligence`, published from annotated tag `v1.3.0` at exact release commit `3c6155c111981632649a3c3207fac8ac1edcea74`. Repository manifests and the published release are normalized to version `1.3.0`. The GitHub Release is non-draft, non-prerelease, and immutable.
 
-The latest GitHub Release remains the publication source of truth. Installing directly from `main` may include post-release documentation or later unreleased work, so use tag `v1.2.0` when exact released content is required.
+The annotated tag object targets the GitHub-verified signed release commit above; the tag object itself is unsigned and is not represented as a signed tag.
+
+The latest GitHub Release remains the publication source of truth. Installing directly from `main` may include post-release documentation or later unreleased work, so use tag `v1.3.0` when exact released content is required.
 
 | Host | Install Surface | Current Status |
 |---|---|---|
@@ -22,7 +24,7 @@ The latest GitHub Release remains the publication source of truth. Installing di
 | Neovim | Scaffold-only packaging and workspace instructions | Scaffold-only |
 | Local AI systems | Manual skill loading | Supported |
 
-Accepted R7 live installed-host continuity evidence is verified and reconciled locally in `docs/validation/R7_LIVE_INSTALLED_HOST_VALIDATION_EVIDENCE.md`; repository validation does not replace that evidence. R8 publication is complete, but the repository simulation fixture remains pending/empty by design and is not live evidence.
+Accepted R7 live installed-host continuity evidence is verified and reconciled locally in `docs/validation/R7_LIVE_INSTALLED_HOST_VALIDATION_EVIDENCE.md`; repository validation does not replace that evidence. The v1.3.0 GitHub publication is complete, but the repository simulation fixture remains pending/empty by design and is not live evidence.
 
 ## 1. Antigravity Plugin Setup
 

--- a/docs/validation/V1_3_0_PUBLICATION_CLOSEOUT.md
+++ b/docs/validation/V1_3_0_PUBLICATION_CLOSEOUT.md
@@ -1,0 +1,150 @@
+# Orchestra v1.3.0 Publication Closeout
+
+## Verdict
+
+```text
+V1_3_0_PUBLICATION=COMPLETE_VERIFIED
+RELEASE_STATE=PUBLISHED_VERIFIED
+CURRENT_PUBLIC_RELEASE=v1.3.0
+RELEASE_NAME=Orchestra v1.3.0: Specialist Intelligence
+RELEASE_COMMIT=3c6155c111981632649a3c3207fac8ac1edcea74
+RELEASE_TREE=5ae72f6ab9ddf5284afdc3d8675f67fc23c24281
+TAG=v1.3.0
+TAG_OBJECT=c66afec49990036d9deb2f07e3363cd664e2dcb1
+GITHUB_RELEASE_ID=369402941
+GITHUB_RELEASE_IMMUTABLE=true
+```
+
+The separately authorized v1.3.0 publication gate completed after README alignment was merged and verified. The publication created annotated tag `v1.3.0` and the immutable, non-draft, non-prerelease GitHub Release `Orchestra v1.3.0: Specialist Intelligence`.
+
+## Release Identity
+
+The annotated tag ref resolves to tag object `c66afec49990036d9deb2f07e3363cd664e2dcb1`. That tag object targets exact release commit `3c6155c111981632649a3c3207fac8ac1edcea74`.
+
+The release commit is the signed canonical Squash result of README-alignment PR #259 and has GitHub signature status `VERIFIED_VALID`. Its tree is `5ae72f6ab9ddf5284afdc3d8675f67fc23c24281`, exactly equal to the reviewed README-alignment tree.
+
+The annotated tag object itself is unsigned. This is recorded as an identity fact, not represented as a signed tag. The prior v1.2.0 annotated tag object is likewise unsigned; release trust remains anchored to the verified signed release commit and exact tag target.
+
+## Publication Metadata
+
+```text
+TAG_REF_TYPE=tag
+TAG_TARGET_TYPE=commit
+TAG_TARGET=3c6155c111981632649a3c3207fac8ac1edcea74
+TAG_OBJECT_SIGNATURE=UNSIGNED
+RELEASE_COMMIT_SIGNATURE=VERIFIED_VALID
+GITHUB_RELEASE_DRAFT=false
+GITHUB_RELEASE_PRERELEASE=false
+GITHUB_RELEASE_IMMUTABLE=true
+GITHUB_RELEASE_PUBLISHED_AT=2026-08-12T17:08:41Z
+LATEST_PUBLIC_RELEASE=v1.3.0
+```
+
+The GitHub Release body records the completed SK1-SK10 Specialist Intelligence scope, `MARKDOWN_PRIMARY_JSON_SELECTIVE`, 11 version surfaces at `1.3.0`, 542 runtime tests, 94.33% coverage, and the successful exact-head validation histories for PRs #255, #257, and #259.
+
+## Pre-Publication Assurance Chain
+
+### Specialist campaign
+
+SK1 through SK10 were `MERGED_VERIFIED` before release preparation began.
+
+### Package preparation
+
+PR #255:
+
+```text
+REVIEWED_HEAD=f63daf49add4887d7fbd1b581959ebf8654150db
+CANONICAL_SQUASH=32257723d6ca72847e4581d8b927c7b14c77039e
+EXACT_HEAD_CHECKS=PASS_9_OF_9
+RUNTIME_TESTS=542_PASSED
+RUNTIME_COVERAGE=94.33_PERCENT
+```
+
+The earlier PR #253 was closed unmerged after Strict Governance correctly rejected missing changelog freshness. Its validation was not reused.
+
+### Revision-bound readiness
+
+PR #257:
+
+```text
+REVIEWED_HEAD=266e4de66e4bb76016c3771229feb11321c3da9d
+CANONICAL_SQUASH=db351796684789987eb5bce85e641ce31c91993b
+EXACT_HEAD_CHECKS=PASS_9_OF_9
+```
+
+### README alignment
+
+PR #259:
+
+```text
+REVIEWED_HEAD=b7b8bfeced7c0719558eb95c0797f0685f0c98f2
+REVIEWED_TREE=5ae72f6ab9ddf5284afdc3d8675f67fc23c24281
+CANONICAL_SQUASH=3c6155c111981632649a3c3207fac8ac1edcea74
+CANONICAL_TREE=5ae72f6ab9ddf5284afdc3d8675f67fc23c24281
+TREE_EQUIVALENCE=EXACT
+CANONICAL_SIGNATURE=VERIFIED_VALID
+EXACT_HEAD_CHECKS=PASS_9_OF_9
+REVIEW_THREADS=0
+EXPECTED_HEAD_GUARD_USED=true
+```
+
+README alignment was required before publication. The tagged source snapshot therefore includes the aligned v1.3.0 Specialist Intelligence public surface.
+
+## Publication Execution History
+
+The publication was executed from an authenticated local host using the governed PowerShell publication gate after the ChatGPT GitHub connector was confirmed not to expose tag/release creation actions.
+
+Three earlier local attempts failed closed before mutation:
+
+1. V1 stopped because Windows PowerShell surfaced ordinary `git fetch` stderr as a terminating `NativeCommandError`.
+2. V2 stopped because local Git returned signature status `E`, meaning the local verifier could not evaluate the canonical commit signature.
+3. V3 stopped because PowerShell treated native `gh api -i` as an ambiguous PowerShell common parameter before `gh` received it.
+
+V4 corrected native-process stderr handling, bound native CLI arguments through explicit string arrays, and required authenticated GitHub exact-commit signature verification when the local verifier returned `E`.
+
+V4 then completed:
+
+```text
+WORKTREE_CLEAN=PASS
+RELEASE_COMMIT_IDENTITY=PASS
+GITHUB_AUTH=PASS
+GITHUB_COMMIT_SIGNATURE=VERIFIED_VALID
+LOCAL_COMMIT_SIGNATURE_STATUS=E_LOCAL_VERIFIER_UNAVAILABLE
+SIGNATURE_FALLBACK=GITHUB_EXACT_COMMIT_VERIFICATION
+LOCAL_ANNOTATED_TAG_CREATED=v1.3.0
+REMOTE_TAG_PUSH=COMPLETE
+REMOTE_TAG_PEELED_COMMIT=3c6155c111981632649a3c3207fac8ac1edcea74
+ANNOTATED_TAG_OBJECT=c66afec49990036d9deb2f07e3363cd664e2dcb1
+ANNOTATED_TAG_TARGET=3c6155c111981632649a3c3207fac8ac1edcea74
+GITHUB_RELEASE_CREATE=COMPLETE
+V1_3_0_TAG=VERIFIED_ANNOTATED
+V1_3_0_GITHUB_RELEASE=VERIFIED
+V1_3_0_RELEASE_DRAFT=False
+V1_3_0_RELEASE_PRERELEASE=False
+V1_3_0_RELEASE_IMMUTABLE=True
+LATEST_PUBLIC_RELEASE=v1.3.0
+ORCHESTRA_V1_3_0_PUBLICATION=COMPLETE_VERIFIED
+```
+
+Independent GitHub reads after the local publication confirmed the same tag object, exact target commit, Release identity, immutable/non-draft/non-prerelease state, and `v1.3.0` latest-release status.
+
+## Protected Actions Not Performed
+
+Publication authority was limited to the v1.3.0 annotated tag and GitHub Release plus ordinary documentation/KB closeout.
+
+The following were not performed:
+
+- deployment or production mutation;
+- marketplace publication;
+- installed-integration refresh;
+- policy activation;
+- destructive cleanup;
+- branch deletion;
+- force push; or
+- history rewrite.
+
+Installed plugin updates remain a separate user-managed marketplace action and are not part of this publication closeout.
+
+## Post-Publication Rule
+
+The `v1.3.0` tag remains fixed at release commit `3c6155c111981632649a3c3207fac8ac1edcea74`. Documentation commits made after publication must not move or rewrite the tag.

--- a/docs/validation/V1_3_0_RELEASE_READINESS_EVIDENCE.md
+++ b/docs/validation/V1_3_0_RELEASE_READINESS_EVIDENCE.md
@@ -2,17 +2,16 @@
 
 ## Verdict
 
-`V1_3_0_RELEASE_PREPARATION=MERGED_VERIFIED`
+```text
+V1_3_0_RELEASE_PREPARATION=MERGED_VERIFIED
+V1_3_0_RELEASE_STATE=PUBLISHED_VERIFIED
+CURRENT_PUBLIC_RELEASE=v1.3.0
+TARGET_VERSION=1.3.0
+TARGET_TAG=v1.3.0
+V1_3_0_PUBLICATION=COMPLETE_VERIFIED
+```
 
-`V1_3_0_RELEASE_STATE=PREPARED_NOT_RELEASED`
-
-`CURRENT_PUBLIC_RELEASE=v1.2.0`
-
-`TARGET_VERSION=1.3.0`
-
-`TARGET_TAG=v1.3.0`
-
-This record is revision-bound release-preparation evidence. It does not authorize tag creation or GitHub Release publication.
+This record preserves the revision-bound v1.3.0 preparation and validation chain and records the independently verified publication outcome. Publication authority was granted separately from preparation and validation.
 
 ## Canonical Preparation Identity
 
@@ -29,13 +28,13 @@ This record is revision-bound release-preparation evidence. It does not authoriz
 - Branch deletion: `NOT_PERFORMED`
 - Force push/history rewrite: `NOT_PERFORMED`
 
-The signed reviewed head and the canonical Squash have the same tree. Squash rewrote commit identity as expected, but not reviewed content.
+The signed reviewed head and canonical Squash have the same tree. Squash rewrote commit identity as expected, not reviewed content.
 
 ## Superseded Candidate Evidence
 
 The first 13-file signed candidate was materialized as `5238abe2c41782e8fe411e178a75b3ec8d7e323b` and opened as PR #253.
 
-PR #253 failed closed at Stage 1 Strict Governance because significant package/test changes had no matching `CHANGELOG.md` update. The finding was:
+PR #253 failed closed at Stage 1 Strict Governance because significant package/test changes had no matching `CHANGELOG.md` update:
 
 ```text
 Significant changes were detected without a matching CHANGELOG.md update.
@@ -44,7 +43,7 @@ Significant paths: plugin.json, tests/runtime/test_release_version_surfaces.py
 
 PR #253 was closed unmerged. Its validation was invalidated and not reused.
 
-The corrected work tree added a focused v1.3.0 preparation changelog entry and restored an accidentally touched historical changelog phrase before signed rematerialization. The final canonical compare shows the release-preparation changelog change as additive only.
+The corrected work tree added a focused v1.3.0 preparation changelog entry and restored an accidentally touched historical changelog phrase before signed rematerialization. The canonical compare shows the release-preparation changelog change as additive only.
 
 ## Exact PR #255 Scope
 
@@ -65,11 +64,11 @@ The canonical preparation changed exactly 14 files:
 13. `plugin.json`
 14. `tests/runtime/test_release_version_surfaces.py`
 
-The package/version change is additive release preparation. It does not graduate any scaffold-only host, change runtime authority, activate policy, deploy software, or publish an integration.
+The package/version change was additive release preparation. It did not graduate a scaffold-only host, change runtime authority, activate policy, deploy software, or publish an integration.
 
 ## Package Version Surface
 
-The new deterministic runtime regression validates these 11 live package/version surfaces as `1.3.0`:
+The deterministic runtime regression validates these 11 live package/version surfaces as `1.3.0`:
 
 - `plugin.json`
 - `.codex-plugin/plugin.json`
@@ -87,7 +86,7 @@ The test `tests/runtime/test_release_version_surfaces.py` passed on the exact re
 
 ## Exact-Head GitHub Checks
 
-Exact reviewed head: `f63daf49add4887d7fbd1b581959ebf8654150db`
+Exact reviewed preparation head: `f63daf49add4887d7fbd1b581959ebf8654150db`
 
 All nine observed checks completed successfully:
 
@@ -103,9 +102,7 @@ All nine observed checks completed successfully:
 | `Analyze (python)` | PASS |
 | `CodeQL` | PASS |
 
-CodeQL reported no new alerts in code changed by PR #255.
-
-PR #255 had zero unresolved review threads and was mergeable on the exact reviewed head immediately before the expected-head Squash merge.
+CodeQL reported no new alerts in code changed by PR #255. PR #255 had zero unresolved review threads and was mergeable on the exact reviewed head immediately before the expected-head Squash merge.
 
 ## Runtime and Repository Validation
 
@@ -119,27 +116,13 @@ Observed coverage: 94.33%
 
 The new v1.3.0 version-parity regression was included in those 542 runtime tests and passed.
 
-The exact-head workflows also passed:
-
-- behavior validation;
-- repository structure validation;
-- manifest validation;
-- IDE/scaffold packaging validation;
-- prompt-load measurement and thresholds;
-- project context validation;
-- Stage 1 Strict Governance after changelog remediation;
-- Dagger guardrail simulation;
-- governance behavior tests;
-- general behavior tests;
-- native Windows/Ubuntu/macOS validation;
-- action and Python static analysis; and
-- CodeQL.
+The exact-head workflows also passed behavior validation, repository structure and manifest validation, IDE/scaffold packaging validation, prompt-load thresholds, project-context validation, Stage 1 Strict Governance after changelog remediation, Dagger guardrail simulation, governance/general behavior tests, native Windows/Ubuntu/macOS validation, action/Python static analysis, and CodeQL.
 
 The Stage 1 remediation demonstrates that stale or incomplete release evidence was not accepted merely because earlier package tests were green.
 
 ## Specialist Campaign Basis
 
-v1.3.0 packages the completed SK1-SK10 Specialist Knowledge Layer campaign. Before release preparation began, canonical campaign closeout recorded all phases as `MERGED_VERIFIED` and the final SK10 assurance included:
+v1.3.0 packages the completed SK1-SK10 Specialist Knowledge Layer campaign. Before release preparation began, canonical campaign closeout recorded all phases as `MERGED_VERIFIED` and final SK10 assurance included:
 
 - 10 adversarial routing, coordination, invalidation, handoff, and protected-action scenarios;
 - complete authoritative behavior validation;
@@ -150,35 +133,87 @@ v1.3.0 packages the completed SK1-SK10 Specialist Knowledge Layer campaign. Befo
 - nine of nine exact-head checks passing; and
 - zero unresolved review threads.
 
-The release-preparation regression raises the current runtime-suite count to 542 and current coverage to 94.33 percent.
+Release preparation raised the runtime-suite count to 542 and coverage to 94.33 percent.
 
-## Public Release Boundary
+## Revision-Bound Readiness Closeout
 
-After canonical package preparation, independent GitHub reads established:
+PR #257 bound the release-readiness record and stable continuity to canonical preparation state:
 
 ```text
-CURRENT_PUBLIC_RELEASE=v1.2.0
-V1_3_0_TAG_EXISTS=NO
-V1_3_0_GITHUB_RELEASE_EXISTS=NO
+REVIEWED_HEAD=266e4de66e4bb76016c3771229feb11321c3da9d
+CANONICAL_SQUASH=db351796684789987eb5bce85e641ce31c91993b
+EXACT_HEAD_CHECKS=PASS_9_OF_9
+REVIEW_THREADS=0
+EXPECTED_HEAD_GUARD_USED=true
+CANONICAL_SIGNATURE=VERIFIED_VALID
 ```
 
-GitHub returned `404 Not Found` for both the `refs/tags/v1.3.0` reference and the release-by-tag `v1.3.0` endpoint at this checkpoint.
+At that checkpoint, `v1.3.0` remained absent and v1.2.0 remained the public release.
 
-The existing `v1.2.0` release/tag history is not modified by v1.3.0 preparation.
+## README Pre-Publication Gate
+
+Before publication, README alignment was treated as a hard gate. PR #259 changed `README.md` only and aligned the public surface with the completed Specialist Intelligence campaign while keeping publication wording neutral.
+
+```text
+README_PR=259
+REVIEWED_HEAD=b7b8bfeced7c0719558eb95c0797f0685f0c98f2
+REVIEWED_TREE=5ae72f6ab9ddf5284afdc3d8675f67fc23c24281
+CANONICAL_RELEASE_COMMIT=3c6155c111981632649a3c3207fac8ac1edcea74
+CANONICAL_RELEASE_TREE=5ae72f6ab9ddf5284afdc3d8675f67fc23c24281
+TREE_EQUIVALENCE=EXACT
+CANONICAL_SIGNATURE=VERIFIED_VALID
+EXACT_HEAD_CHECKS=PASS_9_OF_9
+REVIEW_THREADS=0
+EXPECTED_HEAD_GUARD_USED=true
+```
+
+The tagged source snapshot therefore includes the aligned README.
+
+## Publication State
+
+Separate explicit maintainer authority was granted for the v1.3.0 annotated tag and GitHub Release after README alignment.
+
+Independent GitHub reads after publication established:
+
+```text
+CURRENT_PUBLIC_RELEASE=v1.3.0
+V1_3_0_TAG_EXISTS=YES
+V1_3_0_TAG_REF_TYPE=tag
+V1_3_0_TAG_OBJECT=c66afec49990036d9deb2f07e3363cd664e2dcb1
+V1_3_0_TAG_TARGET_TYPE=commit
+V1_3_0_TAG_TARGET=3c6155c111981632649a3c3207fac8ac1edcea74
+V1_3_0_TAG_OBJECT_SIGNATURE=UNSIGNED
+V1_3_0_RELEASE_COMMIT_SIGNATURE=VERIFIED_VALID
+V1_3_0_GITHUB_RELEASE_EXISTS=YES
+V1_3_0_GITHUB_RELEASE_ID=369402941
+V1_3_0_GITHUB_RELEASE_DRAFT=false
+V1_3_0_GITHUB_RELEASE_PRERELEASE=false
+V1_3_0_GITHUB_RELEASE_IMMUTABLE=true
+V1_3_0_GITHUB_RELEASE_PUBLISHED_AT=2026-08-12T17:08:41Z
+LATEST_PUBLIC_RELEASE=v1.3.0
+V1_3_0_PUBLICATION=COMPLETE_VERIFIED
+```
+
+The annotated tag object itself is unsigned. This is recorded accurately rather than represented as a signed tag. The prior v1.2.0 annotated tag object is also unsigned; the release trust anchor is the exact tag target plus the GitHub-verified signed release commit.
+
+See `docs/validation/V1_3_0_PUBLICATION_CLOSEOUT.md` for the publication execution and independent verification record.
 
 ## Protected Actions
 
-The following were not performed and remain separately gated:
+The separately authorized publication performed:
 
-- annotated tag creation;
-- GitHub Release publication;
+- annotated tag creation for `v1.3.0`; and
+- GitHub Release publication for `Orchestra v1.3.0: Specialist Intelligence`.
+
+The following were not performed:
+
 - deployment or production mutation;
 - marketplace publication;
 - installed-integration refresh;
 - policy activation;
 - destructive cleanup;
 - branch deletion;
-- force push; and
+- force push; or
 - history rewrite.
 
 ```text
@@ -187,14 +222,8 @@ MERGEABILITY != PUBLICATION_AUTHORITY
 PACKAGE_VERSION_1_3_0 != PUBLIC_RELEASE_V1_3_0
 ```
 
-## Publication Gate
+These invariants remain true even though the separate publication gate has now completed.
 
-The repository may be described as **prepared for v1.3.0 publication**, not as already released.
+## Post-Publication Boundary
 
-Required next authority state:
-
-```text
-V1_3_0_PUBLICATION=AWAITING_SEPARATE_AUTHORIZATION
-```
-
-A future publication action must independently re-read live Orchestra `main`, verify this readiness state has not drifted, verify no newer release/version conflict exists, and then follow the separately authorized tag/release publication procedure. Validation or this evidence file alone does not grant that authority.
+The `v1.3.0` tag is fixed at release commit `3c6155c111981632649a3c3207fac8ac1edcea74`. Later documentation or development commits on `main` do not move or redefine the release tag.


### PR DESCRIPTION
## Purpose

Record and reconcile the independently verified Orchestra v1.3.0 publication state after the separately authorized annotated-tag and GitHub Release publication.

## Exact release identity

- release commit: `3c6155c111981632649a3c3207fac8ac1edcea74`
- release tree: `5ae72f6ab9ddf5284afdc3d8675f67fc23c24281`
- annotated tag: `v1.3.0`
- tag object: `c66afec49990036d9deb2f07e3363cd664e2dcb1`
- tag target: exact release commit above
- tag object signature: unsigned, recorded explicitly
- release commit signature: GitHub verified valid
- GitHub Release: `Orchestra v1.3.0: Specialist Intelligence`, non-draft, non-prerelease, immutable, latest public release

## Exact scope

Eight documentation/current-state paths only:
- `PROJECT_CONTEXT.md`
- `PROJECT_STATE.md`
- `SESSION_HANDOFF.md`
- `docs/project/ROADMAP.md`
- `docs/setup/COMPATIBILITY.md`
- `docs/setup/INSTALLATION.md`
- `docs/validation/V1_3_0_PUBLICATION_CLOSEOUT.md`
- `docs/validation/V1_3_0_RELEASE_READINESS_EVIDENCE.md`

Signed reviewed head: `63192c915c346ef7bae2af2ebd7449e7632a355d`
Reviewed tree: `91b152de6d8a0efb9c063289477398f7824c48bb`
Base: exact released commit `3c6155c111981632649a3c3207fac8ac1edcea74`

The reviewed tree is exactly equal to the eight-file work tree materialized through auxiliary PR #260.

## Boundary

This PR does not move or recreate `v1.3.0`. It performs no deployment, marketplace publication, installed-integration refresh, policy activation, destructive cleanup, branch deletion, force push, or history rewrite.