### PR TITLE
chore(docs): materialize v1.5.0 publication closeout as signed commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## Post-v1.4.0 Integrated Release Candidate Hardening - In Progress
+## v1.5.0 Machine-Verifiable Control Plane and Murmurs - Published 2026-08-16
 
-- Adds a cross-layer release-sanity regression proving that Murmurs routine-progress compression does not change the workflow receipt digest, validation result, or Arbiter disposition, while terminal completion remains hard-bound to `EXPLAIN`.
-- Starts fresh post-Murmurs release evidence generation under #292 and #300. Any validation attached to an earlier source head remains stale after subsequent RC changes and cannot authorize the final release.
-- Selects `1.5.0` as the additive minor release candidate from compatibility evidence; no tag or GitHub Release is published by preparation, and no marketplace publication, deployment, installed-integration refresh, ruleset mutation/bypass, branch deletion, force push, history rewrite, destructive cleanup, or MCP implementation is performed.
+- Published `Orchestra v1.5.0: Machine-Verifiable Control Plane and Murmurs` as immutable, non-draft, non-prerelease GitHub Release id `371314544` from lightweight tag `v1.5.0`, which resolves directly to exact signed canonical release commit `b0a56cc7af8ad78234754bcb29ed07f6ab54d920`.
+- Completed the machine-verifiable control-plane re-foundation through `LEGACY_RETIRED`, preserving the versioned machine specialist registry, routing contract, governance policy, exact evidence/receipt stack, deterministic Arbiter Kernel, continuity/context state, persistent remediation circuit, pre-execution policy gate, and host conformance boundaries.
+- Published the fail-closed merge-readiness stabilization requiring current `mergeable=true` and `mergeable_state=clean` for ordinary governed progression, with prior accepted pre-merge state carried into post-merge verification.
+- Published the additive Murmurs communication budget with `NORMAL` as the default and deterministic `SILENT`, local `MURMUR`, and required `EXPLAIN` dispositions; no billing-token savings percentage is claimed without comparable host-reported counters.
+- Final release evidence recorded 1,058 passing runtime tests, 98.47% statement coverage, 95.36% branch coverage, passing critical-module floors, governance, CodeQL and native-platform validation, plus complete Mutmut and Cosmic Ray campaigns.
+- Added `docs/validation/V1_5_0_PUBLICATION_CLOSEOUT.md` and reconciled human/machine current-facing release, setup, roadmap, project-state, context, and handoff documentation without moving the fixed release tag or performing marketplace publication, installed-integration refresh, deployment, policy activation, destructive cleanup, branch deletion, force push, history rewrite, or MCP implementation.
+- MCP was intentionally excluded from v1.5.0. Publication satisfies its sequencing prerequisite only; any MCP work requires a fresh post-release dependency/risk/value and design decision.
 
 ## Post-v1.4.0 Murmurs Communication Budget - Candidate
 
@@ -40,7 +44,7 @@
 - P9 began in `SHADOW`, advanced through separately governed `ADVISORY` and `VALIDATION_AUTHORITY` checkpoints, and this candidate advances only to `CANONICAL_PROMOTION_AUTHORITY`; it does not grant legacy retirement or installed-integration mutation.
 - The versioned machine specialist registry, routing contract, and governance policy now supply runtime default specialist identity, command routes and ambiguity fallback, governance-required specialist classification, runtime validation rules, Arbiter transition precedence, and remediation defaults. Backward-compatible runtime names remain derived compatibility surfaces rather than independent authority.
 - Release hardening persists machine-readable runtime evidence with statement and branch coverage, critical-module floors, property-based regressions, workflow-sanity coverage, bounded mutation-confidence evidence, and cross-platform validation. These measurements are confidence evidence, not proof of correctness.
-- PR #294 is canonical through governed Squash merge and independent readback at signed commit `76eb96b27439700a517f75c5a921465e5c2987e6` with tree `6f98b380d984430303d630462ad4535cda483925`. This post-`v1.4.0` integration preserves `v1.4.0` as the current published release and creates no new tag, version, or GitHub Release.
+- PR #294 is canonical through governed Squash merge and independent readback at signed commit `76eb96b27439700a517f75c5a921465e5c2987e6` with tree `6f98b380d984430303d630462ad4535cda483925`. This post-`v1.4.0` integration preserves `v1.4.0` as the current published release at that checkpoint and creates no new tag, version, or GitHub Release.
 - Added the compact machine release-evidence index at `machine/release-evidence/control-plane-refoundation-p0-p1-p9.json`, referencing the exact final integrated candidate runtime and bounded Cosmic Ray evidence without treating coverage or mutation score as proof of correctness.
 - Added typed migration-state checkpoints and regression coverage for the adjacent `SHADOW -> ADVISORY -> VALIDATION_AUTHORITY -> CANONICAL_PROMOTION_AUTHORITY` progression while preserving `LEGACY_RETIRED` as a separately governed decision.
 
@@ -54,7 +58,7 @@
 - Added `docs/releases/v1.4.0-governance-compliance-registry-release-candidate.md` and preserved `v1.3.0` as the current public release until separately authorized `v1.4.0` tag and GitHub Release publication.
 - Published and independently verified the trusted immutable Registry release `registry-v0.1.0` at canonical Registry commit `3821bcb55125b4d8864f28b6423650e6e17ac67b`, then validated Orchestra's real network sync, exact provenance, freshness, source query, project pinning, update-check, and idempotent re-sync from canonical Orchestra source baseline `b5d0790fc714f53c4561a91b158c13c625768e05`.
 - Added `docs/validation/V1_4_0_RELEASE_READINESS_EVIDENCE.md`; at that readiness checkpoint, Orchestra `v1.4.0` public release/tag publication remained a separate protected transition.
-- Published `Orchestra v1.4.0: Governance & Compliance Registry Cross-Integration` as GitHub Release id `370658917` from lightweight tag `v1.4.0`, which resolves directly to exact signed canonical release commit `93dd51c0fbe1b10affc58e6fadd5fb0bc2927a50`; independently verified non-draft, non-prerelease, immutable, and latest.
+- Published `Orchestra v1.4.0: Governance & Compliance Registry Cross-Integration` as GitHub Release id `370658917` from lightweight tag `v1.4.0`, which resolves directly to exact signed canonical release commit `93dd51c0fbe1b10affc58e6fadd5fb0bc2927a50`; independently verified non-draft, non-prerelease, immutable, and latest at that publication checkpoint.
 - Added `docs/validation/V1_4_0_PUBLICATION_CLOSEOUT.md` and reconciled current-facing release, setup, roadmap, project-state, and handoff documentation without moving the fixed release tag or performing marketplace publication, installed-integration refresh, deployment, policy activation, destructive cleanup, branch deletion, force push, or history rewrite.
 
 ## Post-v1.3.0 Compliance Registry Local Cache - Pending

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -10,7 +10,7 @@ A governance-first specialist skill framework that routes complex AI-assisted so
 Open-source developer tooling and AI orchestration framework
 
 ## Current Stage
-v1.5.0 - Machine-Verifiable Control Plane and Murmurs (`PREPARED_NOT_RELEASED`). Repository package/version surfaces are prepared at `1.5.0`, while the current public GitHub Release remains `v1.4.0` until the separate final publication gate completes. The control-plane migration is `LEGACY_RETIRED`, fail-closed ordinary merge readiness requires `mergeable=true` and `mergeable_state=clean`, and Murmurs is canonical as an additive opt-in presentation mode with `NORMAL` as the default. Fresh post-Murmurs release hardening, exact signed canonical merge, tag publication, and GitHub Release verification remain required. MCP is deferred until v1.5.0 is independently `PUBLISHED_VERIFIED`. No marketplace publication, installed-integration refresh, deployment/production mutation, or policy activation is performed by candidate preparation.
+v1.5.0 - Machine-Verifiable Control Plane and Murmurs (`PUBLISHED_VERIFIED`). Repository package/version surfaces and the current public GitHub Release are aligned to `1.5.0`. The immutable, non-draft, non-prerelease release `Orchestra v1.5.0: Machine-Verifiable Control Plane and Murmurs` is published from lightweight tag `v1.5.0`, which resolves directly to exact signed canonical release commit `b0a56cc7af8ad78234754bcb29ed07f6ab54d920`. The control-plane migration is `LEGACY_RETIRED`, fail-closed ordinary merge readiness requires `mergeable=true` and `mergeable_state=clean`, and Murmurs is canonical as an additive opt-in presentation mode with `NORMAL` as the default. MCP is not part of v1.5.0; its publication prerequisite is satisfied, but any MCP work still requires a fresh post-release priority and design decision. No marketplace publication, installed-integration refresh, deployment/production mutation, or policy activation was performed by release publication.
 
 ## Primary Users
 Developers and maintainers who install Orchestra as a plugin, skill set, or runtime package inside a supported or scaffold-only IDE or coding host (Claude Code, Codex, Antigravity, Cursor, Windsurf, JetBrains, Zed, Neovim)
