### PR TITLE
release: refresh v1.4 prepublication readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,13 @@ The repository/package version is prepared at `1.4.0` for the governance upgrade
 
 v1.4.0 packages the Compliance Registry cross-integration as an Orchestra governance capability: offline-first verified local Registry consumption, explicit integrity/provenance/freshness state, project pinning, progressive-disclosure integration across Governor, Steward, and Arbiter, and preserved routing/authority boundaries.
 
+The Registry foundation, source/freshness pilot, deterministic packaging, and v0.1.0 release-readiness stack are now canonical in `Baelfyre/Orchestra-Compliance-Registry`. The deterministic `registry-v0.1.0` candidate is preserved as revision-bound CI evidence, but **no trusted Registry GitHub Release exists yet**. Orchestra therefore remains in prepublication readiness pending separately authorized Registry publication and real network-provenance validation against the resulting immutable canonical release.
+
 It also adds a fail-closed **README Impact Gate** to the Governance Check workflow. Changes classified as significant to Orchestra's runtime, specialist skills, host adapters/manifests, governance/routing/setup/release contracts, version surfaces, or CI/governance scripts must update `README.md` in the same revision. Tests and validation-evidence-only changes do not force documentation churn.
 
 This documentation gate complements the existing changelog-freshness gate: significant changes must remain visible both as historical change records and as current public-facing project documentation.
 
-See the [v1.4.0 governance upgrade release candidate](docs/releases/v1.4.0-governance-compliance-registry-release-candidate.md) for the preparation scope and publication boundary.
+See the [v1.4.0 governance upgrade release candidate](docs/releases/v1.4.0-governance-compliance-registry-release-candidate.md) and [v1.4.0 prepublication readiness evidence](docs/validation/V1_4_0_PREPUBLICATION_READINESS_EVIDENCE.md) for the current preparation scope, canonical Registry dependency, and remaining publication boundary.
 
 ## v1.3.0 Specialist Intelligence
 
@@ -326,9 +328,11 @@ For autonomous or delegated merges, Orchestra additionally requires the fail-clo
 
 Repository package/version surfaces are prepared at `1.4.0` for the governance upgrade. The scope cross-integrates verified Compliance Registry evidence into Orchestra's established governance responsibilities and adds the README Impact Gate so significant project changes cannot pass normal governance validation while leaving the public README stale.
 
+The Registry implementation and v0.1.0 deterministic candidate preparation are canonical, but a trusted Registry GitHub Release has not yet been published. Orchestra `v1.4.0` therefore remains a prepublication candidate pending that separately authorized Registry release and real network-provenance validation against it.
+
 This repository/package version does **not** by itself establish a public `v1.4.0` release. The current public release remains `v1.3.0`; tag creation and GitHub Release publication remain separate protected actions.
 
-Preparation scope and boundaries are recorded in the [v1.4.0 governance upgrade release candidate](docs/releases/v1.4.0-governance-compliance-registry-release-candidate.md).
+Preparation scope and boundaries are recorded in the [v1.4.0 governance upgrade release candidate](docs/releases/v1.4.0-governance-compliance-registry-release-candidate.md) and [v1.4.0 prepublication readiness evidence](docs/validation/V1_4_0_PREPUBLICATION_READINESS_EVIDENCE.md).
 
 ### v1.3.0 Specialist Intelligence
 
@@ -336,7 +340,7 @@ Repository package/version surfaces are aligned at `1.3.0` for the Specialist In
 
 Package version, validation success, or mergeability does not independently establish public-release state. GitHub Release publication is a separate governed transition. See the repository's Releases page for the current publication state.
 
-Release preparation and revision-bound evidence are recorded in the [v1.3.0 release candidate](docs/releases/v1.3.0-specialist-intelligence-release-candidate.md) and [v1.3.0 release-readiness evidence](docs/validation/V1_3_0_RELEASE_READINESS_EVIDENCE.md).
+Release preparation and revision-bound evidence are recorded in the [v1.3.0 release candidate](docs/releases/v1.3.0-specialist-intelligence-release-candidate.md) and [v1.3.0 release-readiness evidence](docs/validation/V1_3_0_RELEASE_READINESS_EVIDENCE.md) for the completed campaign and preparation record.
 
 ### v1.2.0 Governed Orchestration
 
@@ -393,6 +397,7 @@ See the [v1.2.0 release notes](docs/releases/v1.2.0-governed-orchestration.md). 
 ### Release and maintainers
 
 - [v1.4.0 Governance Upgrade Release Candidate](docs/releases/v1.4.0-governance-compliance-registry-release-candidate.md)
