### PR TITLE
docs: explain why the Compliance Registry matters

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,3 +377,11 @@ Orchestra uses source-pinned, static Artificer reviews to govern selected concep
 These records distinguish static reference review, concept-only adaptation, and Orchestra-native implementation from direct reuse. They do not establish wholesale integration, source-code copying, dependency adoption, endorsement, affiliation, trademark permission, or a blanket licensing conclusion.
 
 The authoritative incorporation record is the governed [Pattern Catalog](docs/internal/PATTERN_CATALOG.md). Source-pinned audit and decision records preserve the detailed provenance and disposition for each reviewed pattern. External source code, datasets, prompts, payloads, examples, media, assets, or documentation expression are not incorporated unless a governed record explicitly authorizes that reuse.
+
+## Contributing, Security, and License
+
+Contributions should preserve specialist ownership, cross-specialist contract boundaries, runtime trust boundaries, validation evidence, and scaffold maturity labels. Start with the [Contributing Guide](docs/CONTRIBUTING.md).
+
+Report vulnerabilities privately through the process in [SECURITY.md](SECURITY.md). Do not commit secrets, credentials, personal data, client information, or private project material.
+
+Orchestra is licensed under the [MIT License](LICENSE). Governed external-pattern records preserve applicable provenance and attribution boundaries; they do not authorize wholesale copying of external projects.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,24 @@ The framework is designed to help developers reduce context drift, make cross-do
 
 > **Core trust boundary:** governance approval, coordination readiness, validation success, and GitHub mergeability are state or evidence signals. None of them grants or expands authority.
 
+## Why the Compliance Registry Matters
+
+Compliance decisions are especially vulnerable to stale context. Laws, platform policies, licensing terms, privacy obligations, provider requirements, and effective dates can change independently of application code. If those facts are copied into prompts or project documents without provenance and freshness metadata, a previously correct assumption can quietly become the next project's bad input.
+
+The **Orchestra Compliance Registry** is designed to prevent that failure mode. It gives Governor, Steward, and Arbiter a reusable, versioned compliance-intelligence layer whose source identity, release identity, file integrity, freshness state, and project pinning can be checked independently of the project being reviewed.
+
+That separation is important because it lets Orchestra:
+
+- reuse source-backed compliance knowledge across projects without duplicating legal or policy conclusions into every repository;
+- distinguish **content integrity** from **distribution provenance**, so a self-consistent local bundle is not automatically treated as trusted;
+- detect stale, unavailable, moved, overdue, or review-required sources instead of silently treating old evidence as current;
+- pin a project to the exact registry version, release sequence, release tag, manifest SHA-256, jurisdictions, and providers used for a governed decision;
+- keep compliance knowledge separate from execution authority: registry records can inform requirements and review, but they cannot authorize release, deployment, policy activation, destructive operations, or other protected actions.
+
+Normal use is local-first: Orchestra reviews a verified active cache and uses network access only for synchronization, update checks, or authoritative-source verification when currentness cannot be established locally. A trusted network sync must come from the canonical registry's immutable GitHub Release boundary; local or air-gapped installation requires a separately verified release-manifest SHA-256 trust anchor.
+
+See [Compliance Registry Integration](docs/governance/COMPLIANCE_REGISTRY_INTEGRATION.md) for the trust model, owner responsibilities, freshness behavior, and release boundaries.
+
 ## How Orchestra Works
 
 Each run begins with project context and three separate choices: risk mode, progression mode, and governance profile. Those choices affect review depth and pause frequency, but they do not create permission. Orchestra composes the trusted runtime, calculates effective authority as the intersection of explicit grants and all applicable constraints, and only then lets Conductor route work. Material multi-domain work uses The Tuner to coordinate specialist-owned contracts; single-owner work bypasses that overhead.
@@ -336,6 +354,7 @@ See the [v1.2.0 release notes](docs/releases/v1.2.0-governed-orchestration.md). 
 - [Governance Review Flow](docs/governance/GOVERNANCE_REVIEW_FLOW.md)
 - [Delegated Execution Policy](docs/governance/DELEGATED_EXECUTION_POLICY.md)
 - [Autonomous Merge Readiness Protocol](docs/governance/AUTONOMOUS_MERGE_READINESS_PROTOCOL.md)
+- [Compliance Registry Integration](docs/governance/COMPLIANCE_REGISTRY_INTEGRATION.md)
 - [Release Gates](docs/governance/RELEASE_GATES.md)
 - [App Release Compliance Gate](docs/governance/APP_RELEASE_COMPLIANCE_GATE.md)
 
@@ -358,11 +377,3 @@ Orchestra uses source-pinned, static Artificer reviews to govern selected concep
 These records distinguish static reference review, concept-only adaptation, and Orchestra-native implementation from direct reuse. They do not establish wholesale integration, source-code copying, dependency adoption, endorsement, affiliation, trademark permission, or a blanket licensing conclusion.
 
 The authoritative incorporation record is the governed [Pattern Catalog](docs/internal/PATTERN_CATALOG.md). Source-pinned audit and decision records preserve the detailed provenance and disposition for each reviewed pattern. External source code, datasets, prompts, payloads, examples, media, assets, or documentation expression are not incorporated unless a governed record explicitly authorizes that reuse.
-
-## Contributing, Security, and License
-
-Contributions should preserve specialist ownership, cross-specialist contract boundaries, runtime trust boundaries, validation evidence, and scaffold maturity labels. Start with the [Contributing Guide](docs/CONTRIBUTING.md).
-
-Report vulnerabilities privately through the process in [SECURITY.md](SECURITY.md). Do not commit secrets, credentials, personal data, client information, or private project material.
-
-Orchestra is licensed under the [MIT License](LICENSE). Governed external-pattern records preserve applicable provenance and attribution boundaries; they do not authorize wholesale copying of external projects.


### PR DESCRIPTION
Adds a first-class README explanation of why the Orchestra Compliance Registry is important to governed AI-assisted development.

The new section explains:
- why compliance facts are uniquely vulnerable to stale context;
- why reusable source-backed compliance knowledge should be separated from project code and prompts;
- integrity vs distribution provenance;
- explicit freshness and review-required states;
- exact project registry pinning;
- the non-expansion of execution/release/deployment authority;
- local-first usage and the immutable canonical-release / external-manifest-digest trust boundaries.

Also adds the existing `docs/governance/COMPLIANCE_REGISTRY_INTEGRATION.md` guide to the README Governance documentation map.

Related tracking:
- #264 — complete the Compliance Registry governance upgrade
- #265 — plan Orchestra v1.4.0 around the Compliance Registry governance capability

Final exact head: `ad8bd024af50b17929ddc0828c3b62dcef71762e`.

Exact-head evidence is green:
- Governance Check
- validate
- runtime-tests
- Analyze (actions)
- Analyze (python)
- CodeQL
- native Ubuntu
- native macOS
- native Windows

The branch is 0 behind canonical `main`, has no unresolved review threads or requested-change reviews, and the final diff is README-only with 19 additions and 0 deletions.

No version bump, package change, release/tag publication, policy activation, repository-setting mutation, deployment, installed-integration refresh, destructive cleanup, branch deletion, force push, or history rewrite.