### PR TITLE
refactor(refoundation): retire duplicate runtime authorities

### DIFF
--- a/.github/workflows/mutation-confidence.yml
+++ b/.github/workflows/mutation-confidence.yml
@@ -93,7 +93,7 @@ jobs:
           python -c "import importlib.metadata; print(importlib.metadata.version('mutmut'))"
           | tee artifacts/mutation/mutmut-version.txt
 
-      - name: Run workspace-isolated LEGACY_RETIRED mutation evidence
+      - name: Run retirement-targeted LEGACY_RETIRED mutation evidence
         env:
           SOURCE_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         shell: bash
@@ -107,6 +107,7 @@ jobs:
           run_target() {
             label="$1"
             config="$2"
+            shift 2
             workspace="$RUNNER_TEMP/orchestra-mutmut-${label}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
             run_output="$artifact_root/${label}-mutmut-run.txt"
             results_output="$artifact_root/${label}-mutmut-results.txt"
@@ -126,9 +127,26 @@ jobs:
 
             (
               cd "$workspace" || exit 1
+              : > "$run_output"
+              run_code=0
+              target_index=0
+              builder_args=()
 
-              mutmut run 2>&1 | tee "$run_output"
-              run_code=${PIPESTATUS[0]}
+              for pattern in "$@"; do
+                target_index=$((target_index + 1))
+                target_output="$artifact_root/${label}-target-${target_index}-run.txt"
+                echo "MUTATION_TARGET_PATTERN=$pattern" | tee -a "$run_output"
+                mutmut run "$pattern" 2>&1 | tee "$target_output"
+                target_code=${PIPESTATUS[0]}
+                cat "$target_output" >> "$run_output"
+                echo "MUTATION_TARGET_EXIT_CODE=$target_code" | tee -a "$run_output"
+                echo "$target_code" > "$artifact_root/${label}-target-${target_index}-exit-code.txt"
+                builder_args+=(--target-run "$pattern=$target_output")
+                if [ "$target_code" != "0" ]; then
+                  run_code=1
+                fi
+              done
+
               echo "$run_code" | tee "$artifact_root/${label}-mutmut-run-exit-code.txt"
 
               mutmut results 2>&1 | tee "$results_output"
@@ -139,6 +157,7 @@ jobs:
                 --run-output "$run_output" \
                 --results-output "$results_output" \
                 --config "$config_copy" \
+                "${builder_args[@]}" \
                 --run-exit-code "$run_code" \
                 --tool-version "$tool_version" \
                 --tested-sha "$SOURCE_HEAD_SHA" \
@@ -152,16 +171,25 @@ jobs:
               evidence_code=$?
               echo "$evidence_code" | tee "$artifact_root/${label}-evidence-exit-code.txt"
 
-              if [ "$results_code" != "0" ] || [ "$evidence_code" != "0" ]; then
+              if [ "$run_code" != "0" ] || [ "$results_code" != "0" ] || [ "$evidence_code" != "0" ]; then
                 exit 1
               fi
               exit 0
             )
           }
 
-          run_target models mutation/legacy-retired-models.cfg
+          run_target models mutation/legacy-retired-models.cfg \
+            "orchestra_runtime.models.__getattr__*"
           models_code=$?
-          run_target services mutation/legacy-retired-services.cfg
+
+          run_target services mutation/legacy-retired-services.cfg \
+            "orchestra_runtime.services._default_governance_rules*" \
+            "orchestra_runtime.services.SkillRegistry.__init__*" \
+            "orchestra_runtime.services.RouterService.__init__*" \
+            "orchestra_runtime.services.RouterService.route*" \
+            "orchestra_runtime.services.GovernanceValidator.__init__*" \
+            "orchestra_runtime.services._compatibility_bindings*" \
+            "orchestra_runtime.services.build_compatibility_composition*"
           services_code=$?
 
           echo "$models_code" | tee "$artifact_root/models-target-exit-code.txt"

--- a/.github/workflows/mutation-confidence.yml
+++ b/.github/workflows/mutation-confidence.yml
@@ -128,6 +128,7 @@ jobs:
             (
               cd "$workspace" || exit 1
               : > "$run_output"
+              : > "$results_output"
               run_code=0
               target_index=0
               builder_args=()
@@ -137,6 +138,8 @@ jobs:
                 mutmut_selector="${target_spec#*=}"
                 target_index=$((target_index + 1))
                 target_output="$artifact_root/${label}-target-${target_index}-run.txt"
+                target_results="$artifact_root/${label}-target-${target_index}-results.txt"
+
                 echo "MUTATION_TARGET_PATTERN=$public_pattern" | tee -a "$run_output"
                 echo "MUTMUT_SELECTOR=$mutmut_selector" | tee -a "$run_output"
                 mutmut run "$mutmut_selector" 2>&1 | tee "$target_output"
@@ -144,17 +147,23 @@ jobs:
                 cat "$target_output" >> "$run_output"
                 echo "MUTATION_TARGET_EXIT_CODE=$target_code" | tee -a "$run_output"
                 echo "$target_code" > "$artifact_root/${label}-target-${target_index}-exit-code.txt"
+
+                mutmut results 2>&1 | tee "$target_results"
+                target_results_code=${PIPESTATUS[0]}
+                echo "$target_results_code" > "$artifact_root/${label}-target-${target_index}-results-exit-code.txt"
+                echo "TARGET_RESULTS_BEGIN=$public_pattern" >> "$results_output"
+                cat "$target_results" >> "$results_output"
+                echo "TARGET_RESULTS_END=$public_pattern" >> "$results_output"
+
                 builder_args+=(--target-run "$public_pattern=$target_output")
-                if [ "$target_code" != "0" ]; then
+                builder_args+=(--target-result "$public_pattern=$target_results")
+                if [ "$target_code" != "0" ] || [ "$target_results_code" != "0" ]; then
                   run_code=1
                 fi
               done
 
               echo "$run_code" | tee "$artifact_root/${label}-mutmut-run-exit-code.txt"
-
-              mutmut results 2>&1 | tee "$results_output"
-              results_code=${PIPESTATUS[0]}
-              echo "$results_code" | tee "$artifact_root/${label}-mutmut-results-exit-code.txt"
+              echo "$run_code" | tee "$artifact_root/${label}-mutmut-results-exit-code.txt"
 
               python scripts/validation/build_mutation_evidence.py \
                 --run-output "$run_output" \
@@ -174,7 +183,7 @@ jobs:
               evidence_code=$?
               echo "$evidence_code" | tee "$artifact_root/${label}-evidence-exit-code.txt"
 
-              if [ "$run_code" != "0" ] || [ "$results_code" != "0" ] || [ "$evidence_code" != "0" ]; then
+              if [ "$run_code" != "0" ] || [ "$evidence_code" != "0" ]; then
                 exit 1
               fi
               exit 0
@@ -203,7 +212,7 @@ jobs:
           fi
           exit 0
 
-      - name: Upload mutation evidence baseline
+      - name: Upload mutation evidence
         if: always()
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/mutation-confidence.yml
+++ b/.github/workflows/mutation-confidence.yml
@@ -5,9 +5,13 @@ on:
   pull_request:
     paths:
       - "setup.cfg"
+      - "mutation/legacy-retired-models.cfg"
+      - "mutation/legacy-retired-services.cfg"
       - ".github/workflows/mutation-confidence.yml"
       - "scripts/validation/build_mutation_evidence.py"
       - "machine/schemas/mutation-evidence.schema.json"
+      - "orchestra_runtime/models.py"
+      - "orchestra_runtime/services.py"
       - "orchestra_runtime/evidence.py"
       - "orchestra_runtime/machine_contracts.py"
       - "orchestra_runtime/compliance_protocol.py"
@@ -37,6 +41,13 @@ on:
       - "tests/runtime/test_refoundation_final_critical_gaps.py"
       - "tests/runtime/test_refoundation_branch_gate.py"
       - "tests/runtime/test_refoundation_properties.py"
+      - "tests/runtime/test_canonical_promotion_authority.py"
+      - "tests/runtime/test_control_plane_migration_state.py"
+      - "tests/runtime/test_runtime_core.py"
+      - "tests/runtime/test_runtime_authority_integration.py"
+      - "tests/runtime/test_governance.py"
+      - "tests/runtime/test_adapter_contracts.py"
+      - "tests/runtime/test_mutation_evidence.py"
 
 permissions:
   contents: read
@@ -47,8 +58,20 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: Checkout repository
+      - name: Checkout exact source head
         uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Verify exact source checkout
+        env:
+          SOURCE_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        shell: bash
+        run: |
+          checked_sha="$(git rev-parse HEAD)"
+          echo "CHECKED_SHA=$checked_sha"
+          echo "SOURCE_HEAD_SHA=$SOURCE_HEAD_SHA"
+          test "$checked_sha" = "$SOURCE_HEAD_SHA"
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -70,45 +93,73 @@ jobs:
           python -c "import importlib.metadata; print(importlib.metadata.version('mutmut'))"
           | tee artifacts/mutation/mutmut-version.txt
 
-      - name: Run bounded trust-module mutation baseline
-        id: mutation
-        shell: bash
-        run: |
-          set +e
-          set -o pipefail
-          mutmut run 2>&1 | tee artifacts/mutation/mutmut-run.txt
-          code=${PIPESTATUS[0]}
-          echo "$code" | tee artifacts/mutation/mutmut-run-exit-code.txt
-          exit 0
-
-      - name: Record raw mutation results
-        if: always()
-        shell: bash
-        run: |
-          set +e
-          mutmut results 2>&1 | tee artifacts/mutation/mutmut-results.txt
-          exit 0
-
-      - name: Build machine-readable mutation evidence
-        if: always()
+      - name: Run module-isolated LEGACY_RETIRED mutation evidence
         env:
           SOURCE_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         shell: bash
         run: |
-          python scripts/validation/build_mutation_evidence.py \
-            --run-output artifacts/mutation/mutmut-run.txt \
-            --results-output artifacts/mutation/mutmut-results.txt \
-            --config setup.cfg \
-            --run-exit-code "$(cat artifacts/mutation/mutmut-run-exit-code.txt)" \
-            --tool-version "$(cat artifacts/mutation/mutmut-version.txt)" \
-            --tested-sha "$(git rev-parse HEAD)" \
-            --source-head-sha "$SOURCE_HEAD_SHA" \
-            --repository "$GITHUB_REPOSITORY" \
-            --workflow-run-id "$GITHUB_RUN_ID" \
-            --workflow-run-attempt "$GITHUB_RUN_ATTEMPT" \
-            --event-name "$GITHUB_EVENT_NAME" \
-            --ref-name "$GITHUB_REF_NAME" \
-            --output artifacts/mutation/mutation-evidence.json
+          set +e
+          set -o pipefail
+          cp setup.cfg artifacts/mutation/repository-setup.cfg
+
+          run_target() {
+            label="$1"
+            config="$2"
+            run_output="artifacts/mutation/${label}-mutmut-run.txt"
+            results_output="artifacts/mutation/${label}-mutmut-results.txt"
+            config_copy="artifacts/mutation/${label}-config.cfg"
+            evidence_output="artifacts/mutation/${label}-mutation-evidence.json"
+
+            rm -rf mutants
+            cp "$config" setup.cfg
+            cp "$config" "$config_copy"
+
+            mutmut run 2>&1 | tee "$run_output"
+            run_code=${PIPESTATUS[0]}
+            echo "$run_code" | tee "artifacts/mutation/${label}-mutmut-run-exit-code.txt"
+
+            mutmut results 2>&1 | tee "$results_output"
+            results_code=${PIPESTATUS[0]}
+            echo "$results_code" | tee "artifacts/mutation/${label}-mutmut-results-exit-code.txt"
+
+            python scripts/validation/build_mutation_evidence.py \
+              --run-output "$run_output" \
+              --results-output "$results_output" \
+              --config "$config_copy" \
+              --run-exit-code "$run_code" \
+              --tool-version "$(cat artifacts/mutation/mutmut-version.txt)" \
+              --tested-sha "$(git rev-parse HEAD)" \
+              --source-head-sha "$SOURCE_HEAD_SHA" \
+              --repository "$GITHUB_REPOSITORY" \
+              --workflow-run-id "$GITHUB_RUN_ID" \
+              --workflow-run-attempt "$GITHUB_RUN_ATTEMPT" \
+              --event-name "$GITHUB_EVENT_NAME" \
+              --ref-name "$GITHUB_REF_NAME" \
+              --output "$evidence_output"
+            evidence_code=$?
+            echo "$evidence_code" | tee "artifacts/mutation/${label}-evidence-exit-code.txt"
+
+            if [ "$results_code" != "0" ] || [ "$evidence_code" != "0" ]; then
+              return 1
+            fi
+            return 0
+          }
+
+          run_target models mutation/legacy-retired-models.cfg
+          models_code=$?
+          run_target services mutation/legacy-retired-services.cfg
+          services_code=$?
+
+          cp artifacts/mutation/repository-setup.cfg setup.cfg
+          rm -rf mutants
+
+          echo "$models_code" | tee artifacts/mutation/models-target-exit-code.txt
+          echo "$services_code" | tee artifacts/mutation/services-target-exit-code.txt
+
+          if [ "$models_code" != "0" ] || [ "$services_code" != "0" ]; then
+            exit 1
+          fi
+          exit 0
 
       - name: Upload mutation evidence baseline
         if: always()

--- a/.github/workflows/mutation-confidence.yml
+++ b/.github/workflows/mutation-confidence.yml
@@ -93,56 +93,70 @@ jobs:
           python -c "import importlib.metadata; print(importlib.metadata.version('mutmut'))"
           | tee artifacts/mutation/mutmut-version.txt
 
-      - name: Run module-isolated LEGACY_RETIRED mutation evidence
+      - name: Run workspace-isolated LEGACY_RETIRED mutation evidence
         env:
           SOURCE_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         shell: bash
         run: |
           set +e
           set -o pipefail
-          cp setup.cfg artifacts/mutation/repository-setup.cfg
+
+          artifact_root="$GITHUB_WORKSPACE/artifacts/mutation"
+          tool_version="$(cat "$artifact_root/mutmut-version.txt")"
 
           run_target() {
             label="$1"
             config="$2"
-            run_output="artifacts/mutation/${label}-mutmut-run.txt"
-            results_output="artifacts/mutation/${label}-mutmut-results.txt"
-            config_copy="artifacts/mutation/${label}-config.cfg"
-            evidence_output="artifacts/mutation/${label}-mutation-evidence.json"
+            workspace="$RUNNER_TEMP/orchestra-mutmut-${label}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+            run_output="$artifact_root/${label}-mutmut-run.txt"
+            results_output="$artifact_root/${label}-mutmut-results.txt"
+            config_copy="$artifact_root/${label}-config.cfg"
+            evidence_output="$artifact_root/${label}-mutation-evidence.json"
 
-            rm -rf mutants
-            cp "$config" setup.cfg
-            cp "$config" "$config_copy"
-
-            mutmut run 2>&1 | tee "$run_output"
-            run_code=${PIPESTATUS[0]}
-            echo "$run_code" | tee "artifacts/mutation/${label}-mutmut-run-exit-code.txt"
-
-            mutmut results 2>&1 | tee "$results_output"
-            results_code=${PIPESTATUS[0]}
-            echo "$results_code" | tee "artifacts/mutation/${label}-mutmut-results-exit-code.txt"
-
-            python scripts/validation/build_mutation_evidence.py \
-              --run-output "$run_output" \
-              --results-output "$results_output" \
-              --config "$config_copy" \
-              --run-exit-code "$run_code" \
-              --tool-version "$(cat artifacts/mutation/mutmut-version.txt)" \
-              --tested-sha "$(git rev-parse HEAD)" \
-              --source-head-sha "$SOURCE_HEAD_SHA" \
-              --repository "$GITHUB_REPOSITORY" \
-              --workflow-run-id "$GITHUB_RUN_ID" \
-              --workflow-run-attempt "$GITHUB_RUN_ATTEMPT" \
-              --event-name "$GITHUB_EVENT_NAME" \
-              --ref-name "$GITHUB_REF_NAME" \
-              --output "$evidence_output"
-            evidence_code=$?
-            echo "$evidence_code" | tee "artifacts/mutation/${label}-evidence-exit-code.txt"
-
-            if [ "$results_code" != "0" ] || [ "$evidence_code" != "0" ]; then
+            mkdir -p "$workspace"
+            git archive "$SOURCE_HEAD_SHA" | tar -x -C "$workspace"
+            archive_code=$?
+            echo "$archive_code" | tee "$artifact_root/${label}-workspace-export-exit-code.txt"
+            if [ "$archive_code" != "0" ]; then
               return 1
             fi
-            return 0
+
+            cp "$GITHUB_WORKSPACE/$config" "$workspace/setup.cfg"
+            cp "$GITHUB_WORKSPACE/$config" "$config_copy"
+
+            (
+              cd "$workspace" || exit 1
+
+              mutmut run 2>&1 | tee "$run_output"
+              run_code=${PIPESTATUS[0]}
+              echo "$run_code" | tee "$artifact_root/${label}-mutmut-run-exit-code.txt"
+
+              mutmut results 2>&1 | tee "$results_output"
+              results_code=${PIPESTATUS[0]}
+              echo "$results_code" | tee "$artifact_root/${label}-mutmut-results-exit-code.txt"
+
+              python scripts/validation/build_mutation_evidence.py \
+                --run-output "$run_output" \
+                --results-output "$results_output" \
+                --config "$config_copy" \
+                --run-exit-code "$run_code" \
+                --tool-version "$tool_version" \
+                --tested-sha "$SOURCE_HEAD_SHA" \
+                --source-head-sha "$SOURCE_HEAD_SHA" \
+                --repository "$GITHUB_REPOSITORY" \
+                --workflow-run-id "$GITHUB_RUN_ID" \
+                --workflow-run-attempt "$GITHUB_RUN_ATTEMPT" \
+                --event-name "$GITHUB_EVENT_NAME" \
+                --ref-name "$GITHUB_REF_NAME" \
+                --output "$evidence_output"
+              evidence_code=$?
+              echo "$evidence_code" | tee "$artifact_root/${label}-evidence-exit-code.txt"
+
+              if [ "$results_code" != "0" ] || [ "$evidence_code" != "0" ]; then
+                exit 1
+              fi
+              exit 0
+            )
           }
 
           run_target models mutation/legacy-retired-models.cfg
@@ -150,11 +164,8 @@ jobs:
           run_target services mutation/legacy-retired-services.cfg
           services_code=$?
 
-          cp artifacts/mutation/repository-setup.cfg setup.cfg
-          rm -rf mutants
-
-          echo "$models_code" | tee artifacts/mutation/models-target-exit-code.txt
-          echo "$services_code" | tee artifacts/mutation/services-target-exit-code.txt
+          echo "$models_code" | tee "$artifact_root/models-target-exit-code.txt"
+          echo "$services_code" | tee "$artifact_root/services-target-exit-code.txt"
 
           if [ "$models_code" != "0" ] || [ "$services_code" != "0" ]; then
             exit 1

--- a/.github/workflows/mutation-confidence.yml
+++ b/.github/workflows/mutation-confidence.yml
@@ -132,16 +132,19 @@ jobs:
               target_index=0
               builder_args=()
 
-              for pattern in "$@"; do
+              for target_spec in "$@"; do
+                public_pattern="${target_spec%%=*}"
+                mutmut_selector="${target_spec#*=}"
                 target_index=$((target_index + 1))
                 target_output="$artifact_root/${label}-target-${target_index}-run.txt"
-                echo "MUTATION_TARGET_PATTERN=$pattern" | tee -a "$run_output"
-                mutmut run "$pattern" 2>&1 | tee "$target_output"
+                echo "MUTATION_TARGET_PATTERN=$public_pattern" | tee -a "$run_output"
+                echo "MUTMUT_SELECTOR=$mutmut_selector" | tee -a "$run_output"
+                mutmut run "$mutmut_selector" 2>&1 | tee "$target_output"
                 target_code=${PIPESTATUS[0]}
                 cat "$target_output" >> "$run_output"
                 echo "MUTATION_TARGET_EXIT_CODE=$target_code" | tee -a "$run_output"
                 echo "$target_code" > "$artifact_root/${label}-target-${target_index}-exit-code.txt"
-                builder_args+=(--target-run "$pattern=$target_output")
+                builder_args+=(--target-run "$public_pattern=$target_output")
                 if [ "$target_code" != "0" ]; then
                   run_code=1
                 fi
@@ -179,17 +182,17 @@ jobs:
           }
 
           run_target models mutation/legacy-retired-models.cfg \