+- [v1.4.0 Prepublication Readiness Evidence](docs/validation/V1_4_0_PREPUBLICATION_READINESS_EVIDENCE.md)
 - [v1.3.0 Release Candidate](docs/releases/v1.3.0-specialist-intelligence-release-candidate.md)
 - [v1.3.0 Release Readiness Evidence](docs/validation/V1_3_0_RELEASE_READINESS_EVIDENCE.md)
 - [v1.2.0 Release Notes](docs/releases/v1.2.0-governed-orchestration.md)

--- a/docs/releases/v1.4.0-governance-compliance-registry-release-candidate.md
+++ b/docs/releases/v1.4.0-governance-compliance-registry-release-candidate.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-`PREPARED_NOT_RELEASED`
+`WAITING_FOR_TRUSTED_REGISTRY_PUBLICATION`
 
 Target version: `1.4.0`
 
@@ -12,13 +12,15 @@ Current public release: `v1.3.0`
 
 Release classification: stable minor governance release candidate.
 
-Preparation baseline: `2023525a322e5d17f71d1bcb88ebd9ffec16392b`
+Current Orchestra candidate baseline: `8008eeb87f54b12136fab1563e0c97061459cf61`
 
-Publication is not authorized by this preparation record. Tag creation and GitHub Release publication remain separate protected actions.
+Current Registry readiness baseline: `3821bcb55125b4d8864f28b6423650e6e17ac67b`
+
+Publication is not authorized by this preparation record. Registry trusted release publication and Orchestra tag/GitHub Release publication remain separate protected actions.
 
 ## Release Theme
 
-Orchestra v1.4.0 packages the Compliance Registry as a cross-integrated governance capability rather than a standalone data feature. The release candidate combines the already-merged offline-first Registry client and progressive-disclosure governance integration with explicit documentation freshness enforcement for future significant Orchestra changes.
+Orchestra v1.4.0 packages the Compliance Registry as a cross-integrated governance capability rather than a standalone data feature. It combines the offline-first verified Registry client, progressive-disclosure governance integration, source freshness and provenance boundaries, project pinning, deterministic Registry release-candidate compatibility, and fail-closed README freshness enforcement.
 
 The release remains reduction-only with respect to authority. Compliance knowledge can inform specialist-owned decisions and transition evidence; it does not create routing, execution, release, deployment, policy, destructive-operation, or legal authority.
 
@@ -34,26 +36,73 @@ Cross-integration preserves existing ownership:
 - **Conductor and The Tuner** may route and coordinate work that depends on those specialist-owned contracts, but Registry content never grants routing or execution authority.
 - **Downstream projects** may reuse the same verified compliance knowledge while their own trackers and repositories remain authoritative for project state and implementation evidence.
 
-The integrated Orchestra client remains local-first. Trusted network synchronization requires the canonical Registry's immutable GitHub Release boundary. Local or air-gapped installation requires a separately verified release-manifest SHA-256 trust anchor.
+The integrated Orchestra client remains local-first. Trusted network synchronization requires the canonical Registry's non-draft, non-prerelease, immutable GitHub Release boundary. Local or air-gapped installation requires a separately verified release-manifest SHA-256 trust anchor.
 
-## Existing Canonical Integration Evidence
+## Canonical Orchestra Evidence
 
-The Orchestra Compliance Registry client and governance integration were reviewed through PR #262 and merged as signed canonical commit `f32df60cf9963ac678d8467c32d7761021500cde`.
+Compliance Registry client and governance integration:
 
-Canonical post-merge validation for that integration recorded:
+- PR #262 -> signed canonical `f32df60cf9963ac678d8467c32d7761021500cde`;
+- canonical post-merge validation: 561 runtime tests PASS, 94.31% coverage, Governance Check PASS, behavior validation PASS, CodeQL actions/Python PASS, Ubuntu/macOS/Windows PASS.
 
-- 561 runtime tests passing;
-- 94.31 percent runtime coverage;
-- Governance Check passing;
-- behavior validation passing;
-- CodeQL actions and Python analysis passing; and
-- native Ubuntu, macOS, and Windows validation passing.
+README and public integration rationale:
 
