### PR TITLE
refactor(refoundation): promote machine governance to validation authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 ## Post-v1.4.0 Control Plane Re-foundation P0/P1-P9 - Canonical Integration
 
 - Consolidated the control-plane re-foundation tracked by #273 into PR #294, covering exact source and validation receipts, typed governance and deterministic Arbiter Kernel enforcement, machine specialist/routing/governance contracts, exact compliance set-equality receipts, host capability/conformance contracts, typed continuity and JSONL context state, persistent remediation circuit breakers, deterministic pre-execution policy gating, and P9 shadow conformance.
-- P9 begins in `SHADOW`; the separately governed migration now records an `ADVISORY` checkpoint candidate without granting validation authority, canonical-promotion authority, legacy retirement, or installed-integration mutation.
+- P9 began in `SHADOW`, advanced through the separately governed `ADVISORY` checkpoint, and this candidate advances only to `VALIDATION_AUTHORITY`; it does not grant canonical-promotion authority, legacy retirement, or installed-integration mutation.
+- The versioned machine governance policy now supplies Arbiter transition precedence and remediation defaults. Public compatibility enums remain fail-closed parity surfaces during migration rather than independent policy authority.
 - Release hardening persists machine-readable runtime evidence with statement and branch coverage, critical-module floors, property-based regressions, workflow-sanity coverage, bounded mutation-confidence evidence, and cross-platform validation. These measurements are confidence evidence, not proof of correctness.
 - PR #294 is canonical through governed Squash merge and independent readback at signed commit `76eb96b27439700a517f75c5a921465e5c2987e6` with tree `6f98b380d984430303d630462ad4535cda483925`. This post-`v1.4.0` integration preserves `v1.4.0` as the current published release and creates no new tag, version, or GitHub Release.
 - Added the compact machine release-evidence index at `machine/release-evidence/control-plane-refoundation-p0-p1-p9.json`, referencing the exact final integrated candidate runtime and bounded Cosmic Ray evidence without treating coverage or mutation score as proof of correctness.
-- Added a typed migration-state checkpoint and regression coverage for the adjacent `SHADOW -> ADVISORY` transition while preserving later authority stages as separately governed decisions.
+- Added typed migration-state checkpoints and regression coverage for the adjacent `SHADOW -> ADVISORY -> VALIDATION_AUTHORITY` progression while preserving later authority stages as separately governed decisions.
 
 ## v1.4.0 Governance and Compliance Registry Cross-Integration - Published 2026-08-14
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ flowchart TD
 
 Accessible summary: a request supplies project context and selects separate risk, progression, and governance-profile settings. Trusted composition and the effective-authority intersection run before Conductor routes work. Single-owner work goes directly to its specialist; material multi-domain work first requires current Tuner coordination. Validation failure returns to the owning boundary. Current evidence goes to Arbiter, which may continue or remediate inside existing authority, wait for evidence or capacity, escalate to a human, or stop safely.
 
+## Control Plane Re-foundation Migration
+
+The cumulative P0/P1 through P9 control-plane re-foundation is canonical through PR #294, with post-merge evidence parity through PR #295. Migration authority progresses only through the explicit sequence `SHADOW -> ADVISORY -> VALIDATION_AUTHORITY -> CANONICAL_PROMOTION_AUTHORITY -> LEGACY_RETIRED`; no stage is inferred from test success or mergeability.
+
+The migration state in this revision is `VALIDATION_AUTHORITY`. The versioned machine governance policy supplies Arbiter transition precedence and remediation defaults, while the compatibility enums remain fail-closed parity surfaces during migration. Machine routing and specialist identity are not yet canonical-promotion authority, legacy runtime authorities are not yet retired, and installed integrations are not mutated by this stage.
+
 ## v1.4.0 Governance and Compliance Registry Cross-Integration
 
 The repository/package version and current public GitHub release are both `v1.4.0`. The immutable, non-draft, non-prerelease release `Orchestra v1.4.0: Governance & Compliance Registry Cross-Integration` is published from exact signed canonical commit `93dd51c0fbe1b10affc58e6fadd5fb0bc2927a50`; tag `v1.4.0` resolves directly to that commit.
@@ -219,7 +225,7 @@ Accepted child work receives an authority subset, capability subset, bounded dep
 
 Runs use typed lifecycle signals and distinct waiting or terminal states. Exact replay of an accepted terminal signal is idempotent; conflicting replay is rejected. Run-linked audit events record authority, capabilities, delegation, coordination, lifecycle, and terminal outcomes without granting permission.
 
-The control-plane re-foundation now begins hardening this boundary with versioned machine evidence receipts. Source-state receipts bind exact 40-character Git identities to observed repository state, while validation-execution receipts derive `PASS`/`FAIL` from process exit codes and hash command output. Agent prose may explain those receipts, but it cannot override their identities or verdicts. See [Control Plane Re-foundation P0-P1](docs/project/CONTROL_PLANE_REFOUNDATION_P0_P1.md).
+The control-plane re-foundation binds exact identities, validation outcomes, governance vocabulary, transition precedence, and remediation defaults to versioned machine contracts. Agent prose may explain those records, but it cannot override their identities or verdicts. The migration remains staged so machine validation authority does not imply routing promotion, legacy retirement, release authority, or installed-host mutation.
 
 ### Coordination state and evidence freshness
 
@@ -276,7 +282,7 @@ Use the host-native path:
 - Antigravity: run `agy plugin install https://github.com/Baelfyre/Orchestra`.
 - Manual or scaffold-only hosts: follow the exact host boundary in the [Installation Guide](docs/setup/INSTALLATION.md).
 
-Repository manifests identify package version `1.4.0`. The current public GitHub release remains `v1.3.0` until a separately authorized publication transition creates and verifies `v1.4.0`. GitHub Release publication, marketplace publication, and installed-integration refresh are separate governed actions and are not implied by the package version. See the Installation Guide for supported installation paths and host-maturity boundaries.
+Repository manifests identify package version `1.4.0`, and the current public GitHub release is `v1.4.0`. GitHub Release publication, marketplace publication, installed-integration refresh, and later control-plane migration stages remain separate governed actions. See the Installation Guide for supported installation paths and host-maturity boundaries.
 
 ## Quick Start
 
@@ -328,13 +334,9 @@ For autonomous or delegated merges, Orchestra additionally requires the fail-clo
 
 ### v1.4.0 Governance and Compliance Registry Cross-Integration
 
-Repository package/version surfaces are prepared at `1.4.0` for the governance upgrade. The scope cross-integrates verified Compliance Registry evidence into Orchestra's established governance responsibilities and adds the README Impact Gate so significant project changes cannot pass normal governance validation while leaving the public README stale.
+`v1.4.0` is the current published Orchestra release. It packages the verified Compliance Registry cross-integration and README Impact Gate from exact signed release commit `93dd51c0fbe1b10affc58e6fadd5fb0bc2927a50`. The GitHub Release is immutable, non-draft, and non-prerelease. Subsequent control-plane re-foundation work is post-v1.4.0 development and does not move the v1.4.0 tag.
 