@@ -42,7 +42,7 @@ Guidance used for this classification:
 - Repository simulation and GitHub CI are not live installed-host evidence. Accepted R7 evidence is recorded separately for installed Codex and Antigravity continuity and Claude Code packaging compatibility; Claude Code active runtime continuity remains unclaimed under `SCAFFOLD_ONLY` maturity.
 - Governed Autonomy Profiles are reduction-only workflow gates. `HUMAN_GOVERNED` is the safe default, children cannot exceed parents, and no profile creates release, deployment, policy, destructive, force-push, history-rewrite, or authority-expansion permission.
 - Murmurs is presentation-only. It cannot modify machine state, authority, governance, validation, blockers, handoffs, or terminal outcomes, and it must not claim token savings without comparable host-reported counters.
-- MCP remains a future transport/integration boundary and must not become a source of authority. MCP implementation is deferred until v1.5.0 publication is complete and independently verified.
+- MCP remains a future transport/integration boundary and must not become a source of authority. The v1.5.0 publication prerequisite is complete, but implementation is not automatic and requires a fresh post-release priority/design gate.
 - No vendoring of external plugin code, and no claiming unsupported compatibility or compliance, per `docs/CONTRIBUTING.md`.
 
 ## Validation Requirements
@@ -53,7 +53,7 @@ Guidance used for this classification:
 - Manifest and packaging validators (`validate_claude_plugin.py`, `validate_ide_packaging.py`, `validate_manifest.py`, `validate_structure.py`) must pass.
 - Cross-layer contract validators and their behavior tests must pass for affected revisions.
 - `python scripts/validate_governed_autonomy_modes_contract.py` and its focused runtime tests must pass when autonomy-profile contracts change.
-- Final v1.5.0 release evidence must include fresh exact-head runtime/coverage, workflow-sanity, P9 conformance, Mutmut, integrated Cosmic Ray, native Windows/Ubuntu/macOS, CodeQL, governance, documentation parity, package-version parity, signed canonical merge, tag identity, and GitHub Release identity.
+- Published v1.5.0 release evidence records fresh exact-head runtime/coverage, workflow-sanity, P9 conformance, Mutmut, integrated Cosmic Ray, native Windows/Ubuntu/macOS, CodeQL, governance, documentation parity, package-version parity, signed canonical merge, tag identity, and GitHub Release identity.
 - `python scripts/preflight_sync_check.py` must be run against `origin/main` before starting a new local editing session, per `docs/CONTRIBUTING.md`.
 
 ## Known Constraints
@@ -61,7 +61,7 @@ Guidance used for this classification:
 - `tests/behavior/run-tests.ps1` is intentionally maintained in parallel with `run_tests.py` as the primary validation path for Windows environments, per `docs/MATURITY.md`.
 - Direct pushes to `main` are not part of the normal workflow; changes go through a branch and pull request except for documented maintainer bypass recovery cases.
 - Installed Codex and Antigravity parity, host context-reset behavior, and Windows filesystem-specific behavior require host-local evidence in addition to repository CI.
-- Repository package metadata is prepared at `1.5.0`, but the current public GitHub Release remains `v1.4.0`; lightweight tag `v1.4.0` continues to resolve to signed release commit `93dd51c0fbe1b10affc58e6fadd5fb0bc2927a50`. Candidate work must not move that fixed release tag.
+- Repository package metadata and the current public GitHub Release are `1.5.0`; lightweight tag `v1.5.0` resolves directly to signed release commit `b0a56cc7af8ad78234754bcb29ed07f6ab54d920`. Later `main` commits must not move that fixed release tag.
 - The Compliance Registry foundation, source/freshness pilot, deterministic packaging, immutable `registry-v0.1.0` publication, and Orchestra real network-provenance validation are complete; future Registry releases remain separately governed transitions.
 - Repository Murmurs simulation demonstrates structural progress-call reduction and outcome parity but does not prove a billing-token savings percentage.
 

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -5,8 +5,8 @@
 - **Canonical Branch:** `main`
 - **Base Branch:** `main`
 - **Stable Continuation Branch:** `main`
-- **Current Public Release:** `v1.4.0`
-- **Release Status:** `v1.5.0 PREPARED_NOT_RELEASED`; `v1.4.0 PUBLISHED_VERIFIED`
+- **Current Public Release:** `v1.5.0`
+- **Release Status:** `v1.5.0 PUBLISHED_VERIFIED`
 - **Target Release:** `v1.5.0`
 - **Release-Candidate Metadata:** `1.5.0`
 - **v1.2.0 Release State:** `PUBLISHED_VERIFIED`
@@ -19,34 +19,39 @@
 - **v1.4.0 Release Commit:** `93dd51c0fbe1b10affc58e6fadd5fb0bc2927a50`
 - **v1.4.0 Release Tree:** `1ef60b00e3ac6deba5da57c47d2a0850872d41a9`
 - **v1.4.0 Tag Ref:** lightweight `commit` ref, exact target verified
-- **v1.4.0 GitHub Release:** id `370658917`, immutable, non-draft, non-prerelease, latest until v1.5.0 publication
-- **v1.5.0 Candidate State:** `PREPARED_NOT_RELEASED`
-- **v1.5.0 Candidate Theme:** Machine-Verifiable Control Plane and Murmurs
-- **MCP State:** `DEFERRED_UNTIL_V1_5_0_PUBLISHED_VERIFIED`
+- **v1.4.0 GitHub Release:** id `370658917`, immutable, non-draft, non-prerelease, historical after v1.5.0 publication
+- **v1.5.0 Release State:** `PUBLISHED_VERIFIED`
+- **v1.5.0 Release Theme:** Machine-Verifiable Control Plane and Murmurs
+- **v1.5.0 Release Commit:** `b0a56cc7af8ad78234754bcb29ed07f6ab54d920`
+- **v1.5.0 Tag Ref:** lightweight `commit` ref, exact target verified
+- **v1.5.0 GitHub Release:** id `371314544`, immutable, non-draft, non-prerelease, independently verified latest
+- **MCP State:** `POST_V1_5_PRIORITY_REVIEW_REQUIRED`
 - **Policy Activation State:** `NOT_PERFORMED`
 
-## v1.5.0 Machine-Verifiable Control Plane and Murmurs - Release Candidate
+## v1.5.0 Machine-Verifiable Control Plane and Murmurs Publication
 
-The post-v1.4.0 control-plane re-foundation has reached `LEGACY_RETIRED` and the forward governance stabilization has repaired merge readiness so `mergeable=true` is insufficient without a current `mergeable_state=clean`. Murmurs is canonical as an additive opt-in presentation layer with `NORMAL` as the default and hard-required explanation for authority, human-action, failure, blocker, governance-stop, handoff, and terminal events.
+The post-v1.4.0 control-plane re-foundation is complete through `LEGACY_RETIRED`. Forward governance stabilization requires both `mergeable=true` and a current `mergeable_state=clean` for ordinary governed merge progression. Murmurs is canonical as an additive opt-in presentation layer with `NORMAL` as the default and hard-required explanation for authority, human-action, failure, blocker, governance-stop, handoff, and terminal events.
 
-Package/version metadata is prepared at `1.5.0` across all 11 release surfaces without changing public command identity, specialist identity, supported/scaffold host maturity, marketplace publication state, deployment state, or installed integrations. Compatibility evidence therefore supports a minor release rather than an intentional breaking major release.
+Package/version metadata is `1.5.0` across all 11 release surfaces without changing public command identity, specialist identity, supported/scaffold host maturity, marketplace publication state, deployment state, or installed integrations. Compatibility evidence supported a minor release rather than an intentional breaking major release.
 
-Fresh post-Murmurs release hardening is active under #292 and #300. A pre-version diagnostic checkpoint on exact source head `754d0183289fd543e9696aeb3c84bb94a42b130f` produced 1,055 passing runtime tests, 98.47% statement coverage, 95.36% branch coverage, all critical coverage floors green, Windows/Ubuntu/macOS validation green, Governance and validate green, and complete classified LEGACY_RETIRED Mutmut evidence. Those results are diagnostic only after release-metadata source movement and must be regenerated on the actual final candidate.
+The final published candidate passed the release campaign's exact-head runtime, statement/branch coverage, critical-module, workflow-sanity, P9 conformance, Mutmut, integrated Cosmic Ray, native Windows/Ubuntu/macOS, CodeQL, governance, package/version, Registry compatibility, signed canonical merge, tag-identity, and GitHub Release identity gates. The immutable GitHub Release was published from exact signed canonical release commit `b0a56cc7af8ad78234754bcb29ed07f6ab54d920` and independently verified.
 
 ```text
-CURRENT_PUBLIC_RELEASE=v1.4.0
+CURRENT_PUBLIC_RELEASE=v1.5.0
 TARGET_VERSION=1.5.0
 TARGET_TAG=v1.5.0
-V1_5_0_RELEASE_STATE=PREPARED_NOT_RELEASED
+V1_5_0_RELEASE_STATE=PUBLISHED_VERIFIED
+V1_5_0_RELEASE_COMMIT=b0a56cc7af8ad78234754bcb29ed07f6ab54d920
+V1_5_0_GITHUB_RELEASE_ID=371314544
 CONTROL_PLANE_STAGE=LEGACY_RETIRED
 MURMURS_DEFAULT=NORMAL
 MURMURS_TOKEN_PERCENT_CLAIM=UNAVAILABLE_WITHOUT_COMPARABLE_HOST_COUNTERS
-MCP_IMPLEMENTATION=DEFERRED_UNTIL_RELEASE_COMPLETE
+MCP_IMPLEMENTATION=NOT_INCLUDED_IN_V1_5_0
 ```
 