-README rationale and initial Registry documentation alignment were reviewed through PR #266 and merged as signed canonical commit `2023525a322e5d17f71d1bcb88ebd9ffec16392b`, with a fully green canonical post-merge matrix.
+- PR #266 -> signed canonical `2023525a322e5d17f71d1bcb88ebd9ffec16392b`;
+- canonical post-merge validation matrix PASS.
+
+v1.4 package/governance preparation:
+
+- PR #267 -> signed canonical `64b9e6f20aa3510fcfc3eb4c60b0074739f284c2`;
+- all 11 live package/version surfaces set to `1.4.0`;
+- README Impact Gate enabled and verified on PR and canonical push;
+- 566 runtime tests PASS at 94.33% coverage with full governance, CodeQL, and native-OS matrix PASS.
+
+Registry candidate compatibility:
+
+- PR #268 -> signed canonical `6e1859f2362978228e7119114abe96e35fddaf4c`;
+- Registry `0.1.0` candidate install/query/pin/freshness and trust-anchor behavior validated;
+- 568 runtime tests PASS at 94.33% coverage with full governance, CodeQL, and native-OS matrix PASS.
+
+Terminology closeout:
+
+- stale PR #263 closed unmerged and superseded without rebase/force update;
+- PR #269 replayed the exact current-facing terminology cleanup on fresh `main` and merged as signed canonical `8008eeb87f54b12136fab1563e0c97061459cf61`;
+- `Downstream Roles` is the public term for specialist/adapter recipients while genuine technical provider/consumer semantics remain unchanged;
+- README Impact Gate required and received a matching README clarification;
+- canonical post-merge Governance Check, validate/runtime, CodeQL actions/Python, Ubuntu, macOS, and Windows PASS.
+
+## Canonical Registry Dependency
+
+`Baelfyre/Orchestra-Compliance-Registry` is no longer a held foundation dependency. Its governed implementation stack is canonical.
+
+Canonical Registry milestones:
+
+- foundation -> signed Squash `1d334bbb4bff0276ca3112b41112ad6094b9a096`;
+- Philippines privacy source/freshness pilot -> signed Squash `e97e1c885f00658b418f0b6ab1841bf021e5582d`;
+- deterministic trusted-release packaging -> signed Squash `6f802f0c32d20fe4ad0e7c8eb3a23f6b883341ac`;
+- v0.1.0 publication-readiness evidence/artifact preservation -> signed Squash `3821bcb55125b4d8864f28b6423650e6e17ac67b`.
+
+The Registry `compliance-ruleset` is active and enforces PR-only canonical promotion, Squash-only merge, current `validate-registry` from GitHub Actions, resolved conversations, blocked force pushes/deletion, and an empty bypass list.
+
+The canonical Registry remains source-state `DRAFT`; trusted distribution identity is applied only to the deterministic staged candidate.
+
+### Registry v0.1.0 candidate
+
+- version: `0.1.0`;
+- release sequence: `1`;
+- release tag: `registry-v0.1.0`;
+- release-manifest SHA-256: `9922ddcce77dfac0c01cac80fe6669aaffe37636826a56a4b54a8312558ee2d1`;
+- ZIP SHA-256: `b64889933d30a8dea27bcbbb95c952e4f053c14a4f345e1e04b27777b5025ec0`;
+- all four pilot sources: `VERIFIED_CURRENT` as of 2026-08-14;
+- earliest next review deadline: 2026-10-13;
+- canonical post-merge Registry Validation run after readiness merge: PASS;
+- revision-bound `registry-v0.1.0-candidate` Actions artifact preserved from canonical readiness validation.
+
+No trusted Registry GitHub Release exists yet. Candidate integrity and readiness therefore do not yet establish network distribution provenance.
 
 ## v1.4.0 Package Version Contract
 
-The release candidate advances the same 11 live package/version surfaces governed by the v1.3.0 release contract:
+The release candidate requires parity across the same 11 live package/version surfaces:
 
 1. `plugin.json`
 2. `.codex-plugin/plugin.json`
@@ -67,67 +116,45 @@ The release candidate advances the same 11 live package/version surfaces governe
 10. `adapters/windsurf/package.json`
 11. `adapters/zed/package.json`
 
-`tests/runtime/test_release_version_surfaces.py` requires deterministic parity at `1.4.0` across all 11 surfaces.
-
-Package/version preparation does not change host maturity. Scaffold-only adapters remain scaffold-only.
+`tests/runtime/test_release_version_surfaces.py` requires deterministic parity at `1.4.0` across all 11 surfaces. Package/version preparation does not change host maturity.
 
 ## README Impact Gate
 
