### PR TITLE
fix(governance): require clean GitHub merge state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@
 ## Post-v1.2.0 Specialist Knowledge Layer - SK10 Hardening and Evaluation - Pending
 
 - Added evidence-driven hardening guides for Weaver model/source traceability, Conductor routing evaluation, The Tuner contradiction/invalidation coordination, and Arbiter continuity/handoff evaluation.
-- Added a selective JSON adversarial scenario catalog with deterministic regression coverage for routing, ownership, contradiction, re-entry, stale diagrams, handoff identity, continuity, and protected-action boundaries.
+- Added a selective JSON adversarial scenario catalog with deterministic regression coverage for routing, ownership, contradiction, re-entry, stale diagrams, handoff identity, and protected-action boundaries.
 - Preserved existing orchestration and governance contracts; no routing, authority, runtime, manifest, policy, release, or deployment redesign was introduced.
 - No release/tag publication, deployment/production mutation, installed-integration refresh, policy activation, destructive cleanup, branch deletion, force push, or history rewrite is performed by SK10.
 
@@ -121,7 +121,7 @@
 - Added progressive-disclosure guidance for semantic HTML, ARIA/accessibility state, keyboard and focus behavior, responsive CSS layout/overflow, forms and validation recovery, design tokens/component states, and frontend routing/component-boundary literacy.
 - Expanded four previously minimal Cloak worked examples covering responsive layout, destructive dialog interaction, navigation structure, and checkout recovery.
 - Kept the campaign Markdown-primary and JSON-selective: the SK4 audit found no concrete machine-parsing need that justified a new Cloak JSON catalog.
-- Preserved implementation ownership with Ponytail, architecture/state ownership with Clockwork, security policy with Cipher, persistence with Chronicler, readiness gates with Overseer, and diagram/documentation ownership with Weaver/Scribe.
+- Preserved implementation ownership with Ponytail, architecture/state ownership with Clockwork, security policy with Cipher, persistence with Chronicler, and diagram/documentation ownership with Weaver/Scribe.
 - Added focused regression coverage for Cloak knowledge depth and canonical/Codex support-file parity.
 - No release/publication, deployment/production mutation, installed-integration refresh, policy activation, destructive cleanup, branch deletion, force push, or history rewrite is performed by SK4.
 ## Post-v1.2.0 Specialist Knowledge Layer - SK3 Cipher - Pending
@@ -165,6 +165,7 @@
 - Performs no release, tag, deployment, marketplace graduation, installed-integration refresh, policy activation, or branch deletion.
 
 ## v1.2.0 - Published 2026-08-09