-Release publication remains separately gated. No v1.5.0 tag or GitHub Release exists merely because package metadata is prepared. The final candidate must pass fresh exact-head runtime/coverage, workflow-sanity, mutation and Cosmic Ray, cross-platform, CodeQL, governance, documentation-parity, signature, protected-merge, tag-identity, and release-identity verification.
+The v1.5.0 release tag is fixed. Post-publication documentation or later implementation may advance `main`, but must not move the immutable release identity. MCP publication dependency is satisfied, but no MCP implementation is implied or authorized by publication alone. It remains subject to a fresh post-v1.5 dependency/risk/value and design decision.
 
-See `docs/releases/v1.5.0-machine-verifiable-control-plane-murmurs-release-candidate.md`.
+See `docs/releases/v1.5.0-machine-verifiable-control-plane-murmurs-release-candidate.md`, `docs/validation/V1_5_0_RELEASE_READINESS_EVIDENCE.md`, and `docs/validation/V1_5_0_PUBLICATION_CLOSEOUT.md`.
 
 ## v1.4.0 Governance and Compliance Registry Cross-Integration Publication
 
@@ -55,7 +60,7 @@ The v1.4.0 governance upgrade is `PUBLISHED_VERIFIED`. The public GitHub Release
 The trusted Registry dependency is also complete: immutable `registry-v0.1.0` targets Registry canonical `3821bcb55125b4d8864f28b6423650e6e17ac67b`, and Orchestra network-provenance run `31811353512` / job `94802485762` passed exact release identity, real bundle integrity, `CURRENT` freshness, PH source query, project pinning, update-check, and idempotent re-sync. Final Orchestra PR #271 then passed the full exact-head matrix and merged as the signed release commit above; its canonical post-merge matrix passed Governance, validate, 568 runtime tests at 94.31% coverage, CodeQL actions/Python, and native Ubuntu/macOS/Windows.
 
 ```text
-CURRENT_PUBLIC_RELEASE=v1.4.0
+CURRENT_PUBLIC_RELEASE_AT_CHECKPOINT=v1.4.0
 V1_4_0_RELEASE_STATE=PUBLISHED_VERIFIED
 V1_4_0_TAG_REF_TYPE=commit
 V1_4_0_TAG_TARGET=93dd51c0fbe1b10affc58e6fadd5fb0bc2927a50
@@ -82,7 +87,7 @@ The first candidate PR #253 is preserved as fail-closed evidence: Stage 1 Strict
 Publication completed under separate explicit maintainer authority:
 
 ```text
-CURRENT_PUBLIC_RELEASE=v1.3.0
+CURRENT_PUBLIC_RELEASE_AT_CHECKPOINT=v1.3.0
 TARGET_VERSION=1.3.0
 TARGET_TAG=v1.3.0
 V1_3_0_RELEASE_STATE=PUBLISHED_VERIFIED
@@ -265,7 +270,7 @@ The current bypass list is intentionally retained for repository-operational acc
 - **v1.3.0 Preparation:** SK1-SK10 are `MERGED_VERIFIED`; package/version preparation is canonical through PR #255 at signed Squash `32257723d6ca72847e4581d8b927c7b14c77039e`, with 542 runtime tests at 94.33% coverage and all 9 observed exact-head checks passing.
 - **v1.3.0 Publication State:** Annotated tag `v1.3.0` targets exact signed release commit `3c6155c111981632649a3c3207fac8ac1edcea74`; the immutable, non-draft, non-prerelease GitHub Release `Orchestra v1.3.0: Specialist Intelligence` is `PUBLISHED_VERIFIED`. No deployment, marketplace publication, installed-integration refresh, or policy activation was performed.
 - **v1.4.0 Publication State:** Lightweight tag `v1.4.0` resolves directly to exact signed release commit `93dd51c0fbe1b10affc58e6fadd5fb0bc2927a50`; GitHub Release id `370658917`, `Orchestra v1.4.0: Governance & Compliance Registry Cross-Integration`, is immutable, non-draft, non-prerelease, and `PUBLISHED_VERIFIED`. No marketplace publication, installed-integration refresh, deployment, or policy activation was performed.
-- **v1.5.0 Preparation:** Package surfaces are prepared at `1.5.0`; fresh final exact-head evidence, signed canonical merge, tag publication, and GitHub Release verification remain pending. MCP remains deferred until that publication is complete.
+- **v1.5.0 Publication State:** Lightweight tag `v1.5.0` resolves directly to exact signed release commit `b0a56cc7af8ad78234754bcb29ed07f6ab54d920`; GitHub Release id `371314544`, `Orchestra v1.5.0: Machine-Verifiable Control Plane and Murmurs`, is immutable, non-draft, non-prerelease, and `PUBLISHED_VERIFIED`. MCP remains unimplemented and requires a fresh post-release priority/design gate.
 
 ## Local Startup Verification
 

--- a/README.json
+++ b/README.json
@@ -12,9 +12,9 @@
     "license": "MIT",
     "package_version": "1.5.0",
     "package_version_source": "plugin.json#/version",
-    "current_public_release": "v1.4.0",
+    "current_public_release": "v1.5.0",
     "release_candidate": "v1.5.0",
-    "release_candidate_status": "PREPARED_NOT_RELEASED"
+    "release_candidate_status": "PUBLISHED_VERIFIED"
   },
   "purpose": {
     "summary": "Portable orchestration runtime for structured AI-assisted software development.",
@@ -124,7 +124,7 @@
     "test_evidence_schema_version": "orchestra.test-evidence.v1",
     "communication_measurement_schema": "machine/schemas/communication-measurement.schema.json",
     "murmurs_measurement_policy": "Repository simulation may prove deterministic structural reductions such as fewer model-progress calls, but billing/model token deltas are reportable only when comparable live host-reported counters share the same counter identity. Unavailable token evidence remains unavailable rather than estimated.",
-    "release_candidate_policy": "v1.5.0 publication requires fresh exact-head runtime, branch, critical-module, mutation, Cosmic Ray, cross-platform, CodeQL, governance, documentation-parity, and release-identity evidence. Pre-version evidence is diagnostic only after source-head movement.",
+    "release_candidate_policy": "v1.5.0 is published and independently verified at signed release commit b0a56cc7af8ad78234754bcb29ed07f6ab54d920 with immutable tag and GitHub Release identity. Any future release candidate requires fresh exact-head runtime, branch, critical-module, mutation, Cosmic Ray, cross-platform, CodeQL, governance, documentation-parity, and release-identity evidence.",
     "mutation_evidence_policy": "Mutation scores are scope-specific and valid only when the configured unmutated baseline passes, all scheduled mutation jobs complete, and the machine-readable evidence artifact binds the tested checkout SHA and source-head SHA.",
     "evidence_policy": "Runtime confidence claims must be derived from persisted machine-readable CI evidence bound to the tested checkout SHA and source-head SHA."
   },
@@ -135,6 +135,7 @@
     "changelog": "CHANGELOG.md",
     "release_docs": "docs/releases/",
     "release_candidate_v1_5_0": "docs/releases/v1.5.0-machine-verifiable-control-plane-murmurs-release-candidate.md",
+    "publication_closeout_v1_5_0": "docs/validation/V1_5_0_PUBLICATION_CLOSEOUT.md",
     "validation_evidence": "docs/validation/",
     "third_party_provenance": "docs/THIRD_PARTY_PROVENANCE.md",
     "merge_readiness": "docs/governance/AUTONOMOUS_MERGE_READINESS_PROTOCOL.md",
@@ -159,6 +160,6 @@
     "treat_mergeable_boolean_without_clean_mergeable_state_as_insufficient": true,
     "treat_murmurs_as_presentation_only": true,
     "do_not_claim_murmurs_token_savings_without_comparable_host_reported_counters": true,
-    "treat_v1_5_0_as_prepared_not_released_until_tag_and_release_identity_are_independently_verified": true
+    "treat_v1_5_0_as_published_verified_only_when_tag_release_and_commit_identity_match": true
   }
 }

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Accessible summary: a request supplies project context and selects separate risk
 
 The cumulative P0/P1 through P9 control-plane re-foundation is canonical through PR #294, with post-merge evidence parity through PR #295. Migration authority progresses only through the explicit sequence `SHADOW -> ADVISORY -> VALIDATION_AUTHORITY -> CANONICAL_PROMOTION_AUTHORITY -> LEGACY_RETIRED`; no stage is inferred from test success or mergeability.
 