-v1.4.0 adds `scripts/check_readme_impact.py` and integrates it into the `Governance Check` workflow as a fail-closed **README Impact Gate**.
+v1.4.0 includes the fail-closed README Impact Gate in `Governance Check`.
 
-The gate requires `README.md` in the same revision when changes affect significant Orchestra surfaces, including:
+Significant runtime, specialist, host-integration, governance/routing/setup/release, package/version, project-contract, or CI/governance changes require `README.md` in the same revision. Tests and validation-evidence-only changes do not force documentation churn.
 
-- runtime behavior;
-- specialist skills and commands;
-- host adapters and package manifests;
-- governance, routing, setup, project-architecture, or release contracts;
-- package/version surfaces; and
-- CI/governance workflow or validation-script behavior.
+The terminology closeout provided an additional live proof: three significant `docs/project/**` changes initially failed the gate until the public terminology note was added to README, after which Governance Check passed.
 
-Tests, validation evidence, historical decision/session records, and assets do not force README churn when changed by themselves.
+## Remaining Publication Dependency
 
-Focused regression coverage verifies:
+The implementation and pre-publication preparation are complete. One evidence dependency remains before Orchestra can be a final publication candidate:
 
-- significant change without README -> `FAIL`;
-- significant change with README -> `PASS`;
-- tests/validation-evidence-only change -> `PASS` without README;
-- package/version and host-surface changes are significant; and
-- governance/CI changes are significant.
+1. explicitly authorize and publish `registry-v0.1.0` from the exact current Registry canonical baseline;
+2. ensure the Registry GitHub Release is non-draft, non-prerelease, and immutable;
+3. publish the candidate ZIP plus independently readable release-manifest and SHA-256 evidence;
+4. run Orchestra's real network synchronization against that immutable canonical release;
+5. validate exact release tag, manifest identity, file inventory/hashes, freshness, query, project pinning, and anti-rollback behavior;
+6. refresh the final Orchestra v1.4.0 exact-head release-readiness matrix after that provenance evidence exists.
 
-This gate complements the existing `CHANGELOG.md` freshness check. The changelog records history; the README must remain an accurate current public entry point.
+Until then:
 
-## Registry Foundation Dependency
+`IMPLEMENTATION_COMPLETE`
 
-The separately governed `Baelfyre/Orchestra-Compliance-Registry` foundation remains intentionally held.
+`REGISTRY_CANDIDATE_READY`
 
-Registry PR #1 is validated but unmerged. Before that foundation can become canonical, the Registry repository requires separately authorized `main` protection/ruleset activation followed by fresh exact-head validation.
+`NETWORK_PROVENANCE_EVIDENCE_PENDING`
 
-A trusted Registry release/tag publication is also a separate protected action. The v1.4.0 package preparation does not perform it.
-
-## Publication Readiness Still Required
-
-Before a public `v1.4.0` release can be authorized, current evidence should establish at minimum:
-
-- Registry `main` protection/ruleset is active and independently verified;
-- Registry PR #1 is freshly reviewed, exact-head validated, and canonically merged if all gates pass;
-- source-backed Registry records and their review/freshness lifecycle are established for the intended release scope;
-- trusted immutable Registry release packaging and independently readable release-manifest SHA-256 evidence are established;
-- end-to-end trusted Registry synchronization, local install, project pinning, freshness, stale-source handling, and audit/release-boundary behavior pass against a real trusted Registry release;
-- all 11 Orchestra package/version surfaces remain exactly `1.4.0`;
-- the README Impact Gate passes at the final release candidate head;
-- full governance, behavior, runtime coverage, CodeQL, and native OS release-readiness checks pass at the exact candidate revision; and
-- zero unresolved blocking review threads remain.
+`ORCHESTRA_PUBLICATION_NOT_AUTHORIZED`
 
 ## Authority and Publication Boundary
 
-This preparation does not authorize or perform:
+This release-candidate refresh does not authorize or perform:
 
-- Registry repository-protection mutation;
-- Registry PR #1 merge;
-- Registry trusted release/tag publication;
+- Registry `registry-v0.1.0` tag/GitHub Release publication;
 - Orchestra `v1.4.0` tag creation;
 - Orchestra GitHub Release publication;
-- marketplace publication;
+- marketplace/package publication;
 - installed-integration refresh;
 - deployment or production mutation;
 - policy activation;
@@ -138,8 +165,12 @@ This preparation does not authorize or perform:
 
 `PACKAGE_VERSION_1_4_0 != PUBLIC_RELEASE_V1_4_0`
 
