### PR TITLE
chore(refoundation): advance P9 migration to advisory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 ## Post-v1.4.0 Control Plane Re-foundation P0/P1-P9 - Canonical Integration
 
 - Consolidated the control-plane re-foundation tracked by #273 into PR #294, covering exact source and validation receipts, typed governance and deterministic Arbiter Kernel enforcement, machine specialist/routing/governance contracts, exact compliance set-equality receipts, host capability/conformance contracts, typed continuity and JSONL context state, persistent remediation circuit breakers, deterministic pre-execution policy gating, and P9 shadow conformance.
-- P9 begins and remains in `SHADOW`; this integration does not advance authority to advisory, validation authority, canonical-promotion authority, or legacy retirement.
+- P9 begins in `SHADOW`; the separately governed migration now records an `ADVISORY` checkpoint candidate without granting validation authority, canonical-promotion authority, legacy retirement, or installed-integration mutation.
 - Release hardening persists machine-readable runtime evidence with statement and branch coverage, critical-module floors, property-based regressions, workflow-sanity coverage, bounded mutation-confidence evidence, and cross-platform validation. These measurements are confidence evidence, not proof of correctness.
 - PR #294 is canonical through governed Squash merge and independent readback at signed commit `76eb96b27439700a517f75c5a921465e5c2987e6` with tree `6f98b380d984430303d630462ad4535cda483925`. This post-`v1.4.0` integration preserves `v1.4.0` as the current published release and creates no new tag, version, or GitHub Release.
 - Added the compact machine release-evidence index at `machine/release-evidence/control-plane-refoundation-p0-p1-p9.json`, referencing the exact final integrated candidate runtime and bounded Cosmic Ray evidence without treating coverage or mutation score as proof of correctness.
+- Added a typed migration-state checkpoint and regression coverage for the adjacent `SHADOW -> ADVISORY` transition while preserving later authority stages as separately governed decisions.
 
 ## v1.4.0 Governance and Compliance Registry Cross-Integration - Published 2026-08-14
 
@@ -93,7 +94,7 @@
 - Added a planning-only bounded load/recovery example that defines an open workload model, thresholds, telemetry, recovery evidence, and cross-specialist handoffs without generating traffic.
 - Preserved `scripts/dagger_guardrail.py` and its simulation-only live-execution block unchanged. Knowledge and tool examples do not grant permission to run destructive, disruptive, externally targeted, or production tests.
 - Kept the campaign Markdown-primary and JSON-selective: the SK5 audit found no deterministic machine-parsing need that justified a Dagger JSON catalog.
-- Added focused regression coverage for Dagger knowledge depth, source/Codex support parity, progressive disclosure, state/evidence separation, and safety-boundary language.
+- Added focused regression coverage for Dagger knowledge depth, source/Codex support-file parity, progressive disclosure, state/evidence separation, and safety-boundary language.
 - No release/tag publication, deployment/production mutation, installed-integration refresh, policy activation, destructive cleanup, branch deletion, force push, or history rewrite is performed by SK5.
 
 ## Post-v1.2.0 Specialist Knowledge Layer - SK4 Cloak - Pending

--- a/machine/migration/control-plane.v1.json
+++ b/machine/migration/control-plane.v1.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "orchestra.control-plane-migration.v1",
+  "stage_order": [
+    "SHADOW",
+    "ADVISORY",
+    "VALIDATION_AUTHORITY",
+    "CANONICAL_PROMOTION_AUTHORITY",
+    "LEGACY_RETIRED"
+  ],
+  "current_stage": "ADVISORY",
+  "previous_stage": "SHADOW",
+  "transition_policy": {
+    "adjacent_stage_only": true,
+    "exact_conformance_evidence_required": true,
+    "separate_governance_authorization_required": true,
+    "automatic_stage_progression_allowed": false
+  },
+  "transition_evidence": {
+    "integration_pull_request": 294,
+    "integration_canonical_sha": "76eb96b27439700a517f75c5a921465e5c2987e6",
+    "post_merge_closeout_sha": "452572f16f232147d05fe0202cbaea8e82b88e56",
+    "validated_source_head_sha": "862ba871d900fe7e31591bec068c8830170dd774",
+    "runtime_evidence_index": "machine/release-evidence/control-plane-refoundation-p0-p1-p9.json",
+    "shadow_fixture_suite": "PASS"
+  },
+  "authority_effect": {
+    "machine_contracts_may_inform_runtime_decisions": true,
+    "machine_contracts_are_validation_authority": false,
+    "machine_contracts_are_canonical_promotion_authority": false,
+    "legacy_runtime_authorities_retired": false,
+    "installed_integrations_mutated": false
+  }
+}