-The Registry implementation and v0.1.0 deterministic candidate preparation are canonical, but a trusted Registry GitHub Release has not yet been published. Orchestra `v1.4.0` therefore remains a prepublication candidate pending that separately authorized Registry release and real network-provenance validation against it.
-
-This repository/package version does **not** by itself establish a public `v1.4.0` release. The current public release remains `v1.3.0`; tag creation and GitHub Release publication remain separate protected actions.
-
-Preparation scope and boundaries are recorded in the [v1.4.0 governance upgrade release candidate](docs/releases/v1.4.0-governance-compliance-registry-release-candidate.md) and [v1.4.0 prepublication readiness evidence](docs/validation/V1_4_0_PREPUBLICATION_READINESS_EVIDENCE.md).
+Release preparation and publication evidence are recorded in the [v1.4.0 governance upgrade release candidate](docs/releases/v1.4.0-governance-compliance-registry-release-candidate.md), [v1.4.0 release-readiness evidence](docs/validation/V1_4_0_RELEASE_READINESS_EVIDENCE.md), and [v1.4.0 publication closeout](docs/validation/V1_4_0_PUBLICATION_CLOSEOUT.md).
 
 ### v1.3.0 Specialist Intelligence
 
@@ -366,7 +368,7 @@ See the [v1.2.0 release notes](docs/releases/v1.2.0-governed-orchestration.md). 
 - Orchestra is developer tooling and a local runtime. It does not store or transmit downstream project data by default.
 - Data sensitivity, privacy, retention, deletion, platform disclosure, and IP obligations depend on the downstream project and host environment.
 - Release governance may require revision or block publication.
-- Package metadata at `1.4.0` does not mean the public `v1.4.0` release has been published.
+- The current public release is `v1.4.0`; post-v1.4.0 control-plane migration work is not a new release until a separately governed publication completes.
 
 ## Documentation Map
 

--- a/machine/migration/control-plane.v1.json
+++ b/machine/migration/control-plane.v1.json
@@ -7,8 +7,8 @@
     "CANONICAL_PROMOTION_AUTHORITY",
     "LEGACY_RETIRED"
   ],
-  "current_stage": "ADVISORY",
-  "previous_stage": "SHADOW",
+  "current_stage": "VALIDATION_AUTHORITY",
+  "previous_stage": "ADVISORY",
   "transition_policy": {
     "adjacent_stage_only": true,
     "exact_conformance_evidence_required": true,
@@ -19,13 +19,14 @@
     "integration_pull_request": 294,
     "integration_canonical_sha": "76eb96b27439700a517f75c5a921465e5c2987e6",
     "post_merge_closeout_sha": "452572f16f232147d05fe0202cbaea8e82b88e56",
+    "previous_stage_canonical_sha": "2b77ccf1a393030c7d4755e64bc5045385de2fde",
     "validated_source_head_sha": "862ba871d900fe7e31591bec068c8830170dd774",
     "runtime_evidence_index": "machine/release-evidence/control-plane-refoundation-p0-p1-p9.json",
     "shadow_fixture_suite": "PASS"
   },
   "authority_effect": {
     "machine_contracts_may_inform_runtime_decisions": true,
-    "machine_contracts_are_validation_authority": false,
+    "machine_contracts_are_validation_authority": true,
     "machine_contracts_are_canonical_promotion_authority": false,
     "legacy_runtime_authorities_retired": false,
     "installed_integrations_mutated": false

--- a/machine/schemas/control-plane-migration.schema.json
+++ b/machine/schemas/control-plane-migration.schema.json
@@ -29,8 +29,14 @@
       ],
       "items": false
     },
-    "current_stage": {"type": "string", "const": "ADVISORY"},
-    "previous_stage": {"type": "string", "const": "SHADOW"},
+    "current_stage": {
+      "type": "string",
+      "enum": ["SHADOW", "ADVISORY", "VALIDATION_AUTHORITY", "CANONICAL_PROMOTION_AUTHORITY", "LEGACY_RETIRED"]
+    },
+    "previous_stage": {
+      "type": "string",
+      "enum": ["SHADOW", "ADVISORY", "VALIDATION_AUTHORITY", "CANONICAL_PROMOTION_AUTHORITY"]
+    },
     "transition_policy": {
       "type": "object",
       "additionalProperties": false,
@@ -54,6 +60,7 @@
         "integration_pull_request",
         "integration_canonical_sha",
         "post_merge_closeout_sha",
+        "previous_stage_canonical_sha",
         "validated_source_head_sha",
         "runtime_evidence_index",
         "shadow_fixture_suite"
@@ -62,6 +69,7 @@
         "integration_pull_request": {"type": "integer", "const": 294},
         "integration_canonical_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
         "post_merge_closeout_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "previous_stage_canonical_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
         "validated_source_head_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
         "runtime_evidence_index": {"type": "string", "minLength": 1},
         "shadow_fixture_suite": {"type": "string", "const": "PASS"}
@@ -79,9 +87,9 @@
       ],
       "properties": {
         "machine_contracts_may_inform_runtime_decisions": {"const": true},
-        "machine_contracts_are_validation_authority": {"const": false},
-        "machine_contracts_are_canonical_promotion_authority": {"const": false},
-        "legacy_runtime_authorities_retired": {"const": false},
+        "machine_contracts_are_validation_authority": {"type": "boolean"},
+        "machine_contracts_are_canonical_promotion_authority": {"type": "boolean"},
+        "legacy_runtime_authorities_retired": {"type": "boolean"},
         "installed_integrations_mutated": {"const": false}
       }
     }

--- a/orchestra_runtime/governance_kernel.py
+++ b/orchestra_runtime/governance_kernel.py
@@ -5,11 +5,18 @@ from enum import Enum
 from typing import Any
 
 from .evidence import receipt_digest
+from .machine_contracts import (
+    default_remediation_limits,
+    governance_decision_values,
+    transition_disposition_values,
+    transition_precedence,
+)
 
 
 GOVERNANCE_KERNEL_SCHEMA_VERSION = "1.0.0"
-DEFAULT_MAX_REMEDIATION_ATTEMPTS = 3
-DEFAULT_MAX_IDENTICAL_FAILURE_REPETITIONS = 2
+_POLICY_REMEDIATION = default_remediation_limits()
+DEFAULT_MAX_REMEDIATION_ATTEMPTS = _POLICY_REMEDIATION["maximum_remediation_attempts_per_unit"]
+DEFAULT_MAX_IDENTICAL_FAILURE_REPETITIONS = _POLICY_REMEDIATION["maximum_identical_failure_repetitions"]
 
 
 class GovernanceDecision(str, Enum):
@@ -27,6 +34,12 @@ class TransitionDisposition(str, Enum):
     WAIT_FOR_CAPACITY = "WAIT_FOR_CAPACITY"
     ESCALATE_HUMAN = "ESCALATE_HUMAN"
     STOP = "STOP"
+
+
+if tuple(item.value for item in GovernanceDecision) != governance_decision_values():
+    raise RuntimeError("GovernanceDecision compatibility enum differs from machine governance policy")
+if set(item.value for item in TransitionDisposition) != set(transition_disposition_values()):
+    raise RuntimeError("TransitionDisposition compatibility enum differs from machine governance policy")
 
 
 class ArbiterReasonCode(str, Enum):
@@ -250,45 +263,23 @@ def _result(
     )
 
 
-def evaluate_arbiter(kernel_input: ArbiterKernelInput) -> ArbiterKernelResult:
+def _candidate_results(kernel_input: ArbiterKernelInput) -> dict[TransitionDisposition, ArbiterKernelResult]:
     decisions = tuple(record.decision for record in kernel_input.governance_decisions)
+    candidates: dict[TransitionDisposition, ArbiterKernelResult] = {}
 
-    # Canonical precedence 1: STOP.
     if not kernel_input.authority_valid:
-        return _result(kernel_input, TransitionDisposition.STOP, ArbiterReasonCode.AUTHORITY_INVALID)
-    if not kernel_input.protected_boundary_clear:
-        return _result(
+        candidates[TransitionDisposition.STOP] = _result(
+            kernel_input, TransitionDisposition.STOP, ArbiterReasonCode.AUTHORITY_INVALID
+        )
+    elif not kernel_input.protected_boundary_clear:
+        candidates[TransitionDisposition.STOP] = _result(
             kernel_input,
             TransitionDisposition.STOP,
             ArbiterReasonCode.PROTECTED_BOUNDARY_VIOLATION,
         )
-    if GovernanceDecision.BLOCKED in decisions:
-        return _result(kernel_input, TransitionDisposition.STOP, ArbiterReasonCode.GOVERNANCE_BLOCKED)
-
-    # Canonical precedence 2: ESCALATE_HUMAN.
-    if any(record.human_review_required for record in kernel_input.governance_decisions):
-        return _result(
-            kernel_input,
-            TransitionDisposition.ESCALATE_HUMAN,
-            ArbiterReasonCode.HUMAN_REVIEW_REQUIRED,
-        )
-    if kernel_input.scope_or_policy_decision_required:
-        return _result(
-            kernel_input,
-            TransitionDisposition.ESCALATE_HUMAN,
-            ArbiterReasonCode.SCOPE_OR_POLICY_DECISION_REQUIRED,
-        )
-    if kernel_input.external_authority_missing:
-        return _result(
-            kernel_input,
-            TransitionDisposition.ESCALATE_HUMAN,
-            ArbiterReasonCode.EXTERNAL_AUTHORITY_REQUIRED,
-        )
-    if kernel_input.contradiction_unresolved:
-        return _result(
-            kernel_input,
-            TransitionDisposition.ESCALATE_HUMAN,
-            ArbiterReasonCode.CONTRADICTION_UNRESOLVED,
+    elif GovernanceDecision.BLOCKED in decisions:
+        candidates[TransitionDisposition.STOP] = _result(
+            kernel_input, TransitionDisposition.STOP, ArbiterReasonCode.GOVERNANCE_BLOCKED
         )
 
     revision_required = GovernanceDecision.REVISION_REQUIRED in decisions
@@ -298,82 +289,73 @@ def evaluate_arbiter(kernel_input: ArbiterKernelInput) -> ArbiterKernelResult:
         and kernel_input.remediation_authorized
         and kernel_input.remediation_in_scope
     )
-    if kernel_input.remediation_attempt_count >= kernel_input.maximum_remediation_attempts:
-        return _result(
-            kernel_input,
-            TransitionDisposition.ESCALATE_HUMAN,
-            ArbiterReasonCode.REMEDIATION_BUDGET_EXHAUSTED,
-        )
-    if (
-        kernel_input.identical_failure_repetitions
-        > kernel_input.maximum_identical_failure_repetitions
-    ):
-        return _result(
-            kernel_input,
-            TransitionDisposition.ESCALATE_HUMAN,
-            ArbiterReasonCode.IDENTICAL_FAILURE_LIMIT_EXCEEDED,
-        )
-    if revision_required and not remediation_candidate:
-        return _result(
-            kernel_input,
-            TransitionDisposition.ESCALATE_HUMAN,
-            ArbiterReasonCode.REVISION_NOT_AUTOREMEDIABLE,
+
+    escalation_reason: ArbiterReasonCode | None = None
+    if any(record.human_review_required for record in kernel_input.governance_decisions):
+        escalation_reason = ArbiterReasonCode.HUMAN_REVIEW_REQUIRED
+    elif kernel_input.scope_or_policy_decision_required:
+        escalation_reason = ArbiterReasonCode.SCOPE_OR_POLICY_DECISION_REQUIRED
+    elif kernel_input.external_authority_missing:
+        escalation_reason = ArbiterReasonCode.EXTERNAL_AUTHORITY_REQUIRED
+    elif kernel_input.contradiction_unresolved:
+        escalation_reason = ArbiterReasonCode.CONTRADICTION_UNRESOLVED
+    elif kernel_input.remediation_attempt_count >= kernel_input.maximum_remediation_attempts:
+        escalation_reason = ArbiterReasonCode.REMEDIATION_BUDGET_EXHAUSTED
+    elif kernel_input.identical_failure_repetitions > kernel_input.maximum_identical_failure_repetitions:
+        escalation_reason = ArbiterReasonCode.IDENTICAL_FAILURE_LIMIT_EXCEEDED
+    elif revision_required and not remediation_candidate:
+        escalation_reason = ArbiterReasonCode.REVISION_NOT_AUTOREMEDIABLE
+    if escalation_reason is not None:
+        candidates[TransitionDisposition.ESCALATE_HUMAN] = _result(
+            kernel_input, TransitionDisposition.ESCALATE_HUMAN, escalation_reason
         )
 
-    # Canonical precedence 3: WAIT_FOR_CAPACITY.
     if not kernel_input.host_capacity_available:
-        return _result(
+        candidates[TransitionDisposition.WAIT_FOR_CAPACITY] = _result(
             kernel_input,
             TransitionDisposition.WAIT_FOR_CAPACITY,
             ArbiterReasonCode.HOST_CAPACITY_UNAVAILABLE,
         )
 
-    # Canonical precedence 4: WAIT_FOR_EVIDENCE.
+    evidence_reason: ArbiterReasonCode | None = None
     if not kernel_input.governance_evidence_complete:
-        return _result(
-            kernel_input,
-            TransitionDisposition.WAIT_FOR_EVIDENCE,
-            ArbiterReasonCode.GOVERNANCE_EVIDENCE_INCOMPLETE,
-        )
-    if not kernel_input.required_receipts_present:
-        return _result(
-            kernel_input,
-            TransitionDisposition.WAIT_FOR_EVIDENCE,
-            ArbiterReasonCode.REQUIRED_RECEIPT_MISSING,
-        )
-    if not kernel_input.exact_state_valid:
-        return _result(
-            kernel_input,
-            TransitionDisposition.WAIT_FOR_EVIDENCE,
-            ArbiterReasonCode.EXACT_STATE_MISMATCH,
-        )
-    if not kernel_input.evidence_fresh:
-        return _result(
-            kernel_input,
-            TransitionDisposition.WAIT_FOR_EVIDENCE,
-            ArbiterReasonCode.EVIDENCE_STALE,
+        evidence_reason = ArbiterReasonCode.GOVERNANCE_EVIDENCE_INCOMPLETE
+    elif not kernel_input.required_receipts_present:
+        evidence_reason = ArbiterReasonCode.REQUIRED_RECEIPT_MISSING
+    elif not kernel_input.exact_state_valid:
+        evidence_reason = ArbiterReasonCode.EXACT_STATE_MISMATCH
+    elif not kernel_input.evidence_fresh:
+        evidence_reason = ArbiterReasonCode.EVIDENCE_STALE
+    elif not kernel_input.validation_passed and not remediation_candidate:
+        evidence_reason = ArbiterReasonCode.VALIDATION_FAILED
+    if evidence_reason is not None:
+        candidates[TransitionDisposition.WAIT_FOR_EVIDENCE] = _result(
+            kernel_input, TransitionDisposition.WAIT_FOR_EVIDENCE, evidence_reason
         )
 
-    # Canonical precedence 5: AUTO_REMEDIATE_AND_REVALIDATE.
     if remediation_candidate:
-        return _result(
+        candidates[TransitionDisposition.AUTO_REMEDIATE_AND_REVALIDATE] = _result(
             kernel_input,
             TransitionDisposition.AUTO_REMEDIATE_AND_REVALIDATE,
             ArbiterReasonCode.BOUNDED_REMEDIATION_AVAILABLE,
         )
-    if not kernel_input.validation_passed:
-        return _result(
-            kernel_input,
-            TransitionDisposition.WAIT_FOR_EVIDENCE,
-            ArbiterReasonCode.VALIDATION_FAILED,
-        )
 
-    # Canonical precedence 6: AUTO_CONTINUE.
-    return _result(
+    candidates[TransitionDisposition.AUTO_CONTINUE] = _result(
         kernel_input,
         TransitionDisposition.AUTO_CONTINUE,
         ArbiterReasonCode.CONTINUATION_READY,
     )
+    return candidates
+
+
+def evaluate_arbiter(kernel_input: ArbiterKernelInput) -> ArbiterKernelResult:
+    candidates = _candidate_results(kernel_input)
+    for disposition_name in transition_precedence():
+        disposition = TransitionDisposition(disposition_name)
+        result = candidates.get(disposition)
+        if result is not None:
+            return result
+    raise RuntimeError("machine governance policy did not select an Arbiter disposition")
 
 
 def safe_evaluate_arbiter(candidate: ArbiterKernelInput | Any) -> ArbiterKernelResult:

--- a/orchestra_runtime/machine_contracts.py
+++ b/orchestra_runtime/machine_contracts.py
@@ -57,6 +57,15 @@ def _frontmatter_list(value: str, *, none_is_empty: bool = False) -> list[str]:
     return [item.strip() for item in cleaned.split(",") if item.strip()]
 
 
+def _unique_strings(values: object, field_name: str) -> tuple[str, ...]:
+    if not isinstance(values, list) or not values:
+        raise ValueError(f"governance policy {field_name} must be a non-empty list")
+    cleaned = tuple(str(item).strip() for item in values)
+    if any(not item for item in cleaned) or len(set(cleaned)) != len(cleaned):
+        raise ValueError(f"governance policy {field_name} contains empty or duplicate values")
+    return cleaned
+
+
 def compile_specialist_registry(root: Path | str | None = None) -> dict[str, Any]:
     repo_root = _root(root)
     manifest = ManifestRepository(repo_root).load_manifest()
@@ -182,6 +191,50 @@ def runtime_validation_rule_records(root: Path | str | None = None) -> tuple[dic
     return tuple(dict(item) for item in rules)
 
 
+def governance_decision_values(root: Path | str | None = None) -> tuple[str, ...]:
+    return _unique_strings(load_governance_policy(root).get("governance_decisions"), "governance_decisions")
+
+
+def transition_disposition_values(root: Path | str | None = None) -> tuple[str, ...]:
+    return _unique_strings(
+        load_governance_policy(root).get("transition_dispositions"),
+        "transition_dispositions",
+    )
+
+
+def transition_precedence(root: Path | str | None = None) -> tuple[str, ...]:
+    policy = load_governance_policy(root)
+    precedence = _unique_strings(policy.get("transition_precedence"), "transition_precedence")
+    dispositions = transition_disposition_values(root)
+    if set(precedence) != set(dispositions) or len(precedence) != len(dispositions):
+        raise ValueError("transition_precedence must contain every transition disposition exactly once")
+    return precedence
+
+
+def default_remediation_limits(root: Path | str | None = None) -> dict[str, int]:
+    remediation = load_governance_policy(root).get("default_remediation", {})
+    if not isinstance(remediation, dict):
+        raise ValueError("default_remediation must be an object")
+    required = (
+        "maximum_remediation_attempts_per_unit",
+        "maximum_identical_failure_repetitions",
+        "maximum_scope_growth",
+    )
+    values: dict[str, int] = {}
+    for key in required:
+        value = remediation.get(key)
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError(f"default_remediation {key} must be an integer")
+        values[key] = value
+    if values["maximum_remediation_attempts_per_unit"] <= 0:
+        raise ValueError("maximum_remediation_attempts_per_unit must be > 0")
+    if values["maximum_identical_failure_repetitions"] <= 0:
+        raise ValueError("maximum_identical_failure_repetitions must be > 0")
+    if values["maximum_scope_growth"] < 0:
+        raise ValueError("maximum_scope_growth must be >= 0")
+    return values
+
+
 def machine_contract_errors(root: Path | str | None = None) -> tuple[str, ...]:
     repo_root = _root(root)
     errors: list[str] = []
@@ -248,6 +301,10 @@ def machine_contract_errors(root: Path | str | None = None) -> tuple[str, ...]:
 
     try:
         policy = load_governance_policy(repo_root)
+        decisions = governance_decision_values(repo_root)
+        dispositions = transition_disposition_values(repo_root)
+        transition_precedence(repo_root)
+        default_remediation_limits(repo_root)
         if set(policy.get("role_ownership", {})) - specialist_ids:
             errors.append("GOVERNANCE_OWNERSHIP_UNKNOWN_SPECIALIST")
         if set(policy.get("specialist_controls", {})) - specialist_ids:
@@ -264,21 +321,14 @@ def machine_contract_errors(root: Path | str | None = None) -> tuple[str, ...]:
             unknown = set(rule.get("skill_slugs", [])) - specialist_ids
             if unknown:
                 errors.append(f"GOVERNANCE_RULE_UNKNOWN_SPECIALIST:{rule_id}:{','.join(sorted(unknown))}")
-        expected_precedence = [
-            "STOP",
-            "ESCALATE_HUMAN",
-            "WAIT_FOR_CAPACITY",
-            "WAIT_FOR_EVIDENCE",
-            "AUTO_REMEDIATE_AND_REVALIDATE",
-            "AUTO_CONTINUE",
-        ]
-        if policy.get("transition_precedence") != expected_precedence:
-            errors.append("GOVERNANCE_PRECEDENCE_DRIFT")
-        remediation = policy.get("default_remediation", {})
-        if remediation.get("maximum_remediation_attempts_per_unit") != 3:
-            errors.append("REMEDIATION_ATTEMPT_DEFAULT_DRIFT")
-        if remediation.get("maximum_identical_failure_repetitions") != 2:
-            errors.append("IDENTICAL_FAILURE_DEFAULT_DRIFT")
+        compatibility = policy.get("compatibility_rules", {})
+        if not isinstance(compatibility, dict) or set(compatibility) != set(decisions):
+            errors.append("GOVERNANCE_COMPATIBILITY_DECISION_SET_MISMATCH")
+        else:
+            known_dispositions = set(dispositions)
+            for decision, allowed in compatibility.items():
+                if not isinstance(allowed, list) or not allowed or set(allowed) - known_dispositions:
+                    errors.append(f"GOVERNANCE_COMPATIBILITY_INVALID:{decision}")
     except (ValueError, OSError) as exc:
         errors.append(f"GOVERNANCE_POLICY_INVALID:{exc}")
 

--- a/tests/runtime/test_control_plane_migration_state.py
+++ b/tests/runtime/test_control_plane_migration_state.py
@@ -16,7 +16,7 @@ def _load(path: Path) -> dict:
     return value
 
 
-def test_advisory_migration_checkpoint_is_adjacent_and_non_authorizing():
+def test_validation_authority_checkpoint_is_adjacent_and_bounded():
     state = _load(STATE_PATH)
     assert state["schema_version"] == "orchestra.control-plane-migration.v1"
     assert state["stage_order"] == [
@@ -26,8 +26,8 @@ def test_advisory_migration_checkpoint_is_adjacent_and_non_authorizing():
         "CANONICAL_PROMOTION_AUTHORITY",
         "LEGACY_RETIRED",
     ]
-    assert state["previous_stage"] == "SHADOW"
-    assert state["current_stage"] == "ADVISORY"
+    assert state["previous_stage"] == "ADVISORY"
+    assert state["current_stage"] == "VALIDATION_AUTHORITY"
     previous_index = state["stage_order"].index(state["previous_stage"])
     current_index = state["stage_order"].index(state["current_stage"])
     assert current_index == previous_index + 1
@@ -39,32 +39,34 @@ def test_advisory_migration_checkpoint_is_adjacent_and_non_authorizing():
     }
     assert state["authority_effect"] == {
         "machine_contracts_may_inform_runtime_decisions": True,
-        "machine_contracts_are_validation_authority": False,
+        "machine_contracts_are_validation_authority": True,
         "machine_contracts_are_canonical_promotion_authority": False,
         "legacy_runtime_authorities_retired": False,
         "installed_integrations_mutated": False,
     }
 
 
-def test_advisory_transition_references_the_canonical_integrated_evidence():
+def test_validation_authority_transition_preserves_prior_evidence_chain():
     state = _load(STATE_PATH)
     evidence = _load(EVIDENCE_PATH)
     transition = state["transition_evidence"]
     assert transition["integration_pull_request"] == evidence["canonical"]["pull_request"] == 294
     assert transition["integration_canonical_sha"] == evidence["canonical"]["merge_commit_sha"]
+    assert transition["post_merge_closeout_sha"] == "452572f16f232147d05fe0202cbaea8e82b88e56"
+    assert transition["previous_stage_canonical_sha"] == "2b77ccf1a393030c7d4755e64bc5045385de2fde"
     assert transition["validated_source_head_sha"] == evidence["canonical"]["source_head_sha"]
     assert transition["runtime_evidence_index"] == "machine/release-evidence/control-plane-refoundation-p0-p1-p9.json"
     assert evidence["runtime_evidence"]["result"] == "PASS"
     assert evidence["mutation_evidence"]["result"] == "PASS"
-    assert evidence["boundaries"]["p9_migration_stage"] == "SHADOW"
     assert transition["shadow_fixture_suite"] == "PASS"
 
 
-def test_migration_schema_encodes_the_same_advisory_boundary():
+def test_migration_schema_preserves_order_and_nonautomatic_progression():
     state = _load(STATE_PATH)
     schema = _load(SCHEMA_PATH)
     stage_consts = [item["const"] for item in schema["properties"]["stage_order"]["prefixItems"]]
     assert stage_consts == state["stage_order"]
-    assert schema["properties"]["current_stage"]["const"] == state["current_stage"]
-    assert schema["properties"]["previous_stage"]["const"] == state["previous_stage"]
+    assert state["current_stage"] in schema["properties"]["current_stage"]["enum"]
+    assert state["previous_stage"] in schema["properties"]["previous_stage"]["enum"]
+    assert schema["properties"]["transition_policy"]["properties"]["automatic_stage_progression_allowed"]["const"] is False
     assert schema["properties"]["authority_effect"]["properties"]["installed_integrations_mutated"]["const"] is False

--- a/tests/runtime/test_governance_kernel.py
+++ b/tests/runtime/test_governance_kernel.py
@@ -143,7 +143,7 @@ class ArbiterKernelTests(unittest.TestCase):
             remediation_in_scope=True,
             maximum_identical_failure_repetitions=2,
         )
-        at = evaluate_arbiter(AriterKernelInput("project", "at", identical_failure_repetitions=2, **bounded))
+        at = evaluate_arbiter(ArbiterKernelInput("project", "at", identical_failure_repetitions=2, **bounded))
         beyond = evaluate_arbiter(ArbiterKernelInput("project", "beyond", identical_failure_repetitions=3, **bounded))
         self.assertEqual(TransitionDisposition.AUTO_REMEDIATE_AND_REVALIDATE, at.disposition)
         self.assertEqual(TransitionDisposition.ESCALATE_HUMAN, beyond.disposition)

--- a/tests/runtime/test_governance_kernel.py
+++ b/tests/runtime/test_governance_kernel.py
@@ -2,7 +2,10 @@ from dataclasses import FrozenInstanceError
 import json
 from pathlib import Path
 import unittest
+from unittest.mock import patch
 
+import orchestra_runtime.governance_kernel as governance_kernel
+from orchestra_runtime import machine_contracts
 from orchestra_runtime.governance_kernel import (
     ArbiterKernelInput,
     ArbiterReasonCode,
@@ -56,6 +59,27 @@ class ArbiterKernelTests(unittest.TestCase):
             )
         )
         self.assertEqual(TransitionDisposition.WAIT_FOR_CAPACITY, result.disposition)
+
+    def test_machine_policy_precedence_selects_between_valid_candidates(self):
+        candidate = ArbiterKernelInput(
+            "project",
+            "unit",
+            (decision(),),
+            authority_valid=False,
+            evidence_fresh=False,
+        )
+        reordered = (
+            "WAIT_FOR_EVIDENCE",
+            "STOP",
+            "ESCALATE_HUMAN",
+            "WAIT_FOR_CAPACITY",
+            "AUTO_REMEDIATE_AND_REVALIDATE",
+            "AUTO_CONTINUE",
+        )
+        with patch.object(governance_kernel, "transition_precedence", return_value=reordered):
+            result = evaluate_arbiter(candidate)
+        self.assertEqual(TransitionDisposition.WAIT_FOR_EVIDENCE, result.disposition)
+        self.assertIn(ArbiterReasonCode.EVIDENCE_STALE, result.reason_codes)
 
     def test_revision_required_autoremediates_only_when_bounded(self):
         result = evaluate_arbiter(
@@ -119,18 +143,28 @@ class ArbiterKernelTests(unittest.TestCase):
             remediation_in_scope=True,
             maximum_identical_failure_repetitions=2,
         )
-        at = evaluate_arbiter(ArbiterKernelInput("project", "at", identical_failure_repetitions=2, **bounded))
+        at = evaluate_arbiter(AriterKernelInput("project", "at", identical_failure_repetitions=2, **bounded))
         beyond = evaluate_arbiter(ArbiterKernelInput("project", "beyond", identical_failure_repetitions=3, **bounded))
         self.assertEqual(TransitionDisposition.AUTO_REMEDIATE_AND_REVALIDATE, at.disposition)
         self.assertEqual(TransitionDisposition.ESCALATE_HUMAN, beyond.disposition)
         self.assertIn(ArbiterReasonCode.IDENTICAL_FAILURE_LIMIT_EXCEEDED, beyond.reason_codes)
 
-    def test_default_remediation_limits_are_contract_values(self):
+    def test_default_remediation_limits_are_machine_policy_values(self):
         kernel_input = ArbiterKernelInput("project", "unit", (decision(),))
-        self.assertEqual(3, DEFAULT_MAX_REMEDIATION_ATTEMPTS)
-        self.assertEqual(2, DEFAULT_MAX_IDENTICAL_FAILURE_REPETITIONS)
-        self.assertEqual(3, kernel_input.maximum_remediation_attempts)
-        self.assertEqual(2, kernel_input.maximum_identical_failure_repetitions)
+        remediation = machine_contracts.default_remediation_limits()
+        self.assertEqual(
+            remediation["maximum_remediation_attempts_per_unit"],
+            DEFAULT_MAX_REMEDIATION_ATTEMPTS,
+        )
+        self.assertEqual(
+            remediation["maximum_identical_failure_repetitions"],
+            DEFAULT_MAX_IDENTICAL_FAILURE_REPETITIONS,
+        )
+        self.assertEqual(DEFAULT_MAX_REMEDIATION_ATTEMPTS, kernel_input.maximum_remediation_attempts)
+        self.assertEqual(
+            DEFAULT_MAX_IDENTICAL_FAILURE_REPETITIONS,
+            kernel_input.maximum_identical_failure_repetitions,
+        )
 
     def test_positive_limit_boundaries_accept_one_and_reject_zero_or_negative(self):
         valid = ArbiterKernelInput(

--- a/tests/runtime/test_machine_contracts.py
+++ b/tests/runtime/test_machine_contracts.py
@@ -31,20 +31,22 @@ def test_machine_contracts_are_internally_consistent():
     contracts.assert_machine_contracts(ROOT)
 
 
-def test_governance_policy_matches_arbiter_kernel_vocabulary_and_defaults():
-    policy = contracts.load_governance_policy(ROOT)
-    assert policy["governance_decisions"] == [item.value for item in GovernanceDecision]
-    assert set(policy["transition_dispositions"]) == {item.value for item in TransitionDisposition}
-    assert policy["transition_precedence"] == [
+def test_governance_policy_is_arbiter_kernel_validation_authority():
+    assert contracts.governance_decision_values(ROOT) == tuple(item.value for item in GovernanceDecision)
+    assert set(contracts.transition_disposition_values(ROOT)) == {
+        item.value for item in TransitionDisposition
+    }
+    assert contracts.transition_precedence(ROOT) == (
         "STOP",
         "ESCALATE_HUMAN",
         "WAIT_FOR_CAPACITY",
         "WAIT_FOR_EVIDENCE",
         "AUTO_REMEDIATE_AND_REVALIDATE",
         "AUTO_CONTINUE",
-    ]
-    assert policy["default_remediation"]["maximum_remediation_attempts_per_unit"] == DEFAULT_MAX_REMEDIATION_ATTEMPTS
-    assert policy["default_remediation"]["maximum_identical_failure_repetitions"] == DEFAULT_MAX_IDENTICAL_FAILURE_REPETITIONS
+    )
+    remediation = contracts.default_remediation_limits(ROOT)
+    assert remediation["maximum_remediation_attempts_per_unit"] == DEFAULT_MAX_REMEDIATION_ATTEMPTS
+    assert remediation["maximum_identical_failure_repetitions"] == DEFAULT_MAX_IDENTICAL_FAILURE_REPETITIONS
 
 
 def test_routing_contract_resolves_only_known_specialists():
@@ -87,11 +89,19 @@ def test_unknown_alias_target_fails_validation(monkeypatch):
     assert "ALIAS_UNKNOWN_SPECIALIST:old-ghost:ghost-specialist" in contracts.machine_contract_errors(ROOT)
 
 
-def test_governance_precedence_drift_fails_validation(monkeypatch):
+def test_governance_precedence_must_be_exact_disposition_permutation(monkeypatch):
     policy = deepcopy(contracts.load_governance_policy(ROOT))
-    policy["transition_precedence"] = list(reversed(policy["transition_precedence"]))
+    policy["transition_precedence"][-1] = policy["transition_precedence"][0]
     monkeypatch.setattr(contracts, "load_governance_policy", lambda root=None: policy)
-    assert "GOVERNANCE_PRECEDENCE_DRIFT" in contracts.machine_contract_errors(ROOT)
+    errors = contracts.machine_contract_errors(ROOT)
+    assert any(error.startswith("GOVERNANCE_POLICY_INVALID:") for error in errors)
+
+
+def test_governance_compatibility_rejects_unknown_disposition(monkeypatch):
+    policy = deepcopy(contracts.load_governance_policy(ROOT))
+    policy["compatibility_rules"]["APPROVED"].append("UNKNOWN_DISPOSITION")
+    monkeypatch.setattr(contracts, "load_governance_policy", lambda root=None: policy)
+    assert "GOVERNANCE_COMPATIBILITY_INVALID:APPROVED" in contracts.machine_contract_errors(ROOT)
 
 
 def test_registry_duplicate_slug_is_rejected(monkeypatch):

--- a/tests/runtime/test_refoundation_contract_failures.py
+++ b/tests/runtime/test_refoundation_contract_failures.py
@@ -75,8 +75,24 @@ def _machine_repo(tmp_path: Path):
         "legacy_aliases": {},
         "ambiguity_fallback": "conductor",
     }
+    dispositions = [
+        "AUTO_CONTINUE",
+        "AUTO_REMEDIATE_AND_REVALIDATE",
+        "WAIT_FOR_EVIDENCE",
+        "WAIT_FOR_CAPACITY",
+        "ESCALATE_HUMAN",
+        "STOP",
+    ]
     policy = {
         "schema_version": mc.GOVERNANCE_POLICY_SCHEMA_VERSION,
+        "governance_decisions": [
+            "APPROVED",
+            "ADVISORY_ONLY",
+            "REVISION_REQUIRED",
+            "BLOCKED",
+            "NOT_APPLICABLE",
+        ],
+        "transition_dispositions": dispositions,
         "role_ownership": {},
         "specialist_controls": {},
         "governance_required_specialists": ["dagger"],
@@ -87,9 +103,17 @@ def _machine_repo(tmp_path: Path):
             "STOP", "ESCALATE_HUMAN", "WAIT_FOR_CAPACITY", "WAIT_FOR_EVIDENCE",
             "AUTO_REMEDIATE_AND_REVALIDATE", "AUTO_CONTINUE",
         ],
+        "compatibility_rules": {
+            "APPROVED": ["AUTO_CONTINUE"],
+            "ADVISORY_ONLY": ["AUTO_CONTINUE"],
+            "REVISION_REQUIRED": ["AUTO_REMEDIATE_AND_REVALIDATE"],
+            "BLOCKED": ["STOP"],
+            "NOT_APPLICABLE": ["AUTO_CONTINUE"],
+        },
         "default_remediation": {
             "maximum_remediation_attempts_per_unit": 3,
             "maximum_identical_failure_repetitions": 2,
+            "maximum_scope_growth": 0,
         },
     }
     _write_json(tmp_path / "machine/routing/routes.v1.json", routing)
@@ -176,11 +200,7 @@ def test_machine_contract_errors_detect_governance_corruption(tmp_path):
         {"rule_id": "dup", "skill_slugs": ["ghost"]},
         {"rule_id": "dup", "skill_slugs": []},
     ]
-    policy["transition_precedence"] = ["AUTO_CONTINUE"]
-    policy["default_remediation"] = {
-        "maximum_remediation_attempts_per_unit": 99,
-        "maximum_identical_failure_repetitions": 99,
-    }
+    policy["compatibility_rules"]["APPROVED"] = ["UNKNOWN_DISPOSITION"]
     _write_json(tmp_path / "machine/governance/policy.v1.json", policy)
     errors = mc.machine_contract_errors(tmp_path)
     assert "GOVERNANCE_OWNERSHIP_UNKNOWN_SPECIALIST" in errors
@@ -188,9 +208,7 @@ def test_machine_contract_errors_detect_governance_corruption(tmp_path):
     assert "GOVERNANCE_REQUIRED_UNKNOWN_SPECIALIST" in errors
     assert any(item.startswith("GOVERNANCE_RULE_ID_INVALID_OR_DUPLICATE") for item in errors)
     assert any(item.startswith("GOVERNANCE_RULE_UNKNOWN_SPECIALIST") for item in errors)
-    assert "GOVERNANCE_PRECEDENCE_DRIFT" in errors
-    assert "REMEDIATION_ATTEMPT_DEFAULT_DRIFT" in errors
-    assert "IDENTICAL_FAILURE_DEFAULT_DRIFT" in errors
+    assert "GOVERNANCE_COMPATIBILITY_INVALID:APPROVED" in errors
     with pytest.raises(ValueError, match="machine contract validation failed"):
         mc.assert_machine_contracts(tmp_path)
 

--- a/tests/runtime/test_validation_authority_contract_edges.py
+++ b/tests/runtime/test_validation_authority_contract_edges.py
@@ -32,20 +32,21 @@ def test_unique_governance_values_fail_closed(monkeypatch):
 
 
 def test_route_map_rejects_missing_and_malformed_records(monkeypatch):
+    routing_template = _routing()
     for routes in ({}, [], None):
-        routing = _routing()
+        routing = deepcopy(routing_template)
         routing["command_routes"] = routes
         monkeypatch.setattr(mc, "load_routing_contract", lambda root=None, routing=routing: routing)
         with pytest.raises(ValueError, match="contains no command routes"):
             mc.command_route_map()
 
-    routing = _routing()
+    routing = deepcopy(routing_template)
     routing["command_routes"] = {"bad": []}
     monkeypatch.setattr(mc, "load_routing_contract", lambda root=None: routing)
     with pytest.raises(ValueError, match="must be an object"):
         mc.command_route_map()
 
-    routing = _routing()
+    routing = deepcopy(routing_template)
     routing["command_routes"] = {"bad": {"specialist": ""}}
     monkeypatch.setattr(mc, "load_routing_contract", lambda root=None: routing)
     with pytest.raises(ValueError, match="has no specialist"):
@@ -53,14 +54,15 @@ def test_route_map_rejects_missing_and_malformed_records(monkeypatch):
 
 
 def test_route_record_rejects_missing_fallback_and_malformed_record(monkeypatch):
-    routing = _routing()
+    routing_template = _routing()
+    routing = deepcopy(routing_template)
     routing["command_routes"] = {}
     routing["ambiguity_fallback"] = ""
     monkeypatch.setattr(mc, "load_routing_contract", lambda root=None: routing)
     with pytest.raises(ValueError, match="no ambiguity fallback"):
         mc.command_route_record("unknown")
 
-    routing = _routing()
+    routing = deepcopy(routing_template)
     routing["command_routes"] = {"bad": []}
     monkeypatch.setattr(mc, "load_routing_contract", lambda root=None: routing)
     with pytest.raises(ValueError, match="must be an object"):
@@ -68,20 +70,21 @@ def test_route_record_rejects_missing_fallback_and_malformed_record(monkeypatch)
 
 
 def test_governance_required_and_validation_rules_fail_closed(monkeypatch):
-    policy = _policy()
+    policy_template = _policy()
+    policy = deepcopy(policy_template)
     policy["governance_required_specialists"] = ["dagger", "dagger"]
     monkeypatch.setattr(mc, "load_governance_policy", lambda root=None: policy)
     with pytest.raises(ValueError, match="invalid governance_required_specialists"):
         mc.governance_required_specialists()
 
-    policy = _policy()
+    policy = deepcopy(policy_template)
     policy["governance_required_specialists"] = [""]
     monkeypatch.setattr(mc, "load_governance_policy", lambda root=None: policy)
     with pytest.raises(ValueError, match="invalid governance_required_specialists"):
         mc.governance_required_specialists()
 
     for rules in (None, {}, []):
-        policy = _policy()
+        policy = deepcopy(policy_template)
         policy["runtime_validation_rules"] = rules
         monkeypatch.setattr(mc, "load_governance_policy", lambda root=None, policy=policy: policy)
         with pytest.raises(ValueError, match="contains no runtime validation rules"):
@@ -97,7 +100,8 @@ def test_transition_precedence_requires_exact_disposition_set(monkeypatch):
 
 
 def test_remediation_limits_validate_shape_types_and_bounds(monkeypatch):
-    policy = _policy()
+    policy_template = _policy()
+    policy = deepcopy(policy_template)
     policy["default_remediation"] = []
     monkeypatch.setattr(mc, "load_governance_policy", lambda root=None: policy)
     with pytest.raises(ValueError, match="must be an object"):
@@ -108,7 +112,7 @@ def test_remediation_limits_validate_shape_types_and_bounds(monkeypatch):
         ("maximum_identical_failure_repetitions", "2"),
         ("maximum_scope_growth", None),
     ):
-        policy = _policy()
+        policy = deepcopy(policy_template)
         policy["default_remediation"][key] = value
         monkeypatch.setattr(mc, "load_governance_policy", lambda root=None, policy=policy: policy)
         with pytest.raises(ValueError, match=f"{key} must be an integer"):
@@ -119,7 +123,7 @@ def test_remediation_limits_validate_shape_types_and_bounds(monkeypatch):
         ("maximum_identical_failure_repetitions", 0, "must be > 0"),
         ("maximum_scope_growth", -1, "must be >= 0"),
     ):