-The migration state in this revision is `LEGACY_RETIRED`. The versioned machine specialist registry, routing contract, and governance policy are the runtime's normative sources for specialist identity, command routing and ambiguity fallback, governance-required specialist classification, and governance validation rules. Runtime construction reads those contracts directly instead of consuming independently maintained compatibility tables. The legacy `VALID_SPECIALISTS` import remains available only as an on-demand machine-derived compatibility view. Installed integrations are not mutated by this stage, and release publication remains a separate governed transition.
+The migration state in this revision is `LEGACY_RETIRED`. The versioned machine specialist registry, routing contract, and governance policy are the runtime's normative sources for specialist identity, command routing and ambiguity fallback, governance-required specialist classification, and governance validation rules. Runtime construction reads those contracts directly instead of consuming independently maintained compatibility tables. The legacy `VALID_SPECIALISTS` import remains available only as an on-demand machine-derived compatibility view. Installed integrations were not mutated by this migration, and v1.5.0 publication was completed through its separate governed transition.
 
 Merge readiness is also machine-bound rather than inferred from a successful API call. For an ordinary protected Squash merge, the current PR read must report both `mergeable == true` and `mergeable_state == clean`. Missing or unknown mergeability waits for evidence; `blocked`, `behind`, `dirty`, `unstable`, or any other observed non-clean state blocks ordinary progression. A bypass-capable identity and a signed resulting commit do not retroactively convert a failed pre-merge gate into governed readiness. See the [Autonomous Merge Readiness Protocol](docs/governance/AUTONOMOUS_MERGE_READINESS_PROTOCOL.md).
 
@@ -129,21 +129,21 @@ Caveman-inspired semantic tool/log compression is deliberately not enabled by th
 
 ## v1.5.0 Machine-Verifiable Control Plane and Murmurs
 
-Repository package/version surfaces are prepared at `1.5.0` for the next governed release candidate. **The current public GitHub release remains `v1.4.0` until the separate final publication gate completes.**
+**`v1.5.0` is the current public GitHub release.** The immutable, non-draft, non-prerelease release `Orchestra v1.5.0: Machine-Verifiable Control Plane and Murmurs` was published from lightweight tag `v1.5.0`, which resolves directly to exact signed canonical release commit `b0a56cc7af8ad78234754bcb29ed07f6ab54d920`.
 
-v1.5.0 packages the completed machine-verifiable control-plane re-foundation, the fail-closed merge-readiness stabilization, and the additive Murmurs communication budget. Public package, command, specialist, and host surfaces remain present; compatibility names retained by the re-foundation are machine-derived rather than independently authoritative; Murmurs remains opt-in with `NORMAL` as the default. That compatibility evidence supports a minor release rather than an intentional breaking major release.
+v1.5.0 packages the completed machine-verifiable control-plane re-foundation, the fail-closed merge-readiness stabilization, and the additive Murmurs communication budget. Public package, command, specialist, and host surfaces remain present; compatibility names retained by the re-foundation are machine-derived rather than independently authoritative; Murmurs remains opt-in with `NORMAL` as the default. That compatibility evidence supported a minor release rather than an intentional breaking major release.
 
-Fresh post-Murmurs release hardening is required on the exact final candidate. A diagnostic pre-version checkpoint reached 1,055 passing runtime tests, 98.47% statement coverage, and 95.36% branch coverage, with the critical coverage floor passing. Those numbers are not final release authority because release metadata and documentation change the source head. Final values will come from the separately validated signed release candidate.
+The final publication boundary recorded 1,058 passing runtime tests, 98.47% statement coverage, and 95.36% branch coverage, together with the required critical-module, workflow-sanity, P9 conformance, Mutmut, integrated Cosmic Ray, native Windows/Ubuntu/macOS, CodeQL, governance, package/version, Registry compatibility, signed canonical merge, tag-identity, and release-identity evidence.
 
-See the [v1.5.0 release candidate](docs/releases/v1.5.0-machine-verifiable-control-plane-murmurs-release-candidate.md). MCP is intentionally deferred until this release is published and independently verified.
+See the [v1.5.0 release candidate](docs/releases/v1.5.0-machine-verifiable-control-plane-murmurs-release-candidate.md), [v1.5.0 release-readiness evidence](docs/validation/V1_5_0_RELEASE_READINESS_EVIDENCE.md), and [v1.5.0 publication closeout](docs/validation/V1_5_0_PUBLICATION_CLOSEOUT.md). MCP was intentionally excluded from v1.5.0. Publication satisfies its sequencing prerequisite only; any MCP work still requires a fresh post-release priority and design decision.
 
 ## v1.4.0 Governance and Compliance Registry Cross-Integration
 
-`v1.4.0` remains the current public GitHub release while v1.5.0 is prepared. The immutable, non-draft, non-prerelease release `Orchestra v1.4.0: Governance & Compliance Registry Cross-Integration` is published from exact signed canonical commit `93dd51c0fbe1b10affc58e6fadd5fb0bc2927a50`; tag `v1.4.0` resolves directly to that commit.
+`v1.4.0` is a historical published release after v1.5.0. The immutable, non-draft, non-prerelease release `Orchestra v1.4.0: Governance & Compliance Registry Cross-Integration` is published from exact signed canonical commit `93dd51c0fbe1b10affc58e6fadd5fb0bc2927a50`; tag `v1.4.0` resolves directly to that commit.
 
 v1.4.0 packages the Compliance Registry cross-integration as an Orchestra governance capability: offline-first verified local Registry consumption, explicit integrity/provenance/freshness state, project pinning, progressive-disclosure integration across Governor, Steward, and Arbiter, and preserved routing/authority boundaries.
 
-The Registry foundation, source/freshness pilot, deterministic packaging, and v0.1.0 release-readiness stack are canonical in `Baelfyre/Orchestra-Compliance-Registry`. The trusted `registry-v0.1.0` GitHub Release is published as non-draft, non-prerelease, and immutable at Registry commit `3821bcb55125b4d8864f28b6423650e6e17ac67b`. Orchestra completed real network-provenance validation from canonical source baseline `b5d0790fc714f53c4561a91b158c13c625768e05`, confirming the exact release identity, manifest and bundle hashes, `CURRENT` freshness, source query, project pinning, update-check behavior, and idempotent re-sync. At the v1.4.0 publication checkpoint, Orchestra's package and public release were both `1.4.0`; current repository package metadata may advance for a later unreleased candidate without moving the immutable v1.4.0 tag.
+The Registry foundation, source/freshness pilot, deterministic packaging, and v0.1.0 release-readiness stack are canonical in `Baelfyre/Orchestra-Compliance-Registry`. The trusted `registry-v0.1.0` GitHub Release is published as non-draft, non-prerelease, and immutable at Registry commit `3821bcb55125b4d8864f28b6423650e6e17ac67b`. Orchestra completed real network-provenance validation from canonical source baseline `b5d0790fc714f53c4561a91b158c13c625768e05`, confirming the exact release identity, manifest and bundle hashes, `CURRENT` freshness, source query, project pinning, update-check behavior, and idempotent re-sync. At the v1.4.0 publication checkpoint, Orchestra's package and public release were both `1.4.0`; subsequent repository package metadata advanced for v1.5.0 without moving the immutable v1.4.0 tag.
 
 It also adds a fail-closed **README Impact Gate** to the Governance Check workflow. Changes classified as significant to Orchestra's runtime, specialist skills, host adapters/manifests, governance/routing/setup/release contracts, version surfaces, or CI/governance scripts must update `README.md` in the same revision. Tests and validation-evidence-only changes do not force documentation churn.
 
@@ -306,7 +306,7 @@ Use the host-native path:
 - Antigravity: run `agy plugin install https://github.com/Baelfyre/Orchestra`.
 - Manual or scaffold-only hosts: follow the exact host boundary in the [Installation Guide](docs/setup/INSTALLATION.md).
 
-Repository manifests identify package version `1.5.0`. The current public GitHub release remains `v1.4.0` until the separately governed v1.5.0 publication transition succeeds. The version bump does not promote scaffold-only hosts, publish marketplaces, deploy anything, or refresh installed integrations.
+Repository manifests and the current public GitHub release identify package version `1.5.0`. The release publication did not promote scaffold-only hosts, publish marketplaces, deploy anything, or refresh installed integrations.
 
 ## Quick Start
 
@@ -359,13 +359,13 @@ For autonomous or delegated merges, Orchestra additionally requires the fail-clo
 
 ### v1.5.0 Machine-Verifiable Control Plane and Murmurs
 