-            "orchestra_runtime.models.__getattr__*"
+            "orchestra_runtime.models.__getattr__*=orchestra_runtime.models.x___getattr__*"
           models_code=$?
 
           run_target services mutation/legacy-retired-services.cfg \
-            "orchestra_runtime.services._default_governance_rules*" \
-            "orchestra_runtime.services.SkillRegistry.__init__*" \
-            "orchestra_runtime.services.RouterService.__init__*" \
-            "orchestra_runtime.services.RouterService.route*" \
-            "orchestra_runtime.services.GovernanceValidator.__init__*" \
-            "orchestra_runtime.services._compatibility_bindings*" \
-            "orchestra_runtime.services.build_compatibility_composition*"
+            "orchestra_runtime.services._default_governance_rules*=orchestra_runtime.services.x__default_governance_rules*" \
+            "orchestra_runtime.services.SkillRegistry.__init__*=orchestra_runtime.services.xǁSkillRegistryǁ__init__*" \
+            "orchestra_runtime.services.RouterService.__init__*=orchestra_runtime.services.xǁRouterServiceǁ__init__*" \
+            "orchestra_runtime.services.RouterService.route*=orchestra_runtime.services.xǁRouterServiceǁroute*" \
+            "orchestra_runtime.services.GovernanceValidator.__init__*=orchestra_runtime.services.xǁGovernanceValidatorǁ__init__*" \
+            "orchestra_runtime.services._compatibility_bindings*=orchestra_runtime.services.x__compatibility_bindings*" \
+            "orchestra_runtime.services.build_compatibility_composition*=orchestra_runtime.services.x_build_compatibility_composition*"
           services_code=$?
 
           echo "$models_code" | tee "$artifact_root/models-target-exit-code.txt"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Post-v1.4.0 Control Plane Re-foundation - LEGACY_RETIRED Candidate
+
+- Advances the separately governed migration from `CANONICAL_PROMOTION_AUTHORITY` to `LEGACY_RETIRED` without changing the published `v1.4.0` release.
+- Removes the runtime's independently addressable service-level authority snapshots for default command routes, ambiguity fallback, governance-required specialist classification, governance validation-rule records, and dry-run rule identity. `SkillRegistry`, `RouterService`, `GovernanceValidator`, compatibility policy bindings, and compatibility capability grants now consume the versioned machine contracts directly.
+- Replaces the stored `models.py::VALID_SPECIALISTS` snapshot with an on-demand machine-derived compatibility view so the legacy import can remain available without becoming an independent specialist-identity authority.
+- Converts routing, shadow-conformance, governance, and migration-state regressions from legacy-table parity checks to direct machine-authority consumption checks, including fail-closed invalid-rule coverage.
+- Marks the machine migration state `LEGACY_RETIRED` only after the adjacent `CANONICAL_PROMOTION_AUTHORITY` checkpoint became signed canonical through PR #298 at `529639beefd8fa0cc153b6e94649b487de4f7bc2`.
+- This candidate does not select or publish a new SemVer, tag, or GitHub Release and does not perform marketplace publication, installed-integration refresh, deployment, production mutation, ruleset bypass, force push, history rewrite, branch deletion, or destructive cleanup.
+
 ## Post-v1.4.0 Control Plane Re-foundation P0/P1-P9 - Canonical Integration
 
 - Consolidated the control-plane re-foundation tracked by #273 into PR #294, covering exact source and validation receipts, typed governance and deterministic Arbiter Kernel enforcement, machine specialist/routing/governance contracts, exact compliance set-equality receipts, host capability/conformance contracts, typed continuity and JSONL context state, persistent remediation circuit breakers, deterministic pre-execution policy gating, and P9 shadow conformance.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Accessible summary: a request supplies project context and selects separate risk
 
 The cumulative P0/P1 through P9 control-plane re-foundation is canonical through PR #294, with post-merge evidence parity through PR #295. Migration authority progresses only through the explicit sequence `SHADOW -> ADVISORY -> VALIDATION_AUTHORITY -> CANONICAL_PROMOTION_AUTHORITY -> LEGACY_RETIRED`; no stage is inferred from test success or mergeability.
 
-The migration state in this revision is `CANONICAL_PROMOTION_AUTHORITY`. The versioned machine specialist registry, routing contract, and governance policy now supply the runtime's default specialist identity, command routing and ambiguity fallback, governance-required specialist classification, and governance validation rules. Backward-compatible runtime names remain available as derived surfaces rather than independently maintained authority. Legacy runtime surfaces are not yet retired, and installed integrations are not mutated by this stage.
+The migration state in this revision is `LEGACY_RETIRED`. The versioned machine specialist registry, routing contract, and governance policy are the runtime's normative sources for specialist identity, command routing and ambiguity fallback, governance-required specialist classification, and governance validation rules. Runtime construction reads those contracts directly instead of consuming independently maintained compatibility tables. The legacy `VALID_SPECIALISTS` import remains available only as an on-demand machine-derived compatibility view. Installed integrations are not mutated by this stage, and release publication remains a separate governed transition.
 
 ## v1.4.0 Governance and Compliance Registry Cross-Integration
 
@@ -225,7 +225,7 @@ Accepted child work receives an authority subset, capability subset, bounded dep
 
 Runs use typed lifecycle signals and distinct waiting or terminal states. Exact replay of an accepted terminal signal is idempotent; conflicting replay is rejected. Run-linked audit events record authority, capabilities, delegation, coordination, lifecycle, and terminal outcomes without granting permission.
 
-The control-plane re-foundation now binds exact identities, validation outcomes, specialist identity, routing defaults, governance classification, validation rules, transition precedence, and remediation defaults to versioned machine contracts. Agent prose may explain those records, but it cannot override their identities or verdicts. The migration remains staged so canonical-promotion authority does not imply legacy retirement, release authority, or installed-host mutation.
+The control-plane re-foundation now binds exact identities, validation outcomes, specialist identity, routing defaults, governance classification, validation rules, transition precedence, and remediation defaults to versioned machine contracts. Agent prose may explain those records, but it cannot override their identities or verdicts. The migration has reached `LEGACY_RETIRED`; that retirement of duplicate runtime authority does not grant release authority, mutate installed hosts, or authorize deployment.
 
 ### Coordination state and evidence freshness
 
@@ -239,7 +239,7 @@ The Tuner's coordination runtime records specialist-owned contracts, dependencie
 | The Governor | Legal/compliance governance, source/applicability verification, privacy-obligation, IP and licensing review | Does not provide legal advice or grant runtime authority |
 | Conductor | Routing and ordered specialist handoffs | Routes work but does not implement it |
 | The Tuner | Cross-specialist contract assembly, contradictions, invalidation, and re-entry recommendations | Cannot route, implement, validate itself, or grant authority |
-| Clockwork | Architecture, service boundaries, distributed patterns, concurrency, API compatibility, and structural design | Does not implement |
+| Clockwork | Architecture, service boundaries, distributed patterns, concurrency, API compatibility/versioning, and structural design | Does not implement |
 | Cloak | UI/UX, accessibility, responsive behavior, forms, design states, and frontend interaction boundaries | Does not own backend policy |
 | Chronicler | Database dialects, transactions, persistence semantics, migrations, query plans, and tenant isolation | Does not own UI or general QA |
 | Ponytail | Stack-aware minimal, reversible implementation and implementation-tooling execution | Requires upstream decisions to be settled |
@@ -282,7 +282,7 @@ Use the host-native path:
 - Antigravity: run `agy plugin install https://github.com/Baelfyre/Orchestra`.
 - Manual or scaffold-only hosts: follow the exact host boundary in the [Installation Guide](docs/setup/INSTALLATION.md).
 
-Repository manifests identify package version `1.4.0`, and the current public GitHub release is `v1.4.0`. GitHub Release publication, marketplace publication, installed-integration refresh, and later control-plane migration stages remain separate governed actions. See the Installation Guide for supported installation paths and host-maturity boundaries.
+Repository manifests identify package version `1.4.0`, and the current public GitHub release is `v1.4.0`. The completed control-plane migration does not itself publish a new version; GitHub Release publication, marketplace publication, and installed-integration refresh remain separate governed actions. See the Installation Guide for supported installation paths and host-maturity boundaries.
 
 ## Quick Start
 

--- a/machine/migration/control-plane.v1.json
+++ b/machine/migration/control-plane.v1.json
@@ -7,8 +7,8 @@
     "CANONICAL_PROMOTION_AUTHORITY",
     "LEGACY_RETIRED"
   ],
-  "current_stage": "CANONICAL_PROMOTION_AUTHORITY",
-  "previous_stage": "VALIDATION_AUTHORITY",
+  "current_stage": "LEGACY_RETIRED",
+  "previous_stage": "CANONICAL_PROMOTION_AUTHORITY",
   "transition_policy": {
     "adjacent_stage_only": true,
     "exact_conformance_evidence_required": true,
@@ -19,7 +19,7 @@
     "integration_pull_request": 294,
     "integration_canonical_sha": "76eb96b27439700a517f75c5a921465e5c2987e6",
     "post_merge_closeout_sha": "452572f16f232147d05fe0202cbaea8e82b88e56",
-    "previous_stage_canonical_sha": "14eab40029e3409dcfe813b398fe8fc3e5295db9",
+    "previous_stage_canonical_sha": "529639beefd8fa0cc153b6e94649b487de4f7bc2",
     "validated_source_head_sha": "862ba871d900fe7e31591bec068c8830170dd774",
     "runtime_evidence_index": "machine/release-evidence/control-plane-refoundation-p0-p1-p9.json",
     "shadow_fixture_suite": "PASS"
@@ -28,7 +28,7 @@
     "machine_contracts_may_inform_runtime_decisions": true,
     "machine_contracts_are_validation_authority": true,
     "machine_contracts_are_canonical_promotion_authority": true,
-    "legacy_runtime_authorities_retired": false,
+    "legacy_runtime_authorities_retired": true,
     "installed_integrations_mutated": false
   }
 }