-        policy = _policy()
+        policy = deepcopy(policy_template)
         policy["default_remediation"][key] = value
         monkeypatch.setattr(mc, "load_governance_policy", lambda root=None, policy=policy: policy)
         with pytest.raises(ValueError, match=message):
@@ -127,12 +131,13 @@ def test_remediation_limits_validate_shape_types_and_bounds(monkeypatch):
 
 
 def test_machine_contract_error_surfaces_cover_policy_set_and_rule_shape(monkeypatch):
-    policy = _policy()
+    policy_template = _policy()
+    policy = deepcopy(policy_template)
     policy["compatibility_rules"].pop("APPROVED")
     monkeypatch.setattr(mc, "load_governance_policy", lambda root=None: policy)
     assert "GOVERNANCE_COMPATIBILITY_DECISION_SET_MISMATCH" in mc.machine_contract_errors()
 
-    policy = _policy()
+    policy = deepcopy(policy_template)
     policy["compatibility_rules"]["APPROVED"] = []
     monkeypatch.setattr(mc, "load_governance_policy", lambda root=None: policy)
     assert "GOVERNANCE_COMPATIBILITY_INVALID:APPROVED" in mc.machine_contract_errors()

--- a/tests/runtime/test_validation_authority_contract_edges.py
+++ b/tests/runtime/test_validation_authority_contract_edges.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from orchestra_runtime import machine_contracts as mc
+
+
+def _policy() -> dict:
+    return deepcopy(mc.load_governance_policy())
+
+
+def _routing() -> dict:
+    return deepcopy(mc.load_routing_contract())
+
+
+def test_unique_governance_values_fail_closed(monkeypatch):
+    policy = _policy()
+    for value in (None, [], "APPROVED"):
+        candidate = deepcopy(policy)
+        candidate["governance_decisions"] = value
+        monkeypatch.setattr(mc, "load_governance_policy", lambda root=None, candidate=candidate: candidate)
+        with pytest.raises(ValueError, match="non-empty list"):
+            mc.governance_decision_values()
+
+    candidate = deepcopy(policy)
+    candidate["governance_decisions"] = ["APPROVED", "APPROVED"]
+    monkeypatch.setattr(mc, "load_governance_policy", lambda root=None: candidate)
+    with pytest.raises(ValueError, match="empty or duplicate"):
+        mc.governance_decision_values()
+
+
+def test_route_map_rejects_missing_and_malformed_records(monkeypatch):
+    for routes in ({}, [], None):
+        routing = _routing()
+        routing["command_routes"] = routes
+        monkeypatch.setattr(mc, "load_routing_contract", lambda root=None, routing=routing: routing)
+        with pytest.raises(ValueError, match="contains no command routes"):
+            mc.command_route_map()
+
+    routing = _routing()
+    routing["command_routes"] = {"bad": []}
+    monkeypatch.setattr(mc, "load_routing_contract", lambda root=None: routing)
+    with pytest.raises(ValueError, match="must be an object"):
+        mc.command_route_map()
+
+    routing = _routing()
+    routing["command_routes"] = {"bad": {"specialist": ""}}
+    monkeypatch.setattr(mc, "load_routing_contract", lambda root=None: routing)
+    with pytest.raises(ValueError, match="has no specialist"):
+        mc.command_route_map()
+
+
+def test_route_record_rejects_missing_fallback_and_malformed_record(monkeypatch):
+    routing = _routing()
+    routing["command_routes"] = {}
+    routing["ambiguity_fallback"] = ""
+    monkeypatch.setattr(mc, "load_routing_contract", lambda root=None: routing)
+    with pytest.raises(ValueError, match="no ambiguity fallback"):
+        mc.command_route_record("unknown")
+
+    routing = _routing()
+    routing["command_routes"] = {"bad": []}
+    monkeypatch.setattr(mc, "load_routing_contract", lambda root=None: routing)
+    with pytest.raises(ValueError, match="must be an object"):
+        mc.command_route_record("bad")
+
+
+def test_governance_required_and_validation_rules_fail_closed(monkeypatch):
+    policy = _policy()
+    policy["governance_required_specialists"] = ["dagger", "dagger"]
+    monkeypatch.setattr(mc, "load_governance_policy", lambda root=None: policy)
+    with pytest.raises(ValueError, match="invalid governance_required_specialists"):
+        mc.governance_required_specialists()
+
+    policy = _policy()
+    policy["governance_required_specialists"] = [""]
+    monkeypatch.setattr(mc, "load_governance_policy", lambda root=None: policy)
+    with pytest.raises(ValueError, match="invalid governance_required_specialists"):
+        mc.governance_required_specialists()
+
+    for rules in (None, {}, []):
+        policy = _policy()
+        policy["runtime_validation_rules"] = rules
+        monkeypatch.setattr(mc, "load_governance_policy", lambda root=None, policy=policy: policy)
+        with pytest.raises(ValueError, match="contains no runtime validation rules"):
+            mc.runtime_validation_rule_records()
+
+
+def test_transition_precedence_requires_exact_disposition_set(monkeypatch):
+    policy = _policy()
+    policy["transition_precedence"] = policy["transition_precedence"][:-1]
+    monkeypatch.setattr(mc, "load_governance_policy", lambda root=None: policy)
+    with pytest.raises(ValueError, match="every transition disposition"):
+        mc.transition_precedence()
+
+
+def test_remediation_limits_validate_shape_types_and_bounds(monkeypatch):
+    policy = _policy()
+    policy["default_remediation"] = []
+    monkeypatch.setattr(mc, "load_governance_policy", lambda root=None: policy)
+    with pytest.raises(ValueError, match="must be an object"):
+        mc.default_remediation_limits()
+
+    for key, value in (
+        ("maximum_remediation_attempts_per_unit", True),
+        ("maximum_identical_failure_repetitions", "2"),
+        ("maximum_scope_growth", None),
+    ):
+        policy = _policy()
+        policy["default_remediation"][key] = value
+        monkeypatch.setattr(mc, "load_governance_policy", lambda root=None, policy=policy: policy)
+        with pytest.raises(ValueError, match=f"{key} must be an integer"):
+            mc.default_remediation_limits()
+
+    for key, value, message in (
+        ("maximum_remediation_attempts_per_unit", 0, "must be > 0"),
+        ("maximum_identical_failure_repetitions", 0, "must be > 0"),
+        ("maximum_scope_growth", -1, "must be >= 0"),
+    ):
+        policy = _policy()
+        policy["default_remediation"][key] = value
+        monkeypatch.setattr(mc, "load_governance_policy", lambda root=None, policy=policy: policy)
+        with pytest.raises(ValueError, match=message):
+            mc.default_remediation_limits()
+
+
+def test_machine_contract_error_surfaces_cover_policy_set_and_rule_shape(monkeypatch):
+    policy = _policy()
+    policy["compatibility_rules"].pop("APPROVED")
+    monkeypatch.setattr(mc, "load_governance_policy", lambda root=None: policy)
+    assert "GOVERNANCE_COMPATIBILITY_DECISION_SET_MISMATCH" in mc.machine_contract_errors()
+
+    policy = _policy()
+    policy["compatibility_rules"]["APPROVED"] = []
+    monkeypatch.setattr(mc, "load_governance_policy", lambda root=None: policy)
+    assert "GOVERNANCE_COMPATIBILITY_INVALID:APPROVED" in mc.machine_contract_errors()
+
+
+def test_contract_loaders_reject_schema_mismatch(tmp_path):
+    (tmp_path / "machine/routing").mkdir(parents=True)
+    (tmp_path / "machine/governance").mkdir(parents=True)
+    (tmp_path / "machine/routing/routes.v1.json").write_text('{"schema_version":"wrong"}', encoding="utf-8")
+    (tmp_path / "machine/governance/policy.v1.json").write_text('{"schema_version":"wrong"}', encoding="utf-8")
+    with pytest.raises(ValueError, match="unsupported routing contract"):
+        mc.load_routing_contract(tmp_path)
+    with pytest.raises(ValueError, match="unsupported governance policy"):
+        mc.load_governance_policy(tmp_path)