--- a/machine/schemas/control-plane-migration.schema.json
+++ b/machine/schemas/control-plane-migration.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Baelfyre/Orchestra/blob/main/machine/schemas/control-plane-migration.schema.json",
+  "title": "Orchestra Control Plane Migration State",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "stage_order",
+    "current_stage",
+    "previous_stage",
+    "transition_policy",
+    "transition_evidence",
+    "authority_effect"
+  ],
+  "properties": {
+    "schema_version": {"type": "string", "const": "orchestra.control-plane-migration.v1"},
+    "stage_order": {
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 5,
+      "uniqueItems": true,
+      "prefixItems": [
+        {"const": "SHADOW"},
+        {"const": "ADVISORY"},
+        {"const": "VALIDATION_AUTHORITY"},
+        {"const": "CANONICAL_PROMOTION_AUTHORITY"},
+        {"const": "LEGACY_RETIRED"}
+      ],
+      "items": false
+    },
+    "current_stage": {"type": "string", "const": "ADVISORY"},
+    "previous_stage": {"type": "string", "const": "SHADOW"},
+    "transition_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "adjacent_stage_only",
+        "exact_conformance_evidence_required",
+        "separate_governance_authorization_required",
+        "automatic_stage_progression_allowed"
+      ],
+      "properties": {
+        "adjacent_stage_only": {"const": true},
+        "exact_conformance_evidence_required": {"const": true},
+        "separate_governance_authorization_required": {"const": true},
+        "automatic_stage_progression_allowed": {"const": false}
+      }
+    },
+    "transition_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "integration_pull_request",
+        "integration_canonical_sha",
+        "post_merge_closeout_sha",
+        "validated_source_head_sha",
+        "runtime_evidence_index",
+        "shadow_fixture_suite"
+      ],
+      "properties": {
+        "integration_pull_request": {"type": "integer", "const": 294},
+        "integration_canonical_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "post_merge_closeout_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "validated_source_head_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "runtime_evidence_index": {"type": "string", "minLength": 1},
+        "shadow_fixture_suite": {"type": "string", "const": "PASS"}
+      }
+    },
+    "authority_effect": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "machine_contracts_may_inform_runtime_decisions",
+        "machine_contracts_are_validation_authority",
+        "machine_contracts_are_canonical_promotion_authority",
+        "legacy_runtime_authorities_retired",
+        "installed_integrations_mutated"
+      ],
+      "properties": {
+        "machine_contracts_may_inform_runtime_decisions": {"const": true},
+        "machine_contracts_are_validation_authority": {"const": false},
+        "machine_contracts_are_canonical_promotion_authority": {"const": false},
+        "legacy_runtime_authorities_retired": {"const": false},
+        "installed_integrations_mutated": {"const": false}
+      }
+    }
+  }
+}

--- a/tests/runtime/test_control_plane_migration_state.py
+++ b/tests/runtime/test_control_plane_migration_state.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+STATE_PATH = ROOT / "machine" / "migration" / "control-plane.v1.json"
+SCHEMA_PATH = ROOT / "machine" / "schemas" / "control-plane-migration.schema.json"
+EVIDENCE_PATH = ROOT / "machine" / "release-evidence" / "control-plane-refoundation-p0-p1-p9.json"
+
+
+def _load(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def test_advisory_migration_checkpoint_is_adjacent_and_non_authorizing():
+    state = _load(STATE_PATH)
+    assert state["schema_version"] == "orchestra.control-plane-migration.v1"
+    assert state["stage_order"] == [
+        "SHADOW",
+        "ADVISORY",
+        "VALIDATION_AUTHORITY",
+        "CANONICAL_PROMOTION_AUTHORITY",
+        "LEGACY_RETIRED",
+    ]
+    assert state["previous_stage"] == "SHADOW"
+    assert state["current_stage"] == "ADVISORY"
+    previous_index = state["stage_order"].index(state["previous_stage"])
+    current_index = state["stage_order"].index(state["current_stage"])
+    assert current_index == previous_index + 1
+    assert state["transition_policy"] == {
+        "adjacent_stage_only": True,
+        "exact_conformance_evidence_required": True,
+        "separate_governance_authorization_required": True,
+        "automatic_stage_progression_allowed": False,
+    }
+    assert state["authority_effect"] == {
+        "machine_contracts_may_inform_runtime_decisions": True,
+        "machine_contracts_are_validation_authority": False,
+        "machine_contracts_are_canonical_promotion_authority": False,
+        "legacy_runtime_authorities_retired": False,
+        "installed_integrations_mutated": False,
+    }
+
+
+def test_advisory_transition_references_the_canonical_integrated_evidence():
+    state = _load(STATE_PATH)
+    evidence = _load(EVIDENCE_PATH)
+    transition = state["transition_evidence"]
+    assert transition["integration_pull_request"] == evidence["canonical"]["pull_request"] == 294
+    assert transition["integration_canonical_sha"] == evidence["canonical"]["merge_commit_sha"]
+    assert transition["validated_source_head_sha"] == evidence["canonical"]["source_head_sha"]
+    assert transition["runtime_evidence_index"] == "machine/release-evidence/control-plane-refoundation-p0-p1-p9.json"
+    assert evidence["runtime_evidence"]["result"] == "PASS"
+    assert evidence["mutation_evidence"]["result"] == "PASS"
+    assert evidence["boundaries"]["p9_migration_stage"] == "SHADOW"
+    assert transition["shadow_fixture_suite"] == "PASS"
+
+
+def test_migration_schema_encodes_the_same_advisory_boundary():
+    state = _load(STATE_PATH)
+    schema = _load(SCHEMA_PATH)
+    stage_consts = [item["const"] for item in schema["properties"]["stage_order"]["prefixItems"]]
+    assert stage_consts == state["stage_order"]
+    assert schema["properties"]["current_stage"]["const"] == state["current_stage"]
+    assert schema["properties"]["previous_stage"]["const"] == state["previous_stage"]
+    assert schema["properties"]["authority_effect"]["properties"]["installed_integrations_mutated"]["const"] is False


### PR DESCRIPTION
## Scope

Advance the control-plane re-foundation from `SHADOW` to the next adjacent `ADVISORY` migration checkpoint only.

- Add a machine-readable migration-state record and JSON Schema.
- Bind the transition to the canonical #294 integration and the existing exact-head release-evidence index.
- Add deterministic regression coverage proving the transition is adjacent and non-authorizing.

## Authority boundary

This PR does **not** make machine contracts validation authority or canonical-promotion authority, does not retire legacy runtime authorities, and does not mutate installed integrations. It publishes no version/tag/release and performs no deployment, ruleset change, branch deletion, force push, or history rewrite.

This is the separately governed `SHADOW -> ADVISORY` transition required before later migration stages under #291.