### PR TITLE
feat(runtime): add deterministic Murmurs presentation core

### DIFF
--- a/machine/presentation/murmurs-policy.v1.json
+++ b/machine/presentation/murmurs-policy.v1.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "orchestra.presentation-policy.v1",
+  "default_disposition": "EXPLAIN",
+  "events": {
+    "EXECUTION_HEARTBEAT": "MURMUR",
+    "TOOL_STARTED": "SILENT",
+    "TOOL_COMPLETED": "MURMUR",
+    "ROUTINE_VALIDATION_PASSED": "MURMUR",
+    "HUMAN_ACTION_REQUIRED": "EXPLAIN",
+    "AUTHORITY_REQUIRED": "EXPLAIN",
+    "VALIDATION_FAILED": "EXPLAIN",
+    "UNRECOVERABLE_BLOCKER": "EXPLAIN",
+    "GOVERNANCE_STOP": "EXPLAIN",
+    "HANDOFF_REQUIRED": "EXPLAIN",
+    "TASK_COMPLETED": "EXPLAIN",
+    "TASK_FAILED": "EXPLAIN"
+  },
+  "explain_required": [
+    "HUMAN_ACTION_REQUIRED",
+    "AUTHORITY_REQUIRED",
+    "VALIDATION_FAILED",
+    "UNRECOVERABLE_BLOCKER",
+    "GOVERNANCE_STOP",
+    "HANDOFF_REQUIRED",
+    "TASK_COMPLETED",
+    "TASK_FAILED"
+  ],
+  "authority_effect": {
+    "presentation_may_change_machine_state": false,
+    "presentation_may_override_governance": false,
+    "presentation_may_suppress_required_explanation": false
+  }
+}

--- a/machine/presentation/murmurs-vocabulary.v1.json
+++ b/machine/presentation/murmurs-vocabulary.v1.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "orchestra.murmurs-vocabulary.v1",
+  "selection": "SHA256_MODULO",
+  "entries": [
+    "...",
+    "hm...",
+    "mhm...",
+    "mm...",
+    "ah..."
+  ],
+  "constraints": {
+    "maximum_characters": 12,
+    "allow_newlines": false,
+    "allow_status_claims": false
+  }
+}

--- a/machine/schemas/murmurs-vocabulary.schema.json
+++ b/machine/schemas/murmurs-vocabulary.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Baelfyre/Orchestra/blob/main/machine/schemas/murmurs-vocabulary.schema.json",
+  "title": "Orchestra Murmurs Vocabulary",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "selection",
+    "entries",
+    "constraints"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "orchestra.murmurs-vocabulary.v1"
+    },
+    "selection": {
+      "type": "string",
+      "const": "SHA256_MODULO"
+    },
+    "entries": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 12,
+        "pattern": "^[^\\r\\n]+$"
+      }
+    },
+    "constraints": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "maximum_characters",
+        "allow_newlines",
+        "allow_status_claims"
+      ],
+      "properties": {
+        "maximum_characters": {"type": "integer", "const": 12},
+        "allow_newlines": {"const": false},
+        "allow_status_claims": {"const": false}
+      }
+    }
+  }
+}