--- a/tests/runtime/test_validation_authority_kernel_edges.py
+++ b/tests/runtime/test_validation_authority_kernel_edges.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import pytest
+
+import orchestra_runtime.governance_kernel as kernel
+
+
+def test_machine_precedence_without_any_registered_disposition_fails_closed(monkeypatch):
+    candidate = kernel.ArbiterKernelInput(
+        project_id="validation-authority",
+        unit_id="precedence-empty",
+        governance_decisions=(
+            kernel.GovernanceDecisionRecord(
+                reviewer="arbiter",
+                project_context="validation-authority",
+                decision="APPROVED",
+                reason="fixture",
+            ),
+        ),
+    )
+    monkeypatch.setattr(kernel, "transition_precedence", lambda: ())
+    with pytest.raises(RuntimeError, match="did not select an Arbiter disposition"):
+        kernel.evaluate_arbiter(candidate)


### PR DESCRIPTION
## Scope

Advance the control-plane migration from canonical `ADVISORY` to `VALIDATION_AUTHORITY` only.

- Make the versioned machine governance policy provide Arbiter transition precedence and remediation defaults.
- Validate machine governance vocabulary and compatibility internally instead of comparing policy values against a second runtime constant set.
- Preserve the current public compatibility enums while fail-closing if they diverge from the machine policy during this migration stage.
- Record the adjacent migration-state transition and its prior canonical checkpoint.
- Add regression coverage proving policy precedence controls Arbiter selection.
- Reconcile README and changelog surfaces with the current published `v1.4.0` state and the bounded migration stage.

## Validation state

The earlier diagnostic head was intentionally non-authorizing and exposed the expected README Impact Gate failure while behavior/runtime diagnostics ran. Documentation parity is now included. All prior CI evidence is stale for merge authorization; final progression requires a fresh full protected matrix on the exact current head.

## Boundaries

Machine routing and specialist identity are not canonical-promotion authority in this PR. Legacy route/specialist/runtime-validation compatibility surfaces are not retired here. No release/version/tag publication, installed-integration mutation, deployment, ruleset mutation, branch deletion, force push, or history rewrite is authorized or performed.