### PR TITLE
docs: clarify user and downstream role terminology

### DIFF
--- a/docs/governance/PHASE_RETROSPECTIVE_PROTOCOL.md
+++ b/docs/governance/PHASE_RETROSPECTIVE_PROTOCOL.md
@@ -29,7 +29,7 @@ It provides a normalized synthesis of execution outcomes, remediation cycles (`A
 ### 2.2 Core Invariants
 1. **Advisory Closeout Evidence Invariant:** Retrospective findings summarize execution history for human maintainers and policy tuning. They do NOT automatically grant authority or alter project state.
 2. **Replacement Effect Invariant (`replacement_effect: none`):** Existing handoff records, post-merge state files, and decision logs remain authoritative continuity references. A retrospective normalizes learning without replacing canonical records.
-3. **Single Canonical Owner Invariant:** Overseer is the single canonical owner of the retrospective protocol. Downstream roles (Arbiter, Steward, Scribe) do not become co-owners.
+3. **Single Canonical Owner Invariant:** Overseer is the single canonical owner of the retrospective protocol. Secondary consumers (Arbiter, Steward, Scribe) do not become co-owners.
 4. **Source Provenance Invariant:** Every retrospective metric and finding MUST cite its canonical source record (`ExecutionResult`, `TransitionDecisionRecord`, `ExecutionEvidencePacket`, `ApprovedUnitPlan`).
 
 ---

--- a/docs/governance/PHASE_RETROSPECTIVE_PROTOCOL.md
+++ b/docs/governance/PHASE_RETROSPECTIVE_PROTOCOL.md
@@ -29,7 +29,7 @@ It provides a normalized synthesis of execution outcomes, remediation cycles (`A
 ### 2.2 Core Invariants
 1. **Advisory Closeout Evidence Invariant:** Retrospective findings summarize execution history for human maintainers and policy tuning. They do NOT automatically grant authority or alter project state.
 2. **Replacement Effect Invariant (`replacement_effect: none`):** Existing handoff records, post-merge state files, and decision logs remain authoritative continuity references. A retrospective normalizes learning without replacing canonical records.
-3. **Single Canonical Owner Invariant:** Overseer is the single canonical owner of the retrospective protocol. Secondary consumers (Arbiter, Steward, Scribe) do not become co-owners.
+3. **Single Canonical Owner Invariant:** Overseer is the single canonical owner of the retrospective protocol. Downstream roles (Arbiter, Steward, Scribe) do not become co-owners.
 4. **Source Provenance Invariant:** Every retrospective metric and finding MUST cite its canonical source record (`ExecutionResult`, `TransitionDecisionRecord`, `ExecutionEvidencePacket`, `ApprovedUnitPlan`).
 
 ---

--- a/docs/project/ORCHESTRA_STATUS_PROJECTION.md
+++ b/docs/project/ORCHESTRA_STATUS_PROJECTION.md
@@ -22,7 +22,7 @@ This document specifies the `OrchestraStatusProjection`, a read-only, determinis
 - **Canonical Owner:** **Scribe** (Documentation and Knowledge Transfer Specialist).
 - **Responsibility:** Owns status summary formats, state projection schemas, knowledge base alignment, and presentation formats.
 - **Implementation Specialist:** **Ponytail** (Implementation and Navigation Specialist).
-- **Secondary Consumers:** Conductor (routing context), Arbiter (continuity validation), Overseer (release readiness check).
+- **Downstream Roles:** Conductor (routing context), Arbiter (continuity validation), Overseer (release readiness check).
 
 ---
 

--- a/docs/project/ORCHESTRA_WORKTREE_CONTRACT.md
+++ b/docs/project/ORCHESTRA_WORKTREE_CONTRACT.md
@@ -21,7 +21,7 @@ This document specifies the `OrchestraWorktreeContract`, an optional, host-capab
 ## 2. Canonical Ownership & Responsibilities
 - **Canonical Owner:** **Ponytail** (Implementation and Navigation Specialist).
 - **Responsibility:** Owns codebase navigation, targeted file changes, Git worktree operations, path confinement validation, and safe workspace boundaries.
-- **Secondary Consumers:** Conductor (routing context), Arbiter (transition verification), Overseer (evidence validation), Host Adapters (capability declaration).
+- **Downstream Roles:** Conductor (routing context), Arbiter (transition verification), Overseer (evidence validation), Host Adapters (capability declaration).
 
 ---
 

--- a/docs/project/SPEC_KITTY_DERIVED_CONTRACT_OWNERSHIP.md
+++ b/docs/project/SPEC_KITTY_DERIVED_CONTRACT_OWNERSHIP.md
@@ -16,14 +16,14 @@
 This document defines canonical placement, single specialist ownership, and architectural boundaries for the Spec Kitty-derived Orchestra upgrade contracts.
 
 1. **Single Source of Truth Invariant:** No new contract creates a second source of truth for existing state or policy.
-2. **Single Canonical Owner Invariant:** Every contract has exactly ONE canonical specialist owner. Secondary consumers or validators are recorded separately.
+2. **Single Canonical Owner Invariant:** Every contract has exactly ONE canonical specialist owner. Downstream roles or validators are recorded separately.
 3. **No Inferred Authority Invariant:** Machine-readable formats, correlation headers, retrospective artifacts, worktree contracts, and status projections track execution; they do NOT grant execution, merge, release, or policy mutation authority.
 
 ---
 
 ## 2. Canonical Phase 2 Contract Ownership Matrix
 
-| Contract Name | Canonical Specification | Canonical Owner | Secondary Consumers | Validation Owner | Continuity Consumer | Design Status | Implementation Status | Policy Integration Status | Release Status |
+| Contract Name | Canonical Specification | Canonical Owner | Downstream Roles | Validation Owner | Continuity Consumer | Design Status | Implementation Status | Policy Integration Status | Release Status |
 |---|---|---|---|---|---|---|---|---|---|
 | **OrchestraRuntimeEnvelope** | `docs/project/ORCHESTRA_RUNTIME_ENVELOPE.md` | Clockwork | Conductor, Arbiter | Overseer | Arbiter | `DESIGN_SPECIFIED` | `IMPLEMENTED_MERGED` | `NOT_APPLICABLE` | `NOT_RELEASED` |
 | **OrchestraCorrelationID** | `docs/governance/CORRELATION_ID_PROTOCOL.md` | Chronicler | Conductor, Overseer | Overseer | Arbiter | `DESIGN_SPECIFIED` | `IMPLEMENTED_MERGED` | `NOT_APPLICABLE` | `NOT_RELEASED` |
@@ -34,7 +34,7 @@ This document defines canonical placement, single specialist ownership, and arch
 
 ## 2.1 Phase 3 Contract Ownership Matrix
 
-| Contract Name | Canonical Specification | Canonical Owner | Secondary Consumers | Validation Owner | Continuity Consumer | Design Status | Implementation Status | Policy Integration Status | Release Status |
+| Contract Name | Canonical Specification | Canonical Owner | Downstream Roles | Validation Owner | Continuity Consumer | Design Status | Implementation Status | Policy Integration Status | Release Status |
 |---|---|---|---|---|---|---|---|---|---|
 | **OrchestraStatusProjection** | `docs/project/ORCHESTRA_STATUS_PROJECTION.md` | Scribe | Conductor, Arbiter, Overseer, Ponytail | Overseer | Arbiter | `DESIGN_ACCEPTED_MERGED` | `IMPLEMENTED_MERGED` | `NOT_APPLICABLE` | `NOT_RELEASED` |
 | **OrchestraWorktreeContract** | `docs/project/ORCHESTRA_WORKTREE_CONTRACT.md` | Ponytail | Conductor, Arbiter, Overseer, Host Adapters | Overseer | Arbiter | `DESIGN_ACCEPTED_MERGED` | `IMPLEMENTED_MERGED` | `NOT_APPLICABLE` | `NOT_RELEASED` |


### PR DESCRIPTION
Terminology cleanup following the compliance-registry audit.

Changes current canonical role-facing documentation from `Secondary Consumers` / `secondary consumers` to `Downstream Roles` / `downstream roles` where the referenced entities are Orchestra specialists or adapters rather than software message consumers.

Genuine technical `consumer` terminology remains unchanged for event-driven architecture, machine serialization, and provider/consumer contract testing.

Historical decision logs, promotion records, and handoff evidence are intentionally unchanged.