### PR TITLE
docs: close downstream-role terminology audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ The framework is designed to help developers reduce context drift, make cross-do
 
 > **Core trust boundary:** governance approval, coordination readiness, validation success, and GitHub mergeability are state or evidence signals. None of them grants or expands authority.
 
+> **Terminology:** Orchestra uses **Downstream Roles** for specialists or adapters that receive governed outputs from another canonical owner. The word **consumer** is reserved for genuine technical provider/consumer or message-consumer semantics.
+
 ## Why the Compliance Registry Matters
 
 Compliance decisions are especially vulnerable to stale context. Laws, platform policies, licensing terms, privacy obligations, provider requirements, and effective dates can change independently of application code. If those facts are copied into prompts or project documents without provenance and freshness metadata, a previously correct assumption can quietly become the next project's bad input.

--- a/docs/project/ORCHESTRA_STATUS_PROJECTION.md
+++ b/docs/project/ORCHESTRA_STATUS_PROJECTION.md
@@ -22,7 +22,7 @@ This document specifies the `OrchestraStatusProjection`, a read-only, determinis
 - **Canonical Owner:** **Scribe** (Documentation and Knowledge Transfer Specialist).
 - **Responsibility:** Owns status summary formats, state projection schemas, knowledge base alignment, and presentation formats.
 - **Implementation Specialist:** **Ponytail** (Implementation and Navigation Specialist).
-- **Secondary Consumers:** Conductor (routing context), Arbiter (continuity validation), Overseer (release readiness check).
+- **Downstream Roles:** Conductor (routing context), Arbiter (continuity validation), Overseer (release readiness check).
 
 ---
 

--- a/docs/project/ORCHESTRA_WORKTREE_CONTRACT.md
+++ b/docs/project/ORCHESTRA_WORKTREE_CONTRACT.md
@@ -21,7 +21,7 @@ This document specifies the `OrchestraWorktreeContract`, an optional, host-capab
 ## 2. Canonical Ownership & Responsibilities
 - **Canonical Owner:** **Ponytail** (Implementation and Navigation Specialist).
 - **Responsibility:** Owns codebase navigation, targeted file changes, Git worktree operations, path confinement validation, and safe workspace boundaries.
-- **Secondary Consumers:** Conductor (routing context), Arbiter (transition verification), Overseer (evidence validation), Host Adapters (capability declaration).
+- **Downstream Roles:** Conductor (routing context), Arbiter (transition verification), Overseer (evidence validation), Host Adapters (capability declaration).
 
 ---
 

--- a/docs/project/SPEC_KITTY_DERIVED_CONTRACT_OWNERSHIP.md
+++ b/docs/project/SPEC_KITTY_DERIVED_CONTRACT_OWNERSHIP.md
@@ -16,14 +16,14 @@
 This document defines canonical placement, single specialist ownership, and architectural boundaries for the Spec Kitty-derived Orchestra upgrade contracts.
 
 1. **Single Source of Truth Invariant:** No new contract creates a second source of truth for existing state or policy.
-2. **Single Canonical Owner Invariant:** Every contract has exactly ONE canonical specialist owner. Secondary consumers or validators are recorded separately.
+2. **Single Canonical Owner Invariant:** Every contract has exactly ONE canonical specialist owner. Downstream roles or validators are recorded separately.
 3. **No Inferred Authority Invariant:** Machine-readable formats, correlation headers, retrospective artifacts, worktree contracts, and status projections track execution; they do NOT grant execution, merge, release, or policy mutation authority.
 
 ---
 
 ## 2. Canonical Phase 2 Contract Ownership Matrix
 
-| Contract Name | Canonical Specification | Canonical Owner | Secondary Consumers | Validation Owner | Continuity Consumer | Design Status | Implementation Status | Policy Integration Status | Release Status |
+| Contract Name | Canonical Specification | Canonical Owner | Downstream Roles | Validation Owner | Continuity Consumer | Design Status | Implementation Status | Policy Integration Status | Release Status |
 |---|---|---|---|---|---|---|---|---|---|
 | **OrchestraRuntimeEnvelope** | `docs/project/ORCHESTRA_RUNTIME_ENVELOPE.md` | Clockwork | Conductor, Arbiter | Overseer | Arbiter | `DESIGN_SPECIFIED` | `IMPLEMENTED_MERGED` | `NOT_APPLICABLE` | `NOT_RELEASED` |
 | **OrchestraCorrelationID** | `docs/governance/CORRELATION_ID_PROTOCOL.md` | Chronicler | Conductor, Overseer | Overseer | Arbiter | `DESIGN_SPECIFIED` | `IMPLEMENTED_MERGED` | `NOT_APPLICABLE` | `NOT_RELEASED` |
@@ -34,7 +34,7 @@ This document defines canonical placement, single specialist ownership, and arch
 
 ## 2.1 Phase 3 Contract Ownership Matrix
 
-| Contract Name | Canonical Specification | Canonical Owner | Secondary Consumers | Validation Owner | Continuity Consumer | Design Status | Implementation Status | Policy Integration Status | Release Status |
+| Contract Name | Canonical Specification | Canonical Owner | Downstream Roles | Validation Owner | Continuity Consumer | Design Status | Implementation Status | Policy Integration Status | Release Status |
 |---|---|---|---|---|---|---|---|---|---|
 | **OrchestraStatusProjection** | `docs/project/ORCHESTRA_STATUS_PROJECTION.md` | Scribe | Conductor, Arbiter, Overseer, Ponytail | Overseer | Arbiter | `DESIGN_ACCEPTED_MERGED` | `IMPLEMENTED_MERGED` | `NOT_APPLICABLE` | `NOT_RELEASED` |
 | **OrchestraWorktreeContract** | `docs/project/ORCHESTRA_WORKTREE_CONTRACT.md` | Ponytail | Conductor, Arbiter, Overseer, Host Adapters | Overseer | Arbiter | `DESIGN_ACCEPTED_MERGED` | `IMPLEMENTED_MERGED` | `NOT_APPLICABLE` | `NOT_RELEASED` |


### PR DESCRIPTION
Replays the documentation-only terminology cleanup from stale draft PR #263 onto current canonical Orchestra `main`.

Scope is exactly three current-facing project documentation files:
- `docs/project/ORCHESTRA_STATUS_PROJECTION.md`
- `docs/project/ORCHESTRA_WORKTREE_CONTRACT.md`
- `docs/project/SPEC_KITTY_DERIVED_CONTRACT_OWNERSHIP.md`

Changes role-facing terminology from `Secondary Consumers` / `secondary consumers` to `Downstream Roles` / `downstream roles` where the referenced entities are Orchestra specialists or adapters. Genuine technical consumer terminology and historical evidence remain unchanged.

The original PR #263 is four commits behind current `main`; this PR is the 0-behind forward replay. No runtime behavior, authority, package version, release state, Registry state, deployment, policy activation, destructive action, branch deletion, force push, or history rewrite is included.