--- a/machine/schemas/presentation-policy.schema.json
+++ b/machine/schemas/presentation-policy.schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Baelfyre/Orchestra/blob/main/machine/schemas/presentation-policy.schema.json",
+  "title": "Orchestra Presentation Policy",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "default_disposition",
+    "events",
+    "explain_required",
+    "authority_effect"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "orchestra.presentation-policy.v1"
+    },
+    "default_disposition": {
+      "type": "string",
+      "const": "EXPLAIN"
+    },
+    "events": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "EXECUTION_HEARTBEAT",
+        "TOOL_STARTED",
+        "TOOL_COMPLETED",
+        "ROUTINE_VALIDATION_PASSED",
+        "HUMAN_ACTION_REQUIRED",
+        "AUTHORITY_REQUIRED",
+        "VALIDATION_FAILED",
+        "UNRECOVERABLE_BLOCKER",
+        "GOVERNANCE_STOP",
+        "HANDOFF_REQUIRED",
+        "TASK_COMPLETED",
+        "TASK_FAILED"
+      ],
+      "properties": {
+        "EXECUTION_HEARTBEAT": {"enum": ["SILENT", "MURMUR", "EXPLAIN"]},
+        "TOOL_STARTED": {"enum": ["SILENT", "MURMUR", "EXPLAIN"]},
+        "TOOL_COMPLETED": {"enum": ["SILENT", "MURMUR", "EXPLAIN"]},
+        "ROUTINE_VALIDATION_PASSED": {"enum": ["SILENT", "MURMUR", "EXPLAIN"]},
+        "HUMAN_ACTION_REQUIRED": {"const": "EXPLAIN"},
+        "AUTHORITY_REQUIRED": {"const": "EXPLAIN"},
+        "VALIDATION_FAILED": {"const": "EXPLAIN"},
+        "UNRECOVERABLE_BLOCKER": {"const": "EXPLAIN"},
+        "GOVERNANCE_STOP": {"const": "EXPLAIN"},
+        "HANDOFF_REQUIRED": {"const": "EXPLAIN"},
+        "TASK_COMPLETED": {"const": "EXPLAIN"},
+        "TASK_FAILED": {"const": "EXPLAIN"}
+      }
+    },
+    "explain_required": {
+      "type": "array",
+      "minItems": 8,
+      "maxItems": 8,
+      "uniqueItems": true,
+      "prefixItems": [
+        {"const": "HUMAN_ACTION_REQUIRED"},
+        {"const": "AUTHORITY_REQUIRED"},
+        {"const": "VALIDATION_FAILED"},
+        {"const": "UNRECOVERABLE_BLOCKER"},
+        {"const": "GOVERNANCE_STOP"},
+        {"const": "HANDOFF_REQUIRED"},
+        {"const": "TASK_COMPLETED"},
+        {"const": "TASK_FAILED"}
+      ],
+      "items": false
+    },
+    "authority_effect": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "presentation_may_change_machine_state",
+        "presentation_may_override_governance",
+        "presentation_may_suppress_required_explanation"
+      ],
+      "properties": {
+        "presentation_may_change_machine_state": {"const": false},
+        "presentation_may_override_governance": {"const": false},
+        "presentation_may_suppress_required_explanation": {"const": false}
+      }
+    }
+  }
+}