--- a/machine/schemas/mutation-evidence.schema.json
+++ b/machine/schemas/mutation-evidence.schema.json
@@ -17,7 +17,7 @@
     "reports"
   ],
   "properties": {
-    "schema_version": {"type": "string", "const": "orchestra.mutation-evidence.v1"},
+    "schema_version": {"type": "string", "const": "orchestra.mutation-evidence.v2"},
     "generated_at": {"type": "string", "format": "date-time"},
     "repository": {"type": "string", "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"},
     "tested_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
@@ -28,16 +28,36 @@
       "required": ["name", "version"],
       "properties": {
         "name": {"type": "string", "const": "mutmut"},
-        "version": {"type": "string", "minLength": 1}
+        "version": {"type": "string", "minLength": 1
+        }
       }
     },
-    "scope": {"type": "object"},
+    "scope": {
+      "type": "object",
+      "required": ["modules", "mutant_patterns", "target_runs", "configuration", "mutate_only_covered_lines", "max_stack_depth"]
+    },
     "execution": {
       "type": "object",
-      "required": ["run_exit_code", "score_status", "interpretation"],
+      "required": [
+        "run_exit_code",
+        "score_status",
+        "classification_status",
+        "target_mutant_total",
+        "target_killed_count",
+        "target_survived_count",
+        "target_score_percent",
+        "not_checked_count",
+        "interpretation"
+      ],
       "properties": {
-        "run_exit_code": {"type": "integer"},
-        "score_status": {"type": "string", "const": "UNSCORED_BASELINE"},
+        "run_exit_code": {"type": "integer", "const": 0},
+        "score_status": {"type": "string", "const": "VALID_CLASSIFIED_SCORE"},
+        "classification_status": {"type": "string", "const": "COMPLETE"},
+        "target_mutant_total": {"type": "integer", "minimum": 1},
+        "target_killed_count": {"type": "integer", "minimum": 0},
+        "target_survived_count": {"type": "integer", "minimum": 0},
+        "target_score_percent": {"type": "number", "minimum": 0, "maximum": 100},
+        "not_checked_count": {"type": "integer", "const": 0},
         "interpretation": {"type": "string", "minLength": 1}
       }
     },

--- a/mutation/legacy-retired-models.cfg
+++ b/mutation/legacy-retired-models.cfg
@@ -1,0 +1,13 @@
+[mutmut]
+source_paths=orchestra_runtime/
+only_mutate=
+    orchestra_runtime/models.py
+pytest_add_cli_args_test_selection=
+    tests/runtime
+also_copy=
+    machine/
+    plugin.json
+    skills/
+    README.json
+mutate_only_covered_lines=true
+max_stack_depth=8

--- a/mutation/legacy-retired-models.cfg
+++ b/mutation/legacy-retired-models.cfg
@@ -5,6 +5,7 @@ only_mutate=
 pytest_add_cli_args_test_selection=
     tests/runtime
 also_copy=
+    adapters/
     machine/
     plugin.json
     skills/

--- a/mutation/legacy-retired-models.cfg
+++ b/mutation/legacy-retired-models.cfg
@@ -3,7 +3,10 @@ source_paths=orchestra_runtime/
 only_mutate=
     orchestra_runtime/models.py
 pytest_add_cli_args_test_selection=
-    tests/runtime
+    tests/runtime/test_canonical_promotion_authority.py
+    tests/runtime/test_runtime_core.py
+    tests/runtime/test_governance.py
+    tests/runtime/test_runtime_authority_integration.py
 also_copy=
     adapters/
     machine/

--- a/mutation/legacy-retired-models.cfg
+++ b/mutation/legacy-retired-models.cfg
@@ -8,6 +8,7 @@ also_copy=
     machine/
     plugin.json
     skills/
+    scripts/
     README.json
 mutate_only_covered_lines=true
-max_stack_depth=8
+max_stack_depth=-1

--- a/mutation/legacy-retired-services.cfg
+++ b/mutation/legacy-retired-services.cfg
@@ -3,7 +3,10 @@ source_paths=orchestra_runtime/
 only_mutate=
     orchestra_runtime/services.py
 pytest_add_cli_args_test_selection=
-    tests/runtime
+    tests/runtime/test_canonical_promotion_authority.py
+    tests/runtime/test_runtime_core.py
+    tests/runtime/test_governance.py
+    tests/runtime/test_runtime_authority_integration.py
 also_copy=
     adapters/
     machine/

--- a/mutation/legacy-retired-services.cfg
+++ b/mutation/legacy-retired-services.cfg
@@ -5,6 +5,7 @@ only_mutate=
 pytest_add_cli_args_test_selection=
     tests/runtime
 also_copy=
+    adapters/
     machine/
     plugin.json
     skills/

--- a/mutation/legacy-retired-services.cfg
+++ b/mutation/legacy-retired-services.cfg
@@ -1,0 +1,13 @@
+[mutmut]
+source_paths=orchestra_runtime/
+only_mutate=
+    orchestra_runtime/services.py
+pytest_add_cli_args_test_selection=
+    tests/runtime
+also_copy=
+    machine/
+    plugin.json
+    skills/
+    README.json
+mutate_only_covered_lines=true
+max_stack_depth=8

--- a/mutation/legacy-retired-services.cfg
+++ b/mutation/legacy-retired-services.cfg
@@ -8,6 +8,7 @@ also_copy=
     machine/
     plugin.json
     skills/
+    scripts/
     README.json
 mutate_only_covered_lines=true
-max_stack_depth=8
+max_stack_depth=-1

--- a/orchestra_runtime/models.py
+++ b/orchestra_runtime/models.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from .correlation import validate_correlation_id
-from .machine_contracts import valid_specialist_ids
 
 if TYPE_CHECKING:
     from .lifecycle import StructuredTerminalResult
@@ -14,10 +13,14 @@ if TYPE_CHECKING:
 
 APPROVED_UNIT_PLAN_SCHEMA_VERSION = "1.0.0"
 
-# Backward-compatible runtime surface derived from the canonical machine registry.
-# This name is intentionally retained during CANONICAL_PROMOTION_AUTHORITY; it is
-# no longer an independently maintained specialist identity authority.
-VALID_SPECIALISTS = valid_specialist_ids()
+
+def __getattr__(name: str) -> object:
+    """Preserve the legacy specialist-identity import as a derived compatibility view."""
+    if name == "VALID_SPECIALISTS":
+        from .machine_contracts import valid_specialist_ids
+
+        return valid_specialist_ids()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def _validate_repository_relative_path(p: str, field_name: str) -> str:

--- a/orchestra_runtime/services.py
+++ b/orchestra_runtime/services.py
@@ -103,15 +103,18 @@ from .models import (
 from .repositories import ManifestRepository, SkillSourceRepository
 
 
-# Legacy authority snapshots are retired. Runtime defaults are accepted only
-# after the complete machine specialist/routing/governance contract set conforms,
-# and each runtime boundary derives its effective values from those contracts.
-assert_machine_contracts()
-
+# Legacy authority snapshots are retired. Runtime boundaries validate the
+# complete machine specialist/routing/governance contract set immediately
+# before consuming machine-derived defaults. This preserves fail-closed runtime
+# construction without introducing import-time execution side effects.
 COMPATIBILITY_POLICY_ID = "orchestra.runtime.compatibility"
 COMPATIBILITY_POLICY_VERSION = "1"
 RUNTIME_IDENTIFIER_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_.:-]*$")
 ROUTE_IDENTIFIER_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_.:-]*$")
+
+
+def _assert_runtime_machine_contracts() -> None:
+    assert_machine_contracts()
 
 
 def _stable_id(prefix: str, payload: object) -> str:
@@ -301,6 +304,7 @@ class SkillRegistry(ISkillRegistry):
         skill_repository: SkillSourceRepository,
         command_routes: dict[str, str] | None = None,
     ):
+        _assert_runtime_machine_contracts()
         self._manifest_repository = manifest_repository
         self._skill_repository = skill_repository
         self._command_routes = command_routes or command_route_map()
@@ -332,6 +336,7 @@ class SkillRegistry(ISkillRegistry):
 
 class RouterService(IRouterService):
     def __init__(self, skill_registry: ISkillRegistry, command_routes: dict[str, str] | None = None):
+        _assert_runtime_machine_contracts()
         self._skill_registry = skill_registry
         self._command_routes = command_routes or command_route_map()
         self._fallback_specialist = str(command_route_record("__orchestra_ambiguity_fallback__")["specialist"])
@@ -378,6 +383,7 @@ class ContextAssembler:
 
 class GovernanceValidator(IGovernanceValidator):
     def __init__(self, rules: Iterable[GovernanceRule] | None = None):