+
 - Published the stable minor release from annotated tag `v1.2.0` at exact release commit `4f3c45f6d1e5f290aca108ddf5810c1b18f1dc76`.
 - Published [Orchestra v1.2.0: Governed Orchestration](https://github.com/Baelfyre/Orchestra/releases/tag/v1.2.0) as a non-draft, non-prerelease, immutable GitHub Release.
 - Preserved R7-E2, R7-F, R7-G, and R7-H evidence identities, Claude Code `SCAFFOLD_ONLY` maturity, and the repository simulation fixture as pending/empty by design.
@@ -244,6 +245,7 @@ The first autonomous finalization experiment was rolled back to the verified rec
 Historical fail-open or bypass-capable platform behavior is not successful validation precedent.
 
 ### Capability Merge Map
+
 Key post-`v1.1.2` canonical milestones include:
 
 - PR #190 - Delegated Phase B instruction-level progression.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,7 +121,7 @@
 - Added progressive-disclosure guidance for semantic HTML, ARIA/accessibility state, keyboard and focus behavior, responsive CSS layout/overflow, forms and validation recovery, design tokens/component states, and frontend routing/component-boundary literacy.
 - Expanded four previously minimal Cloak worked examples covering responsive layout, destructive dialog interaction, navigation structure, and checkout recovery.
 - Kept the campaign Markdown-primary and JSON-selective: the SK4 audit found no concrete machine-parsing need that justified a new Cloak JSON catalog.
-- Preserved implementation ownership with Ponytail, architecture/state ownership with Clockwork, security policy with Cipher, persistence with Chronicler, and diagram/documentation ownership with Weaver/Scribe.
+- Preserved implementation ownership with Ponytail, architecture/state ownership with Clockwork, security policy with Cipher, persistence with Chronicler, readiness gates with Overseer, and diagram/documentation ownership with Weaver/Scribe.
 - Added focused regression coverage for Cloak knowledge depth and canonical/Codex support-file parity.
 - No release/publication, deployment/production mutation, installed-integration refresh, policy activation, destructive cleanup, branch deletion, force push, or history rewrite is performed by SK4.
 ## Post-v1.2.0 Specialist Knowledge Layer - SK3 Cipher - Pending

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Post-v1.4.0 Governance Stabilization - Merge-State Fail-Closed Repair
+
+- Repairs autonomous merge readiness so `mergeable=true` is insufficient for ordinary governed progression; the current PR read must also report `mergeable_state=clean`.
+- Treats missing or unknown mergeability as `WAIT_FOR_EVIDENCE` and fails closed on `blocked`, `behind`, `dirty`, `unstable`, or any other observed non-clean merge state.
+- Carries the accepted pre-merge disposition, mergeable state, and bypass-use record into post-merge verification so API success, a signed canonical commit, or matching tree content cannot retroactively satisfy a failed pre-merge gate.
+- Adds regression coverage for the PR #299 incident shape and documents a forward-only stabilization boundary under #302 without claiming a GitHub-recorded bypass event that is not independently available.
+- Does not rewrite PR #299 history, change the `Protect main` ruleset, weaken validation or coverage, select a version, publish a release, deploy, refresh installed integrations, or begin Murmurs or MCP work.
+
 ## Post-v1.4.0 Control Plane Re-foundation - LEGACY_RETIRED Candidate
 
 - Advances the separately governed migration from `CANONICAL_PROMOTION_AUTHORITY` to `LEGACY_RETIRED` without changing the published `v1.4.0` release.
@@ -50,7 +58,7 @@
 ## Post-v1.2.0 Specialist Knowledge Layer - SK10 Hardening and Evaluation - Pending
 
 - Added evidence-driven hardening guides for Weaver model/source traceability, Conductor routing evaluation, The Tuner contradiction/invalidation coordination, and Arbiter continuity/handoff evaluation.
-- Added a selective JSON adversarial scenario catalog with deterministic regression coverage for routing, ownership, contradiction, re-entry, stale diagrams, handoff identity, and protected-action boundaries.
+- Added a selective JSON adversarial scenario catalog with deterministic regression coverage for routing, ownership, contradiction, re-entry, stale diagrams, handoff identity, continuity, and protected-action boundaries.
 - Preserved existing orchestration and governance contracts; no routing, authority, runtime, manifest, policy, release, or deployment redesign was introduced.
 - No release/tag publication, deployment/production mutation, installed-integration refresh, policy activation, destructive cleanup, branch deletion, force push, or history rewrite is performed by SK10.
 
@@ -157,7 +165,6 @@
 - Performs no release, tag, deployment, marketplace graduation, installed-integration refresh, policy activation, or branch deletion.
 
 ## v1.2.0 - Published 2026-08-09
-
 - Published the stable minor release from annotated tag `v1.2.0` at exact release commit `4f3c45f6d1e5f290aca108ddf5810c1b18f1dc76`.
 - Published [Orchestra v1.2.0: Governed Orchestration](https://github.com/Baelfyre/Orchestra/releases/tag/v1.2.0) as a non-draft, non-prerelease, immutable GitHub Release.
 - Preserved R7-E2, R7-F, R7-G, and R7-H evidence identities, Claude Code `SCAFFOLD_ONLY` maturity, and the repository simulation fixture as pending/empty by design.
@@ -237,7 +244,6 @@ The first autonomous finalization experiment was rolled back to the verified rec
 Historical fail-open or bypass-capable platform behavior is not successful validation precedent.
 
 ### Capability Merge Map
-
 Key post-`v1.1.2` canonical milestones include:
 
 - PR #190 - Delegated Phase B instruction-level progression.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ The cumulative P0/P1 through P9 control-plane re-foundation is canonical through
 
 The migration state in this revision is `LEGACY_RETIRED`. The versioned machine specialist registry, routing contract, and governance policy are the runtime's normative sources for specialist identity, command routing and ambiguity fallback, governance-required specialist classification, and governance validation rules. Runtime construction reads those contracts directly instead of consuming independently maintained compatibility tables. The legacy `VALID_SPECIALISTS` import remains available only as an on-demand machine-derived compatibility view. Installed integrations are not mutated by this stage, and release publication remains a separate governed transition.
 
+Merge readiness is also machine-bound rather than inferred from a successful API call. For an ordinary protected Squash merge, the current PR read must report both `mergeable == true` and `mergeable_state == clean`. Missing or unknown mergeability waits for evidence; `blocked`, `behind`, `dirty`, `unstable`, or any other observed non-clean state blocks ordinary progression. A bypass-capable identity and a signed resulting commit do not retroactively convert a failed pre-merge gate into governed readiness. See the [Autonomous Merge Readiness Protocol](docs/governance/AUTONOMOUS_MERGE_READINESS_PROTOCOL.md).
+
 ## v1.4.0 Governance and Compliance Registry Cross-Integration
 
 The repository/package version and current public GitHub release are both `v1.4.0`. The immutable, non-draft, non-prerelease release `Orchestra v1.4.0: Governance & Compliance Registry Cross-Integration` is published from exact signed canonical commit `93dd51c0fbe1b10affc58e6fadd5fb0bc2927a50`; tag `v1.4.0` resolves directly to that commit.
@@ -328,7 +330,7 @@ The validation chain covers:
 - native Windows, Ubuntu, and macOS validation;
 - `git diff --check` and exact authorized scope.
 
-For autonomous or delegated merges, Orchestra additionally requires the fail-closed [Autonomous Merge Readiness Protocol](docs/governance/AUTONOMOUS_MERGE_READINESS_PROTOCOL.md): a green canonical baseline, exact-head evidence, complete successful required checks, expected-head merge guard where supported, and independent post-merge verification.
+For autonomous or delegated merges, Orchestra additionally requires the fail-closed [Autonomous Merge Readiness Protocol](docs/governance/AUTONOMOUS_MERGE_READINESS_PROTOCOL.md): a green canonical baseline, exact-head evidence, a raw current PR state with `mergeable == true` and `mergeable_state == clean`, complete successful required checks, expected-head merge guard where supported, no governed bypass use, and independent post-merge verification.
 
 ## Release Lineage
 

--- a/docs/governance/AUTONOMOUS_MERGE_READINESS_PROTOCOL.md
+++ b/docs/governance/AUTONOMOUS_MERGE_READINESS_PROTOCOL.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This protocol defines Orchestra's fail-closed evidence gate for autonomous or delegated pull-request merges. It exists because GitHub may technically accept a merge even when repository validation is missing, red, stale, or bypassable. Platform capability is not governance readiness.
+This protocol defines Orchestra's fail-closed evidence gate for autonomous or delegated pull-request merges. It exists because GitHub may technically accept a merge even when repository validation is missing, red, stale, blocked, or bypassable. Platform capability is not governance readiness.
 
 Canonical merge rules:
 
@@ -71,8 +71,11 @@ A pre-merge snapshot must bind all evidence to one exact current PR head SHA and
 - changelog freshness when significant paths changed;
 - unresolved blocking findings;
 - unresolved review-thread count;
-- Git mergeability state;
+- GitHub's boolean `mergeable` value;
+- GitHub's raw `mergeable_state` value from the current PR REST representation;
 - every required workflow/job result with its exact head SHA, status, and conclusion.
+
+For an ordinary protected merge, `mergeable == true` and `mergeable_state == clean` are both required. The boolean alone is insufficient. A missing or `unknown` mergeable state is pending evidence. Any observed non-clean state such as `blocked`, `behind`, `dirty`, or `unstable` fails closed and must not be converted into readiness merely because the active identity has bypass capability.
 
 The canonical exact required-check inventory is:
 
@@ -107,14 +110,20 @@ UNRESOLVED_REVIEW_THREAD = BLOCK
 REQUIRED_CHANGELOG_MISSING = BLOCK
 RULESET_PROFILE_DRIFT = BLOCK
 MERGE_METHOD_NOT_SQUASH = BLOCK
+MERGEABLE_UNKNOWN = WAIT_FOR_EVIDENCE
+MERGEABLE_STATE_UNKNOWN = WAIT_FOR_EVIDENCE
+MERGEABLE_STATE_BLOCKED = BLOCK
+MERGEABLE_STATE_NON_CLEAN = BLOCK
 BYPASS_USED_WITHOUT_SEPARATE_AUTHORITY = BLOCK
 ```
 
-A high passing-test count, passing coverage threshold, `mergeable: true`, a bypass-capable actor, or a successful merge API call cannot override a failed or missing required check.
+A high passing-test count, passing coverage threshold, `mergeable: true`, a bypass-capable actor, or a successful merge API call cannot override a failed or missing required check or a non-clean GitHub merge state.
 
-`mergeable: true` is informational only: it means Git can construct a merge. It never proves governance readiness.
+`mergeable: true` is informational only. It means Git can construct a merge. It never proves governance readiness.
 
 `mergeable: false` blocks because the PR has a technical merge conflict.
+
+A missing or `unknown` `mergeable_state` returns `WAIT_FOR_EVIDENCE`. Ordinary governed merge readiness requires the exact current PR read to report `mergeable_state == clean`. Any other observed state blocks ordinary merge execution.
 
 ## Exact-Head Rule
 
@@ -132,11 +141,15 @@ Before merge:
 8. Require every required job conclusion to be `success`.
 9. Require every job's evidence head SHA to equal the current PR head SHA.
 10. Require zero unresolved review threads.
-11. Re-read the PR immediately before merge.
+11. Re-read the current PR REST state immediately before merge, including both `mergeable` and raw `mergeable_state`.
 12. If the head changed, discard prior evidence and return `STALE_EVIDENCE`.
-13. Use `expected_head_sha` or the platform's equivalent compare-and-swap guard when issuing the merge.
+13. If `mergeable` is not yet known or `mergeable_state` is missing/`unknown`, return `WAIT_FOR_EVIDENCE`.
+14. Require `mergeable == true` and `mergeable_state == clean`; otherwise return `BLOCK`.
+15. Use `expected_head_sha` or the platform's equivalent compare-and-swap guard when issuing the merge.
 
 Any remediation commit invalidates all earlier check evidence. The complete required matrix must be collected again for the new head.
+
+An accepted merge API response cannot retroactively repair a pre-merge `BLOCK`. When the acting identity can bypass repository rules, API acceptance is especially not evidence that the ordinary protected path was used.
 
 ## Canonical Baseline Rule
 
@@ -156,13 +169,16 @@ When repository governance classifies changed paths as significant, `CHANGELOG.m
 
 The Orchestra ruleset permits Squash only. A squash merge intentionally creates a new canonical commit SHA, so successful post-merge verification must not require the reviewed PR head SHA itself to remain in canonical `main` ancestry.
 
-Instead, the controller must prove that the canonical squash result is the exact reviewed change applied to the exact pre-merge base.
+Instead, the controller must prove that the canonical squash result is the exact reviewed change applied to the exact pre-merge base and that the pre-merge disposition was itself valid.
 
 Required evidence:
 
 - exact reviewed PR head SHA;
 - exact pre-merge base SHA;
 - exact reviewed head tree SHA;
+- pre-merge disposition `READY_FOR_MERGE`;
+- pre-merge `mergeable_state` equal to `clean`;
+- `bypass_used` equal to `false` for ordinary governed execution;
 - exact canonical main SHA after merge;
 - exact canonical main parent SHA;
 - exact canonical tree SHA after merge;
@@ -173,13 +189,16 @@ Required evidence:
 Required equivalence:
 
 ```text
+pre_merge_disposition == READY_FOR_MERGE
+pre_merge_mergeable_state == clean
+bypass_used == false
 canonical_tree == reviewed_tree
 canonical_parent == pre_merge_base
 content_diff_empty == true
 canonical_signature_verified == true
 ```
 
-Tree/content equivalence is not a substitute for pre-merge exact-head CI. It is the post-write proof that the newly created squash commit contains exactly the already-reviewed result.
+Tree/content equivalence is not a substitute for pre-merge exact-head CI or ordinary merge readiness. It is the post-write proof that the newly created squash commit contains exactly the already-reviewed result.
 
 A rebase merge is not valid under the current ruleset. A merge commit is not valid while linear history is required.
 
@@ -187,8 +206,11 @@ A rebase merge is not valid under the current ruleset. A merge commit is not val
 
 A merge write is not complete merely because an API returned success.
 
-The controller must perform a canonical remote read after the write and verify:
+The controller must first retain the accepted pre-merge evidence and then perform a canonical remote read after the write. It must verify:
 
+- the recorded pre-merge disposition was `READY_FOR_MERGE`;
+- the recorded pre-merge `mergeable_state` was `clean`;
+- no bypass was used by the governed merge path;
 - the PR now reports `merged == true`;
 - the observed merge method is `squash`;
 - the exact canonical main SHA is resolved from the remote;
@@ -210,13 +232,25 @@ Otherwise:
 MERGE_STATE_UNVERIFIED
 ```
 
-An intended action, attempted action, successful API response, or actor bypass capability must not be recorded as executed governance fact without this independent canonical remote read.
+An intended action, attempted action, successful API response, actor bypass capability, signed resulting commit, or matching tree must not be recorded as a governed-complete merge when the pre-merge gate was not `READY_FOR_MERGE`.
 
 ## PR #230 Historical Incident Boundary
 
 PR #230 exposed the previous ancestry-only post-merge assumption. Its reviewed head `f49a03c929be7df7c10c457a227a46532ef47854` and canonical rebase result `80f9bc71f00cc86c0021fd9da258f2eec596d7e0` have equivalent trees/content, but the reviewed head is not in canonical ancestry and the platform-generated canonical commit is unsigned.
 
 The repository history must not be rewritten merely to satisfy the old validator. That incident requires an explicit human canonical-history disposition and forward-only governance remediation. It is not successful precedent for future unsigned or rebase merges.
+
+## PR #299 Merge-State Incident Boundary
+
+PR #299 exposed a separate pre-merge evidence gap in the v2 machine-readable contract. The pre-merge PR representation recorded `mergeable=true` and `mergeable_state=blocked`, while the validator modeled only the boolean `mergeable` field. The linked identity also had repository bypass capability. The merge was accepted and produced a signed canonical Squash commit, but the available evidence cannot prove that the merge was an ordinary protected merge.
+
+The incident must therefore be handled forward-only:
+
+- do not rewrite or delete canonical history merely to erase the incident;
+- do not claim a recorded bypass unless GitHub evidence establishes it;
+- do not classify API acceptance or a signed resulting commit as proof of ordinary pre-merge readiness;
+- require the v3 contract to reject `mergeable=true` with `mergeable_state=blocked`;
+- establish a later clean canonical stabilization checkpoint through an ordinary `mergeable_state=clean` Squash path before relying on this campaign for release readiness.
 
 ## Server-Side Protection
 
@@ -236,4 +270,4 @@ The executable contract is:
 - `tests/behavior/autonomous-merge-readiness-fixtures.json`
 - `tests/runtime/test_autonomous_merge_readiness_contract.py`
 
-The fixtures intentionally cover missing check data, pending jobs, failed governance/runtime/cross-platform/CodeQL checks, stale heads, red baseline progression, changelog omission, mergeability misuse, ruleset drift, unauthorized bypass use, non-Squash merge selection, unresolved review threads, tree mismatch, parent drift, unsigned canonical commits, and unverified post-merge state.
+The fixtures intentionally cover missing check data, pending jobs, failed governance/runtime/cross-platform/CodeQL checks, stale heads, red baseline progression, changelog omission, boolean mergeability misuse, missing and unknown mergeable state, blocked/behind/dirty/unstable mergeable states, ruleset drift, unauthorized bypass use, non-Squash merge selection, unresolved review threads, pre-merge gate preservation, tree mismatch, parent drift, unsigned canonical commits, and unverified post-merge state.

--- a/scripts/validate_autonomous_merge_readiness_contract.py
+++ b/scripts/validate_autonomous_merge_readiness_contract.py
@@ -4,7 +4,7 @@ import re
 import sys
 from pathlib import Path
 
-SCHEMA_VERSION = "orchestra-autonomous-merge-readiness-v2"
+SCHEMA_VERSION = "orchestra-autonomous-merge-readiness-v3"
 
 REQUIRED_CHECKS = (
     ("Governance Check", "governance-check"),
@@ -36,6 +36,8 @@ EXPECTED_RULESET = {
 
 CHECK_STATUSES = {"queued", "in_progress", "completed"}
 PASS_CONCLUSION = "success"
+ORDINARY_MERGEABLE_STATE = "clean"
+PENDING_MERGEABLE_STATES = {"unknown"}
 PRE_MERGE_DISPOSITIONS = {
     "READY_FOR_MERGE",
     "WAIT_FOR_EVIDENCE",
@@ -60,6 +62,25 @@ def ruleset_matches(snapshot):
     if not isinstance(ruleset, dict):
         return False
     return all(ruleset.get(key) == value for key, value in EXPECTED_RULESET.items())
+
+
+def evaluate_mergeability(snapshot):
+    mergeable = snapshot.get("mergeable")
+    if mergeable is False:
+        return "BLOCK"
+    if mergeable is not True:
+        return "WAIT_FOR_EVIDENCE"
+
+    mergeable_state = snapshot.get("mergeable_state")
+    if not isinstance(mergeable_state, str) or not mergeable_state.strip():
+        return "WAIT_FOR_EVIDENCE"
+
+    normalized_state = mergeable_state.strip().lower()
+    if normalized_state in PENDING_MERGEABLE_STATES:
+        return "WAIT_FOR_EVIDENCE"
+    if normalized_state != ORDINARY_MERGEABLE_STATE:
+        return "BLOCK"
+    return None
 
 
 def evaluate_pre_merge(snapshot):
@@ -88,8 +109,9 @@ def evaluate_pre_merge(snapshot):
     if snapshot.get("changelog_required") and not snapshot.get("changelog_updated"):
         return "BLOCK"
 
-    if snapshot.get("mergeable") is False:
-        return "BLOCK"
+    mergeability_disposition = evaluate_mergeability(snapshot)
+    if mergeability_disposition is not None:
+        return mergeability_disposition
 
     if not snapshot.get("head_reconfirmed"):
         return "WAIT_FOR_EVIDENCE"
@@ -126,6 +148,12 @@ def evaluate_pre_merge(snapshot):
 
 
 def evaluate_post_merge(snapshot):
+    if snapshot.get("pre_merge_disposition") != "READY_FOR_MERGE":
+        return "MERGE_STATE_UNVERIFIED"
+    if str(snapshot.get("pre_merge_mergeable_state", "")).strip().lower() != ORDINARY_MERGEABLE_STATE:
+        return "MERGE_STATE_UNVERIFIED"
+    if snapshot.get("bypass_used") is not False:
+        return "MERGE_STATE_UNVERIFIED"
     if snapshot.get("merge_api_result") != "success":
         return "MERGE_STATE_UNVERIFIED"
     if not snapshot.get("canonical_read_completed"):
@@ -292,6 +320,8 @@ def validate(root):
         "NO_EVIDENCE != APPROVAL",
         "BYPASS_CAPABILITY != GOVERNANCE_AUTHORIZATION",
         "NO_CHECK_DATA = WAIT_FOR_EVIDENCE",
+        "MERGEABLE_STATE_BLOCKED = BLOCK",
+        "mergeable_state == clean",
         "Squash",
         "expected_head_sha",
         "MERGED_VERIFIED",

--- a/tests/behavior/autonomous-merge-readiness-fixtures.json
+++ b/tests/behavior/autonomous-merge-readiness-fixtures.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "orchestra-autonomous-merge-readiness-v2",
+  "schema_version": "orchestra-autonomous-merge-readiness-v3",
   "required_checks": [
     {"workflow": "Governance Check", "job": "governance-check"},
     {"workflow": "validate", "job": "validate"},
@@ -35,6 +35,7 @@
     "unresolved_blockers": 0,
     "unresolved_review_threads": 0,
     "mergeable": true,
+    "mergeable_state": "clean",
     "selected_merge_method": "squash",
     "bypass_used": false,
     "ruleset": {
@@ -83,7 +84,14 @@
     {"id": "changelog-missing", "overrides": {"changelog_required": true, "changelog_updated": false}, "expected_disposition": "BLOCK"},
     {"id": "head-not-reconfirmed", "overrides": {"head_reconfirmed": false}, "expected_disposition": "WAIT_FOR_EVIDENCE"},
     {"id": "merge-conflict", "overrides": {"mergeable": false}, "expected_disposition": "BLOCK"},
-    {"id": "mergeable-is-not-enough", "overrides": {"checks": null, "mergeable": true}, "expected_disposition": "WAIT_FOR_EVIDENCE"},
+    {"id": "mergeability-missing", "overrides": {"mergeable": null}, "expected_disposition": "WAIT_FOR_EVIDENCE"},
+    {"id": "mergeable-state-missing", "overrides": {"mergeable_state": null}, "expected_disposition": "WAIT_FOR_EVIDENCE"},
+    {"id": "mergeable-state-unknown", "overrides": {"mergeable_state": "unknown"}, "expected_disposition": "WAIT_FOR_EVIDENCE"},
+    {"id": "mergeable-state-blocked", "overrides": {"mergeable": true, "mergeable_state": "blocked"}, "expected_disposition": "BLOCK"},
+    {"id": "mergeable-state-behind", "overrides": {"mergeable": true, "mergeable_state": "behind"}, "expected_disposition": "BLOCK"},
+    {"id": "mergeable-state-dirty", "overrides": {"mergeable": true, "mergeable_state": "dirty"}, "expected_disposition": "BLOCK"},
+    {"id": "mergeable-state-unstable", "overrides": {"mergeable": true, "mergeable_state": "unstable"}, "expected_disposition": "BLOCK"},
+    {"id": "mergeable-is-not-enough", "overrides": {"checks": null, "mergeable": true, "mergeable_state": "clean"}, "expected_disposition": "WAIT_FOR_EVIDENCE"},
     {"id": "unresolved-blocker", "overrides": {"unresolved_blockers": 1}, "expected_disposition": "BLOCK"},
     {"id": "unresolved-thread", "overrides": {"unresolved_review_threads": 1}, "expected_disposition": "BLOCK"},
     {"id": "approval-requirement-drift", "ruleset_overrides": {"required_approvals": 1}, "expected_disposition": "BLOCK"},
@@ -97,6 +105,51 @@
       "id": "verified-squash",
       "expected_disposition": "MERGED_VERIFIED",
       "snapshot": {
+        "pre_merge_disposition": "READY_FOR_MERGE",
+        "pre_merge_mergeable_state": "clean",
+        "bypass_used": false,
+        "merge_api_result": "success",
+        "canonical_read_completed": true,
+        "pr_merged": true,
+        "merge_method": "squash",
+        "reviewed_head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "canonical_main_sha": "cccccccccccccccccccccccccccccccccccccccc",
+        "reviewed_tree_sha": "dddddddddddddddddddddddddddddddddddddddd",
+        "canonical_tree_sha": "dddddddddddddddddddddddddddddddddddddddd",
+        "pre_merge_base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "canonical_parent_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "content_diff_empty": true,
+        "canonical_signature_verified": true
+      }
+    },
+    {
+      "id": "blocked-pre-merge-state",
+      "expected_disposition": "MERGE_STATE_UNVERIFIED",
+      "snapshot": {
+        "pre_merge_disposition": "BLOCK",
+        "pre_merge_mergeable_state": "blocked",
+        "bypass_used": false,
+        "merge_api_result": "success",
+        "canonical_read_completed": true,
+        "pr_merged": true,
+        "merge_method": "squash",
+        "reviewed_head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "canonical_main_sha": "cccccccccccccccccccccccccccccccccccccccc",
+        "reviewed_tree_sha": "dddddddddddddddddddddddddddddddddddddddd",
+        "canonical_tree_sha": "dddddddddddddddddddddddddddddddddddddddd",
+        "pre_merge_base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "canonical_parent_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "content_diff_empty": true,
+        "canonical_signature_verified": true
+      }
+    },
+    {
+      "id": "bypass-post-merge-state",
+      "expected_disposition": "MERGE_STATE_UNVERIFIED",
+      "snapshot": {
+        "pre_merge_disposition": "READY_FOR_MERGE",
+        "pre_merge_mergeable_state": "clean",
+        "bypass_used": true,
         "merge_api_result": "success",
         "canonical_read_completed": true,
         "pr_merged": true,

--- a/tests/runtime/test_autonomous_merge_readiness_contract.py
+++ b/tests/runtime/test_autonomous_merge_readiness_contract.py
@@ -39,6 +39,8 @@ def test_real_repository_contract_passes():
 
 def test_fully_green_exact_head_is_ready():
     case, snapshot = pre_case("fully-green")
+    assert snapshot["mergeable"] is True
+    assert snapshot["mergeable_state"] == "clean"
     assert validator.evaluate_pre_merge(snapshot) == case["expected_disposition"]
 
 
@@ -50,6 +52,9 @@ def test_missing_and_pending_evidence_waits():
         "queued-windows",
         "in-progress-macos",
         "head-not-reconfirmed",
+        "mergeability-missing",
+        "mergeable-state-missing",
+        "mergeable-state-unknown",
         "mergeable-is-not-enough",
     ):
         case, snapshot = pre_case(case_id)
@@ -90,12 +95,26 @@ def test_required_changelog_omission_blocks():
 def test_mergeable_true_cannot_shortcut_missing_checks():
     _, snapshot = pre_case("mergeable-is-not-enough")
     assert snapshot["mergeable"] is True
+    assert snapshot["mergeable_state"] == "clean"
     assert validator.evaluate_pre_merge(snapshot) == "WAIT_FOR_EVIDENCE"
 
 
 def test_merge_conflict_blocks():
     _, snapshot = pre_case("merge-conflict")
     assert validator.evaluate_pre_merge(snapshot) == "BLOCK"
+
+
+def test_non_clean_mergeable_states_fail_closed():
+    for case_id in (
+        "mergeable-state-blocked",
+        "mergeable-state-behind",
+        "mergeable-state-dirty",
+        "mergeable-state-unstable",
+    ):
+        _, snapshot = pre_case(case_id)
+        assert snapshot["mergeable"] is True
+        assert snapshot["mergeable_state"] != "clean"
+        assert validator.evaluate_pre_merge(snapshot) == "BLOCK"
 
 
 def test_unresolved_blocker_and_thread_block():
@@ -123,6 +142,12 @@ def test_bypass_capability_is_not_governance_authority():
 def test_merge_api_success_alone_is_not_verified():
     case = post_case("api-success-only")
     assert validator.evaluate_post_merge(case["snapshot"]) == "MERGE_STATE_UNVERIFIED"
+
+
+def test_post_merge_requires_clean_pre_merge_state_and_no_bypass():
+    for case_id in ("blocked-pre-merge-state", "bypass-post-merge-state"):
+        case = post_case(case_id)
+        assert validator.evaluate_post_merge(case["snapshot"]) == "MERGE_STATE_UNVERIFIED"
 
 
 def test_post_merge_requires_squash_equivalence_and_signature():


### PR DESCRIPTION
## Scope

Forward-only stabilization for governance incident #302 on exact canonical base `7070a9d9b31c190b95a2a8a40c410e5aa41e89a0`.

This change repairs the autonomous merge-readiness contract so `mergeable=true` cannot be interpreted as governed readiness when GitHub reports a non-clean `mergeable_state`.

### Changes
- advance the merge-readiness fixture contract to v3;
- require `mergeable == true` and `mergeable_state == clean` for ordinary `READY_FOR_MERGE`;
- treat missing/unknown mergeability as `WAIT_FOR_EVIDENCE`;
- fail closed on `blocked`, `behind`, `dirty`, `unstable`, and any other observed non-clean state;
- preserve the pre-merge disposition, mergeable state, and bypass-use record in post-merge verification;
- add regression coverage matching the PR #299 incident shape;
- document PR #299 as a forward-only incident boundary without asserting a GitHub-recorded bypass event.

## Boundaries

- no ruleset mutation;
- no validation or coverage weakening;
- no history rewrite or force push;
- no branch deletion;
- no release/version/tag action;
- no deployment, marketplace publication, or installed-integration refresh;
- no Murmurs implementation;
- no MCP work.

This PR does not retroactively classify PR #299 as an ordinary protected merge. It establishes a machine-enforced guard against recurrence and a clean forward stabilization path.

Tracks #302, #291, #279, #292, #273.