-Repository package/version surfaces are prepared at `1.5.0`; publication is not yet complete. The candidate packages the machine-verifiable control plane, `LEGACY_RETIRED` migration closeout, merge-state fail-closed stabilization, and additive Murmurs communication budget. Fresh post-Murmurs exact-head release evidence and a signed protected canonical candidate are required before a `v1.5.0` tag or GitHub Release may be created.
+`v1.5.0` is the current published Orchestra release. It packages the machine-verifiable control plane, `LEGACY_RETIRED` migration closeout, merge-state fail-closed stabilization, and additive Murmurs communication budget from exact signed release commit `b0a56cc7af8ad78234754bcb29ed07f6ab54d920`. The GitHub Release is immutable, non-draft, and non-prerelease, and the fixed lightweight tag resolves directly to that commit.
 
-See the [v1.5.0 release candidate](docs/releases/v1.5.0-machine-verifiable-control-plane-murmurs-release-candidate.md).
+Release preparation and publication evidence are recorded in the [v1.5.0 release candidate](docs/releases/v1.5.0-machine-verifiable-control-plane-murmurs-release-candidate.md), [v1.5.0 release-readiness evidence](docs/validation/V1_5_0_RELEASE_READINESS_EVIDENCE.md), and [v1.5.0 publication closeout](docs/validation/V1_5_0_PUBLICATION_CLOSEOUT.md).
 
 ### v1.4.0 Governance and Compliance Registry Cross-Integration
 
-`v1.4.0` is the current published Orchestra release. It packages the verified Compliance Registry cross-integration and README Impact Gate from exact signed release commit `93dd51c0fbe1b10affc58e6fadd5fb0bc2927a50`. The GitHub Release is immutable, non-draft, and non-prerelease. Subsequent control-plane, Murmurs, and v1.5.0 preparation work does not move the v1.4.0 tag.
+`v1.4.0` is a historical published Orchestra release. It packages the verified Compliance Registry cross-integration and README Impact Gate from exact signed release commit `93dd51c0fbe1b10affc58e6fadd5fb0bc2927a50`. The GitHub Release is immutable, non-draft, and non-prerelease. Subsequent control-plane, Murmurs, and v1.5.0 publication work does not move the v1.4.0 tag.
 
 Release preparation and publication evidence are recorded in the [v1.4.0 governance upgrade release candidate](docs/releases/v1.4.0-governance-compliance-registry-release-candidate.md), [v1.4.0 release-readiness evidence](docs/validation/V1_4_0_RELEASE_READINESS_EVIDENCE.md), and [v1.4.0 publication closeout](docs/validation/V1_4_0_PUBLICATION_CLOSEOUT.md).
 
@@ -400,7 +400,7 @@ See the [v1.2.0 release notes](docs/releases/v1.2.0-governed-orchestration.md). 
 - Data sensitivity, privacy, retention, deletion, platform disclosure, and IP obligations depend on the downstream project and host environment.
 - Release governance may require revision or block publication.
 - Murmurs repository simulation does not prove a billing-token savings percentage; comparable host-reported counters are required for token claims.
-- Repository package metadata is prepared at `1.5.0`, while the current public release remains `v1.4.0` until the separately governed publication gate completes.
+- Repository package metadata and the current public release are `1.5.0`. Later `main` commits do not move the fixed v1.5.0 release tag.
 
 ## Documentation Map
 
@@ -434,6 +434,8 @@ See the [v1.2.0 release notes](docs/releases/v1.2.0-governed-orchestration.md). 
 ### Release and maintainers
 
 - [v1.5.0 Machine-Verifiable Control Plane and Murmurs Release Candidate](docs/releases/v1.5.0-machine-verifiable-control-plane-murmurs-release-candidate.md)
+- [v1.5.0 Release Readiness Evidence](docs/validation/V1_5_0_RELEASE_READINESS_EVIDENCE.md)
+- [v1.5.0 Publication Closeout](docs/validation/V1_5_0_PUBLICATION_CLOSEOUT.md)
 - [v1.4.0 Governance Upgrade Release Candidate](docs/releases/v1.4.0-governance-compliance-registry-release-candidate.md)
 - [v1.4.0 Prepublication Readiness Evidence](docs/validation/V1_4_0_PREPUBLICATION_READINESS_EVIDENCE.md)
 - [v1.3.0 Release Candidate](docs/releases/v1.3.0-specialist-intelligence-release-candidate.md)

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -3,9 +3,9 @@
 - **Canonical Repo:** `Baelfyre/Orchestra`
 - **Canonical Branch:** `main`
 - **Base Branch:** `main`
-- **Current Public Release:** `v1.4.0`
-- **Release-Candidate Metadata:** `v1.4.0`
-- **Target Release:** `v1.4.0`
+- **Current Public Release:** `v1.5.0`
+- **Release-Candidate Metadata:** `v1.5.0`
+- **Target Release:** `v1.5.0`
 - **v1.2.0 Release State:** `PUBLISHED_VERIFIED`
 - **v1.3.0 Release State:** `PUBLISHED_VERIFIED`
 - **v1.3.0 Release Commit:** `3c6155c111981632649a3c3207fac8ac1edcea74`
@@ -15,16 +15,33 @@
 - **v1.4.0 Release Commit:** `93dd51c0fbe1b10affc58e6fadd5fb0bc2927a50`
 - **v1.4.0 Release Tree:** `1ef60b00e3ac6deba5da57c47d2a0850872d41a9`
 - **v1.4.0 Tag Ref:** lightweight `commit` ref targeting the exact release commit
-- **v1.4.0 GitHub Release:** id `370658917`, immutable, non-draft, non-prerelease, latest
+- **v1.4.0 GitHub Release:** id `370658917`, immutable, non-draft, non-prerelease, historical after v1.5.0 publication
+- **v1.5.0 Release State:** `PUBLISHED_VERIFIED`
+- **v1.5.0 Release Commit:** `b0a56cc7af8ad78234754bcb29ed07f6ab54d920`
+- **v1.5.0 Release Tree:** `4045bde297951b6cafa107ea39c227555e13bd02`
+- **v1.5.0 Tag Ref:** lightweight `commit` ref targeting the exact release commit
+- **v1.5.0 GitHub Release:** id `371314544`, immutable, non-draft, non-prerelease, independently verified latest
+- **Control Plane State:** `LEGACY_RETIRED`
+- **MCP State:** `POST_V1_5_PRIORITY_REVIEW_REQUIRED`
 - **Policy Activation:** `NOT_PERFORMED`
+
+## v1.5.0 Machine-Verifiable Control Plane and Murmurs Publication Continuity
+
+Orchestra `v1.5.0` is `PUBLISHED_VERIFIED`. Release id `371314544`, `Orchestra v1.5.0: Machine-Verifiable Control Plane and Murmurs`, was published from lightweight tag `v1.5.0`, which resolves directly to exact signed canonical release commit `b0a56cc7af8ad78234754bcb29ed07f6ab54d920` with tree `4045bde297951b6cafa107ea39c227555e13bd02`. The release is non-draft, non-prerelease, immutable, and independently verified as latest.
+
+The publication campaign completed from the `LEGACY_RETIRED` machine-control-plane state and preserved Murmurs as additive presentation only, with `NORMAL` as the default. Final release evidence recorded 1,058 passing runtime tests, 98.47% statement coverage, 95.36% branch coverage, passing critical-module floors, Governance, CodeQL, and native-platform validation, plus complete Mutmut and Cosmic Ray campaigns.
+
+Publication did not include MCP. The prior sequencing prerequisite for MCP is satisfied, but implementation remains unselected and requires a fresh post-release dependency/risk/value and design decision. No marketplace publication, installed-integration refresh, deployment/production mutation, policy activation, destructive cleanup, branch deletion, force push, history rewrite, or fixed-tag movement was performed.
+
+Evidence: `docs/validation/V1_5_0_PUBLICATION_CLOSEOUT.md`.
 
 ## v1.4.0 Governance and Compliance Registry Publication Continuity
 
-Orchestra `v1.4.0` is now `PUBLISHED_VERIFIED`. Release id `370658917`, `Orchestra v1.4.0: Governance & Compliance Registry Cross-Integration`, was published at `2026-08-14T15:21:25Z`. Lightweight tag `v1.4.0` resolves directly to exact signed canonical release commit `93dd51c0fbe1b10affc58e6fadd5fb0bc2927a50`; the release is non-draft, non-prerelease, immutable, and latest.
+Orchestra `v1.4.0` is historical `PUBLISHED_VERIFIED` release evidence after v1.5.0. Release id `370658917`, `Orchestra v1.4.0: Governance & Compliance Registry Cross-Integration`, was published at `2026-08-14T15:21:25Z`. Lightweight tag `v1.4.0` resolves directly to exact signed canonical release commit `93dd51c0fbe1b10affc58e6fadd5fb0bc2927a50`; the release is non-draft, non-prerelease, and immutable.
 