+`REGISTRY_CANDIDATE_READY != TRUSTED_REGISTRY_RELEASE_PUBLISHED`
+
 `VALIDATION_SUCCESS != RELEASE_AUTHORITY`
 
 `MERGEABILITY != PUBLICATION_AUTHORITY`
 
-The preparation campaign stops at `PREPARED_NOT_RELEASED` until the remaining dependencies are current and publication is separately authorized.
+## Verdict
+
+`V1_4_IMPLEMENTATION_AND_PREPUBLICATION_PREPARATION_COMPLETE_WAITING_FOR_TRUSTED_REGISTRY_PUBLICATION`

--- a/docs/validation/V1_4_0_PREPUBLICATION_READINESS_EVIDENCE.md
+++ b/docs/validation/V1_4_0_PREPUBLICATION_READINESS_EVIDENCE.md
@@ -1,0 +1,145 @@
+# Orchestra v1.4.0 Prepublication Readiness Evidence
+
+## Verdict
+
+`PREPUBLICATION_READY_TRUSTED_REGISTRY_PUBLICATION_REQUIRED`
+
+This record captures the exact evidence available before any Registry or Orchestra public release is published. It is not release authorization.
+
+## Orchestra canonical baseline
+
+- Repository: `Baelfyre/Orchestra`
+- Canonical branch: `main`
+- Exact baseline: `8008eeb87f54b12136fab1563e0c97061459cf61`
+- Package version: `1.4.0`
+- Current public release: `v1.3.0`
+- Target public release: `v1.4.0`
+
+The exact baseline is a verified GitHub-signed Squash commit whose parent is the previously validated Registry compatibility baseline `6e1859f2362978228e7119114abe96e35fddaf4c`.
+
+## Canonical Orchestra validation
+
+For `8008eeb87f54b12136fab1563e0c97061459cf61`:
+
+- Governance Check: PASS
+- README Impact Gate: PASS
+- behavior `validate`: PASS
+- runtime tests: PASS
+- CodeQL Analyze (actions): PASS
+- CodeQL Analyze (python): PASS
+- native Ubuntu: PASS
+- native macOS: PASS
+- native Windows: PASS
+
+This baseline contains no runtime change relative to the already verified PR #268 compatibility implementation; the terminology closeout changes only README and three project/governance documentation surfaces. PR #268 canonical runtime evidence was 568 tests PASS at 94.33% coverage.
+
+## Terminology audit closure
+
+The previous documentation audit branch PR #263 was stale against the v1.4 implementation line and was closed without merge. Its intended three-file role terminology changes were replayed on current canonical `main` through PR #269.
+
+The replay established:
+
+- `Downstream Roles` for Orchestra specialist/adapter recipients of another canonical owner's output;
+- retention of `consumer` for actual provider/consumer, message-consumer, or other technical consumer semantics;
+- live enforcement of the README Impact Gate: the initial three-file project-doc replay failed until README was updated in the same revision;
+- exact-head and post-merge validation PASS.
+
+## Registry canonical baseline
+
+- Repository: `Baelfyre/Orchestra-Compliance-Registry`
+- Canonical branch: `main`
+- Exact readiness baseline: `3821bcb55125b4d8864f28b6423650e6e17ac67b`
+- Canonical signature: VERIFIED
+- Registry source state: `DRAFT`
+- Registry source version: `0.1.0-dev.2`
+- Source release sequence: `0`
+
+Canonical implementation milestones:
+
+1. foundation -> `1d334bbb4bff0276ca3112b41112ad6094b9a096`
+2. Philippines source/freshness pilot -> `e97e1c885f00658b418f0b6ab1841bf021e5582d`
+3. deterministic release packaging -> `6f802f0c32d20fe4ad0e7c8eb3a23f6b883341ac`
+4. publication-readiness/artifact preservation -> `3821bcb55125b4d8864f28b6423650e6e17ac67b`
+
+Registry canonical validation after the readiness merge: PASS.
+
+## Registry governance enforcement
+
+The active `compliance-ruleset` applies to the default branch and enforces:
+
+- pull request before merge;
+- Squash-only merge;
+- required `validate-registry` check from GitHub Actions;
+- up-to-date target branch before merge;
+- conversation resolution;
+- blocked force pushes;
+- blocked canonical branch deletion;
+- empty bypass list.
+
+The solo-maintainer configuration intentionally does not require self-approval or CODEOWNERS approval because all protected paths resolve only to the PR author.
+
+## Registry v0.1.0 deterministic candidate
+
+- version: `0.1.0`
+- release sequence: `1`
+- tag: `registry-v0.1.0`
+- file count: `7`
+- release-manifest SHA-256: `9922ddcce77dfac0c01cac80fe6669aaffe37636826a56a4b54a8312558ee2d1`
+- ZIP SHA-256: `b64889933d30a8dea27bcbbb95c952e4f053c14a4f345e1e04b27777b5025ec0`
+
+Independent candidate builds reproduced the same hashes. The canonical readiness workflow also preserves the candidate as the revision-bound `registry-v0.1.0-candidate` Actions artifact.
+
+## Registry freshness
+
+All four bounded Philippines pilot sources are recorded `VERIFIED_CURRENT` with `checked_at: 2026-08-14`.
+
+Earliest next review deadline: `2026-10-13`.
+
+Registry Validation runs daily and fails closed if a current source passes its review deadline without an explicit freshness-state transition.
+
+## Evidence that cannot exist yet
+
+No trusted Registry GitHub Release currently exists. Therefore the following evidence is intentionally absent and must not be inferred from candidate packaging:
+
+- immutable GitHub Release provenance;
+- successful Orchestra network sync from an immutable canonical Registry release;
+- production of a network-fetched active cache whose release identity is proven by the GitHub Release boundary;
+- final anti-rollback/update-check behavior against a real published Registry release.
+
+Candidate compatibility tests prove Orchestra can consume the expected bundle contract; they are not a substitute for real distribution provenance.
+
+## Required final sequence after publication authorization
+
+1. Reverify Registry canonical `main`, source freshness, candidate hashes, and absence of an existing `registry-v0.1.0` collision.
+2. Publish the separately authorized non-draft, non-prerelease Registry release with the reviewed candidate assets/evidence.
+3. Verify the release is immutable and belongs to `Baelfyre/Orchestra-Compliance-Registry`.
+4. Run Orchestra real network sync/update-check against that release.
+5. Verify manifest identity, exact file inventory/hash integrity, freshness, query, project pinning, and anti-rollback behavior.
+6. Re-run the final Orchestra exact-head Governance/README/behavior/runtime/CodeQL/native matrix.
+7. Only then present Orchestra `v1.4.0` for its separate publication authorization.
+
+## Protected transitions not performed
+
+- Registry tag/GitHub Release publication
+- Orchestra tag/GitHub Release publication
+- marketplace/package publication
+- deployment/production mutation
+- policy activation
+- installed-integration refresh
+- destructive cleanup
+- branch deletion
+- force push/history rewrite
+
+## State
+
+`IMPLEMENTATION_COMPLETE`
+
+`DOCUMENTATION_CLOSEOUT_COMPLETE`
+
+`REGISTRY_CANONICAL_STACK_COMPLETE`
+
+`REGISTRY_V0_1_0_CANDIDATE_READY`
+
+`TRUSTED_REGISTRY_PUBLICATION_PENDING`
+
+`ORCHESTRA_V1_4_PUBLICATION_PENDING_AFTER_NETWORK_PROVENANCE_VALIDATION`


