### PR TITLE
feat: prepare v1.4.0 governance and Compliance Registry cross-integration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "orchestra",
       "source": "./",
       "description": "Governance-first specialist skill framework for routed, auditable AI coding workflows.",
-      "version": "1.3.0"
+      "version": "1.4.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra",
   "description": "Governance-first specialist skill framework for routed, auditable AI coding workflows.",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "update_check": {
     "update_check_enabled": true,
     "update_check_channel": "stable",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conductor",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "An installable AI workflow plugin that routes complex software tasks through focused specialist skills for architecture, UI/UX, documentation, diagrams, databases, QA, security, and gated resilience review.",
   "author": {
     "name": "Baelfyre",

--- a/.github/workflows/governance-check.yml
+++ b/.github/workflows/governance-check.yml
@@ -33,6 +33,16 @@ jobs:
       - name: Create Artifacts Directory
         run: mkdir -p artifacts
 
+      - name: Enforce README Impact Gate
+        run: |
+          set +e
+          python scripts/check_readme_impact.py > artifacts/readme_impact_report.txt
+          status=$?
+          set -e
+
+          cat artifacts/readme_impact_report.txt
+          exit $status
+
       - name: Run Router Benchmark Validation
         run: |
           python scripts/router_benchmark_runner.py > artifacts/router_benchmark_report.txt
@@ -90,7 +100,7 @@ jobs:
         run: |
           echo "# Governance Validation Report" >> $GITHUB_STEP_SUMMARY
           echo "## Stage 1 Strict Deterministic Gates: ON" >> $GITHUB_STEP_SUMMARY
-          echo "Governance validation completed with Stage 1 strict deterministic gates. Review artifacts and logs for advisory findings that remain non-blocking." >> $GITHUB_STEP_SUMMARY
+          echo "README Impact Gate and Stage 1 strict deterministic governance validation completed. Review artifacts and logs for any fail-closed documentation or governance findings." >> $GITHUB_STEP_SUMMARY
 
       - name: Upload Governance Artifacts
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@
 - Expanded documentation standards and audit checks for heading/anchor stability, fenced code and tables, source revisions, effective dates, verified commands, API examples, version selectors, redirects, and broken-link reporting.
 - Added a worked source-backed API change example that separates verified current behavior, compatibility status, planned work, and release authority.
 - Kept the campaign Markdown-primary and JSON-selective: the SK8 audit found no deterministic machine-parsing need that justified a Scribe JSON catalog.
-- Added focused regression coverage for Scribe knowledge depth, source/Codex parity, link/claim discipline, and no-publication boundaries.
+- Added focused regression coverage for Scribe knowledge depth, progressive disclosure, source/Codex parity, link/claim discipline, and no-publication boundaries.
 - No release/tag publication, documentation-site deployment, installed-integration refresh, policy activation, destructive cleanup, branch deletion, force push, or history rewrite is performed by SK8.
 
 ## Post-v1.2.0 Specialist Knowledge Layer - SK7 Overseer - Pending
@@ -58,7 +58,7 @@
 - Expanded quality standards and testing checks with contract identity, shrinking and reproducibility, mutation-score interpretation, quarantine controls, environment matrices, percentile evidence, and privacy-safe test-data lifecycle requirements.
 - Added a worked risk-based validation matrix example that separates planned evidence from executed results and preserves domain-specialist ownership.
 - Kept the campaign Markdown-primary and JSON-selective: the SK7 audit found no deterministic machine-parsing need that justified an Overseer JSON catalog.
-- Added focused regression coverage for Overseer knowledge depth, source/Codex parity, and evidence-state discipline.
+- Added focused regression coverage for Overseer knowledge depth, progressive disclosure, source/Codex parity, and evidence-state discipline.
 - No CI/release-gate mutation, test execution beyond repository validation, deployment, release/tag publication, installed-integration refresh, policy activation, destructive cleanup, branch deletion, force push, or history rewrite is performed by SK7.
 
 ## Post-v1.2.0 Specialist Knowledge Layer - SK6 Chronicler - Pending
@@ -69,7 +69,7 @@
 - Expanded database standards and review checks for dialect/version identity, ORM/schema parity, lock and retry behavior, tenant predicates and composite integrity, plan estimates, backfill checkpoints, and compatibility windows.
 - Added a planning-only worked expand-contract migration example with bounded batches, read/write compatibility, validation, rollback boundaries, and no executable production command.
 - Kept the campaign Markdown-primary and JSON-selective: the SK6 audit found no deterministic machine-parsing need that justified a Chronicler JSON catalog.
-- Added focused regression coverage for Chronicler knowledge depth, source/Codex parity, and the no-execution boundary.
+- Added focused regression coverage for Chronicler knowledge depth, progressive disclosure, source/Codex parity, and the no-execution boundary.
 - No schema change, migration execution, live-data access, destructive SQL, release/tag publication, deployment/production mutation, installed-integration refresh, policy activation, destructive cleanup, branch deletion, force push, or history rewrite is performed by SK6.
 
 ## Post-v1.2.0 Specialist Knowledge Layer - SK5 Dagger - Pending

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@
 - Expanded documentation standards and audit checks for heading/anchor stability, fenced code and tables, source revisions, effective dates, verified commands, API examples, version selectors, redirects, and broken-link reporting.
 - Added a worked source-backed API change example that separates verified current behavior, compatibility status, planned work, and release authority.
 - Kept the campaign Markdown-primary and JSON-selective: the SK8 audit found no deterministic machine-parsing need that justified a Scribe JSON catalog.
-- Added focused regression coverage for Scribe knowledge depth, progressive disclosure, source/Codex parity, link/claim discipline, and no-publication boundaries.
+- Added focused regression coverage for Scribe knowledge depth, source/Codex parity, link/claim discipline, and no-publication boundaries.
 - No release/tag publication, documentation-site deployment, installed-integration refresh, policy activation, destructive cleanup, branch deletion, force push, or history rewrite is performed by SK8.
 
 ## Post-v1.2.0 Specialist Knowledge Layer - SK7 Overseer - Pending
@@ -58,18 +58,18 @@
 - Expanded quality standards and testing checks with contract identity, shrinking and reproducibility, mutation-score interpretation, quarantine controls, environment matrices, percentile evidence, and privacy-safe test-data lifecycle requirements.
 - Added a worked risk-based validation matrix example that separates planned evidence from executed results and preserves domain-specialist ownership.
 - Kept the campaign Markdown-primary and JSON-selective: the SK7 audit found no deterministic machine-parsing need that justified an Overseer JSON catalog.
-- Added focused regression coverage for Overseer knowledge depth, progressive disclosure, source/Codex parity, and evidence-state discipline.
+- Added focused regression coverage for Overseer knowledge depth, source/Codex parity, and evidence-state discipline.
 - No CI/release-gate mutation, test execution beyond repository validation, deployment, release/tag publication, installed-integration refresh, policy activation, destructive cleanup, branch deletion, force push, or history rewrite is performed by SK7.
 
 ## Post-v1.2.0 Specialist Knowledge Layer - SK6 Chronicler - Pending
 
 - Deepened Chronicler's persistence knowledge without changing routing, runtime architecture, schema state, or database execution authority.
 - Added engine-evidence guidance for PostgreSQL, MySQL, SQL Server, and SQLite plus ORM mapping and migration-state semantics.
-- Added progressive-disclosure guidance for transaction isolation, MVCC, locking, deadlock analysis, query-plan evidence, tenant isolation, and expand-contract zero-downtime schema-change planning.
+- Added progressive-disclosure guidance for transaction isolation, MVCC, locking, deadlock analysis, query-plan evidence, tenant isolation, and expand-contract zero-downtime migrations.
 - Expanded database standards and review checks for dialect/version identity, ORM/schema parity, lock and retry behavior, tenant predicates and composite integrity, plan estimates, backfill checkpoints, and compatibility windows.
 - Added a planning-only worked expand-contract migration example with bounded batches, read/write compatibility, validation, rollback boundaries, and no executable production command.
 - Kept the campaign Markdown-primary and JSON-selective: the SK6 audit found no deterministic machine-parsing need that justified a Chronicler JSON catalog.
-- Added focused regression coverage for Chronicler knowledge depth, progressive disclosure, source/Codex parity, and the no-execution boundary.
+- Added focused regression coverage for Chronicler knowledge depth, source/Codex parity, and the no-execution boundary.
 - No schema change, migration execution, live-data access, destructive SQL, release/tag publication, deployment/production mutation, installed-integration refresh, policy activation, destructive cleanup, branch deletion, force push, or history rewrite is performed by SK6.
 
 ## Post-v1.2.0 Specialist Knowledge Layer - SK5 Dagger - Pending

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.4.0 Governance and Compliance Registry Cross-Integration - Release Preparation - Pending
+
+- Normalized the root, Claude Code, Codex, Cursor, JetBrains, Neovim, VS Code, Windsurf, and Zed package/version surfaces to `1.4.0` for the governance release candidate without changing host maturity.
+- Added a deterministic runtime regression that requires all 11 live package/version surfaces to agree on `1.4.0`.
+- Elevated the Compliance Registry from a local-cache integration into an explicitly documented Orchestra cross-integration across Governor, Steward, Arbiter, Conductor/The Tuner coordination, and downstream project handoffs while preserving specialist and authority boundaries.
+- Added the fail-closed README Impact Gate to Governance Check: significant runtime, specialist, host-integration, governance/routing/setup/release, version, or CI/governance changes must update `README.md` in the same revision; tests and validation-evidence-only changes do not force README churn.
+- Added `docs/releases/v1.4.0-governance-compliance-registry-release-candidate.md` and preserved `v1.3.0` as the current public release until separately authorized `v1.4.0` tag and GitHub Release publication.
+- Registry repository protection, Registry PR #1 merge, trusted Registry release/tag publication, Orchestra `v1.4.0` public release, marketplace publication, installed-integration refresh, deployment, policy activation, destructive cleanup, branch deletion, force push, and history rewrite remain separately gated and are not performed by this preparation.
+
 ## Post-v1.3.0 Compliance Registry Local Cache - Pending
 
 - Added an offline-first verified local client for `Baelfyre/Orchestra-Compliance-Registry` with status, verification, controlled synchronization, local bundle installation, query, project pinning, and update-check operations.
@@ -56,7 +65,7 @@
 
 - Deepened Chronicler's persistence knowledge without changing routing, runtime architecture, schema state, or database execution authority.
 - Added engine-evidence guidance for PostgreSQL, MySQL, SQL Server, and SQLite plus ORM mapping and migration-state semantics.
-- Added progressive-disclosure guidance for transaction isolation, MVCC, locking, deadlock analysis, query-plan evidence, tenant isolation, and expand-contract zero-downtime migrations.
+- Added progressive-disclosure guidance for transaction isolation, MVCC, locking, deadlock analysis, query-plan evidence, tenant isolation, and expand-contract zero-downtime schema-change planning.
 - Expanded database standards and review checks for dialect/version identity, ORM/schema parity, lock and retry behavior, tenant predicates and composite integrity, plan estimates, backfill checkpoints, and compatibility windows.
 - Added a planning-only worked expand-contract migration example with bounded batches, read/write compatibility, validation, rollback boundaries, and no executable production command.
 - Kept the campaign Markdown-primary and JSON-selective: the SK6 audit found no deterministic machine-parsing need that justified a Chronicler JSON catalog.

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -10,7 +10,7 @@ A governance-first specialist skill framework that routes complex AI-assisted so
 Open-source developer tooling and AI orchestration framework
 
 ## Current Stage
-Published release `v1.3.0` (`PUBLISHED_VERIFIED`) from annotated tag `v1.3.0` at exact release commit `3c6155c111981632649a3c3207fac8ac1edcea74`. The release packages the completed SK1-SK10 Specialist Intelligence campaign, 11 aligned package/version surfaces at `1.3.0`, 542 runtime tests at 94.33% coverage, revision-bound release-readiness evidence, and the README-alignment gate through PR #259. The GitHub Release is non-draft, non-prerelease, and immutable. Publication performed no deployment, installed-integration refresh, branch deletion, marketplace publication, or policy activation.
+v1.4.0 - Governance and Compliance Registry Cross-Integration package/version preparation (`PREPARED_NOT_RELEASED`). Repository package surfaces are aligned to `1.4.0` for the governance upgrade while the current public release remains `v1.3.0`. The candidate cross-integrates verified Compliance Registry provenance, integrity, freshness, and project-pinning evidence across Governor, Steward, Arbiter, and Conductor/The Tuner coordination boundaries, and adds a fail-closed README Impact Gate for significant Orchestra changes. The separately governed Registry foundation remains held pending authorized `main` protection and fresh exact-head validation; no `v1.4.0` tag or GitHub Release publication is authorized by package preparation.
 
 ## Primary Users
 Developers and maintainers who install Orchestra as a plugin, skill set, or runtime package inside a supported or scaffold-only IDE or coding host (Claude Code, Codex, Antigravity, Cursor, Windsurf, JetBrains, Zed, Neovim)
@@ -38,6 +38,7 @@ Guidance used for this classification:
 - `OrchestraStatusProjection` is read-only and derived; it does not mutate repository state, Git refs, or governance policy. It is not a source of truth. Missing or conflicting data reports UNKNOWN. Exit codes report command execution success only and do not create governance authority.
 - `OrchestraWorktreeContract` is optional and host-capability-dependent. Worktree isolation must not be mandatory for single-agent or lightweight execution. Cleanup is `EXPLICIT_HOST_ACTION_ONLY`; no automatic deletion of dirty, unrelated, or user-owned worktrees is permitted.
 - The cross-module audit protocol coordinates specialist-owned findings and evidence; it creates no implementation, Git, merge, release, deployment, or policy authority.
+- Compliance Registry evidence is reusable governance input, not a new authority layer. Governor retains compliance/source-applicability ownership, Steward retains requirements/change-control ownership, Arbiter retains transition/evidence-freshness ownership, and Conductor/The Tuner retain routing/coordination boundaries. Registry state cannot authorize release, deployment, policy activation, destructive operations, or legal conclusions.
 - Repository simulation and GitHub CI are not live installed-host evidence. Accepted R7 evidence is recorded separately for installed Codex and Antigravity continuity and Claude Code packaging compatibility; Claude Code active runtime continuity remains unclaimed under `SCAFFOLD_ONLY` maturity.
 - Governed Autonomy Profiles are reduction-only workflow gates. `HUMAN_GOVERNED` is the safe default, children cannot exceed parents, and no profile creates release, deployment, policy, destructive, force-push, history-rewrite, or authority-expansion permission.
 - No vendoring of external plugin code, and no claiming unsupported compatibility or compliance, per `docs/CONTRIBUTING.md`.
@@ -46,6 +47,7 @@ Guidance used for this classification:
 - `pytest tests/runtime` must pass with `--cov-fail-under=90` as enforced in CI via `validate.yml`.
 - `python tests/behavior/run_tests.py` must pass.
 - `python scripts/governance_check.py --strict` must pass as enforced in CI via `governance-check.yml`.
+- `python scripts/check_readme_impact.py` must pass for pull-request and push revisions; significant Orchestra runtime, specialist, host-integration, governance/routing/setup/release, version, or CI/governance changes require `README.md` in the same revision.
 - Manifest and packaging validators (`validate_claude_plugin.py`, `validate_ide_packaging.py`, `validate_manifest.py`, `validate_structure.py`) must pass.
 - Cross-layer contract validators and their behavior tests must pass for affected revisions.
 - `python scripts/validate_governed_autonomy_modes_contract.py` and its focused runtime tests must pass when autonomy-profile contracts change.
@@ -56,7 +58,8 @@ Guidance used for this classification:
 - `tests/behavior/run-tests.ps1` is intentionally maintained in parallel with `run_tests.py` as the primary validation path for Windows environments, per `docs/MATURITY.md`.
 - Direct pushes to `main` are not part of the normal workflow; changes go through a branch and pull request except for documented maintainer bypass recovery cases.
 - Installed Codex and Antigravity parity, host context-reset behavior, and Windows filesystem-specific behavior require host-local evidence in addition to repository CI.
-- Repository package metadata is `1.3.0`, and public release `v1.3.0` is independently verified. Later `main` commits may contain post-release documentation or future unreleased work and do not move the `v1.3.0` tag.
+- Repository package metadata is prepared at `1.4.0`; public release `v1.3.0` remains independently verified until a separately authorized and validated `v1.4.0` publication transition. Later `main` commits do not move the immutable `v1.3.0` tag.
+- The Compliance Registry foundation is validated but held until its repository `main` protection/ruleset is separately authorized and independently verified; trusted Registry publication is a separate protected action.
 
 ## Known Non-Goals
 - Orchestra does not store, process, or transmit end-user or client data itself.
@@ -72,4 +75,4 @@ Guidance used for this classification:
 Not yet decided. No project-specific maintainer preferences beyond `docs/CONTRIBUTING.md` are currently documented for this field.
 
 ## Last Reviewed
-2026-08-13
+2026-08-14

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     <a href="CHANGELOG.md">Changelog</a>
   </p>
   <p>
-    <img src="https://img.shields.io/badge/package_version-v1.3.0-blue" alt="Repository package version v1.3.0" />
+    <img src="https://img.shields.io/badge/package_version-v1.4.0-blue" alt="Repository package version v1.4.0" />
     <a href="https://github.com/Baelfyre/Orchestra/actions/workflows/validate.yml">
       <img src="https://github.com/Baelfyre/Orchestra/actions/workflows/validate.yml/badge.svg" alt="Repository validation status" />
     </a>
@@ -42,6 +42,14 @@ The framework is designed to help developers reduce context drift, make cross-do
 Compliance decisions are especially vulnerable to stale context. Laws, platform policies, licensing terms, privacy obligations, provider requirements, and effective dates can change independently of application code. If those facts are copied into prompts or project documents without provenance and freshness metadata, a previously correct assumption can quietly become the next project's bad input.
 
 The **Orchestra Compliance Registry** is designed to prevent that failure mode. It gives Governor, Steward, and Arbiter a reusable, versioned compliance-intelligence layer whose source identity, release identity, file integrity, freshness state, and project pinning can be checked independently of the project being reviewed.
+
+The important part is the **cross-integration**. The Registry is not a sidecar knowledge dump and it is not a new authority layer. It provides one verifiable compliance substrate that Orchestra can carry across projects and specialist handoffs while each responsibility keeps its existing owner:
+
+- **The Governor** consumes source identity, applicability, jurisdiction/provider scope, effective dates, and freshness evidence for compliance review.
+- **The Steward** maps current, Governor-qualified obligations into requirements, FR/NFR traceability, acceptance criteria, and change-control impact without becoming the legal/compliance authority.
+- **Arbiter** carries the exact pinned Registry version and freshness state into continuity, evidence-freshness, transition, and release-readiness decisions so stale compliance evidence cannot silently authorize a later transition.
+- **Conductor and The Tuner** can route and coordinate work that depends on those specialist-owned contracts, but Registry facts never become routing authority, execution permission, or a substitute for specialist decisions.
+- **Downstream projects** can reuse the same verified compliance knowledge instead of copying conclusions into each repository, while the downstream project's own tracker and repository remain authoritative for project state and implementation evidence.
 
 That separation is important because it lets Orchestra:
 
@@ -96,6 +104,18 @@ flowchart TD
 ~~~
 
 Accessible summary: a request supplies project context and selects separate risk, progression, and governance-profile settings. Trusted composition and the effective-authority intersection run before Conductor routes work. Single-owner work goes directly to its specialist; material multi-domain work first requires current Tuner coordination. Validation failure returns to the owning boundary. Current evidence goes to Arbiter, which may continue or remediate inside existing authority, wait for evidence or capacity, escalate to a human, or stop safely.
+
+## v1.4.0 Governance and Compliance Registry Cross-Integration
+
+The repository/package version is prepared at `1.4.0` for the governance upgrade. **The current public GitHub release remains `v1.3.0` until a separate release/tag publication gate is explicitly authorized and completed.**
+
+v1.4.0 packages the Compliance Registry cross-integration as an Orchestra governance capability: offline-first verified local Registry consumption, explicit integrity/provenance/freshness state, project pinning, progressive-disclosure integration across Governor, Steward, and Arbiter, and preserved routing/authority boundaries.
+
+It also adds a fail-closed **README Impact Gate** to the Governance Check workflow. Changes classified as significant to Orchestra's runtime, specialist skills, host adapters/manifests, governance/routing/setup/release contracts, version surfaces, or CI/governance scripts must update `README.md` in the same revision. Tests and validation-evidence-only changes do not force documentation churn.
+
+This documentation gate complements the existing changelog-freshness gate: significant changes must remain visible both as historical change records and as current public-facing project documentation.
+
+See the [v1.4.0 governance upgrade release candidate](docs/releases/v1.4.0-governance-compliance-registry-release-candidate.md) for the preparation scope and publication boundary.
 
 ## v1.3.0 Specialist Intelligence
 
@@ -250,7 +270,7 @@ Use the host-native path:
 - Antigravity: run `agy plugin install https://github.com/Baelfyre/Orchestra`.
 - Manual or scaffold-only hosts: follow the exact host boundary in the [Installation Guide](docs/setup/INSTALLATION.md).
 
-Repository manifests identify package version `1.3.0`. GitHub Release publication, marketplace publication, and installed-integration refresh are separate governed actions and are not implied by the package version. Check the repository's Releases page for the currently published GitHub release, and see the Installation Guide for supported installation paths and host-maturity boundaries.
+Repository manifests identify package version `1.4.0`. The current public GitHub release remains `v1.3.0` until a separately authorized publication transition creates and verifies `v1.4.0`. GitHub Release publication, marketplace publication, and installed-integration refresh are separate governed actions and are not implied by the package version. See the Installation Guide for supported installation paths and host-maturity boundaries.
 
 ## Quick Start
 
@@ -290,6 +310,7 @@ The validation chain covers:
 - Artificer internal, record, governance-record, and Pattern Catalog validation;
 - prompt-load thresholds and budget;
 - governance protocol, routing contracts, Tuner collaboration, evidence identity, and strict governance;
+- the fail-closed **README Impact Gate**, which requires `README.md` in the same revision whenever significant runtime, specialist, host-integration, governance/routing/setup/release, version, or CI/governance surfaces change;
 - behavior validation and runtime tests with the required coverage threshold;
 - security, compatibility, licensing, version consistency, stale references, and release readiness;
 - native Windows, Ubuntu, and macOS validation;
@@ -298,6 +319,14 @@ The validation chain covers:
 For autonomous or delegated merges, Orchestra additionally requires the fail-closed [Autonomous Merge Readiness Protocol](docs/governance/AUTONOMOUS_MERGE_READINESS_PROTOCOL.md): a green canonical baseline, exact-head evidence, complete successful required checks, expected-head merge guard where supported, and independent post-merge verification.
 
 ## Release Lineage
+
+### v1.4.0 Governance and Compliance Registry Cross-Integration
+
+Repository package/version surfaces are prepared at `1.4.0` for the governance upgrade. The scope cross-integrates verified Compliance Registry evidence into Orchestra's established governance responsibilities and adds the README Impact Gate so significant project changes cannot pass normal governance validation while leaving the public README stale.
+
+This repository/package version does **not** by itself establish a public `v1.4.0` release. The current public release remains `v1.3.0`; tag creation and GitHub Release publication remain separate protected actions.
+
+Preparation scope and boundaries are recorded in the [v1.4.0 governance upgrade release candidate](docs/releases/v1.4.0-governance-compliance-registry-release-candidate.md).
 
 ### v1.3.0 Specialist Intelligence
 
@@ -329,6 +358,7 @@ See the [v1.2.0 release notes](docs/releases/v1.2.0-governed-orchestration.md). 
 - Orchestra is developer tooling and a local runtime. It does not store or transmit downstream project data by default.
 - Data sensitivity, privacy, retention, deletion, platform disclosure, and IP obligations depend on the downstream project and host environment.
 - Release governance may require revision or block publication.
+- Package metadata at `1.4.0` does not mean the public `v1.4.0` release has been published.
 
 ## Documentation Map
 
@@ -360,6 +390,7 @@ See the [v1.2.0 release notes](docs/releases/v1.2.0-governed-orchestration.md). 
 
 ### Release and maintainers
 
+- [v1.4.0 Governance Upgrade Release Candidate](docs/releases/v1.4.0-governance-compliance-registry-release-candidate.md)
 - [v1.3.0 Release Candidate](docs/releases/v1.3.0-specialist-intelligence-release-candidate.md)
 - [v1.3.0 Release Readiness Evidence](docs/validation/V1_3_0_RELEASE_READINESS_EVIDENCE.md)
 - [v1.2.0 Release Notes](docs/releases/v1.2.0-governed-orchestration.md)

--- a/adapters/cursor/package.json
+++ b/adapters/cursor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-cursor-scaffold",
   "displayName": "Orchestra Cursor Scaffold",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Scaffold-only Cursor packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/jetbrains/package.json
+++ b/adapters/jetbrains/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-jetbrains-scaffold",
   "displayName": "Orchestra JetBrains Scaffold",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Scaffold-only JetBrains packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/jetbrains/plugin.xml
+++ b/adapters/jetbrains/plugin.xml
@@ -2,7 +2,7 @@
   <id>com.baelfyre.orchestra.scaffold</id>
   <name>Orchestra JetBrains Scaffold</name>
   <vendor>Baelfyre</vendor>
-  <version>1.3.0</version>
+  <version>1.4.0</version>
   <description>Scaffold-only JetBrains packaging metadata for Orchestra runtime adapter integration.</description>
   <depends>com.intellij.modules.platform</depends>
   <extensions defaultExtensionNs="com.intellij">

--- a/adapters/neovim/package.json
+++ b/adapters/neovim/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-neovim-scaffold",
   "displayName": "Orchestra Neovim Scaffold",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Scaffold-only Neovim packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/vscode/package.json
+++ b/adapters/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-vscode-scaffold",
   "displayName": "Orchestra VS Code Scaffold",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Scaffold-only VS Code packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/windsurf/package.json
+++ b/adapters/windsurf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-windsurf-scaffold",
   "displayName": "Orchestra Windsurf Scaffold",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Scaffold-only Windsurf packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/zed/package.json
+++ b/adapters/zed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-zed-scaffold",
   "displayName": "Orchestra Zed Scaffold",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Scaffold-only Zed packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/docs/releases/v1.4.0-governance-compliance-registry-release-candidate.md
+++ b/docs/releases/v1.4.0-governance-compliance-registry-release-candidate.md
@@ -1,0 +1,145 @@
+# Orchestra v1.4.0: Governance and Compliance Registry Cross-Integration - Release Candidate
+
+## Status
+
+`PREPARED_NOT_RELEASED`
+
+Target version: `1.4.0`
+
+Target tag: `v1.4.0`
+
+Current public release: `v1.3.0`
+
+Release classification: stable minor governance release candidate.
+
+Preparation baseline: `2023525a322e5d17f71d1bcb88ebd9ffec16392b`
+
+Publication is not authorized by this preparation record. Tag creation and GitHub Release publication remain separate protected actions.
+
+## Release Theme
+
+Orchestra v1.4.0 packages the Compliance Registry as a cross-integrated governance capability rather than a standalone data feature. The release candidate combines the already-merged offline-first Registry client and progressive-disclosure governance integration with explicit documentation freshness enforcement for future significant Orchestra changes.
+
+The release remains reduction-only with respect to authority. Compliance knowledge can inform specialist-owned decisions and transition evidence; it does not create routing, execution, release, deployment, policy, destructive-operation, or legal authority.
+
+## Compliance Registry Cross-Integration
+
+The Registry provides a reusable, versioned, evidence-backed compliance substrate whose source identity, distribution provenance, file integrity, freshness state, and project pinning can be verified independently of downstream project code.
+
+Cross-integration preserves existing ownership:
+
+- **The Governor** owns compliance source/applicability review and consumes Registry source identity, jurisdiction/provider scope, effective dates, and freshness evidence.
+- **The Steward** maps Governor-qualified obligations into requirements, FR/NFR traceability, acceptance criteria, and change-control impact without taking over compliance authority.
+- **Arbiter** carries the pinned Registry identity and freshness state into continuity, validation-state, transition, and release-readiness evidence.
+- **Conductor and The Tuner** may route and coordinate work that depends on those specialist-owned contracts, but Registry content never grants routing or execution authority.
+- **Downstream projects** may reuse the same verified compliance knowledge while their own trackers and repositories remain authoritative for project state and implementation evidence.
+
+The integrated Orchestra client remains local-first. Trusted network synchronization requires the canonical Registry's immutable GitHub Release boundary. Local or air-gapped installation requires a separately verified release-manifest SHA-256 trust anchor.
+
+## Existing Canonical Integration Evidence
+
+The Orchestra Compliance Registry client and governance integration were reviewed through PR #262 and merged as signed canonical commit `f32df60cf9963ac678d8467c32d7761021500cde`.
+
+Canonical post-merge validation for that integration recorded:
+
+- 561 runtime tests passing;
+- 94.31 percent runtime coverage;
+- Governance Check passing;
+- behavior validation passing;
+- CodeQL actions and Python analysis passing; and
+- native Ubuntu, macOS, and Windows validation passing.
+
+README rationale and initial Registry documentation alignment were reviewed through PR #266 and merged as signed canonical commit `2023525a322e5d17f71d1bcb88ebd9ffec16392b`, with a fully green canonical post-merge matrix.
+
+## v1.4.0 Package Version Contract
+
+The release candidate advances the same 11 live package/version surfaces governed by the v1.3.0 release contract:
+
+1. `plugin.json`
+2. `.codex-plugin/plugin.json`
+3. `.claude-plugin/plugin.json`
+4. `.claude-plugin/marketplace.json`
+5. `adapters/cursor/package.json`
+6. `adapters/jetbrains/package.json`
+7. `adapters/jetbrains/plugin.xml`
+8. `adapters/neovim/package.json`
+9. `adapters/vscode/package.json`
+10. `adapters/windsurf/package.json`
+11. `adapters/zed/package.json`
+
+`tests/runtime/test_release_version_surfaces.py` requires deterministic parity at `1.4.0` across all 11 surfaces.
+
+Package/version preparation does not change host maturity. Scaffold-only adapters remain scaffold-only.
+
+## README Impact Gate
+
+v1.4.0 adds `scripts/check_readme_impact.py` and integrates it into the `Governance Check` workflow as a fail-closed **README Impact Gate**.
+
+The gate requires `README.md` in the same revision when changes affect significant Orchestra surfaces, including:
+
+- runtime behavior;
+- specialist skills and commands;
+- host adapters and package manifests;
+- governance, routing, setup, project-architecture, or release contracts;
+- package/version surfaces; and
+- CI/governance workflow or validation-script behavior.
+
+Tests, validation evidence, historical decision/session records, and assets do not force README churn when changed by themselves.
+
+Focused regression coverage verifies:
+
+- significant change without README -> `FAIL`;
+- significant change with README -> `PASS`;
+- tests/validation-evidence-only change -> `PASS` without README;
+- package/version and host-surface changes are significant; and
+- governance/CI changes are significant.
+
+This gate complements the existing `CHANGELOG.md` freshness check. The changelog records history; the README must remain an accurate current public entry point.
+
+## Registry Foundation Dependency
+
+The separately governed `Baelfyre/Orchestra-Compliance-Registry` foundation remains intentionally held.
+
+Registry PR #1 is validated but unmerged. Before that foundation can become canonical, the Registry repository requires separately authorized `main` protection/ruleset activation followed by fresh exact-head validation.
+
+A trusted Registry release/tag publication is also a separate protected action. The v1.4.0 package preparation does not perform it.
+
+## Publication Readiness Still Required
+
+Before a public `v1.4.0` release can be authorized, current evidence should establish at minimum:
+
+- Registry `main` protection/ruleset is active and independently verified;
+- Registry PR #1 is freshly reviewed, exact-head validated, and canonically merged if all gates pass;
+- source-backed Registry records and their review/freshness lifecycle are established for the intended release scope;
+- trusted immutable Registry release packaging and independently readable release-manifest SHA-256 evidence are established;
+- end-to-end trusted Registry synchronization, local install, project pinning, freshness, stale-source handling, and audit/release-boundary behavior pass against a real trusted Registry release;
+- all 11 Orchestra package/version surfaces remain exactly `1.4.0`;
+- the README Impact Gate passes at the final release candidate head;
+- full governance, behavior, runtime coverage, CodeQL, and native OS release-readiness checks pass at the exact candidate revision; and
+- zero unresolved blocking review threads remain.
+
+## Authority and Publication Boundary
+
+This preparation does not authorize or perform:
+
+- Registry repository-protection mutation;
+- Registry PR #1 merge;
+- Registry trusted release/tag publication;
+- Orchestra `v1.4.0` tag creation;
+- Orchestra GitHub Release publication;
+- marketplace publication;
+- installed-integration refresh;
+- deployment or production mutation;
+- policy activation;
+- destructive cleanup;
+- branch deletion;
+- force push; or
+- history rewrite.
+
+`PACKAGE_VERSION_1_4_0 != PUBLIC_RELEASE_V1_4_0`
+
+`VALIDATION_SUCCESS != RELEASE_AUTHORITY`
+
+`MERGEABILITY != PUBLICATION_AUTHORITY`
+
+The preparation campaign stops at `PREPARED_NOT_RELEASED` until the remaining dependencies are current and publication is separately authorized.

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "name": "conductor",
   "display_name": "Orchestra",
   "description": "An installable AI workflow plugin that routes tasks through focused specialist skills. See SKILL_INDEX.md and ROUTING_MAP.md for detailed routing behavior.",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "license": "MIT",
   "repository": "https://github.com/Baelfyre/Orchestra",
   "icon_path": "assets/icons/conductor.ico",

--- a/scripts/check_readme_impact.py
+++ b/scripts/check_readme_impact.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Fail closed when significant Orchestra changes omit README.md.
+
+The gate is intentionally deterministic. It classifies repository paths whose
+changes materially affect Orchestra's user-facing capabilities, governance,
+routing, installation, host integrations, release/version contract, or CI
+policy. Any such change must update README.md in the same revision.
+"""
+from __future__ import annotations
+
+import fnmatch
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable
+
+
+README_PATH = "README.md"
+
+SIGNIFICANT_CHANGE_PATTERNS = (
+    ".agents/plugins/marketplace.json",
+    ".claude-plugin/**",
+    ".codex-plugin/**",
+    ".github/workflows/**",
+    "adapters/**",
+    "commands/**",
+    "orchestra_runtime/**",
+    "scripts/**",
+    "skills/**",
+    "templates/**",
+    "docs/governance/**",
+    "docs/project/**",
+    "docs/releases/**",
+    "docs/routing/**",
+    "docs/setup/**",
+    "AGENTS.md",
+    "PROJECT_CONTEXT.md",
+    "PROJECT_STATE.md",
+    "ROUTING_MAP.md",
+    "SKILL_INDEX.md",
+    "plugin.json",
+)
+
+# These paths are evidence, tests, or documentation maintenance that should not
+# force meaningless README churn when changed by themselves.
+NON_SIGNIFICANT_PATTERNS = (
+    "README.md",
+    "CHANGELOG.md",
+    "DECISION_LOG.md",
+    "SESSION_HANDOFF.md",
+    "assets/**",
+    "docs/validation/**",
+    "docs/artificer/**",
+    "tests/**",
+)
+
+
+def normalize_paths(paths: Iterable[str]) -> list[str]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw in paths:
+        path = str(raw).strip().replace("\\", "/")
+        if path and path not in seen:
+            seen.add(path)
+            normalized.append(path)
+    return normalized
+
+
+def _matches(path: str, patterns: Iterable[str]) -> bool:
+    return any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
+
+
+def is_significant_change(path: str) -> bool:
+    path = path.strip().replace("\\", "/")
+    if not path or _matches(path, NON_SIGNIFICANT_PATTERNS):
+        return False
+    return _matches(path, SIGNIFICANT_CHANGE_PATTERNS)
+
+
+def evaluate_changed_paths(paths: Iterable[str]) -> dict[str, object]:
+    changed = normalize_paths(paths)
+    significant = sorted(path for path in changed if is_significant_change(path))
+    readme_updated = README_PATH in changed
+    passed = not significant or readme_updated
+    return {
+        "passed": passed,
+        "changed": changed,
+        "significant": significant,
+        "readme_updated": readme_updated,
+    }
+
+
+def _git(repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _commit_exists(repo_root: Path, revision: str) -> bool:
+    if not revision:
+        return False
+    return _git(repo_root, "cat-file", "-e", f"{revision}^{{commit}}").returncode == 0
+
+
+def _ensure_commit(repo_root: Path, revision: str, label: str) -> None:
+    if _commit_exists(repo_root, revision):
+        return
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        fetch = _git(repo_root, "fetch", "--no-tags", "--depth=1", "origin", revision)
+        if fetch.returncode == 0 and _commit_exists(repo_root, revision):
+            return
+    raise RuntimeError(f"Verified {label} commit is unavailable: {revision or '<missing>'}")
+
+
+def _load_event() -> tuple[str, dict[str, object]]:
+    event_name = os.environ.get("GITHUB_EVENT_NAME", "").strip()
+    event_path = os.environ.get("GITHUB_EVENT_PATH", "").strip()
+    if not event_path or not Path(event_path).is_file():
+        return event_name, {}
+    return event_name, json.loads(Path(event_path).read_text(encoding="utf-8"))
+
+
+def resolve_change_range(repo_root: Path) -> tuple[str, str, str] | None:
+    """Return (label, base, head) for PR/push events, or None for manual runs."""
+    event_name, event = _load_event()
+
+    if event_name in {"pull_request", "pull_request_target"}:
+        pull_request = event.get("pull_request")
+        if not isinstance(pull_request, dict):
+            raise RuntimeError("Pull-request event payload is missing pull_request data")
+        base_obj = pull_request.get("base")
+        if not isinstance(base_obj, dict):
+            raise RuntimeError("Pull-request event payload is missing base data")
+        base = str(base_obj.get("sha", "")).strip()
+        # GITHUB_SHA is the tested merge revision for pull_request workflows.
+        head = os.environ.get("GITHUB_SHA", "").strip() or "HEAD"
+        _ensure_commit(repo_root, base, "pull-request base")
+        _ensure_commit(repo_root, head, "pull-request tested head")
+        return "pull-request-base..tested-head", base, head
+
+    if event_name == "push":
+        base = str(event.get("before", "")).strip()
+        head = str(event.get("after", "")).strip() or os.environ.get("GITHUB_SHA", "").strip()
+        if base and set(base) == {"0"}:
+            base = ""
+        if not base:
+            raise RuntimeError("Push event has no usable before commit; README impact cannot be verified")
+        _ensure_commit(repo_root, base, "push-before")
+        _ensure_commit(repo_root, head, "push-after")
+        return "push-before..push-after", base, head
+
+    # workflow_dispatch has no trustworthy change range. The gate remains
+    # enforced on pull_request and push, where a revision transition exists.
+    return None
+
+
+def changed_paths_for_range(repo_root: Path, base: str, head: str) -> list[str]:
+    result = _git(repo_root, "diff", "--name-only", base, head)
+    if result.returncode != 0:
+        raise RuntimeError(
+            "Could not enumerate changed paths for README impact validation: "
+            + (result.stderr.strip() or "git diff failed")
+        )
+    return normalize_paths(result.stdout.splitlines())
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    try:
+        change_range = resolve_change_range(repo_root)
+        if change_range is None:
+            print("README_IMPACT_GATE=SKIP event=workflow_dispatch reason=no_revision_transition")
+            return 0
+
+        label, base, head = change_range
+        result = evaluate_changed_paths(changed_paths_for_range(repo_root, base, head))
+        significant = result["significant"]
+        if result["passed"]:
+            print(
+                "README_IMPACT_GATE=PASS "
+                f"comparison={label} significant={len(significant)} "
+                f"readme_updated={str(result['readme_updated']).lower()}"
+            )
+            if significant:
+                print("SIGNIFICANT_PATHS=" + ",".join(significant))
+            return 0
+
+        print(
+            "README_IMPACT_GATE=FAIL "
+            f"comparison={label} significant={len(significant)} readme_updated=false"
+        )
+        print("SIGNIFICANT_PATHS=" + ",".join(significant))
+        print(
+            "REMEDIATION=Update README.md in the same change so public documentation "
+            "reflects the significant Orchestra capability/governance change."
+        )
+        return 1
+    except (OSError, RuntimeError, json.JSONDecodeError) as exc:
+        print(f"README_IMPACT_GATE=FAIL error={exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/runtime/test_readme_impact_gate.py
+++ b/tests/runtime/test_readme_impact_gate.py
@@ -1,0 +1,52 @@
+from scripts import check_readme_impact as gate
+
+
+def test_significant_runtime_change_requires_readme() -> None:
+    result = gate.evaluate_changed_paths(["orchestra_runtime/runtime.py"])
+    assert result["passed"] is False
+    assert result["readme_updated"] is False
+    assert result["significant"] == ["orchestra_runtime/runtime.py"]
+
+
+def test_significant_change_passes_with_readme() -> None:
+    result = gate.evaluate_changed_paths(
+        ["docs/governance/GOVERNANCE_LAYER.md", "README.md"]
+    )
+    assert result["passed"] is True
+    assert result["readme_updated"] is True
+    assert result["significant"] == ["docs/governance/GOVERNANCE_LAYER.md"]
+
+
+def test_test_and_validation_evidence_only_changes_do_not_require_readme() -> None:
+    result = gate.evaluate_changed_paths(
+        [
+            "tests/runtime/test_example.py",
+            "docs/validation/EXAMPLE_EVIDENCE.md",
+            "CHANGELOG.md",
+        ]
+    )
+    assert result["passed"] is True
+    assert result["significant"] == []
+
+
+def test_version_and_host_surfaces_are_significant() -> None:
+    paths = [
+        "plugin.json",
+        ".claude-plugin/plugin.json",
+        "adapters/vscode/package.json",
+        "docs/releases/v1.4.0-governance-upgrade.md",
+    ]
+    result = gate.evaluate_changed_paths(paths)
+    assert result["passed"] is False
+    assert result["significant"] == sorted(paths)
+
+
+def test_governance_and_ci_changes_are_significant() -> None:
+    paths = [
+        ".github/workflows/governance-check.yml",
+        "scripts/check_readme_impact.py",
+        "skills/the-governor/SKILL.md",
+    ]
+    result = gate.evaluate_changed_paths(paths)
+    assert result["passed"] is False
+    assert result["significant"] == sorted(paths)

--- a/tests/runtime/test_release_version_surfaces.py
+++ b/tests/runtime/test_release_version_surfaces.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[2]
-EXPECTED_VERSION = "1.3.0"
+EXPECTED_VERSION = "1.4.0"
 
 JSON_VERSION_SURFACES = (
     "plugin.json",


### PR DESCRIPTION
Prepares Orchestra package/repository metadata for **v1.4.0 Governance and Compliance Registry Cross-Integration** while preserving `v1.3.0` as the current public release until a separately authorized publication gate.

Exact base: `2023525a322e5d17f71d1bcb88ebd9ffec16392b`.
Final reviewed head: `f77ec12786f844d999da3d852d0190b13b9d6c51`.
Reviewed tree: `dc915a4dd1d35ef0c5cc9828dfe9ef4fdc8acf4c`.

## Scope
- advances the same 11 live package/version surfaces used by the v1.3.0 release contract to `1.4.0`;
- advances the deterministic version-parity regression to require exactly `1.4.0`;
- expands README to explain Registry cross-integration across Governor, Steward, Arbiter, Conductor/The Tuner coordination, and downstream project handoffs;
- distinguishes package metadata `1.4.0` from the still-current public release `v1.3.0`;
- adds `scripts/check_readme_impact.py`, a fail-closed README Impact Gate for significant Orchestra changes;
- integrates the README Impact Gate into Governance Check;
- adds focused runtime regressions for gate classification and pass/fail behavior;
- adds `docs/releases/v1.4.0-governance-compliance-registry-release-candidate.md` with `PREPARED_NOT_RELEASED` boundaries;
- adds a focused v1.4.0 changelog entry without rewriting historical release records;
- aligns `PROJECT_CONTEXT.md` with the v1.4.0 preparation and the still-published v1.3.0 state.

## README Impact Gate
Significant changes to runtime, skills/commands, host adapters/manifests, governance/routing/setup/release/project contracts, package/version surfaces, or CI/governance scripts must include `README.md` in the same revision. Tests, validation evidence, historical decision/session records, and assets do not force README churn by themselves.

The exact-head Governance Check exercised the new gate against this PR and returned:
`README_IMPACT_GATE=PASS comparison=pull-request-base..tested-head significant=15 readme_updated=true`

The gate complements the existing fail-closed `CHANGELOG.md` freshness check: the changelog records history; README remains the current public entry point.

## Exact-head validation
All required checks are green on `f77ec12786f844d999da3d852d0190b13b9d6c51`:
- Governance Check: PASS (`README_IMPACT_GATE=PASS`, strict governance 0 errors / 0 warnings)
- validate: PASS
- runtime-tests: PASS — 566 tests, 94.33% coverage
- Analyze (actions): PASS
- Analyze (python): PASS
- native Ubuntu: PASS
- native macOS: PASS
- native Windows: PASS

## Exact-head review
- 19 changed files
- 0 commits behind canonical `main`
- no unresolved review threads
- no requested-change review
- mergeable
- changelog final diff contains only the new v1.4.0 preparation block; historical wording was preserved

## Related issues
- #264 — Orchestra governance upgrade: Compliance Registry cross-integration
- #265 — Orchestra v1.4.0: Governance & Compliance Registry Cross-Integration

## Separate Registry dependency
`Baelfyre/Orchestra-Compliance-Registry` PR #1 remains validated but held. Registry `main` protection/ruleset mutation, Registry PR #1 merge, source-record activation, and trusted Registry release publication remain separately governed.

## Protected boundaries
This PR does **not** authorize or perform Orchestra `v1.4.0` tag/GitHub Release publication, Registry repository-setting mutation, Registry PR #1 merge, trusted Registry release/tag publication, marketplace publication, installed-integration refresh, deployment/production mutation, policy activation, destructive cleanup, branch deletion, force push, or history rewrite.

`PACKAGE_VERSION_1_4_0 != PUBLIC_RELEASE_V1_4_0`

Merge is permitted only with the exact reviewed-head guard.