+        _assert_runtime_machine_contracts()
         self._rules = tuple(rules) if rules is not None else _default_governance_rules()
         dry_run_required_rules = frozenset(
             str(record.get("rule_id", "")).strip()
@@ -546,6 +552,7 @@ class CoordinationRuntimeService:
 
 
 def _compatibility_bindings() -> tuple[RuntimePolicyBinding, ...]:
+    _assert_runtime_machine_contracts()
     routes = command_route_map()
     return tuple(sorted((
         RuntimePolicyBinding(

--- a/orchestra_runtime/services.py
+++ b/orchestra_runtime/services.py
@@ -103,22 +103,10 @@ from .models import (
 from .repositories import ManifestRepository, SkillSourceRepository
 
 
-# Promotion authority is fail-closed: runtime defaults are admitted only after
-# the complete machine specialist/routing/governance contract set conforms.
+# Legacy authority snapshots are retired. Runtime defaults are accepted only
+# after the complete machine specialist/routing/governance contract set conforms,
+# and each runtime boundary derives its effective values from those contracts.
 assert_machine_contracts()
-
-# Backward-compatible public/runtime names remain available during this stage,
-# but their values are derived from machine contracts rather than maintained as
-# independent normative tables.
-DEFAULT_COMMAND_ROUTES = command_route_map()
-DEFAULT_AMBIGUITY_FALLBACK = command_route_record("__orchestra_ambiguity_fallback__")["specialist"]
-DEFAULT_GOVERNANCE_REQUIRED_SPECIALISTS = governance_required_specialists()
-_DEFAULT_RUNTIME_VALIDATION_RULE_RECORDS = runtime_validation_rule_records()
-_DEFAULT_DRY_RUN_REQUIRED_RULES = frozenset(
-    str(record.get("rule_id", "")).strip()
-    for record in _DEFAULT_RUNTIME_VALIDATION_RULE_RECORDS
-    if record.get("dry_run_required") is True
-)
 
 COMPATIBILITY_POLICY_ID = "orchestra.runtime.compatibility"
 COMPATIBILITY_POLICY_VERSION = "1"
@@ -143,10 +131,13 @@ def _runtime_identifier(value: object, field_name: str, *, route: bool = False) 
     return text
 
 
-def _default_governance_rules() -> tuple[GovernanceRule, ...]:
+def _default_governance_rules(
+    records: Iterable[dict[str, object]] | None = None,
+) -> tuple[GovernanceRule, ...]:
+    rule_records = tuple(records) if records is not None else runtime_validation_rule_records()
     rules: list[GovernanceRule] = []
     seen_rule_ids: set[str] = set()
-    for record in _DEFAULT_RUNTIME_VALIDATION_RULE_RECORDS:
+    for record in rule_records:
         rule_id = str(record.get("rule_id", "")).strip()
         validator_key = str(record.get("validator_key", "")).strip()
         skill_slugs = tuple(str(item).strip() for item in record.get("skill_slugs", ()))
@@ -312,7 +303,7 @@ class SkillRegistry(ISkillRegistry):
     ):
         self._manifest_repository = manifest_repository
         self._skill_repository = skill_repository
-        self._command_routes = command_routes or DEFAULT_COMMAND_ROUTES
+        self._command_routes = command_routes or command_route_map()
         self._cache: dict[str, object] | None = None
 
     def load_skills(self) -> tuple:
@@ -342,15 +333,17 @@ class SkillRegistry(ISkillRegistry):
 class RouterService(IRouterService):
     def __init__(self, skill_registry: ISkillRegistry, command_routes: dict[str, str] | None = None):
         self._skill_registry = skill_registry
-        self._command_routes = command_routes or DEFAULT_COMMAND_ROUTES
+        self._command_routes = command_routes or command_route_map()
+        self._fallback_specialist = str(command_route_record("__orchestra_ambiguity_fallback__")["specialist"])
+        self._governance_required_specialists = governance_required_specialists()
 
     def route(self, command: Command, context: ContextPackage) -> RouteDecision:
-        skill_slug = self._command_routes.get(command.name, DEFAULT_AMBIGUITY_FALLBACK)
-        skill = self._skill_registry.get_skill(skill_slug) or self._skill_registry.get_skill(DEFAULT_AMBIGUITY_FALLBACK)
+        skill_slug = self._command_routes.get(command.name, self._fallback_specialist)
+        skill = self._skill_registry.get_skill(skill_slug) or self._skill_registry.get_skill(self._fallback_specialist)
         if skill is None:
             raise ValueError(f"Unable to resolve skill for command '{command.name}'")
 
-        governance_required = skill.slug in DEFAULT_GOVERNANCE_REQUIRED_SPECIALISTS
+        governance_required = skill.slug in self._governance_required_specialists
         reason = (
             f"{context.adapter_name} command '{command.name}' maps to skill '{skill.slug}' via runtime router"
         )
@@ -386,8 +379,13 @@ class ContextAssembler:
 class GovernanceValidator(IGovernanceValidator):
     def __init__(self, rules: Iterable[GovernanceRule] | None = None):
         self._rules = tuple(rules) if rules is not None else _default_governance_rules()
+        dry_run_required_rules = frozenset(
+            str(record.get("rule_id", "")).strip()
+            for record in runtime_validation_rule_records()
+            if record.get("dry_run_required") is True
+        )
         self._dry_run_required_rules = frozenset(
-            rule.name for rule in self._rules if rule.name in _DEFAULT_DRY_RUN_REQUIRED_RULES
+            rule.name for rule in self._rules if rule.name in dry_run_required_rules
         )
 
     def validate(self, decision: RouteDecision, context: ContextPackage) -> ValidationResult:
@@ -548,6 +546,7 @@ class CoordinationRuntimeService:
 
 
 def _compatibility_bindings() -> tuple[RuntimePolicyBinding, ...]:
+    routes = command_route_map()
     return tuple(sorted((
         RuntimePolicyBinding(
             command_name=command_name,
@@ -557,7 +556,7 @@ def _compatibility_bindings() -> tuple[RuntimePolicyBinding, ...]:
             capability_id=f"runtime.execute.{skill_slug}",
             capability_operation="execute",
         )
-        for command_name, skill_slug in DEFAULT_COMMAND_ROUTES.items()
+        for command_name, skill_slug in routes.items()
     ), key=lambda item: (item.command_name, item.skill_slug)))
 
 
@@ -741,7 +740,7 @@ def build_compatibility_composition(
             ("execute",),
             provenance,
         )
-        for skill_slug in sorted(set(DEFAULT_COMMAND_ROUTES.values()))
+        for skill_slug in sorted({binding.skill_slug for binding in bindings})
     )
     cid = generate_correlation_id()
     manifest = resolver.build_manifest(

--- a/scripts/validation/build_mutation_evidence.py
+++ b/scripts/validation/build_mutation_evidence.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+from collections import Counter
 from datetime import datetime, timezone
 import hashlib
 import json
@@ -11,6 +12,12 @@ from typing import Any
 
 MUTATION_EVIDENCE_SCHEMA_VERSION = "orchestra.mutation-evidence.v1"
 _SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+_RESULT_RE = re.compile(r"^\s*(?P<mutant>\S+):\s*(?P<status>.+?)\s*$")
+_FATAL_RUN_MARKERS = (
+    "failed to collect stats",
+    "failed to collect stats, no active tests found",
+    "stopping early, because we could not find any test case for any mutant",
+)
 
 
 def _sha256(path: Path) -> str:
@@ -42,10 +49,22 @@ def _read_modules(config_path: Path) -> list[str]:
                 break
             modules.append(stripped)
     if not modules:
-        raise ValueError("setup.cfg contains no only_mutate entries")
+        raise ValueError("mutation configuration contains no only_mutate entries")
     if len(modules) != len(set(modules)):
         raise ValueError("mutation scope contains duplicate modules")
     return modules
+
+
+def _read_mutant_statuses(results_output: Path) -> list[str]:
+    statuses: list[str] = []
+    for line in results_output.read_text(encoding="utf-8", errors="replace").splitlines():
+        match = _RESULT_RE.match(line)
+        if match is None:
+            continue
+        statuses.append(match.group("status").strip().casefold())
+    if not statuses:
+        raise ValueError("mutation results contain no mutant classification records")
+    return statuses
 
 
 def build_mutation_evidence(
@@ -71,12 +90,34 @@ def build_mutation_evidence(
     repo = str(repository or "").strip()
     if "/" not in repo:
         raise ValueError("repository must use owner/name form")
+
+    tested = _git_sha(tested_sha, "tested_sha")
+    source_head = _git_sha(source_head_sha, "source_head_sha")
+    if tested != source_head:
+        raise ValueError("tested_sha must exactly match source_head_sha")
+    if int(run_exit_code) != 0:
+        raise ValueError(f"mutation execution failed with exit code {int(run_exit_code)}")
+
+    run_text = run_output.read_text(encoding="utf-8", errors="replace").casefold()
+    fatal_markers = [marker for marker in _FATAL_RUN_MARKERS if marker in run_text]
+    if fatal_markers:
+        raise ValueError(f"mutation execution contains fatal instrumentation marker: {fatal_markers[0]}")
+
+    statuses = _read_mutant_statuses(results_output)
+    status_counts = Counter(statuses)
+    not_checked_count = status_counts.get("not checked", 0)
+    interrupted_count = status_counts.get("check was interrupted by user", 0)
+    if not_checked_count:
+        raise ValueError(f"mutation results contain {not_checked_count} not checked mutants")
+    if interrupted_count:
+        raise ValueError(f"mutation results contain {interrupted_count} interrupted mutants")
+
     return {
         "schema_version": MUTATION_EVIDENCE_SCHEMA_VERSION,
         "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
         "repository": repo,
-        "tested_sha": _git_sha(tested_sha, "tested_sha"),
-        "source_head_sha": _git_sha(source_head_sha, "source_head_sha"),
+        "tested_sha": tested,
+        "source_head_sha": source_head,
         "workflow": {
             "run_id": str(workflow_run_id or "").strip(),
             "run_attempt": str(workflow_run_attempt or "").strip(),
@@ -93,7 +134,14 @@ def build_mutation_evidence(
         "execution": {
             "run_exit_code": int(run_exit_code),
             "score_status": "UNSCORED_BASELINE",
-            "interpretation": "Raw mutation baseline only. Surviving and suspicious mutants require classification before a release score or gate is defined."
+            "classification_status": "COMPLETE",
+            "result_record_count": len(statuses),
+            "not_checked_count": not_checked_count,
+            "status_counts": dict(sorted(status_counts.items())),
+            "interpretation": (
+                "Mutmut completed on the exact source head and every reported mutant record was classified. "
+                "This remains an unscored baseline; surviving or suspicious mutants remain explicit confidence findings."
+            ),
         },
         "reports": {
             "run_output": run_output.name,
@@ -136,7 +184,20 @@ def main(argv: list[str] | None = None) -> int:
     )
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    print(json.dumps({"tested_sha": evidence["tested_sha"], "source_head_sha": evidence["source_head_sha"], "run_exit_code": evidence["execution"]["run_exit_code"], "score_status": evidence["execution"]["score_status"]}, sort_keys=True))
+    print(
+        json.dumps(
+            {
+                "tested_sha": evidence["tested_sha"],
+                "source_head_sha": evidence["source_head_sha"],
+                "run_exit_code": evidence["execution"]["run_exit_code"],
+                "score_status": evidence["execution"]["score_status"],
+                "classification_status": evidence["execution"]["classification_status"],
+                "result_record_count": evidence["execution"]["result_record_count"],
+                "not_checked_count": evidence["execution"]["not_checked_count"],
+            },
+            sort_keys=True,
+        )
+    )
     return 0
 
 

--- a/scripts/validation/build_mutation_evidence.py
+++ b/scripts/validation/build_mutation_evidence.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 from collections import Counter
 from datetime import datetime, timezone
+from fnmatch import fnmatchcase
 import hashlib
 import json
 from pathlib import Path
@@ -13,6 +14,8 @@ from typing import Any
 MUTATION_EVIDENCE_SCHEMA_VERSION = "orchestra.mutation-evidence.v1"
 _SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 _RESULT_RE = re.compile(r"^\s*(?P<mutant>\S+):\s*(?P<status>.+?)\s*$")
+_MUTANT_SUFFIX_RE = re.compile(r"__mutmut_\d+$")
+_PROGRESS_RE = re.compile(r"(?P<done>\d+)\s*/\s*(?P<total>\d+)")
 _FATAL_RUN_MARKERS = (
     "failed to collect stats",
     "failed to collect stats, no active tests found",
@@ -85,16 +88,79 @@ def _read_int_config(config_path: Path, key: str) -> int:
         raise ValueError(f"mutation configuration {key} must be an integer") from exc
 
 
-def _read_mutant_statuses(results_output: Path) -> list[str]:
-    statuses: list[str] = []
+def _normalize_mutant_identifier(identifier: str) -> str:
+    normalized = _MUTANT_SUFFIX_RE.sub("", identifier.strip())
+    if ".xǁ" in normalized:
+        normalized = normalized.replace(".xǁ", ".", 1).replace("ǁ", ".")
+    elif ".x_" in normalized:
+        normalized = normalized.replace(".x_", ".", 1)
+    return normalized
+
+
+def _parse_result_records(results_output: Path) -> list[tuple[str, str]]:
+    records: list[tuple[str, str]] = []
     for line in results_output.read_text(encoding="utf-8", errors="replace").splitlines():
         match = _RESULT_RE.match(line)
         if match is None:
             continue
-        statuses.append(match.group("status").strip().casefold())
-    if not statuses:
-        raise ValueError("mutation results contain no mutant classification records")
-    return statuses
+        records.append(
+            (
+                _normalize_mutant_identifier(match.group("mutant")),
+                match.group("status").strip().casefold(),
+            )
+        )
+    return records
+
+
+def _parse_target_run_spec(raw: str) -> tuple[str, Path]:
+    pattern, separator, path_text = str(raw or "").partition("=")
+    pattern = pattern.strip()
+    path_text = path_text.strip()
+    if not separator or not pattern or not path_text:
+        raise ValueError("target_run must use PATTERN=PATH form")
+    return pattern, Path(path_text)
+
+
+def _read_target_runs(target_run_specs: list[str]) -> list[dict[str, Any]]:
+    if not target_run_specs:
+        raise ValueError("at least one target_run is required")
+    summaries: list[dict[str, Any]] = []
+    seen_patterns: set[str] = set()
+    for raw_spec in target_run_specs:
+        pattern, path = _parse_target_run_spec(raw_spec)
+        if pattern in seen_patterns:
+            raise ValueError(f"duplicate mutation target pattern: {pattern}")
+        seen_patterns.add(pattern)
+        if not path.is_file():
+            raise ValueError(f"target mutation run output does not exist: {path}")
+        text = path.read_text(encoding="utf-8", errors="replace")
+        folded = text.casefold()
+        fatal_markers = [marker for marker in _FATAL_RUN_MARKERS if marker in folded]
+        if fatal_markers:
+            raise ValueError(
+                f"target mutation run {pattern} contains fatal instrumentation marker: {fatal_markers[0]}"
+            )
+        progress = list(_PROGRESS_RE.finditer(text))
+        if not progress:
+            raise ValueError(f"target mutation run {pattern} contains no completion count")
+        done = int(progress[-1].group("done"))
+        total = int(progress[-1].group("total"))
+        if total <= 0:
+            raise ValueError(f"target mutation run {pattern} executed zero mutants")
+        if done != total:
+            raise ValueError(
+                f"target mutation run {pattern} incomplete: completed {done} of {total} mutants"
+            )
+        summaries.append(
+            {
+                "pattern": pattern,
+                "completed": done,
+                "total": total,
+                "output": path.name,
+                "output_sha256": _sha256(path),
+            }
+        )
+    return summaries
 
 
 def build_mutation_evidence(
@@ -102,6 +168,7 @@ def build_mutation_evidence(
     run_output: Path,
     results_output: Path,
     config_path: Path,
+    target_run_specs: list[str],
     run_exit_code: int,
     tool_version: str,
     tested_sha: str,
@@ -133,14 +200,34 @@ def build_mutation_evidence(
     if fatal_markers:
         raise ValueError(f"mutation execution contains fatal instrumentation marker: {fatal_markers[0]}")
 
-    statuses = _read_mutant_statuses(results_output)
-    status_counts = Counter(statuses)
-    not_checked_count = status_counts.get("not checked", 0)
-    interrupted_count = status_counts.get("check was interrupted by user", 0)
+    target_runs = _read_target_runs(target_run_specs)
+    patterns = [item["pattern"] for item in target_runs]
+    all_records = _parse_result_records(results_output)
+    scoped_records = [
+        (identifier, status)
+        for identifier, status in all_records
+        if any(fnmatchcase(identifier, pattern) for pattern in patterns)
+    ]
+    scoped_status_counts = Counter(status for _, status in scoped_records)
+    not_checked_count = scoped_status_counts.get("not checked", 0)
+    interrupted_count = scoped_status_counts.get("check was interrupted by user", 0)
     if not_checked_count:
-        raise ValueError(f"mutation results contain {not_checked_count} not checked mutants")
+        raise ValueError(f"scoped mutation results contain {not_checked_count} not checked mutants")
     if interrupted_count:
-        raise ValueError(f"mutation results contain {interrupted_count} interrupted mutants")
+        raise ValueError(f"scoped mutation results contain {interrupted_count} interrupted mutants")
+
+    unexpected_statuses = sorted(status for status in scoped_status_counts if status != "survived")
+    if unexpected_statuses:
+        raise ValueError(
+            "scoped mutation results contain non-classified outcomes: " + ", ".join(unexpected_statuses)
+        )
+
+    target_total = sum(int(item["total"]) for item in target_runs)
+    survived_count = scoped_status_counts.get("survived", 0)
+    if survived_count > target_total:
+        raise ValueError("scoped survivor count exceeds executed target mutant count")
+    killed_count = target_total - survived_count
+    score_percent = round((killed_count / target_total) * 100.0, 2)
 
     return {
         "schema_version": MUTATION_EVIDENCE_SCHEMA_VERSION,
@@ -157,6 +244,8 @@ def build_mutation_evidence(
         "tool": {"name": "mutmut", "version": version},
         "scope": {
             "modules": _read_modules(config_path),
+            "mutant_patterns": patterns,
+            "target_runs": target_runs,
             "configuration": config_path.name,
             "mutate_only_covered_lines": _read_bool_config(config_path, "mutate_only_covered_lines"),
             "max_stack_depth": _read_int_config(config_path, "max_stack_depth"),
@@ -165,12 +254,19 @@ def build_mutation_evidence(
             "run_exit_code": int(run_exit_code),
             "score_status": "UNSCORED_BASELINE",
             "classification_status": "COMPLETE",
-            "result_record_count": len(statuses),
+            "target_mutant_total": target_total,
+            "target_killed_count": killed_count,
+            "target_survived_count": survived_count,
+            "target_score_percent": score_percent,
+            "scoped_result_record_count": len(scoped_records),
+            "out_of_scope_result_record_count": len(all_records) - len(scoped_records),
             "not_checked_count": not_checked_count,
-            "status_counts": dict(sorted(status_counts.items())),
+            "status_counts": dict(sorted(scoped_status_counts.items())),
             "interpretation": (
-                "Mutmut completed on the exact source head and every reported mutant record was classified. "
-                "This remains an unscored baseline; surviving or suspicious mutants remain explicit confidence findings."
+                "Mutmut completed every declared LEGACY_RETIRED target pattern on the exact source head. "
+                "Scoped non-killed results contain only survived mutants; no scoped not-checked, interrupted, "
+                "timeout, suspicious, or unknown outcome is accepted. The percentage is diagnostic and no "
+                "numeric acceptance threshold is introduced by this bounded evidence."
             ),
         },
         "reports": {
@@ -183,10 +279,17 @@ def build_mutation_evidence(
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Build Orchestra mutation evidence baseline")
+    parser = argparse.ArgumentParser(description="Build Orchestra bounded mutation evidence")
     parser.add_argument("--run-output", type=Path, required=True)
     parser.add_argument("--results-output", type=Path, required=True)
     parser.add_argument("--config", type=Path, default=Path("setup.cfg"))
+    parser.add_argument(
+        "--target-run",
+        action="append",
+        dest="target_run_specs",
+        default=[],
+        help="Required bounded Mutmut target in PATTERN=PATH form; repeat for each target pattern.",
+    )
     parser.add_argument("--run-exit-code", type=int, required=True)
     parser.add_argument("--tool-version", required=True)
     parser.add_argument("--tested-sha", required=True)
@@ -202,6 +305,7 @@ def main(argv: list[str] | None = None) -> int:
         run_output=args.run_output,
         results_output=args.results_output,
         config_path=args.config,
+        target_run_specs=args.target_run_specs,
         run_exit_code=args.run_exit_code,
         tool_version=args.tool_version,
         tested_sha=args.tested_sha,
@@ -222,7 +326,10 @@ def main(argv: list[str] | None = None) -> int:
                 "run_exit_code": evidence["execution"]["run_exit_code"],
                 "score_status": evidence["execution"]["score_status"],
                 "classification_status": evidence["execution"]["classification_status"],
-                "result_record_count": evidence["execution"]["result_record_count"],
+                "target_mutant_total": evidence["execution"]["target_mutant_total"],
+                "target_killed_count": evidence["execution"]["target_killed_count"],
+                "target_survived_count": evidence["execution"]["target_survived_count"],
+                "target_score_percent": evidence["execution"]["target_score_percent"],
                 "not_checked_count": evidence["execution"]["not_checked_count"],
             },
             sort_keys=True,

--- a/scripts/validation/build_mutation_evidence.py
+++ b/scripts/validation/build_mutation_evidence.py
@@ -35,8 +35,12 @@ def _git_sha(value: str, field: str) -> str:
     return cleaned
 
 
+def _config_lines(config_path: Path) -> list[str]:
+    return config_path.read_text(encoding="utf-8").splitlines()
+
+
 def _read_modules(config_path: Path) -> list[str]:
-    lines = config_path.read_text(encoding="utf-8").splitlines()
+    lines = _config_lines(config_path)
     modules: list[str] = []
     collecting = False
     for line in lines:
@@ -53,6 +57,32 @@ def _read_modules(config_path: Path) -> list[str]:
     if len(modules) != len(set(modules)):
         raise ValueError("mutation scope contains duplicate modules")
     return modules
+
+
+def _read_config_value(config_path: Path, key: str) -> str:
+    prefix = f"{key}="
+    for line in _config_lines(config_path):
+        stripped = line.strip()
+        if stripped.startswith(prefix):
+            return stripped[len(prefix) :].strip()
+    raise ValueError(f"mutation configuration is missing {key}")
+
+
+def _read_bool_config(config_path: Path, key: str) -> bool:
+    value = _read_config_value(config_path, key).casefold()
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    raise ValueError(f"mutation configuration {key} must be true or false")
+
+
+def _read_int_config(config_path: Path, key: str) -> int:
+    value = _read_config_value(config_path, key)
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise ValueError(f"mutation configuration {key} must be an integer") from exc
 
 
 def _read_mutant_statuses(results_output: Path) -> list[str]:
@@ -128,8 +158,8 @@ def build_mutation_evidence(
         "scope": {
             "modules": _read_modules(config_path),
             "configuration": config_path.name,
-            "mutate_only_covered_lines": True,
-            "max_stack_depth": 8,
+            "mutate_only_covered_lines": _read_bool_config(config_path, "mutate_only_covered_lines"),
+            "max_stack_depth": _read_int_config(config_path, "max_stack_depth"),
         },
         "execution": {
             "run_exit_code": int(run_exit_code),

--- a/scripts/validation/build_mutation_evidence.py
+++ b/scripts/validation/build_mutation_evidence.py
@@ -11,16 +11,17 @@ import re
 from typing import Any
 
 
-MUTATION_EVIDENCE_SCHEMA_VERSION = "orchestra.mutation-evidence.v1"
+MUTATION_EVIDENCE_SCHEMA_VERSION = "orchestra.mutation-evidence.v2"
 _SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 _RESULT_RE = re.compile(r"^\s*(?P<mutant>\S+):\s*(?P<status>.+?)\s*$")
 _MUTANT_SUFFIX_RE = re.compile(r"__mutmut_\d+$")
-_PROGRESS_RE = re.compile(r"(?P<done>\d+)\s*/\s*(?P<total>\d+)")
+_TARGET_OUTCOME_RE = re.compile(r"^\s*(?P<icon>🎉|🙁|🫥|⏰|🤔|🔇|🧙)\s+(?P<mutant>\S+)\s*$")
 _FATAL_RUN_MARKERS = (
     "failed to collect stats",
     "failed to collect stats, no active tests found",
     "stopping early, because we could not find any test case for any mutant",
 )
+_ALLOWED_RESULT_STATUSES = frozenset({"survived", "killed"})
 
 
 def _sha256(path: Path) -> str:
@@ -97,67 +98,125 @@ def _normalize_mutant_identifier(identifier: str) -> str:
     return normalized
 
 
-def _parse_result_records(results_output: Path) -> list[tuple[str, str]]:
-    records: list[tuple[str, str]] = []
-    for line in results_output.read_text(encoding="utf-8", errors="replace").splitlines():
-        match = _RESULT_RE.match(line)
-        if match is None:
-            continue
-        records.append(
-            (
-                _normalize_mutant_identifier(match.group("mutant")),
-                match.group("status").strip().casefold(),
-            )
-        )
-    return records
-
-
-def _parse_target_run_spec(raw: str) -> tuple[str, Path]:
+def _parse_path_spec(raw: str, field: str) -> tuple[str, Path]:
     pattern, separator, path_text = str(raw or "").partition("=")
     pattern = pattern.strip()
     path_text = path_text.strip()
     if not separator or not pattern or not path_text:
-        raise ValueError("target_run must use PATTERN=PATH form")
+        raise ValueError(f"{field} must use PATTERN=PATH form")
     return pattern, Path(path_text)
 
 
-def _read_target_runs(target_run_specs: list[str]) -> list[dict[str, Any]]:
-    if not target_run_specs:
-        raise ValueError("at least one target_run is required")
-    summaries: list[dict[str, Any]] = []
-    seen_patterns: set[str] = set()
-    for raw_spec in target_run_specs:
-        pattern, path = _parse_target_run_spec(raw_spec)
-        if pattern in seen_patterns:
-            raise ValueError(f"duplicate mutation target pattern: {pattern}")
-        seen_patterns.add(pattern)
+def _spec_map(specs: list[str], field: str) -> dict[str, Path]:
+    if not specs:
+        raise ValueError(f"at least one {field} is required")
+    mapped: dict[str, Path] = {}
+    for raw in specs:
+        pattern, path = _parse_path_spec(raw, field)
+        if pattern in mapped:
+            raise ValueError(f"duplicate mutation target pattern in {field}: {pattern}")
         if not path.is_file():
-            raise ValueError(f"target mutation run output does not exist: {path}")
-        text = path.read_text(encoding="utf-8", errors="replace")
-        folded = text.casefold()
-        fatal_markers = [marker for marker in _FATAL_RUN_MARKERS if marker in folded]
-        if fatal_markers:
+            raise ValueError(f"{field} file does not exist: {path}")
+        mapped[pattern] = path
+    return mapped
+
+
+def _target_run_outcomes(path: Path, pattern: str) -> dict[str, str]:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    folded = text.casefold()
+    fatal_markers = [marker for marker in _FATAL_RUN_MARKERS if marker in folded]
+    if fatal_markers:
+        raise ValueError(f"target mutation run {pattern} contains fatal instrumentation marker: {fatal_markers[0]}")
+
+    outcomes: dict[str, str] = {}
+    for line in text.splitlines():
+        match = _TARGET_OUTCOME_RE.match(line)
+        if match is None:
+            continue
+        mutant = match.group("mutant").strip()
+        normalized = _normalize_mutant_identifier(mutant)
+        if not fnmatchcase(normalized, pattern):
+            continue
+        icon = match.group("icon")
+        outcome = "killed" if icon == "🎉" else "survived" if icon == "🙁" else f"non_classified:{icon}"
+        previous = outcomes.get(mutant)
+        if previous is not None and previous != outcome:
+            raise ValueError(f"target mutation run {pattern} reports conflicting outcomes for {mutant}")
+        outcomes[mutant] = outcome
+
+    if not outcomes:
+        raise ValueError(f"target mutation run {pattern} contains no classified target mutants")
+    non_classified = sorted({outcome for outcome in outcomes.values() if outcome.startswith("non_classified:")})
+    if non_classified:
+        raise ValueError(
+            f"target mutation run {pattern} contains non-classified outcomes: " + ", ".join(non_classified)
+        )
+    return outcomes
+
+
+def _target_result_records(path: Path, pattern: str) -> dict[str, str]:
+    records: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        match = _RESULT_RE.match(line)
+        if match is None:
+            continue
+        mutant = match.group("mutant").strip()
+        if not fnmatchcase(_normalize_mutant_identifier(mutant), pattern):
+            continue
+        status = match.group("status").strip().casefold()
+        previous = records.get(mutant)
+        if previous is not None and previous != status:
+            raise ValueError(f"target mutation results {pattern} contain conflicting status for {mutant}")
+        records[mutant] = status
+    return records
+
+
+def _build_target_summaries(target_run_specs: list[str], target_result_specs: list[str]) -> list[dict[str, Any]]:
+    run_paths = _spec_map(target_run_specs, "target_run")
+    result_paths = _spec_map(target_result_specs, "target_result")
+    if run_paths.keys() != result_paths.keys():
+        missing_results = sorted(run_paths.keys() - result_paths.keys())
+        missing_runs = sorted(result_paths.keys() - run_paths.keys())
+        raise ValueError(
+            f"target run/result patterns differ; missing_results={missing_results}, missing_runs={missing_runs}"
+        )
+
+    summaries: list[dict[str, Any]] = []
+    for pattern, run_path in run_paths.items():
+        result_path = result_paths[pattern]
+        outcomes = _target_run_outcomes(run_path, pattern)
+        result_records = _target_result_records(result_path, pattern)
+        result_status_counts = Counter(result_records.values())
+        invalid_statuses = sorted(status for status in result_status_counts if status not in _ALLOWED_RESULT_STATUSES)
+        if invalid_statuses:
             raise ValueError(
-                f"target mutation run {pattern} contains fatal instrumentation marker: {fatal_markers[0]}"
+                f"target mutation results {pattern} contain non-classified statuses: " + ", ".join(invalid_statuses)
             )
-        progress = list(_PROGRESS_RE.finditer(text))
-        if not progress:
-            raise ValueError(f"target mutation run {pattern} contains no completion count")
-        done = int(progress[-1].group("done"))
-        total = int(progress[-1].group("total"))
-        if total <= 0:
-            raise ValueError(f"target mutation run {pattern} executed zero mutants")
-        if done != total:
-            raise ValueError(
-                f"target mutation run {pattern} incomplete: completed {done} of {total} mutants"
-            )
+
+        survived_ids = {mutant for mutant, outcome in outcomes.items() if outcome == "survived"}
+        killed_ids = {mutant for mutant, outcome in outcomes.items() if outcome == "killed"}
+        result_survived_ids = {mutant for mutant, status in result_records.items() if status == "survived"}
+        result_killed_ids = {mutant for mutant, status in result_records.items() if status == "killed"}
+        if result_survived_ids != survived_ids:
+            raise ValueError(f"target mutation results {pattern} do not reconcile with run-output survivors")
+        if not result_killed_ids.issubset(killed_ids):
+            raise ValueError(f"target mutation results {pattern} contain killed records absent from run output")
+
+        total = len(outcomes)
+        killed = len(killed_ids)
+        survived = len(survived_ids)
         summaries.append(
             {
                 "pattern": pattern,
-                "completed": done,
                 "total": total,
-                "output": path.name,
-                "output_sha256": _sha256(path),
+                "killed": killed,
+                "survived": survived,
+                "score_percent": round((killed / total) * 100.0, 2),
+                "run_output": run_path.name,
+                "run_output_sha256": _sha256(run_path),
+                "results_output": result_path.name,
+                "results_output_sha256": _sha256(result_path),
+                "result_status_counts": dict(sorted(result_status_counts.items())),
             }
         )
     return summaries
@@ -169,6 +228,7 @@ def build_mutation_evidence(
     results_output: Path,
     config_path: Path,
     target_run_specs: list[str],
+    target_result_specs: list[str],
     run_exit_code: int,
     tool_version: str,
     tested_sha: str,
@@ -179,8 +239,9 @@ def build_mutation_evidence(
     event_name: str,
     ref_name: str,
 ) -> dict[str, Any]:
-    if not run_output.is_file() or not results_output.is_file():
-        raise ValueError("mutation raw output files must exist")
+    for path in (run_output, results_output, config_path):
+        if not path.is_file():
+            raise ValueError(f"required mutation evidence file missing: {path}")
     version = str(tool_version or "").strip()
     if not version:
         raise ValueError("tool_version must be non-empty")
@@ -200,33 +261,12 @@ def build_mutation_evidence(
     if fatal_markers:
         raise ValueError(f"mutation execution contains fatal instrumentation marker: {fatal_markers[0]}")
 
-    target_runs = _read_target_runs(target_run_specs)
-    patterns = [item["pattern"] for item in target_runs]
-    all_records = _parse_result_records(results_output)
-    scoped_records = [
-        (identifier, status)
-        for identifier, status in all_records
-        if any(fnmatchcase(identifier, pattern) for pattern in patterns)
-    ]
-    scoped_status_counts = Counter(status for _, status in scoped_records)
-    not_checked_count = scoped_status_counts.get("not checked", 0)
-    interrupted_count = scoped_status_counts.get("check was interrupted by user", 0)
-    if not_checked_count:
-        raise ValueError(f"scoped mutation results contain {not_checked_count} not checked mutants")
-    if interrupted_count:
-        raise ValueError(f"scoped mutation results contain {interrupted_count} interrupted mutants")
-
-    unexpected_statuses = sorted(status for status in scoped_status_counts if status != "survived")
-    if unexpected_statuses:
-        raise ValueError(
-            "scoped mutation results contain non-classified outcomes: " + ", ".join(unexpected_statuses)
-        )
-
+    target_runs = _build_target_summaries(target_run_specs, target_result_specs)
     target_total = sum(int(item["total"]) for item in target_runs)
-    survived_count = scoped_status_counts.get("survived", 0)
-    if survived_count > target_total:
-        raise ValueError("scoped survivor count exceeds executed target mutant count")
-    killed_count = target_total - survived_count
+    killed_count = sum(int(item["killed"]) for item in target_runs)
+    survived_count = sum(int(item["survived"]) for item in target_runs)
+    if target_total <= 0 or target_total != killed_count + survived_count:
+        raise ValueError("target mutation counts are empty or do not reconcile")
     score_percent = round((killed_count / target_total) * 100.0, 2)
 
     return {
@@ -244,7 +284,7 @@ def build_mutation_evidence(
         "tool": {"name": "mutmut", "version": version},
         "scope": {
             "modules": _read_modules(config_path),
-            "mutant_patterns": patterns,
+            "mutant_patterns": [item["pattern"] for item in target_runs],
             "target_runs": target_runs,
             "configuration": config_path.name,
             "mutate_only_covered_lines": _read_bool_config(config_path, "mutate_only_covered_lines"),
@@ -252,21 +292,18 @@ def build_mutation_evidence(
         },
         "execution": {
             "run_exit_code": int(run_exit_code),
-            "score_status": "UNSCORED_BASELINE",
+            "score_status": "VALID_CLASSIFIED_SCORE",
             "classification_status": "COMPLETE",
             "target_mutant_total": target_total,
             "target_killed_count": killed_count,
             "target_survived_count": survived_count,
             "target_score_percent": score_percent,
-            "scoped_result_record_count": len(scoped_records),
-            "out_of_scope_result_record_count": len(all_records) - len(scoped_records),
-            "not_checked_count": not_checked_count,
-            "status_counts": dict(sorted(scoped_status_counts.items())),
+            "not_checked_count": 0,
             "interpretation": (
-                "Mutmut completed every declared LEGACY_RETIRED target pattern on the exact source head. "
-                "Scoped non-killed results contain only survived mutants; no scoped not-checked, interrupted, "
-                "timeout, suspicious, or unknown outcome is accepted. The percentage is diagnostic and no "
-                "numeric acceptance threshold is introduced by this bounded evidence."
+                "Every declared LEGACY_RETIRED target completed on the exact source head. Mutmut run output and "
+                "the immediately captured per-target results reconcile for all survivors, with no target-level "
+                "not-checked, interrupted, timeout, suspicious, skipped, or unknown outcome accepted. The score "
+                "is a classified confidence measure; no new numeric acceptance threshold is introduced."
             ),
         },
         "reports": {
@@ -283,13 +320,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--run-output", type=Path, required=True)
     parser.add_argument("--results-output", type=Path, required=True)
     parser.add_argument("--config", type=Path, default=Path("setup.cfg"))
-    parser.add_argument(
-        "--target-run",
-        action="append",
-        dest="target_run_specs",
-        default=[],
-        help="Required bounded Mutmut target in PATTERN=PATH form; repeat for each target pattern.",
-    )
+    parser.add_argument("--target-run", action="append", dest="target_run_specs", default=[])
+    parser.add_argument("--target-result", action="append", dest="target_result_specs", default=[])
     parser.add_argument("--run-exit-code", type=int, required=True)
     parser.add_argument("--tool-version", required=True)
     parser.add_argument("--tested-sha", required=True)
@@ -306,6 +338,7 @@ def main(argv: list[str] | None = None) -> int:
         results_output=args.results_output,
         config_path=args.config,
         target_run_specs=args.target_run_specs,
+        target_result_specs=args.target_result_specs,
         run_exit_code=args.run_exit_code,
         tool_version=args.tool_version,
         tested_sha=args.tested_sha,
@@ -323,7 +356,6 @@ def main(argv: list[str] | None = None) -> int:
             {
                 "tested_sha": evidence["tested_sha"],
                 "source_head_sha": evidence["source_head_sha"],
-                "run_exit_code": evidence["execution"]["run_exit_code"],
                 "score_status": evidence["execution"]["score_status"],
                 "classification_status": evidence["execution"]["classification_status"],
                 "target_mutant_total": evidence["execution"]["target_mutant_total"],

--- a/tests/runtime/test_canonical_promotion_authority.py
+++ b/tests/runtime/test_canonical_promotion_authority.py
@@ -6,14 +6,11 @@ from pathlib import Path
 import pytest
 
 from orchestra_runtime import machine_contracts as contracts
-from orchestra_runtime.models import (
-    ContextPackage,
-    RouteDecision,
-    VALID_SPECIALISTS,
-)
-from orchestra_runtime import services
+from orchestra_runtime import models, services
 from orchestra_runtime.errors import RuntimeInitializationError
-from orchestra_runtime.services import GovernanceValidator
+from orchestra_runtime.models import ContextPackage, RouteDecision, VALID_SPECIALISTS
+from orchestra_runtime.repositories import ManifestRepository, SkillSourceRepository
+from orchestra_runtime.services import GovernanceValidator, RouterService, SkillRegistry
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -39,28 +36,42 @@ def _decision(command: str, specialist: str) -> RouteDecision:
     )
 
 
-def test_compatibility_specialist_identity_is_derived_from_machine_registry():
+def test_legacy_specialist_identity_import_is_a_derived_compatibility_view():
     assert VALID_SPECIALISTS == contracts.valid_specialist_ids(ROOT)
-    source = inspect.getsource(__import__("orchestra_runtime.models", fromlist=["VALID_SPECIALISTS"]))
-    assert "VALID_SPECIALISTS = frozenset({" not in source
-    assert "VALID_SPECIALISTS = valid_specialist_ids()" in source
+    source = inspect.getsource(models)
+    assert "VALID_SPECIALISTS =" not in source
+    assert 'if name == "VALID_SPECIALISTS"' in source
+    assert "return valid_specialist_ids()" in source
 
 
-def test_compatibility_command_routes_are_derived_from_machine_routing_contract():
-    assert services.DEFAULT_COMMAND_ROUTES == contracts.command_route_map(ROOT)
-    assert services.DEFAULT_AMBIGUITY_FALLBACK == contracts.command_route_record(
-        "__canonical-promotion-unknown__", ROOT
-    )["specialist"]
-    source = inspect.getsource(services)
-    assert "DEFAULT_COMMAND_ROUTES = {" not in source
-    assert "DEFAULT_COMMAND_ROUTES = command_route_map()" in source
+def test_legacy_service_authority_snapshots_are_absent():
+    for name in (
+        "DEFAULT_COMMAND_ROUTES",
+        "DEFAULT_AMBIGUITY_FALLBACK",
+        "DEFAULT_GOVERNANCE_REQUIRED_SPECIALISTS",
+        "_DEFAULT_RUNTIME_VALIDATION_RULE_RECORDS",
+        "_DEFAULT_DRY_RUN_REQUIRED_RULES",
+    ):
+        assert not hasattr(services, name)
 
 
-def test_router_governance_required_specialists_are_machine_derived():
-    assert services.DEFAULT_GOVERNANCE_REQUIRED_SPECIALISTS == contracts.governance_required_specialists(ROOT)
+def test_skill_registry_and_router_read_machine_routing_contract_directly():
+    expected_routes = contracts.command_route_map(ROOT)
+    expected_fallback = contracts.command_route_record("__legacy-retired-unknown__", ROOT)["specialist"]
+    expected_governance = contracts.governance_required_specialists(ROOT)
+
+    registry = SkillRegistry(ManifestRepository(ROOT), SkillSourceRepository(ROOT))
+    router = RouterService(registry)
+
+    assert registry._command_routes == expected_routes
+    assert router._command_routes == expected_routes
+    assert router._fallback_specialist == expected_fallback
+    assert router._governance_required_specialists == expected_governance
+
     source = inspect.getsource(services.RouterService)
-    assert "{\"dagger\", \"cipher\", \"the-steward\", \"the-governor\"}" not in source
-    assert "DEFAULT_GOVERNANCE_REQUIRED_SPECIALISTS" in source
+    assert "command_route_map()" in source
+    assert "command_route_record(" in source
+    assert "governance_required_specialists()" in source
 
 
 def test_default_governance_validator_rules_match_machine_policy():
@@ -88,7 +99,7 @@ def test_default_governance_validator_rules_match_machine_policy():
     assert actual == expected
 
 
-def test_default_governance_rules_fail_closed_on_duplicate_rule_identity(monkeypatch):
+def test_default_governance_rules_fail_closed_on_duplicate_rule_identity():
     records = (
         {
             "rule_id": "duplicate-rule",
@@ -105,17 +116,14 @@ def test_default_governance_rules_fail_closed_on_duplicate_rule_identity(monkeyp
             "dry_run_required": False,
         },
     )
-    monkeypatch.setattr(services, "_DEFAULT_RUNTIME_VALIDATION_RULE_RECORDS", records)
 
     with pytest.raises(RuntimeInitializationError, match="machine governance validation rule is invalid"):
-        services._default_governance_rules()
+        services._default_governance_rules(records)
 
 
-def test_default_governance_rules_fail_closed_when_machine_policy_has_no_runtime_rules(monkeypatch):
-    monkeypatch.setattr(services, "_DEFAULT_RUNTIME_VALIDATION_RULE_RECORDS", ())
-
+def test_default_governance_rules_fail_closed_when_machine_policy_has_no_runtime_rules():
     with pytest.raises(RuntimeInitializationError, match="machine governance policy contains no runtime validation rules"):
-        services._default_governance_rules()
+        services._default_governance_rules(())
 
 
 def test_machine_dry_run_requirement_is_enforced_without_rule_name_special_case():
@@ -152,7 +160,9 @@ def test_machine_policy_does_not_require_dry_run_for_high_risk_security_rule():
     assert result.status == "APPROVED"
 
 
-def test_runtime_services_assert_complete_machine_contracts_before_deriving_defaults():
+def test_runtime_services_fail_closed_before_consuming_machine_contracts():
     source = inspect.getsource(services)
     assert "assert_machine_contracts()" in source
-    assert source.index("assert_machine_contracts()") < source.index("DEFAULT_COMMAND_ROUTES = command_route_map()")
+    assert source.index("assert_machine_contracts()") < source.index("class SkillRegistry")
+    assert source.index("assert_machine_contracts()") < source.index("class RouterService")
+    assert source.index("assert_machine_contracts()") < source.index("class GovernanceValidator")

--- a/tests/runtime/test_canonical_promotion_authority.py
+++ b/tests/runtime/test_canonical_promotion_authority.py
@@ -160,9 +160,30 @@ def test_machine_policy_does_not_require_dry_run_for_high_risk_security_rule():
     assert result.status == "APPROVED"
 
 
-def test_runtime_services_fail_closed_before_consuming_machine_contracts():
+def test_runtime_machine_guard_is_deferred_from_module_import():
     source = inspect.getsource(services)
-    assert "assert_machine_contracts()" in source
-    assert source.index("assert_machine_contracts()") < source.index("class SkillRegistry")
-    assert source.index("assert_machine_contracts()") < source.index("class RouterService")
-    assert source.index("assert_machine_contracts()") < source.index("class GovernanceValidator")
+    preamble = source[: source.index("def _stable_id")]
+    assert "\nassert_machine_contracts()\n" not in preamble
+    assert "def _assert_runtime_machine_contracts()" in preamble
+    assert "    assert_machine_contracts()" in preamble
+
+
+def test_runtime_consumers_guard_machine_contracts_before_defaults():
+    registry_source = inspect.getsource(services.SkillRegistry.__init__)
+    router_source = inspect.getsource(services.RouterService.__init__)
+    governance_source = inspect.getsource(services.GovernanceValidator.__init__)
+    compatibility_source = inspect.getsource(services._compatibility_bindings)
+
+    assert registry_source.index("_assert_runtime_machine_contracts()") < registry_source.index("command_route_map()")
+    assert router_source.index("_assert_runtime_machine_contracts()") < router_source.index("command_route_map()")
+    assert governance_source.index("_assert_runtime_machine_contracts()") < governance_source.index("_default_governance_rules()")
+    assert compatibility_source.index("_assert_runtime_machine_contracts()") < compatibility_source.index("command_route_map()")
+
+
+def test_runtime_machine_guard_fails_closed_at_construction_boundary(monkeypatch):
+    def reject_drift() -> None:
+        raise ValueError("synthetic machine-contract drift")
+
+    monkeypatch.setattr(services, "assert_machine_contracts", reject_drift)
+    with pytest.raises(ValueError, match="synthetic machine-contract drift"):
+        GovernanceValidator()

--- a/tests/runtime/test_control_plane_migration_state.py
+++ b/tests/runtime/test_control_plane_migration_state.py
@@ -16,7 +16,7 @@ def _load(path: Path) -> dict:
     return value
 
 
-def test_canonical_promotion_authority_checkpoint_is_adjacent_and_bounded():
+def test_legacy_retired_checkpoint_is_adjacent_and_bounded():
     state = _load(STATE_PATH)
     assert state["schema_version"] == "orchestra.control-plane-migration.v1"
     assert state["stage_order"] == [
@@ -26,8 +26,8 @@ def test_canonical_promotion_authority_checkpoint_is_adjacent_and_bounded():
         "CANONICAL_PROMOTION_AUTHORITY",
         "LEGACY_RETIRED",
     ]
-    assert state["previous_stage"] == "VALIDATION_AUTHORITY"
-    assert state["current_stage"] == "CANONICAL_PROMOTION_AUTHORITY"
+    assert state["previous_stage"] == "CANONICAL_PROMOTION_AUTHORITY"
+    assert state["current_stage"] == "LEGACY_RETIRED"
     previous_index = state["stage_order"].index(state["previous_stage"])
     current_index = state["stage_order"].index(state["current_stage"])
     assert current_index == previous_index + 1
@@ -41,19 +41,19 @@ def test_canonical_promotion_authority_checkpoint_is_adjacent_and_bounded():
         "machine_contracts_may_inform_runtime_decisions": True,
         "machine_contracts_are_validation_authority": True,
         "machine_contracts_are_canonical_promotion_authority": True,
-        "legacy_runtime_authorities_retired": False,
+        "legacy_runtime_authorities_retired": True,
         "installed_integrations_mutated": False,
     }
 
 
-def test_canonical_promotion_transition_preserves_prior_evidence_chain():
+def test_legacy_retirement_preserves_prior_evidence_chain():
     state = _load(STATE_PATH)
     evidence = _load(EVIDENCE_PATH)
     transition = state["transition_evidence"]
     assert transition["integration_pull_request"] == evidence["canonical"]["pull_request"] == 294
     assert transition["integration_canonical_sha"] == evidence["canonical"]["merge_commit_sha"]
     assert transition["post_merge_closeout_sha"] == "452572f16f232147d05fe0202cbaea8e82b88e56"
-    assert transition["previous_stage_canonical_sha"] == "14eab40029e3409dcfe813b398fe8fc3e5295db9"
+    assert transition["previous_stage_canonical_sha"] == "529639beefd8fa0cc153b6e94649b487de4f7bc2"
     assert transition["validated_source_head_sha"] == evidence["canonical"]["source_head_sha"]
     assert transition["runtime_evidence_index"] == "machine/release-evidence/control-plane-refoundation-p0-p1-p9.json"
     assert evidence["runtime_evidence"]["result"] == "PASS"

--- a/tests/runtime/test_machine_contracts.py
+++ b/tests/runtime/test_machine_contracts.py
@@ -22,7 +22,7 @@ def test_checked_registry_is_exact_frontmatter_compilation():
     assert contracts.load_specialist_registry(ROOT) == contracts.compile_specialist_registry(ROOT)
 
 
-def test_specialist_identity_set_matches_existing_runtime_constant_during_migration():
+def test_legacy_specialist_identity_import_remains_machine_derived_compatibility():
     assert contracts.valid_specialist_ids(ROOT) == VALID_SPECIALISTS
 
 

--- a/tests/runtime/test_mutation_evidence.py
+++ b/tests/runtime/test_mutation_evidence.py
@@ -8,6 +8,8 @@ from scripts.validation import build_mutation_evidence as mutation_evidence
 SHA = "a" * 40
 OTHER_SHA = "b" * 40
 PATTERN = "orchestra_runtime.services.RouterService.route*"
+SURVIVOR = "orchestra_runtime.services.xǁRouterServiceǁroute__mutmut_3"
+KILLED = "orchestra_runtime.services.xǁRouterServiceǁroute__mutmut_4"
 
 
 def _config(tmp_path: Path) -> Path:
@@ -27,38 +29,42 @@ def _config(tmp_path: Path) -> Path:
 def _raw_outputs(
     tmp_path: Path,
     *,
-    results: str,
-    target_progress: str = "13/13",
-) -> tuple[Path, Path, Path]:
+    target_output: str | None = None,
+    target_results: str | None = None,
+) -> tuple[Path, Path, Path, Path]:
     run_output = tmp_path / "run.txt"
-    target_output = tmp_path / "target-run.txt"
     results_output = tmp_path / "results.txt"
-    target_text = f"Generating mutants\nRunning stats done\n{target_progress}  🎉 10  🙁 3\n"
-    run_output.write_text(target_text, encoding="utf-8")
-    target_output.write_text(target_text, encoding="utf-8")
-    results_output.write_text(results, encoding="utf-8")
-    return run_output, results_output, target_output
+    target_run = tmp_path / "target-run.txt"
+    target_result = tmp_path / "target-results.txt"
+    target_output = target_output or f"Mutant results\n🎉 {KILLED}\n🙁 {SURVIVOR}\n"
+    target_results = target_results if target_results is not None else f"    {SURVIVOR}: survived\n"
+    run_output.write_text(target_output, encoding="utf-8")
+    results_output.write_text(target_results, encoding="utf-8")
+    target_run.write_text(target_output, encoding="utf-8")
+    target_result.write_text(target_results, encoding="utf-8")
+    return run_output, results_output, target_run, target_result
 
 
 def _build(
     tmp_path: Path,
     *,
-    results: str,
+    target_output: str | None = None,
+    target_results: str | None = None,
     run_exit_code: int = 0,
     tested_sha: str = SHA,
     source_head_sha: str = SHA,
-    target_progress: str = "13/13",
 ):
-    run_output, results_output, target_output = _raw_outputs(
+    run_output, results_output, target_run, target_result = _raw_outputs(
         tmp_path,
-        results=results,
-        target_progress=target_progress,
+        target_output=target_output,
+        target_results=target_results,
     )
     return mutation_evidence.build_mutation_evidence(
         run_output=run_output,
         results_output=results_output,
         config_path=_config(tmp_path),
-        target_run_specs=[f"{PATTERN}={target_output}"],
+        target_run_specs=[f"{PATTERN}={target_run}"],
+        target_result_specs=[f"{PATTERN}={target_result}"],
         run_exit_code=run_exit_code,
         tool_version="3.6.0",
         tested_sha=tested_sha,
@@ -71,31 +77,23 @@ def _build(
     )
 
 
-def test_classified_exact_head_target_builds_bounded_evidence(tmp_path: Path):
-    evidence = _build(
-        tmp_path,
-        results=(
-            "    orchestra_runtime.services.xǁRouterServiceǁroute__mutmut_3: survived\n"
-            "    orchestra_runtime.services.xǁRouterServiceǁroute__mutmut_5: survived\n"
-            "    orchestra_runtime.services.xǁRouterServiceǁroute__mutmut_9: survived\n"
-            "    orchestra_runtime.services.xǁRuntimeExecutorǁ_execute__mutmut_1: not checked\n"
-        ),
-    )
+def test_classified_exact_head_target_builds_valid_score(tmp_path: Path):
+    evidence = _build(tmp_path)
 
+    assert evidence["schema_version"] == "orchestra.mutation-evidence.v2"
     assert evidence["tested_sha"] == SHA
     assert evidence["source_head_sha"] == SHA
     assert evidence["scope"]["modules"] == ["orchestra_runtime/services.py"]
     assert evidence["scope"]["mutant_patterns"] == [PATTERN]
     assert evidence["scope"]["mutate_only_covered_lines"] is True
     assert evidence["scope"]["max_stack_depth"] == -1
+    assert evidence["execution"]["score_status"] == "VALID_CLASSIFIED_SCORE"
     assert evidence["execution"]["classification_status"] == "COMPLETE"
-    assert evidence["execution"]["target_mutant_total"] == 13
-    assert evidence["execution"]["target_killed_count"] == 10
-    assert evidence["execution"]["target_survived_count"] == 3
-    assert evidence["execution"]["target_score_percent"] == 76.92
+    assert evidence["execution"]["target_mutant_total"] == 2
+    assert evidence["execution"]["target_killed_count"] == 1
+    assert evidence["execution"]["target_survived_count"] == 1
+    assert evidence["execution"]["target_score_percent"] == 50.0
     assert evidence["execution"]["not_checked_count"] == 0
-    assert evidence["execution"]["out_of_scope_result_record_count"] == 1
-    assert evidence["execution"]["status_counts"] == {"survived": 3}
 
 
 def test_top_level_and_class_mutant_identifiers_normalize_to_public_patterns():
@@ -121,57 +119,56 @@ def test_top_level_and_class_mutant_identifiers_normalize_to_public_patterns():
 
 def test_nonzero_mutmut_run_is_rejected(tmp_path: Path):
     with pytest.raises(ValueError, match="mutation execution failed with exit code 1"):
-        _build(tmp_path, results="", run_exit_code=1)
+        _build(tmp_path, run_exit_code=1)
 
 
-def test_scoped_not_checked_mutants_are_rejected(tmp_path: Path):
-    with pytest.raises(ValueError, match="scoped mutation results contain 1 not checked mutants"):
-        _build(
-            tmp_path,
-            results="    orchestra_runtime.services.xǁRouterServiceǁroute__mutmut_3: not checked\n",
-        )
+def test_target_not_checked_result_is_rejected(tmp_path: Path):
+    with pytest.raises(ValueError, match="non-classified statuses: not checked"):
+        _build(tmp_path, target_results=f"    {SURVIVOR}: not checked\n")
 
 
-def test_scoped_suspicious_outcome_is_rejected(tmp_path: Path):
-    with pytest.raises(ValueError, match="non-classified outcomes: suspicious"):
-        _build(
-            tmp_path,
-            results="    orchestra_runtime.services.xǁRouterServiceǁroute__mutmut_3: suspicious\n",
-        )
+def test_target_timeout_outcome_is_rejected(tmp_path: Path):
+    with pytest.raises(ValueError, match="non-classified outcomes"):
+        _build(tmp_path, target_output=f"Mutant results\n⏰ {SURVIVOR}\n")
 
 
 def test_all_killed_target_is_valid_with_empty_results(tmp_path: Path):
-    evidence = _build(tmp_path, results="")
-    assert evidence["execution"]["target_mutant_total"] == 13
-    assert evidence["execution"]["target_killed_count"] == 13
+    evidence = _build(
+        tmp_path,
+        target_output=f"Mutant results\n🎉 {KILLED}\n",
+        target_results="",
+    )
+    assert evidence["execution"]["target_mutant_total"] == 1
+    assert evidence["execution"]["target_killed_count"] == 1
     assert evidence["execution"]["target_survived_count"] == 0
     assert evidence["execution"]["target_score_percent"] == 100.0
 
 
-def test_incomplete_target_run_is_rejected(tmp_path: Path):
-    with pytest.raises(ValueError, match="incomplete: completed 12 of 13 mutants"):
-        _build(tmp_path, results="", target_progress="12/13")
+def test_target_run_without_classified_mutants_is_rejected(tmp_path: Path):
+    with pytest.raises(ValueError, match="contains no classified target mutants"):
+        _build(tmp_path, target_output="Running mutation testing\n", target_results="")
 
 
-def test_zero_mutant_target_run_is_rejected(tmp_path: Path):
-    with pytest.raises(ValueError, match="executed zero mutants"):
-        _build(tmp_path, results="", target_progress="0/0")
+def test_survivor_results_must_reconcile_with_run_output(tmp_path: Path):
+    with pytest.raises(ValueError, match="do not reconcile with run-output survivors"):
+        _build(tmp_path, target_results="")
 
 
 def test_synthetic_merge_sha_cannot_substitute_for_source_head(tmp_path: Path):
     with pytest.raises(ValueError, match="tested_sha must exactly match source_head_sha"):
-        _build(tmp_path, results="", tested_sha=OTHER_SHA)
+        _build(tmp_path, tested_sha=OTHER_SHA)
 
 
 def test_fatal_stats_collection_marker_is_rejected(tmp_path: Path):
-    run_output, results_output, target_output = _raw_outputs(tmp_path, results="")
+    run_output, results_output, target_run, target_result = _raw_outputs(tmp_path)
     run_output.write_text("failed to collect stats. runner returned 1\n", encoding="utf-8")
     with pytest.raises(ValueError, match="fatal instrumentation marker"):
         mutation_evidence.build_mutation_evidence(
             run_output=run_output,
             results_output=results_output,
             config_path=_config(tmp_path),
-            target_run_specs=[f"{PATTERN}={target_output}"],
+            target_run_specs=[f"{PATTERN}={target_run}"],
+            target_result_specs=[f"{PATTERN}={target_result}"],
             run_exit_code=0,
             tool_version="3.6.0",
             tested_sha=SHA,

--- a/tests/runtime/test_mutation_evidence.py
+++ b/tests/runtime/test_mutation_evidence.py
@@ -1,0 +1,114 @@
+from pathlib import Path
+
+import pytest
+
+from scripts.validation import build_mutation_evidence as mutation_evidence
+
+
+SHA = "a" * 40
+OTHER_SHA = "b" * 40
+
+
+def _config(tmp_path: Path) -> Path:
+    path = tmp_path / "isolated.cfg"
+    path.write_text(
+        "[mutmut]\n"
+        "source_paths=orchestra_runtime/\n"
+        "only_mutate=\n"
+        "    orchestra_runtime/services.py\n"
+        "mutate_only_covered_lines=true\n"
+        "max_stack_depth=8\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _raw_outputs(tmp_path: Path, *, results: str) -> tuple[Path, Path]:
+    run_output = tmp_path / "run.txt"
+    results_output = tmp_path / "results.txt"
+    run_output.write_text("Generating mutants\nRunning stats done\n", encoding="utf-8")
+    results_output.write_text(results, encoding="utf-8")
+    return run_output, results_output
+
+
+def _build(
+    tmp_path: Path,
+    *,
+    results: str,
+    run_exit_code: int = 0,
+    tested_sha: str = SHA,
+    source_head_sha: str = SHA,
+):
+    run_output, results_output = _raw_outputs(tmp_path, results=results)
+    return mutation_evidence.build_mutation_evidence(
+        run_output=run_output,
+        results_output=results_output,
+        config_path=_config(tmp_path),
+        run_exit_code=run_exit_code,
+        tool_version="3.6.0",
+        tested_sha=tested_sha,
+        source_head_sha=source_head_sha,
+        repository="Baelfyre/Orchestra",
+        workflow_run_id="123",
+        workflow_run_attempt="1",
+        event_name="pull_request",
+        ref_name="299/merge",
+    )
+
+
+def test_classified_exact_head_run_builds_valid_baseline(tmp_path: Path):
+    evidence = _build(
+        tmp_path,
+        results=(
+            "    orchestra_runtime.services.x_one__mutmut_1: killed\n"
+            "    orchestra_runtime.services.x_two__mutmut_1: survived\n"
+        ),
+    )
+
+    assert evidence["tested_sha"] == SHA
+    assert evidence["source_head_sha"] == SHA
+    assert evidence["scope"]["modules"] == ["orchestra_runtime/services.py"]
+    assert evidence["execution"]["classification_status"] == "COMPLETE"
+    assert evidence["execution"]["result_record_count"] == 2
+    assert evidence["execution"]["not_checked_count"] == 0
+    assert evidence["execution"]["status_counts"] == {"killed": 1, "survived": 1}
+
+
+def test_nonzero_mutmut_run_is_rejected(tmp_path: Path):
+    with pytest.raises(ValueError, match="mutation execution failed with exit code 1"):
+        _build(tmp_path, results="    mutant: killed\n", run_exit_code=1)
+
+
+def test_not_checked_mutants_are_rejected(tmp_path: Path):
+    with pytest.raises(ValueError, match="not checked mutants"):
+        _build(tmp_path, results="    mutant: not checked\n")
+
+
+def test_empty_mutation_results_are_rejected(tmp_path: Path):
+    with pytest.raises(ValueError, match="no mutant classification records"):
+        _build(tmp_path, results="")
+
+
+def test_synthetic_merge_sha_cannot_substitute_for_source_head(tmp_path: Path):
+    with pytest.raises(ValueError, match="tested_sha must exactly match source_head_sha"):
+        _build(tmp_path, results="    mutant: killed\n", tested_sha=OTHER_SHA)
+
+
+def test_fatal_stats_collection_marker_is_rejected(tmp_path: Path):
+    run_output, results_output = _raw_outputs(tmp_path, results="    mutant: killed\n")
+    run_output.write_text("failed to collect stats. runner returned 1\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="fatal instrumentation marker"):
+        mutation_evidence.build_mutation_evidence(
+            run_output=run_output,
+            results_output=results_output,
+            config_path=_config(tmp_path),
+            run_exit_code=0,
+            tool_version="3.6.0",
+            tested_sha=SHA,
+            source_head_sha=SHA,
+            repository="Baelfyre/Orchestra",
+            workflow_run_id="123",
+            workflow_run_attempt="1",
+            event_name="pull_request",
+            ref_name="299/merge",
+        )

--- a/tests/runtime/test_mutation_evidence.py
+++ b/tests/runtime/test_mutation_evidence.py
@@ -17,7 +17,7 @@ def _config(tmp_path: Path) -> Path:
         "only_mutate=\n"
         "    orchestra_runtime/services.py\n"
         "mutate_only_covered_lines=true\n"
-        "max_stack_depth=8\n",
+        "max_stack_depth=-1\n",
         encoding="utf-8",
     )
     return path
@@ -68,6 +68,8 @@ def test_classified_exact_head_run_builds_valid_baseline(tmp_path: Path):
     assert evidence["tested_sha"] == SHA
     assert evidence["source_head_sha"] == SHA
     assert evidence["scope"]["modules"] == ["orchestra_runtime/services.py"]
+    assert evidence["scope"]["mutate_only_covered_lines"] is True
+    assert evidence["scope"]["max_stack_depth"] == -1
     assert evidence["execution"]["classification_status"] == "COMPLETE"
     assert evidence["execution"]["result_record_count"] == 2
     assert evidence["execution"]["not_checked_count"] == 0

--- a/tests/runtime/test_mutation_evidence.py
+++ b/tests/runtime/test_mutation_evidence.py
@@ -7,6 +7,7 @@ from scripts.validation import build_mutation_evidence as mutation_evidence
 
 SHA = "a" * 40
 OTHER_SHA = "b" * 40
+PATTERN = "orchestra_runtime.services.RouterService.route*"
 
 
 def _config(tmp_path: Path) -> Path:
@@ -23,12 +24,20 @@ def _config(tmp_path: Path) -> Path:
     return path
 
 
-def _raw_outputs(tmp_path: Path, *, results: str) -> tuple[Path, Path]:
+def _raw_outputs(
+    tmp_path: Path,
+    *,
+    results: str,
+    target_progress: str = "13/13",
+) -> tuple[Path, Path, Path]:
     run_output = tmp_path / "run.txt"
+    target_output = tmp_path / "target-run.txt"
     results_output = tmp_path / "results.txt"
-    run_output.write_text("Generating mutants\nRunning stats done\n", encoding="utf-8")
+    target_text = f"Generating mutants\nRunning stats done\n{target_progress}  🎉 10  🙁 3\n"
+    run_output.write_text(target_text, encoding="utf-8")
+    target_output.write_text(target_text, encoding="utf-8")
     results_output.write_text(results, encoding="utf-8")
-    return run_output, results_output
+    return run_output, results_output, target_output
 
 
 def _build(
@@ -38,12 +47,18 @@ def _build(
     run_exit_code: int = 0,
     tested_sha: str = SHA,
     source_head_sha: str = SHA,
+    target_progress: str = "13/13",
 ):
-    run_output, results_output = _raw_outputs(tmp_path, results=results)
+    run_output, results_output, target_output = _raw_outputs(
+        tmp_path,
+        results=results,
+        target_progress=target_progress,
+    )
     return mutation_evidence.build_mutation_evidence(
         run_output=run_output,
         results_output=results_output,
         config_path=_config(tmp_path),
+        target_run_specs=[f"{PATTERN}={target_output}"],
         run_exit_code=run_exit_code,
         tool_version="3.6.0",
         tested_sha=tested_sha,
@@ -56,54 +71,107 @@ def _build(
     )
 
 
-def test_classified_exact_head_run_builds_valid_baseline(tmp_path: Path):
+def test_classified_exact_head_target_builds_bounded_evidence(tmp_path: Path):
     evidence = _build(
         tmp_path,
         results=(
-            "    orchestra_runtime.services.x_one__mutmut_1: killed\n"
-            "    orchestra_runtime.services.x_two__mutmut_1: survived\n"
+            "    orchestra_runtime.services.xǁRouterServiceǁroute__mutmut_3: survived\n"
+            "    orchestra_runtime.services.xǁRouterServiceǁroute__mutmut_5: survived\n"
+            "    orchestra_runtime.services.xǁRouterServiceǁroute__mutmut_9: survived\n"
+            "    orchestra_runtime.services.xǁRuntimeExecutorǁ_execute__mutmut_1: not checked\n"
         ),
     )
 
     assert evidence["tested_sha"] == SHA
     assert evidence["source_head_sha"] == SHA
     assert evidence["scope"]["modules"] == ["orchestra_runtime/services.py"]
+    assert evidence["scope"]["mutant_patterns"] == [PATTERN]
     assert evidence["scope"]["mutate_only_covered_lines"] is True
     assert evidence["scope"]["max_stack_depth"] == -1
     assert evidence["execution"]["classification_status"] == "COMPLETE"
-    assert evidence["execution"]["result_record_count"] == 2
+    assert evidence["execution"]["target_mutant_total"] == 13
+    assert evidence["execution"]["target_killed_count"] == 10
+    assert evidence["execution"]["target_survived_count"] == 3
+    assert evidence["execution"]["target_score_percent"] == 76.92
     assert evidence["execution"]["not_checked_count"] == 0
-    assert evidence["execution"]["status_counts"] == {"killed": 1, "survived": 1}
+    assert evidence["execution"]["out_of_scope_result_record_count"] == 1
+    assert evidence["execution"]["status_counts"] == {"survived": 3}
+
+
+def test_top_level_and_class_mutant_identifiers_normalize_to_public_patterns():
+    assert (
+        mutation_evidence._normalize_mutant_identifier(
+            "orchestra_runtime.models.x___getattr____mutmut_4"
+        )
+        == "orchestra_runtime.models.__getattr__"
+    )
+    assert (
+        mutation_evidence._normalize_mutant_identifier(
+            "orchestra_runtime.services.xǁRouterServiceǁroute__mutmut_27"
+        )
+        == "orchestra_runtime.services.RouterService.route"
+    )
+    assert (
+        mutation_evidence._normalize_mutant_identifier(
+            "orchestra_runtime.services.x__default_governance_rules__mutmut_2"
+        )
+        == "orchestra_runtime.services._default_governance_rules"
+    )
 
 
 def test_nonzero_mutmut_run_is_rejected(tmp_path: Path):
     with pytest.raises(ValueError, match="mutation execution failed with exit code 1"):
-        _build(tmp_path, results="    mutant: killed\n", run_exit_code=1)
+        _build(tmp_path, results="", run_exit_code=1)
 
 
-def test_not_checked_mutants_are_rejected(tmp_path: Path):
-    with pytest.raises(ValueError, match="not checked mutants"):
-        _build(tmp_path, results="    mutant: not checked\n")
+def test_scoped_not_checked_mutants_are_rejected(tmp_path: Path):
+    with pytest.raises(ValueError, match="scoped mutation results contain 1 not checked mutants"):
+        _build(
+            tmp_path,
+            results="    orchestra_runtime.services.xǁRouterServiceǁroute__mutmut_3: not checked\n",
+        )
 
 
-def test_empty_mutation_results_are_rejected(tmp_path: Path):
-    with pytest.raises(ValueError, match="no mutant classification records"):
-        _build(tmp_path, results="")
+def test_scoped_suspicious_outcome_is_rejected(tmp_path: Path):
+    with pytest.raises(ValueError, match="non-classified outcomes: suspicious"):
+        _build(
+            tmp_path,
+            results="    orchestra_runtime.services.xǁRouterServiceǁroute__mutmut_3: suspicious\n",
+        )
+
+
+def test_all_killed_target_is_valid_with_empty_results(tmp_path: Path):
+    evidence = _build(tmp_path, results="")
+    assert evidence["execution"]["target_mutant_total"] == 13
+    assert evidence["execution"]["target_killed_count"] == 13
+    assert evidence["execution"]["target_survived_count"] == 0
+    assert evidence["execution"]["target_score_percent"] == 100.0
+
+
+def test_incomplete_target_run_is_rejected(tmp_path: Path):
+    with pytest.raises(ValueError, match="incomplete: completed 12 of 13 mutants"):
+        _build(tmp_path, results="", target_progress="12/13")
+
+
+def test_zero_mutant_target_run_is_rejected(tmp_path: Path):
+    with pytest.raises(ValueError, match="executed zero mutants"):
+        _build(tmp_path, results="", target_progress="0/0")
 
 
 def test_synthetic_merge_sha_cannot_substitute_for_source_head(tmp_path: Path):
     with pytest.raises(ValueError, match="tested_sha must exactly match source_head_sha"):
-        _build(tmp_path, results="    mutant: killed\n", tested_sha=OTHER_SHA)
+        _build(tmp_path, results="", tested_sha=OTHER_SHA)
 
 
 def test_fatal_stats_collection_marker_is_rejected(tmp_path: Path):
-    run_output, results_output = _raw_outputs(tmp_path, results="    mutant: killed\n")
+    run_output, results_output, target_output = _raw_outputs(tmp_path, results="")
     run_output.write_text("failed to collect stats. runner returned 1\n", encoding="utf-8")
     with pytest.raises(ValueError, match="fatal instrumentation marker"):
         mutation_evidence.build_mutation_evidence(
             run_output=run_output,
             results_output=results_output,
             config_path=_config(tmp_path),
+            target_run_specs=[f"{PATTERN}={target_output}"],
             run_exit_code=0,
             tool_version="3.6.0",
             tested_sha=SHA,

--- a/tests/runtime/test_shadow_conformance.py
+++ b/tests/runtime/test_shadow_conformance.py
@@ -7,9 +7,10 @@ from orchestra_runtime.governance_kernel import (
     GovernanceDecisionRecord,
     evaluate_arbiter,
 )
+from orchestra_runtime.machine_contracts import command_route_map
 from orchestra_runtime.models import Command, ContextPackage
 from orchestra_runtime.repositories import ManifestRepository, SkillSourceRepository
-from orchestra_runtime.services import DEFAULT_COMMAND_ROUTES, GovernanceValidator, RouterService, SkillRegistry
+from orchestra_runtime.services import GovernanceValidator, RouterService, SkillRegistry
 from orchestra_runtime.shadow_conformance import (
     LegacyWorkflowClaim,
     MigrationStage,
@@ -25,6 +26,7 @@ EVIDENCE_B = "b" * 64
 
 
 def _runtime(command_name: str, metadata: dict | None = None):
+    routes = command_route_map(ROOT)
     registry = SkillRegistry(ManifestRepository(ROOT), SkillSourceRepository(ROOT))
     router = RouterService(registry)
     governance = GovernanceValidator()
@@ -33,7 +35,7 @@ def _runtime(command_name: str, metadata: dict | None = None):
         adapter_name="codex",
         prompt=command_name,
         project_root=ROOT,
-        available_commands=tuple(DEFAULT_COMMAND_ROUTES),
+        available_commands=tuple(routes),
         manifest_version="1.4.0",
         metadata=metadata or {},
     )

--- a/tests/runtime/test_workflow_sanity.py
+++ b/tests/runtime/test_workflow_sanity.py
@@ -13,12 +13,7 @@ from orchestra_runtime.machine_contracts import (
 )
 from orchestra_runtime.models import Command, ContextPackage
 from orchestra_runtime.repositories import ManifestRepository, SkillSourceRepository
-from orchestra_runtime.services import (
-    DEFAULT_COMMAND_ROUTES,
-    GovernanceValidator,
-    RouterService,
-    SkillRegistry,
-)
+from orchestra_runtime.services import GovernanceValidator, RouterService, SkillRegistry
 from orchestra_runtime.workflow_contracts import build_workflow_sanity_receipt
 
 
@@ -26,6 +21,7 @@ ROOT = Path(__file__).resolve().parents[2]
 
 
 def _route(command_name: str, metadata: dict | None = None):
+    routes = command_route_map(ROOT)
     registry = SkillRegistry(ManifestRepository(ROOT), SkillSourceRepository(ROOT))
     router = RouterService(registry)
     governance = GovernanceValidator()
@@ -34,7 +30,7 @@ def _route(command_name: str, metadata: dict | None = None):
         adapter_name="codex",
         prompt=command_name,
         project_root=ROOT,
-        available_commands=tuple(DEFAULT_COMMAND_ROUTES),
+        available_commands=tuple(routes),
         manifest_version="1.4.0",
         metadata=metadata or {},
     )
@@ -63,28 +59,37 @@ def _arbiter(**overrides):
     return evaluate_arbiter(ArbiterKernelInput(**values))
 
 
-def test_machine_command_routes_match_existing_runtime_table_exactly():
-    assert command_route_map(ROOT) == DEFAULT_COMMAND_ROUTES
+def test_machine_command_routes_are_runtime_router_defaults():
+    routes = command_route_map(ROOT)
+    registry = SkillRegistry(ManifestRepository(ROOT), SkillSourceRepository(ROOT))
+    router = RouterService(registry)
+    assert registry._command_routes == routes
+    assert router._command_routes == routes
 
 
 def test_machine_governance_required_set_matches_runtime_router_behavior():
     expected = governance_required_specialists(ROOT)
-    for command_name, specialist in DEFAULT_COMMAND_ROUTES.items():
+    for command_name, specialist in command_route_map(ROOT).items():
         route, _ = _route(command_name)
         assert route.skill_slug == specialist
         assert route.governance_required is (specialist in expected)
 
 
-def test_machine_validation_rules_match_existing_governance_validator():
+def test_machine_validation_rules_are_runtime_governance_defaults():
     runtime_rules = GovernanceValidator()._rules
     machine_rules = runtime_validation_rule_records(ROOT)
+    dry_run_required = {
+        str(record["rule_id"])
+        for record in machine_rules
+        if record.get("dry_run_required") is True
+    }
     normalized_runtime = [
         {
             "rule_id": rule.name,
             "skill_slugs": list(rule.skill_slugs),
             "command_names": list(rule.command_names),
             "validator_key": rule.validator_key,
-            "dry_run_required": rule.name == "destructive-skill-approval",
+            "dry_run_required": rule.name in dry_run_required,
         }
         for rule in runtime_rules
     ]


### PR DESCRIPTION
## Migration transition

Advances the control-plane migration by exactly one governed stage:

`CANONICAL_PROMOTION_AUTHORITY -> LEGACY_RETIRED`

Base canonical SHA: `529639beefd8fa0cc153b6e94649b487de4f7bc2`
Candidate source head at PR creation: `99e7c5269ba33f5479ff36a69d37bd7df3071101`
Candidate source tree: `4e6013c217cb159b93c7365baa852efa2745fe59`

## Scope

- retire service-level runtime authority snapshots for command routes, ambiguity fallback, governance-required specialist classification, governance validation records, and dry-run rule identity;
- make `SkillRegistry`, `RouterService`, `GovernanceValidator`, compatibility bindings, and compatibility capability grants consume machine contracts directly;
- replace the stored `models.py::VALID_SPECIALISTS` snapshot with an on-demand machine-derived compatibility view so the legacy import remains available without remaining normative;
- convert runtime, shadow-conformance, governance, and migration-state regressions from legacy-table parity to direct machine-authority consumption;
- advance machine migration state to `LEGACY_RETIRED` with installed-integration mutation still false;
- reconcile README and CHANGELOG without selecting a new version.

## Compatibility boundary

Repository search found the retired service constants referenced only by runtime tests, not by public documentation. The `VALID_SPECIALISTS` import is retained as a derived compatibility view. Compatibility mode remains supported and finite; only duplicate authority ownership is retired.

## Explicitly not included

- no SemVer selection or version normalization;
- no tag or GitHub Release publication;
- no marketplace publication;
- no installed-integration refresh;
- no deployment or production mutation;
- no ruleset bypass, force push, history rewrite, branch deletion, or destructive cleanup.

## Required evidence before merge

This PR is not merge-ready until its exact current head passes the full protected matrix, relevant bounded mutation-confidence evidence, zero unresolved review threads, strict-up-to-date/mergeable state, and ordinary Squash with expected-head protection. The existing Cosmic Ray pilot is scoped to `evidence.py`, `governance_kernel.py`, and `preexecution.py`; it is not represented as retirement-specific evidence for `models.py` or `services.py`. A fresh integrated Cosmic Ray run remains required for the final release candidate.

Any source-head movement invalidates prior validation evidence.

Tracks #273, #279, #291, #292.