-Publication used the separately authorized guarded workflow run `31814065248`, job `94811383024`. That publisher first required canonical `main` to equal the exact release commit and required both the tag and release to be absent, then independently verified immutability, latest-release state, and the exact tag target. External reads after the workflow confirmed the same state.
+Publication used the separately authorized guarded workflow run `31814065248`, job `94811383024`. That publisher first required canonical `main` to equal the exact release commit and required both the tag and release to be absent, then independently verified immutability, latest-release state at that publication checkpoint, and the exact tag target. External reads after the workflow confirmed the same state.
 
-The trusted Registry and network-provenance dependency chain is complete. `registry-v0.1.0` is immutable at Registry canonical `3821bcb55125b4d8864f28b6423650e6e17ac67b`; Orchestra run `31811353512` / job `94802485762` passed the real network path. Final readiness PR #271 merged as the release commit and passed the complete exact-head and post-merge matrix.
+The trusted Registry and network-provenance dependency chain is complete. `registry-v0.1.0` is immutable at Registry canonical `3821bcb55125b4df28b6423650e6e17ac67b`; Orchestra run `31811353512` / job `94802485762` passed the real network path. Final readiness PR #271 merged as the release commit and passed the complete exact-head and post-merge matrix.
 
 No marketplace publication, installed-integration refresh, deployment/production mutation, policy activation, destructive cleanup, branch deletion, force push, or history rewrite was performed.
 
@@ -40,10 +57,10 @@ The earlier PR #253 is intentionally retained as fail-closed evidence. It was cl
 
 Revision-bound readiness was merged through PR #257 at signed canonical commit `db351796684789987eb5bce85e641ce31c91993b`. README alignment was then reviewed through PR #259 at signed head `b7b8bfeced7c0719558eb95c0797f0685f0c98f2`, passed all nine exact-head checks with zero review threads, and Squash-merged with an expected-head guard as signed release commit `3c6155c111981632649a3c3207fac8ac1edcea74`.
 
-Current publication state:
+Historical v1.3.0 publication state:
 
 ```text
-CURRENT_PUBLIC_RELEASE=v1.3.0
+CURRENT_PUBLIC_RELEASE_AT_CHECKPOINT=v1.3.0
 TARGET_VERSION=1.3.0
 TARGET_TAG=v1.3.0
 V1_3_0_RELEASE_PREPARATION=MERGED_VERIFIED
@@ -56,7 +73,7 @@ V1_3_0_GITHUB_RELEASE_IMMUTABLE=true
 V1_3_0_PUBLICATION=COMPLETE_VERIFIED
 ```
 
-The GitHub Release is non-draft, non-prerelease, immutable, and the latest public release. The annotated tag object is unsigned, as was the prior v1.2.0 annotated tag object; the exact target is verified and the release commit itself is GitHub-verified and valid.
+At that checkpoint, the GitHub Release was non-draft, non-prerelease, immutable, and latest. The annotated tag object is unsigned, as was the prior v1.2.0 annotated tag object; the exact target is verified and the release commit itself is GitHub-verified and valid.
 
 No deployment, production mutation, marketplace publication, installed-integration refresh, policy activation, destructive cleanup, branch deletion, force push, or history rewrite was performed.
 
@@ -106,14 +123,16 @@ The clean replay then completed R1 through R5B:
 
 R6 normalized repository release-candidate metadata to `1.2.0`, consolidated README/setup/current-state/release notes, and prepared exact-head release-readiness evidence. This section records the pre-publication checkpoint; it is not the current release-candidate state.
 
-Historical R6 and current publication state:
+Historical R6 and later publication state:
 
 ```text
 HISTORICAL_RELEASE_CANDIDATE_VERSION=1.2.0
 HISTORICAL_R6_RELEASE_STATE=PREPARED_NOT_RELEASED
-CURRENT_PUBLIC_RELEASE=v1.3.0
+CURRENT_PUBLIC_RELEASE_AT_THIS_LATER_RECORD=v1.5.0
 V1_2_0_RELEASE_STATE=PUBLISHED_VERIFIED
 V1_3_0_RELEASE_STATE=PUBLISHED_VERIFIED
+V1_4_0_RELEASE_STATE=PUBLISHED_VERIFIED
+V1_5_0_RELEASE_STATE=PUBLISHED_VERIFIED
 POLICY_ACTIVATION=NOT_PERFORMED
 LIVE_INSTALLED_HOST_VALIDATION=VERIFIED_RECONCILED_LOCALLY
 ```
@@ -165,7 +184,13 @@ V1.4-REGISTRY trusted immutable registry-v0.1.0 dependency - complete verified
 V1.4-PROVENANCE real Orchestra network provenance - complete verified
 V1.4-READY   exact-head and canonical release readiness - complete verified
 V1.4-PUBLISH lightweight tag and immutable GitHub Release - complete verified
-V1.4-CLOSE   post-publication repository and Padayon continuity - current closeout
+V1.4-CLOSE   post-publication repository and Padayon continuity - complete
+V1.5-P0..P9  machine-verifiable control-plane re-foundation through LEGACY_RETIRED - complete verified
+V1.5-MURMURS additive communication-budget implementation and validation - complete verified
+V1.5-READY   exact-head release hardening, signed canonicalization, and readiness - complete verified
+V1.5-PUBLISH lightweight tag and immutable GitHub Release - complete verified
+V1.5-CLOSE   current-facing post-publication documentation parity - current closeout
+POST-V1.5    fresh dependency/risk/value priority review - next after closeout
 ```
 
 Historical first-run failures remain preserved as audit evidence. They must not be silently rewritten or deleted during cleanup.

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -41,7 +41,7 @@ Orchestra `v1.4.0` is historical `PUBLISHED_VERIFIED` release evidence after v1.
 
 Publication used the separately authorized guarded workflow run `31814065248`, job `94811383024`. That publisher first required canonical `main` to equal the exact release commit and required both the tag and release to be absent, then independently verified immutability, latest-release state at that publication checkpoint, and the exact tag target. External reads after the workflow confirmed the same state.
 
-The trusted Registry and network-provenance dependency chain is complete. `registry-v0.1.0` is immutable at Registry canonical `3821bcb55125b4df28b6423650e6e17ac67b`; Orchestra run `31811353512` / job `94802485762` passed the real network path. Final readiness PR #271 merged as the release commit and passed the complete exact-head and post-merge matrix.
+The trusted Registry and network-provenance dependency chain is complete. `registry-v0.1.0` is immutable at Registry canonical `3821bcb55125b4d8864f28b6423650e6e17ac67b`; Orchestra run `31811353512` / job `94802485762` passed the real network path. Final readiness PR #271 merged as the release commit and passed the complete exact-head and post-merge matrix.
 
 No marketplace publication, installed-integration refresh, deployment/production mutation, policy activation, destructive cleanup, branch deletion, force push, or history rewrite was performed.
 

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -96,7 +96,7 @@ Publication closeout evidence is recorded in `docs/validation/V1_3_0_PUBLICATION
 - [x] Add and exercise the fail-closed README Impact Gate.
 - [x] Validate Registry `0.1.0` candidate compatibility, freshness propagation, source query, and project pinning.
 - [x] Activate and independently verify the Registry `compliance-ruleset`, then merge foundation, source/freshness pilot, deterministic packaging, and publication-readiness phases.
-- [x] Publish immutable trusted Registry release `registry-v0.1.0` at exact Registry canonical `3821bcb55125b4df28b6423650e6e17ac67b`.
+- [x] Publish immutable trusted Registry release `registry-v0.1.0` at exact Registry canonical `3821bcb55125b4d8864f28b6423650e6e17ac67b`.
 - [x] Run real Orchestra network provenance against the immutable Registry release and verify exact identity, bundle/manifest trust, `CURRENT` freshness, PH source query, pinning, update-check, and idempotent re-sync.
 - [x] Finalize Orchestra exact-head release readiness through PR #271 and signed canonical `93dd51c0fbe1b10affc58e6fadd5fb0bc2927a50` with the complete validation matrix green.
 - [x] Under separate explicit publication authority, publish lightweight tag `v1.4.0` resolving directly to the exact release commit and GitHub Release id `370658917`, then independently verify non-draft, non-prerelease, immutable, and latest state at that checkpoint.

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -82,7 +82,7 @@ Phases 6B-A through 6C are complete and merged through PR #183. Phase 6D produce
 - [x] Prepare revision-bound release-readiness evidence and stable continuity surfaces through PR #257.
 - [x] Align README public-facing scope with the completed Specialist Intelligence campaign through PR #259, pass all nine exact-head checks, and merge exact signed release commit `3c6155c111981632649a3c3207fac8ac1edcea74`.
 - [x] Under separate explicit publication authority, create annotated tag `v1.3.0` targeting exact release commit `3c6155c111981632649a3c3207fac8ac1edcea74`.
-- [x] Publish `Orchestra v1.3.0: Specialist Intelligence` as a non-draft, non-prerelease, immutable GitHub Release and independently verify it as the latest public release.
+- [x] Publish `Orchestra v1.3.0: Specialist Intelligence` as a non-draft, non-prerelease, immutable GitHub Release and independently verify it as the latest public release at that checkpoint.
 - [x] Record the annotated tag object as unsigned while preserving the GitHub-verified signed release commit as the release trust anchor, consistent with the v1.2.0 tag pattern.
 - [x] Confirm publication performed no deployment, marketplace publication, installed-integration refresh, policy activation, destructive cleanup, branch deletion, force push, or history rewrite.
 