### PR DESCRIPTION
Refreshes Orchestra v1.4.0 release-readiness evidence to the actual canonical Registry state after the Registry implementation stack and terminology closeout were completed.

Scope:
- update the v1.4 release-candidate record from stale foundation-pending language to `WAITING_FOR_TRUSTED_REGISTRY_PUBLICATION`;
- add exact prepublication readiness evidence for Orchestra `8008eeb87f54b12136fab1563e0c97061459cf61` and Registry `3821bcb55125b4d8864f28b6423650e6e17ac67b`;
- update README in the same revision, as required by the README Impact Gate, to state that Registry implementation/candidate preparation are canonical but no trusted Registry GitHub Release exists yet.

Current Registry candidate evidence:
- version `0.1.0`
- sequence `1`
- tag `registry-v0.1.0`
- release-manifest SHA-256 `9922ddcce77dfac0c01cac80fe6669aaffe37636826a56a4b54a8312558ee2d1`
- ZIP SHA-256 `b64889933d30a8dea27bcbbb95c952e4f053c14a4f345e1e04b27777b5025ec0`
- canonical Registry readiness validation PASS
- revision-bound candidate artifact preserved

This PR performs no Registry tag/GitHub Release publication, Orchestra `v1.4.0` publication, marketplace/package publication, deployment, policy activation, installed-integration refresh, destructive cleanup, branch deletion, force push, or history rewrite.