--- a/orchestra_runtime/presentation.py
+++ b/orchestra_runtime/presentation.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from hashlib import sha256
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+from .lifecycle import LifecycleSignal, LifecycleSignalType
+
+
+PRESENTATION_POLICY_SCHEMA_VERSION = "orchestra.presentation-policy.v1"
+MURMURS_VOCABULARY_SCHEMA_VERSION = "orchestra.murmurs-vocabulary.v1"
+
+_MACHINE_ROOT = Path("machine")
+_PRESENTATION_POLICY = _MACHINE_ROOT / "presentation" / "murmurs-policy.v1.json"
+_MURMURS_VOCABULARY = _MACHINE_ROOT / "presentation" / "murmurs-vocabulary.v1.json"
+
+
+class PresentationDisposition(str, Enum):
+    SILENT = "SILENT"
+    MURMUR = "MURMUR"
+    EXPLAIN = "EXPLAIN"
+
+
+class PresentationEventKind(str, Enum):
+    EXECUTION_HEARTBEAT = "EXECUTION_HEARTBEAT"
+    TOOL_STARTED = "TOOL_STARTED"
+    TOOL_COMPLETED = "TOOL_COMPLETED"
+    ROUTINE_VALIDATION_PASSED = "ROUTINE_VALIDATION_PASSED"
+    HUMAN_ACTION_REQUIRED = "HUMAN_ACTION_REQUIRED"
+    AUTHORITY_REQUIRED = "AUTHORITY_REQUIRED"
+    VALIDATION_FAILED = "VALIDATION_FAILED"
+    UNRECOVERABLE_BLOCKER = "UNRECOVERABLE_BLOCKER"
+    GOVERNANCE_STOP = "GOVERNANCE_STOP"
+    HANDOFF_REQUIRED = "HANDOFF_REQUIRED"
+    TASK_COMPLETED = "TASK_COMPLETED"
+    TASK_FAILED = "TASK_FAILED"
+
+
+FORCED_EXPLAIN_EVENTS = (
+    PresentationEventKind.HUMAN_ACTION_REQUIRED,
+    PresentationEventKind.AUTHORITY_REQUIRED,
+    PresentationEventKind.VALIDATION_FAILED,
+    PresentationEventKind.UNRECOVERABLE_BLOCKER,
+    PresentationEventKind.GOVERNANCE_STOP,
+    PresentationEventKind.HANDOFF_REQUIRED,
+    PresentationEventKind.TASK_COMPLETED,
+    PresentationEventKind.TASK_FAILED,
+)
+
+_LIFECYCLE_EVENT_MAP = {
+    LifecycleSignalType.ACTIVATE: PresentationEventKind.EXECUTION_HEARTBEAT,
+    LifecycleSignalType.WAIT: PresentationEventKind.EXECUTION_HEARTBEAT,
+    LifecycleSignalType.RESUME: PresentationEventKind.EXECUTION_HEARTBEAT,
+    LifecycleSignalType.COMPLETE: PresentationEventKind.TASK_COMPLETED,
+    LifecycleSignalType.FAIL: PresentationEventKind.TASK_FAILED,
+    LifecycleSignalType.CANCEL: PresentationEventKind.TASK_FAILED,
+    LifecycleSignalType.TIME_OUT: PresentationEventKind.TASK_FAILED,
+    LifecycleSignalType.BLOCK: PresentationEventKind.UNRECOVERABLE_BLOCKER,
+}
+
+_FORBIDDEN_STATUS_TERMS = frozenset(
+    {
+        "almost",
+        "blocked",
+        "complete",
+        "completed",
+        "done",
+        "error",
+        "fail",
+        "failed",
+        "fixed",
+        "pass",
+        "passed",
+        "success",
+        "working",
+    }
+)
+
+
+def repository_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def _root(root: Path | str | None) -> Path:
+    return repository_root() if root is None else Path(root)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"presentation contract missing: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"presentation contract is invalid JSON: {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"presentation contract must be a JSON object: {path}")
+    return value
+
+
+def _text(value: object, field_name: str) -> str:
+    text = "" if value is None else str(value).strip()
+    if not text:
+        raise ValueError(f"{field_name} must be non-empty")
+    return text
+
+
+def _validate_policy(policy: dict[str, Any]) -> dict[str, Any]:
+    if policy.get("schema_version") != PRESENTATION_POLICY_SCHEMA_VERSION:
+        raise ValueError("unsupported presentation policy schema_version")
+    if policy.get("default_disposition") != PresentationDisposition.EXPLAIN.value:
+        raise ValueError("presentation default disposition must fail closed to EXPLAIN")
+
+    events = policy.get("events")
+    if not isinstance(events, dict):
+        raise ValueError("presentation policy events must be an object")
+    expected_events = {item.value for item in PresentationEventKind}
+    if set(events) != expected_events:
+        raise ValueError("presentation policy event set does not match the runtime vocabulary")
+    for event_name, raw_disposition in events.items():
+        try:
+            disposition = PresentationDisposition(raw_disposition)
+        except ValueError as exc:
+            raise ValueError(f"presentation event {event_name!r} has an invalid disposition") from exc
+        if PresentationEventKind(event_name) in FORCED_EXPLAIN_EVENTS and disposition is not PresentationDisposition.EXPLAIN:
+            raise ValueError(f"presentation event {event_name!r} must require EXPLAIN")
+
+    explain_required = policy.get("explain_required")
+    if not isinstance(explain_required, list):
+        raise ValueError("presentation explain_required must be a list")
+    expected_explain = [item.value for item in FORCED_EXPLAIN_EVENTS]
+    if explain_required != expected_explain:
+        raise ValueError("presentation explain_required does not match fail-closed runtime requirements")
+
+    authority_effect = policy.get("authority_effect")
+    expected_authority_effect = {
+        "presentation_may_change_machine_state": False,
+        "presentation_may_override_governance": False,
+        "presentation_may_suppress_required_explanation": False,
+    }
+    if authority_effect != expected_authority_effect:
+        raise ValueError("presentation policy cannot create authority or suppress required explanation")
+    return policy
+
+
+def _validate_vocabulary(vocabulary: dict[str, Any]) -> dict[str, Any]:
+    if vocabulary.get("schema_version") != MURMURS_VOCABULARY_SCHEMA_VERSION:
+        raise ValueError("unsupported Murmurs vocabulary schema_version")
+    if vocabulary.get("selection") != "SHA256_MODULO":
+        raise ValueError("unsupported Murmurs vocabulary selection strategy")
+    constraints = vocabulary.get("constraints")
+    if constraints != {
+        "maximum_characters": 12,
+        "allow_newlines": False,
+        "allow_status_claims": False,
+    }:
+        raise ValueError("Murmurs vocabulary constraints must preserve the non-semantic presentation boundary")
+
+    entries = vocabulary.get("entries")
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("Murmurs vocabulary entries must be a non-empty list")
+    cleaned = tuple(str(item) for item in entries)
+    if len(set(cleaned)) != len(cleaned):
+        raise ValueError("Murmurs vocabulary entries must be unique")
+    for entry in cleaned:
+        if not entry or entry != entry.strip():
+            raise ValueError("Murmurs vocabulary entries must be non-empty and trimmed")
+        if len(entry) > 12 or "\n" in entry or "\r" in entry:
+            raise ValueError("Murmurs vocabulary entry violates length/newline constraints")
+        words = set(re.findall(r"[a-z]+", entry.lower()))
+        if words & _FORBIDDEN_STATUS_TERMS:
+            raise ValueError("Murmurs vocabulary entries cannot contain status or completion claims")
+    return vocabulary
+
+
+def load_presentation_policy(root: Path | str | None = None) -> dict[str, Any]:
+    return _validate_policy(_load_json(_root(root) / _PRESENTATION_POLICY))
+
+
+def load_murmurs_vocabulary(root: Path | str | None = None) -> dict[str, Any]:
+    return _validate_vocabulary(_load_json(_root(root) / _MURMURS_VOCABULARY))
+
+
+@dataclass(frozen=True, slots=True)
+class PresentationEvent:
+    run_id: str
+    event_kind: PresentationEventKind
+    sequence: int
+    source_component: str = "runtime"
+    evidence_refs: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        run_id = _text(self.run_id, "run_id")
+        event_kind = PresentationEventKind(self.event_kind)
+        if isinstance(self.sequence, bool) or not isinstance(self.sequence, int) or self.sequence < 0:
+            raise ValueError("presentation sequence must be a non-negative integer")
+        source_component = _text(self.source_component, "source_component")
+        evidence_refs = tuple(sorted({_text(item, "evidence_ref") for item in self.evidence_refs}))
+        object.__setattr__(self, "run_id", run_id)
+        object.__setattr__(self, "event_kind", event_kind)
+        object.__setattr__(self, "source_component", source_component)
+        object.__setattr__(self, "evidence_refs", evidence_refs)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "run_id": self.run_id,
+            "event_kind": self.event_kind.value,
+            "sequence": self.sequence,
+            "source_component": self.source_component,
+            "evidence_refs": list(self.evidence_refs),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class PresentationDecision:
+    event: PresentationEvent
+    disposition: PresentationDisposition
+    reason_code: str
+    murmur_text: str | None = None
+
+    def __post_init__(self) -> None:
+        disposition = PresentationDisposition(self.disposition)
+        reason_code = _text(self.reason_code, "reason_code")
+        murmur_text = self.murmur_text
+        if disposition is PresentationDisposition.MURMUR:
+            if murmur_text is None or not str(murmur_text).strip():
+                raise ValueError("MURMUR presentation requires local murmur_text")
+            murmur_text = str(murmur_text)
+        elif murmur_text is not None:
+            raise ValueError("only MURMUR presentation may carry murmur_text")
+        object.__setattr__(self, "disposition", disposition)
+        object.__setattr__(self, "reason_code", reason_code)
+        object.__setattr__(self, "murmur_text", murmur_text)
+
+    @property
+    def requires_explanation(self) -> bool:
+        return self.disposition is PresentationDisposition.EXPLAIN
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "event": self.event.to_dict(),
+            "disposition": self.disposition.value,
+            "reason_code": self.reason_code,
+            "murmur_text": self.murmur_text,
+        }
+
+
+def presentation_decision_digest(decision: PresentationDecision) -> str:
+    payload = json.dumps(decision.to_dict(), sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _select_murmur(event: PresentationEvent, entries: tuple[str, ...]) -> str:
+    seed = f"{event.run_id}\0{event.sequence}\0{event.event_kind.value}".encode("utf-8")
+    index = int.from_bytes(sha256(seed).digest()[:8], "big") % len(entries)
+    return entries[index]
+
+
+def decide_presentation(event: PresentationEvent, root: Path | str | None = None) -> PresentationDecision:
+    try:
+        policy = load_presentation_policy(root)
+        disposition = PresentationDisposition(policy["events"][event.event_kind.value])
+        if disposition is PresentationDisposition.MURMUR:
+            vocabulary = load_murmurs_vocabulary(root)
+            entries = tuple(str(item) for item in vocabulary["entries"])
+            return PresentationDecision(
+                event,
+                disposition,
+                "POLICY_MURMUR",
+                _select_murmur(event, entries),
+            )
+        if disposition is PresentationDisposition.SILENT:
+            return PresentationDecision(event, disposition, "POLICY_SILENT")
+        return PresentationDecision(event, disposition, "POLICY_EXPLAIN")
+    except (KeyError, OSError, TypeError, ValueError):
+        return PresentationDecision(event, PresentationDisposition.EXPLAIN, "PRESENTATION_CONTRACT_INVALID")
+
+
+def render_presentation(decision: PresentationDecision) -> str | None:
+    if decision.disposition is PresentationDisposition.SILENT:
+        return ""
+    if decision.disposition is PresentationDisposition.MURMUR:
+        return decision.murmur_text
+    return None
+
+
+def lifecycle_presentation_event(signal: LifecycleSignal, sequence: int) -> PresentationEvent:
+    if not isinstance(signal, LifecycleSignal):
+        raise ValueError("lifecycle presentation input must be a LifecycleSignal")
+    return PresentationEvent(
+        run_id=signal.run_id,
+        event_kind=_LIFECYCLE_EVENT_MAP[signal.signal_type],
+        sequence=sequence,
+        source_component=signal.source_component,
+        evidence_refs=signal.evidence_refs,
+    )
+
+
+def decide_lifecycle_presentation(
+    signal: LifecycleSignal,
+    sequence: int,
+    root: Path | str | None = None,
+) -> PresentationDecision:
+    return decide_presentation(lifecycle_presentation_event(signal, sequence), root)

--- a/tests/runtime/test_presentation.py
+++ b/tests/runtime/test_presentation.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from orchestra_runtime.authority import AuthorityProvenance, ProvenanceSource
+from orchestra_runtime.lifecycle import (
+    LifecycleSignal,
+    LifecycleSignalType,
+    LifecycleState,
+    StructuredTerminalResult,
+    lifecycle_signal_fingerprint,
+)
+from orchestra_runtime.presentation import (
+    FORCED_EXPLAIN_EVENTS,
+    MURMURS_VOCABULARY_SCHEMA_VERSION,
+    PRESENTATION_POLICY_SCHEMA_VERSION,
+    PresentationDecision,
+    PresentationDisposition,
+    PresentationEvent,
+    PresentationEventKind,
+    decide_lifecycle_presentation,
+    decide_presentation,
+    lifecycle_presentation_event,
+    load_murmurs_vocabulary,
+    load_presentation_policy,
+    presentation_decision_digest,
+    render_presentation,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+POLICY_PATH = ROOT / "machine" / "presentation" / "murmurs-policy.v1.json"
+VOCABULARY_PATH = ROOT / "machine" / "presentation" / "murmurs-vocabulary.v1.json"
+POLICY_SCHEMA_PATH = ROOT / "machine" / "schemas" / "presentation-policy.schema.json"
+VOCABULARY_SCHEMA_PATH = ROOT / "machine" / "schemas" / "murmurs-vocabulary.schema.json"
+
+
+def _load(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def _write_contracts(tmp_path: Path, policy: dict | None = None, vocabulary: dict | None = None) -> None:
+    destination = tmp_path / "machine" / "presentation"
+    destination.mkdir(parents=True)
+    (destination / "murmurs-policy.v1.json").write_text(
+        json.dumps(policy or _load(POLICY_PATH)),
+        encoding="utf-8",
+    )
+    (destination / "murmurs-vocabulary.v1.json").write_text(
+        json.dumps(vocabulary or _load(VOCABULARY_PATH)),
+        encoding="utf-8",
+    )
+
+
+def _provenance() -> AuthorityProvenance:
+    return AuthorityProvenance(
+        ProvenanceSource.TRUSTED_COMPOSITION,
+        "runtime.root",
+        "v1",
+        "runtime",
+    )
+
+
+def _activate_signal() -> LifecycleSignal:
+    return LifecycleSignal(
+        signal_id="signal.activate",
+        run_id="run-1",
+        signal_type=LifecycleSignalType.ACTIVATE,
+        expected_state=LifecycleState.INITIALIZING,
+        requested_state=LifecycleState.ACTIVE,
+        reason_code="START",
+        source_component="runtime",
+        provenance=_provenance(),
+        evidence_refs=("evidence-2", "evidence-1"),
+    )
+
+
+def _complete_signal() -> LifecycleSignal:
+    return LifecycleSignal(
+        signal_id="signal.complete",
+        run_id="run-1",
+        signal_type=LifecycleSignalType.COMPLETE,
+        expected_state=LifecycleState.ACTIVE,
+        requested_state=LifecycleState.COMPLETED,
+        reason_code="COMPLETE",
+        source_component="runtime",
+        provenance=_provenance(),
+        evidence_refs=("evidence-final",),
+        terminal_result=StructuredTerminalResult(
+            "run-1",
+            LifecycleState.COMPLETED,
+            "COMPLETE",
+            evidence_refs=("evidence-final",),
+        ),
+    )
+
+
+def test_machine_presentation_contracts_are_valid_and_bounded():
+    policy = load_presentation_policy()
+    vocabulary = load_murmurs_vocabulary()
+
+    assert policy["schema_version"] == PRESENTATION_POLICY_SCHEMA_VERSION
+    assert policy["default_disposition"] == "EXPLAIN"
+    assert policy["explain_required"] == [item.value for item in FORCED_EXPLAIN_EVENTS]
+    assert policy["authority_effect"] == {
+        "presentation_may_change_machine_state": False,
+        "presentation_may_override_governance": False,
+        "presentation_may_suppress_required_explanation": False,
+    }
+    assert vocabulary["schema_version"] == MURMURS_VOCABULARY_SCHEMA_VERSION
+    assert vocabulary["selection"] == "SHA256_MODULO"
+    assert vocabulary["entries"]
+    assert all(len(item) <= 12 and "\n" not in item and "\r" not in item for item in vocabulary["entries"])
+
+
+def test_schema_documents_match_runtime_contract_versions_and_required_events():
+    policy_schema = _load(POLICY_SCHEMA_PATH)
+    vocabulary_schema = _load(VOCABULARY_SCHEMA_PATH)
+    assert policy_schema["properties"]["schema_version"]["const"] == PRESENTATION_POLICY_SCHEMA_VERSION
+    assert vocabulary_schema["properties"]["schema_version"]["const"] == MURMURS_VOCABULARY_SCHEMA_VERSION
+    assert set(policy_schema["properties"]["events"]["required"]) == {
+        item.value for item in PresentationEventKind
+    }
+    assert policy_schema["properties"]["default_disposition"]["const"] == "EXPLAIN"
+    assert vocabulary_schema["properties"]["selection"]["const"] == "SHA256_MODULO"
+
+
+def test_routine_events_use_local_murmurs_or_silence():
+    heartbeat = PresentationEvent("run-1", PresentationEventKind.EXECUTION_HEARTBEAT, 3)
+    heartbeat_decision = decide_presentation(heartbeat)
+    assert heartbeat_decision.disposition is PresentationDisposition.MURMUR
+    assert heartbeat_decision.murmur_text in load_murmurs_vocabulary()["entries"]
+    assert render_presentation(heartbeat_decision) == heartbeat_decision.murmur_text
+    assert heartbeat_decision.requires_explanation is False
+
+    tool_started = PresentationEvent("run-1", PresentationEventKind.TOOL_STARTED, 4)
+    tool_decision = decide_presentation(tool_started)
+    assert tool_decision.disposition is PresentationDisposition.SILENT
+    assert tool_decision.murmur_text is None
+    assert render_presentation(tool_decision) == ""
+
+
+@pytest.mark.parametrize("event_kind", FORCED_EXPLAIN_EVENTS)
+def test_required_explanation_events_can_never_be_murmured(event_kind: PresentationEventKind):
+    decision = decide_presentation(PresentationEvent("run-required", event_kind, 1))
+    assert decision.disposition is PresentationDisposition.EXPLAIN
+    assert decision.requires_explanation is True
+    assert decision.murmur_text is None
+    assert render_presentation(decision) is None
+
+
+def test_murmur_selection_and_decision_digest_are_deterministic():
+    event = PresentationEvent(
+        "run-deterministic",
+        PresentationEventKind.TOOL_COMPLETED,
+        17,
+        evidence_refs=("receipt-b", "receipt-a", "receipt-a"),
+    )
+    first = decide_presentation(event)
+    second = decide_presentation(event)
+    assert first == second
+    assert first.event.evidence_refs == ("receipt-a", "receipt-b")
+    assert presentation_decision_digest(first) == presentation_decision_digest(second)
+    assert len(presentation_decision_digest(first)) == 64
+
+
+def test_lifecycle_adapter_does_not_mutate_signal_identity_and_terminal_events_explain():
+    activate = _activate_signal()
+    activate_fingerprint = lifecycle_signal_fingerprint(activate)
+    presentation_event = lifecycle_presentation_event(activate, 8)
+    activate_decision = decide_lifecycle_presentation(activate, 8)
+
+    assert presentation_event.event_kind is PresentationEventKind.EXECUTION_HEARTBEAT
+    assert presentation_event.evidence_refs == activate.evidence_refs
+    assert activate_decision.disposition is PresentationDisposition.MURMUR
+    assert lifecycle_signal_fingerprint(activate) == activate_fingerprint
+
+    complete = _complete_signal()
+    complete_fingerprint = lifecycle_signal_fingerprint(complete)
+    complete_decision = decide_lifecycle_presentation(complete, 9)
+    assert complete_decision.event.event_kind is PresentationEventKind.TASK_COMPLETED
+    assert complete_decision.disposition is PresentationDisposition.EXPLAIN
+    assert render_presentation(complete_decision) is None
+    assert lifecycle_signal_fingerprint(complete) == complete_fingerprint
+
+
+def test_invalid_policy_fails_closed_to_explain(tmp_path: Path):
+    policy = _load(POLICY_PATH)
+    policy["events"]["TASK_COMPLETED"] = "MURMUR"
+    _write_contracts(tmp_path, policy=policy)
+
+    with pytest.raises(ValueError, match="must require EXPLAIN"):
+        load_presentation_policy(tmp_path)
+
+    decision = decide_presentation(
+        PresentationEvent("run-invalid-policy", PresentationEventKind.EXECUTION_HEARTBEAT, 1),
+        tmp_path,
+    )
+    assert decision.disposition is PresentationDisposition.EXPLAIN
+    assert decision.reason_code == "PRESENTATION_CONTRACT_INVALID"
+    assert render_presentation(decision) is None
+
+
+def test_status_claim_in_vocabulary_fails_closed_to_explain(tmp_path: Path):
+    vocabulary = _load(VOCABULARY_PATH)
+    vocabulary["entries"] = ["done"]
+    _write_contracts(tmp_path, vocabulary=vocabulary)
+
+    with pytest.raises(ValueError, match="status or completion claims"):
+        load_murmurs_vocabulary(tmp_path)
+
+    decision = decide_presentation(
+        PresentationEvent("run-invalid-vocabulary", PresentationEventKind.EXECUTION_HEARTBEAT, 2),
+        tmp_path,
+    )
+    assert decision.disposition is PresentationDisposition.EXPLAIN
+    assert decision.reason_code == "PRESENTATION_CONTRACT_INVALID"
+
+
+def test_missing_or_invalid_contract_fails_closed_to_explain(tmp_path: Path):
+    decision = decide_presentation(
+        PresentationEvent("run-missing", PresentationEventKind.EXECUTION_HEARTBEAT, 1),
+        tmp_path,
+    )
+    assert decision.disposition is PresentationDisposition.EXPLAIN
+
+    destination = tmp_path / "machine" / "presentation"
+    destination.mkdir(parents=True)
+    (destination / "murmurs-policy.v1.json").write_text("[]", encoding="utf-8")
+    second = decide_presentation(
+        PresentationEvent("run-invalid-json-shape", PresentationEventKind.EXECUTION_HEARTBEAT, 2),
+        tmp_path,
+    )
+    assert second.disposition is PresentationDisposition.EXPLAIN
+
+
+@pytest.mark.parametrize("bad_sequence", [-1, True, 1.5])
+def test_presentation_event_rejects_invalid_sequence(bad_sequence):
+    with pytest.raises(ValueError, match="non-negative integer"):
+        PresentationEvent("run-1", PresentationEventKind.EXECUTION_HEARTBEAT, bad_sequence)
+
+
+def test_presentation_event_requires_identity_and_source_component():
+    with pytest.raises(ValueError, match="run_id"):
+        PresentationEvent(" ", PresentationEventKind.EXECUTION_HEARTBEAT, 0)
+    with pytest.raises(ValueError, match="source_component"):
+        PresentationEvent("run-1", PresentationEventKind.EXECUTION_HEARTBEAT, 0, source_component=" ")
+
+
+def test_presentation_decision_rejects_semantically_invalid_murmur_payloads():
+    event = PresentationEvent("run-1", PresentationEventKind.EXECUTION_HEARTBEAT, 0)
+    with pytest.raises(ValueError, match="requires local murmur_text"):
+        PresentationDecision(event, PresentationDisposition.MURMUR, "TEST")
+    with pytest.raises(ValueError, match="only MURMUR"):
+        PresentationDecision(event, PresentationDisposition.EXPLAIN, "TEST", "hm...")
+
+
+def test_lifecycle_adapter_rejects_unstructured_input():
+    with pytest.raises(ValueError, match="LifecycleSignal"):
+        lifecycle_presentation_event(object(), 1)

--- a/tests/runtime/test_presentation.py
+++ b/tests/runtime/test_presentation.py
@@ -206,6 +206,85 @@ def test_invalid_policy_fails_closed_to_explain(tmp_path: Path):
     assert render_presentation(decision) is None
 
 
+@pytest.mark.parametrize(
+    ("case", "message"),
+    [
+        ("schema_version", "schema_version"),
+        ("default_disposition", "default disposition"),
+        ("events_type", "events must be an object"),
+        ("event_set", "event set"),
+        ("event_disposition", "invalid disposition"),
+        ("explain_type", "explain_required must be a list"),
+        ("explain_values", "explain_required does not match"),
+        ("authority_effect", "cannot create authority"),
+    ],
+)
+def test_policy_contract_rejects_every_fail_closed_boundary(tmp_path: Path, case: str, message: str):
+    policy = _load(POLICY_PATH)
+    if case == "schema_version":
+        policy["schema_version"] = "orchestra.presentation-policy.v0"
+    elif case == "default_disposition":
+        policy["default_disposition"] = "MURMUR"
+    elif case == "events_type":
+        policy["events"] = []
+    elif case == "event_set":
+        del policy["events"]["TOOL_STARTED"]
+    elif case == "event_disposition":
+        policy["events"]["TOOL_STARTED"] = "UNKNOWN"
+    elif case == "explain_type":
+        policy["explain_required"] = "TASK_COMPLETED"
+    elif case == "explain_values":
+        policy["explain_required"] = policy["explain_required"][:-1]
+    elif case == "authority_effect":
+        policy["authority_effect"]["presentation_may_change_machine_state"] = True
+    else:  # pragma: no cover - parametrization owns the finite cases
+        raise AssertionError(case)
+    _write_contracts(tmp_path, policy=policy)
+    with pytest.raises(ValueError, match=message):
+        load_presentation_policy(tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("case", "message"),
+    [
+        ("schema_version", "schema_version"),
+        ("selection", "selection strategy"),
+        ("constraints", "constraints"),
+        ("entries_type", "non-empty list"),
+        ("entries_empty", "non-empty list"),
+        ("duplicate", "unique"),
+        ("untrimmed", "trimmed"),
+        ("too_long", "length/newline"),
+        ("newline", "length/newline"),
+    ],
+)
+def test_vocabulary_contract_rejects_nonsemantic_boundary_violations(tmp_path: Path, case: str, message: str):
+    vocabulary = _load(VOCABULARY_PATH)
+    if case == "schema_version":
+        vocabulary["schema_version"] = "orchestra.murmurs-vocabulary.v0"
+    elif case == "selection":
+        vocabulary["selection"] = "RANDOM"
+    elif case == "constraints":
+        vocabulary["constraints"]["allow_status_claims"] = True
+    elif case == "entries_type":
+        vocabulary["entries"] = "hm..."
+    elif case == "entries_empty":
+        vocabulary["entries"] = []
+    elif case == "duplicate":
+        vocabulary["entries"] = ["hm...", "hm..."]
+    elif case == "untrimmed":
+        vocabulary["entries"] = [" hm..."]
+    elif case == "too_long":
+        vocabulary["entries"] = ["abcdefghijklmnop"]
+    elif case == "newline":
+        vocabulary["entries"] = ["hm...\n"]
+    else:  # pragma: no cover - parametrization owns the finite cases
+        raise AssertionError(case)
+    _write_contracts(tmp_path, vocabulary=vocabulary)
+    with pytest.raises(ValueError, match=message):
+        load_murmurs_vocabulary(tmp_path)
+
+
 def test_status_claim_in_vocabulary_fails_closed_to_explain(tmp_path: Path):
     vocabulary = _load(VOCABULARY_PATH)
     vocabulary["entries"] = ["done"]


### PR DESCRIPTION
## Scope

Implements the first bounded core slice of #300 on historical canonical base `7070a9d9b31c190b95a2a8a40c410e5aa41e89a0`.

This candidate added the initial Murmurs policy/vocabulary/schema and deterministic presentation core. It was intentionally incomplete and predates the governance stabilization checkpoint.

## Superseded closeout

This draft is now **superseded** and must not be used as a canonical implementation or merge candidate.

After the merge-readiness governance defect was repaired, Murmurs was re-established on the corrected canonical base, expanded with shared adapter integration, measurement contracts, safety/documentation coverage, and signed materialization, then merged through canonical PR #308.

Canonical Murmurs merge:
- PR #308
- canonical merge commit: `b8d32a29bd0d6210bd3eb31ff63e474a88b9ebb9`

The current canonical main has advanced beyond that checkpoint. This PR is closed only as superseded bookkeeping. Its branch/history is intentionally preserved.

No branch deletion, force push, history rewrite, release/version/tag, ruleset change, deployment, installed-integration refresh, or MCP work is performed by this closeout.