@@ -96,15 +96,15 @@ Publication closeout evidence is recorded in `docs/validation/V1_3_0_PUBLICATION
 - [x] Add and exercise the fail-closed README Impact Gate.
 - [x] Validate Registry `0.1.0` candidate compatibility, freshness propagation, source query, and project pinning.
 - [x] Activate and independently verify the Registry `compliance-ruleset`, then merge foundation, source/freshness pilot, deterministic packaging, and publication-readiness phases.
-- [x] Publish immutable trusted Registry release `registry-v0.1.0` at exact Registry canonical `3821bcb55125b4d8864f28b6423650e6e17ac67b`.
+- [x] Publish immutable trusted Registry release `registry-v0.1.0` at exact Registry canonical `3821bcb55125b4df28b6423650e6e17ac67b`.
 - [x] Run real Orchestra network provenance against the immutable Registry release and verify exact identity, bundle/manifest trust, `CURRENT` freshness, PH source query, pinning, update-check, and idempotent re-sync.
 - [x] Finalize Orchestra exact-head release readiness through PR #271 and signed canonical `93dd51c0fbe1b10affc58e6fadd5fb0bc2927a50` with the complete validation matrix green.
-- [x] Under separate explicit publication authority, publish lightweight tag `v1.4.0` resolving directly to the exact release commit and GitHub Release id `370658917`, then independently verify non-draft, non-prerelease, immutable, and latest state.
+- [x] Under separate explicit publication authority, publish lightweight tag `v1.4.0` resolving directly to the exact release commit and GitHub Release id `370658917`, then independently verify non-draft, non-prerelease, immutable, and latest state at that checkpoint.
 - [x] Confirm publication performed no marketplace publication, installed-integration refresh, deployment/production mutation, policy activation, destructive cleanup, branch deletion, force push, or history rewrite.
 
 Publication closeout evidence is recorded in `docs/validation/V1_4_0_PUBLICATION_CLOSEOUT.md`.
 
-## v1.5.0 Machine-Verifiable Control Plane and Murmurs - Release Preparation
+## v1.5.0 Machine-Verifiable Control Plane and Murmurs - Published Verified
 
 - [x] Complete the controlled P0/P1-P9 control-plane re-foundation and advance the migration through separately governed checkpoints to `LEGACY_RETIRED`.
 - [x] Repair merge readiness forward-only so ordinary progression requires both `mergeable=true` and a current `mergeable_state=clean` without ruleset bypass.
@@ -115,14 +115,17 @@ Publication closeout evidence is recorded in `docs/validation/V1_4_0_PUBLICATION
 - [x] Produce complete exact-head LEGACY_RETIRED Mutmut evidence on the pre-version diagnostic candidate with no not-checked, interrupted, timeout, suspicious, skipped, or unknown outcomes accepted.
 - [x] Select `1.5.0` from compatibility evidence: package/command/specialist/host surfaces remain present, retained compatibility views are derived rather than removed, and Murmurs is opt-in.
 - [x] Prepare all 11 package/version surfaces and release-candidate notes for `1.5.0` without changing host maturity or installed integrations.
-- [ ] Classify the final current coverage misses without removing them from the denominator or using broad exclusions.
-- [ ] Generate fresh final-candidate runtime, branch, critical-module, Mutmut, integrated Cosmic Ray, workflow-sanity, P9 conformance, Windows/Ubuntu/macOS, CodeQL, and governance evidence after release metadata is complete.
-- [ ] Persist machine release evidence and revision-bound `V1_5_0_RELEASE_READINESS_EVIDENCE.md`.
-- [ ] Materialize the reviewed release tree as a GitHub-signed commit and validate it through a fresh protected canonical PR.
-- [ ] Squash-merge only from a current ordinary `mergeable_state=clean` state with exact-head protection and independently verify canonical parent/tree/signature/state.
-- [ ] Close #292 and #300 only when their evidence exit criteria are truthfully satisfied; advance #273 to release readiness only then.
-- [ ] Under the already-approved release campaign, publish tag `v1.5.0` and a non-draft, non-prerelease GitHub Release from the exact signed validated canonical commit, then independently verify identity.
-- [ ] Begin MCP only after v1.5.0 is `PUBLISHED_VERIFIED`; MCP is a possible transport, not a source of authority.
+- [x] Classify the final current coverage misses without removing them from the denominator or using broad exclusions.
+- [x] Generate fresh final-candidate runtime, branch, critical-module, Mutmut, integrated Cosmic Ray, workflow-sanity, P9 conformance, Windows/Ubuntu/macOS, CodeQL, and governance evidence after release metadata is complete.
+- [x] Persist machine release evidence and revision-bound `V1_5_0_RELEASE_READINESS_EVIDENCE.md`.
+- [x] Materialize the reviewed release tree as a GitHub-signed commit and validate it through a fresh protected canonical PR.
+- [x] Squash-merge only from a current ordinary `mergeable_state=clean` state with exact-head protection and independently verify canonical parent/tree/signature/state.
+- [x] Close #292 and #300 only after their evidence exit criteria were satisfied; advance #273 to post-publication documentation closeout only from verified canonical state.
+- [x] Under the approved release campaign, publish lightweight tag `v1.5.0` and a non-draft, non-prerelease immutable GitHub Release from exact signed validated canonical commit `b0a56cc7af8ad78234754bcb29ed07f6ab54d920`, then independently verify identity.
+- [x] Record final publication evidence: release id `371314544`, 1,058 runtime tests, 98.47% statement coverage, 95.36% branch coverage, passing critical-module floors, Governance, CodeQL and native platforms, complete Mutmut and Cosmic Ray, and immutable fixed-tag identity.
+- [x] Reconcile current-facing human and machine documentation through `docs/validation/V1_5_0_PUBLICATION_CLOSEOUT.md` without moving the release tag or changing runtime behavior.
+
+MCP was not part of v1.5.0. Publication completes its sequencing prerequisite only; the next implementation phase must be selected by a fresh post-release dependency/risk/value review.
 
 ### Current `Protect main` Development Baseline
 
@@ -141,7 +144,7 @@ The existing bypass list remains operationally available. Orchestra governance m
 
 ## Deferred and Future Work
 
-- [ ] After v1.5.0 publication, evaluate and implement MCP as a portable transport/integration boundary without making it an authority source.
+- [ ] Perform a fresh post-v1.5 dependency/risk/value and architecture review before any MCP implementation; if selected, keep MCP a transport/integration boundary rather than an authority source.
 - [ ] Add host-specific update commands after the shared notification-only update check stabilizes.
 - [ ] Add host-specific update commands on top of the reproducible temp-staged runtime refresh pipeline.
 - [ ] Publish an Adapter SDK with base classes, helper utilities, templates, and a reference implementation.
@@ -167,3 +170,4 @@ The existing bypass list remains operationally available. Orchestra governance m
 - [x] Publish `v1.2.0` after R7R, GA-0 through GA-7, refreshed release evidence, independent final verification, and the separate R8 publication gate completed.
 - [x] Publish `v1.3.0` after the SK1-SK10 Specialist Intelligence campaign, release preparation, revision-bound readiness, README alignment, and separate publication authority completed.
 - [x] Publish `v1.4.0` after Compliance Registry cross-integration, trusted immutable Registry publication, real network-provenance validation, final exact-head readiness, and separate Orchestra publication authority completed.
+- [x] Publish `v1.5.0` after the machine-verifiable control-plane re-foundation, merge-readiness stabilization, Murmurs, fresh exact-head release evidence, signed canonicalization, and separate publication transition completed.

--- a/docs/setup/COMPATIBILITY.md
+++ b/docs/setup/COMPATIBILITY.md
@@ -1,8 +1,10 @@
 # Compatibility
 
-The current public GitHub Release is Orchestra `v1.4.0: Governance & Compliance Registry Cross-Integration`, published from lightweight tag `v1.4.0` at exact signed release commit `93dd51c0fbe1b10affc58e6fadd5fb0bc2927a50`. The release is non-draft, non-prerelease, immutable, and latest. Publication did not graduate scaffold-only hosts or perform marketplace publication.
+The current public GitHub Release is Orchestra `v1.5.0: Machine-Verifiable Control Plane and Murmurs`, published from lightweight tag `v1.5.0` at exact signed release commit `b0a56cc7af8ad78234754bcb29ed07f6ab54d920`. The release is non-draft, non-prerelease, immutable, and independently verified as latest. Publication did not graduate scaffold-only hosts or perform marketplace publication.
 
