### PR TITLE
docs(refoundation): close post-merge documentation and evidence parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
 
-## Post-v1.4.0 Control Plane Re-foundation P0/P1-P9 - Integration Candidate
+## Post-v1.4.0 Control Plane Re-foundation P0/P1-P9 - Canonical Integration
 
 - Consolidated the control-plane re-foundation tracked by #273 into PR #294, covering exact source and validation receipts, typed governance and deterministic Arbiter Kernel enforcement, machine specialist/routing/governance contracts, exact compliance set-equality receipts, host capability/conformance contracts, typed continuity and JSONL context state, persistent remediation circuit breakers, deterministic pre-execution policy gating, and P9 shadow conformance.
 - P9 begins and remains in `SHADOW`; this integration does not advance authority to advisory, validation authority, canonical-promotion authority, or legacy retirement.
 - Release hardening persists machine-readable runtime evidence with statement and branch coverage, critical-module floors, property-based regressions, workflow-sanity coverage, bounded mutation-confidence evidence, and cross-platform validation. These measurements are confidence evidence, not proof of correctness.
-- The integration candidate preserves `v1.4.0` as the current published release. PR #294 is not canonical until governed Squash merge and independent canonical readback succeed, and this work does not create a new tag, version, or GitHub Release.
+- PR #294 is canonical through governed Squash merge and independent readback at signed commit `76eb96b27439700a517f75c5a921465e5c2987e6` with tree `6f98b380d984430303d630462ad4535cda483925`. This post-`v1.4.0` integration preserves `v1.4.0` as the current published release and creates no new tag, version, or GitHub Release.
+- Added the compact machine release-evidence index at `machine/release-evidence/control-plane-refoundation-p0-p1-p9.json`, referencing the exact final integrated candidate runtime and bounded Cosmic Ray evidence without treating coverage or mutation score as proof of correctness.
 
 ## v1.4.0 Governance and Compliance Registry Cross-Integration - Published 2026-08-14
 

--- a/machine/release-evidence/control-plane-refoundation-p0-p1-p9.json
+++ b/machine/release-evidence/control-plane-refoundation-p0-p1-p9.json
@@ -36,7 +36,9 @@
       "branches": 2250,
       "covered_branches": 2138,
       "minimum_branch_coverage": 95.0,
-      "critical_module_inventory": "PASS"
+      "critical_ready": true,
+      "critical_minimum_statement_percent": 98.0,
+      "critical_minimum_branch_percent": 95.0
     },
     "python_version": "3.12.13"
   },

--- a/machine/release-evidence/control-plane-refoundation-p0-p1-p9.json
+++ b/machine/release-evidence/control-plane-refoundation-p0-p1-p9.json
@@ -1,0 +1,82 @@
+{
+  "format_version": 1,
+  "campaign": "control-plane-refoundation-p0-p1-p9",
+  "integration_status": "MERGED_VERIFIED",
+  "canonical": {
+    "pull_request": 294,
+    "merge_commit_sha": "76eb96b27439700a517f75c5a921465e5c2987e6",
+    "tree_sha": "6f98b380d984430303d630462ad4535cda483925",
+    "source_head_sha": "862ba871d900fe7e31591bec068c8830170dd774",
+    "tested_pr_merge_sha": "7fcbf8a6d497c6c6b97ed3170266df5b7897a09b",
+    "merge_commit_signature_verified": true
+  },
+  "runtime_evidence": {
+    "result": "PASS",
+    "workflow_run_id": 31905614753,
+    "run_attempt": 1,
+    "artifact": {
+      "id": 9252243432,
+      "name": "runtime-test-evidence-31905614753-1",
+      "digest": "sha256:823435de0ca7cfe589a825b9fbb462e9569506108185bb7b6ffe22fe812a50bc"
+    },
+    "manifest": "test-evidence.json",
+    "tests": {
+      "total": 944,
+      "passed": 944,
+      "failures": 0,
+      "errors": 0,
+      "skipped": 0
+    },
+    "coverage": {
+      "statement_percent": 98.31,
+      "statements": 6696,
+      "covered_statements": 6583,
+      "minimum_statement_coverage": 97.0,
+      "branch_percent": 95.02,
+      "branches": 2250,
+      "covered_branches": 2138,
+      "minimum_branch_coverage": 95.0,
+      "critical_module_inventory": "PASS"
+    },
+    "python_version": "3.12.13"
+  },
+  "mutation_evidence": {
+    "result": "PASS",
+    "workflow_run_id": 31905614751,
+    "run_attempt": 1,
+    "artifact": {
+      "id": 9252337259,
+      "name": "cosmic-ray-confidence-31905614751-1",
+      "digest": "sha256:ee86b6c2a65656025794e922d3ca5dcad8c547ea18b73846ab3b484bc21dfb48"
+    },
+    "manifest": "cosmic-ray-evidence.json",
+    "tool": {
+      "name": "cosmic-ray",
+      "version": "8.7.0"
+    },
+    "score_status": "VALID_CLASSIFIED_SCORE",
+    "raw": {
+      "total": 691,
+      "killed": 405,
+      "survived": 286,
+      "score_percent": 58.61
+    },
+    "excluded_equivalent": {
+      "count": 154,
+      "classification": "NON_RUNTIME_POSTPONED_ANNOTATION"
+    },
+    "runtime_relevant": {
+      "total": 537,
+      "killed": 405,
+      "survived": 132,
+      "score_percent": 75.42
+    }
+  },
+  "boundaries": {
+    "confidence_evidence_is_not_proof_of_correctness": true,
+    "p9_migration_stage": "SHADOW",
+    "authority_stage_advanced_by_closeout": false,
+    "current_public_release": "v1.4.0",
+    "new_version_or_tag_published_by_refoundation": false
+  }
+}


### PR DESCRIPTION
## Scope

Post-merge closeout only for the control-plane re-foundation integrated by #294.

- Reconcile `CHANGELOG.md` from integration-candidate wording to the verified canonical #294 merge state.
- Add the compact machine release-evidence index required by #292 under `machine/release-evidence/`, sourced from the persisted final #294 runtime and Cosmic Ray artifacts.
- Preserve P9 at `SHADOW`.
- Preserve `v1.4.0` as the current public release.

## Boundaries

No runtime, workflow, ruleset, package/version, tag, GitHub Release, deployment, installed integration, migration-authority stage, branch deletion, force push, or history rewrite change is included.

Coverage and mutation measurements are recorded as confidence evidence only, not proof of correctness.

Closes no migration issue by itself. #279 and #291 remain governed separately.