-The `v1.4.0` tag is a lightweight `commit` ref resolving directly to the GitHub-verified signed release commit above; there is no separate tag object. Historical v1.2.0/v1.3.0 annotated-tag evidence remains unchanged.
+The `v1.5.0` tag is a lightweight `commit` ref resolving directly to the GitHub-verified signed release commit above; there is no separate tag object. Historical v1.2.0/v1.3.0 annotated-tag evidence and the v1.4.0 lightweight-tag evidence remain unchanged.
+
+v1.5.0 preserves the existing public package, command, specialist, and host surfaces while making the machine contracts and deterministic kernel the canonical control-plane boundary at `LEGACY_RETIRED`. Murmurs is additive and opt-in with `NORMAL` as the default presentation mode. MCP is not part of v1.5.0 and remains a post-publication transport/integration candidate, not a source of authority.
 
 Scaffold-only hosts are not full support claims. Promotion requirements and graduation order live in `docs/project/SCAFFOLD_ADAPTER_GRADUATION_CRITERIA.md`.
 

--- a/docs/setup/INSTALLATION.md
+++ b/docs/setup/INSTALLATION.md
@@ -4,11 +4,11 @@ Orchestra can be installed in several ways depending on your AI host or IDE.
 
 ## Release Status
 
-The current public GitHub Release is `v1.4.0: Governance & Compliance Registry Cross-Integration`, published from lightweight tag `v1.4.0` at exact signed release commit `93dd51c0fbe1b10affc58e6fadd5fb0bc2927a50`. Repository manifests and the published release are normalized to version `1.4.0`. The GitHub Release is non-draft, non-prerelease, immutable, and independently verified as latest.
+The current public GitHub Release is `v1.5.0: Machine-Verifiable Control Plane and Murmurs`, published from lightweight tag `v1.5.0` at exact signed release commit `b0a56cc7af8ad78234754bcb29ed07f6ab54d920`. Repository manifests and the published release are normalized to version `1.5.0`. The GitHub Release is non-draft, non-prerelease, immutable, and independently verified as latest.
 
-Unlike the historical annotated `v1.3.0` tag, `v1.4.0` is a lightweight tag ref whose object type is `commit` and whose SHA is the exact GitHub-verified signed release commit above; there is no separate tag object to represent as signed or unsigned.
+Like `v1.4.0`, `v1.5.0` is a lightweight tag ref whose object type is `commit` and whose SHA is the exact GitHub-verified signed release commit above; there is no separate tag object to represent as signed or unsigned. Historical annotated-tag evidence for v1.2.0 and v1.3.0 remains unchanged.
 
-The latest GitHub Release remains the publication source of truth. Installing directly from `main` may include post-release documentation or later unreleased work, so use tag `v1.4.0` when exact released content is required.
+The latest GitHub Release remains the publication source of truth. Installing directly from `main` may include post-release documentation or later unreleased work, so use tag `v1.5.0` when exact released content is required.
 
 | Host | Install Surface | Current Status |
 |---|---|---|
@@ -24,7 +24,7 @@ The latest GitHub Release remains the publication source of truth. Installing di
 | Neovim | Scaffold-only packaging and workspace instructions | Scaffold-only |
 | Local AI systems | Manual skill loading | Supported |
 
-Accepted R7 live installed-host continuity evidence is verified and reconciled locally in `docs/validation/R7_LIVE_INSTALLED_HOST_VALIDATION_EVIDENCE.md`; repository validation does not replace that evidence. The v1.4.0 GitHub publication is complete, but the repository simulation fixture remains pending/empty by design and is not live evidence.
+Accepted R7 live installed-host continuity evidence is verified and reconciled locally in `docs/validation/R7_LIVE_INSTALLED_HOST_VALIDATION_EVIDENCE.md`; repository validation does not replace that evidence. The v1.5.0 GitHub publication is complete, but the repository simulation fixture remains pending/empty by design and is not live evidence.
 
 ## 1. Antigravity Plugin Setup
 

--- a/docs/validation/V1_5_0_PUBLICATION_CLOSEOUT.md
+++ b/docs/validation/V1_5_0_PUBLICATION_CLOSEOUT.md
@@ -1,0 +1,98 @@
+# v1.5.0 Publication Closeout
+
+## Status
+
+`PUBLISHED_VERIFIED`
+
+Orchestra `v1.5.0: Machine-Verifiable Control Plane and Murmurs` is published and independently verified from the exact signed canonical release boundary below.
+
+```text
+repository=Baelfyre/Orchestra
+release=v1.5.0
+release_id=371314544
+release_commit=b0a56cc7af8ad78234754bcb29ed07f6ab54d920
+release_tree=4045bde297951b6cafa107ea39c227555e13bd02
+release_commit_signature=VERIFIED_VALID
+tag=v1.5.0
+tag_kind=LIGHTWEIGHT_COMMIT_REF
+tag_target=b0a56cc7af8ad78234754bcb29ed07f6ab54d920
+release_immutable=true
+release_latest=true
+publication_workflow_run=31946111993
+publication_workflow_result=PASS
+```
+
+The GitHub Release is non-draft, non-prerelease, immutable, and bound to lightweight tag `v1.5.0`, which resolves directly to the exact release commit. The fixed release tag is not moved by this post-publication documentation closeout.
+
+## Release Validation Boundary
+
+The published release campaign recorded:
+
+```text
+runtime_tests=1058
+statement_coverage_percent=98.47
+branch_coverage_percent=95.36
+critical_module_floors=PASS
+governance=PASS
+codeql=PASS
+native_platforms=PASS
+mutmut=COMPLETE
+cosmic_ray=COMPLETE
+control_plane_stage=LEGACY_RETIRED
+```
+
+These measurements are revision-bound release evidence. They do not create authority and must not be reused to authorize a later source head without fresh validation.
+
+## Compliance Registry Boundary
+
+The release remains aligned to the separately governed Compliance Registry publication:
+
+```text
+registry_repository=Baelfyre/Orchestra-Compliance-Registry
+registry_canonical_main=b1f181cef862f9dcb4df225e90f69ac970f708c3
+trusted_registry_release=registry-v0.1.0
+trusted_registry_release_target=3821bcb55125b4d8864f28b6423650e6e17ac67b
+compatibility=V0_1_COMPATIBLE
+```
+
+Registry evidence remains reusable governance input rather than execution, release, deployment, policy, or legal authority.
+
+## Publication Scope
+
+v1.5.0 publishes the machine-verifiable control-plane re-foundation through `LEGACY_RETIRED`, the fail-closed ordinary merge-readiness stabilization, and the additive Murmurs communication budget with `NORMAL` as the default presentation mode.
+
+MCP is not part of v1.5.0. Publication satisfies the previously required sequencing prerequisite only. Any MCP transport or integration work remains subject to a fresh post-release dependency, risk, value, authority, and design review and must not become a source of Orchestra authority.
+
+## Post-Publication Documentation Closeout
+
+This record accompanies the current-facing documentation parity update for:
+
+- `README.md`
+- `README.json`
+- `CHANGELOG.md`
+- `PROJECT_STATE.md`
+- `PROJECT_CONTEXT.md`
+- `SESSION_HANDOFF.md`
+- `docs/project/ROADMAP.md`
+- `docs/setup/INSTALLATION.md`
+- `docs/setup/COMPATIBILITY.md`
+
+The closeout must pass the repository's current protected pull-request validation at its exact documentation head before it may become canonical. Historical release evidence remains historical and is not rewritten.
+
+## Protected Actions Not Performed
+
+This post-publication closeout does not perform:
+
+- marketplace or package publication;
+- installed-integration refresh;
+- deployment or production mutation;
+- policy activation;
+- force push or history rewrite;
+- branch deletion;
+- destructive cleanup;
+- release-tag movement; or
+- MCP implementation.
+
+## Continuation
+
+After this documentation closeout is merged and independently verified, master issue #273 may be assessed against its documented exit criteria. Any later implementation lane requires fresh live-state and dependency/risk/value selection; v1.5.0 publication does not automatically authorize the next feature phase.


### PR DESCRIPTION
## Purpose

Materialize the exact validated v1.5.0 post-publication documentation-closeout tree as one GitHub-signed commit on an isolated non-main staging branch, following the repository's prior signed-materialization pattern.

## Exact identity

- canonical base `main`: `b0a56cc7af8ad78234754bcb29ed07f6ab54d920`
- validated unsigned source head: `0320354be76a5ba8e0c6d6cf5e323eb984329f0a`
- validated source tree: `51d624210198b4fdea96b8314ea5b666b33fb897`
- target staging branch: `recovery/v1-5-post-publication-closeout-signed-20260816`
- source PR: #317

The exact source head has all live `Protect main` required contexts successful, zero review threads, and a 10-file documentation-only diff from the fixed published v1.5.0 boundary. The source head is unsigned, so it is not eligible for ordinary canonical progression under the signed-commit rule.

This auxiliary PR does not target `main` and does not change runtime, package, dependency, ruleset, deployment, installed-integration, marketplace, policy, release-tag, or MCP state. Its sole purpose is signed materialization of the reviewed tree before a fresh protected canonical PR.