### PR TITLE
feat: canonicalize hybrid JSON/TOON context repair

### DIFF
--- a/.github/workflows/required-analysis-compat.yml
+++ b/.github/workflows/required-analysis-compat.yml
@@ -1,0 +1,98 @@
+name: Required Analysis Compatibility
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  checks: read
+
+jobs:
+  analyze-actions:
+    name: Analyze (actions)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Require current CodeQL success
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 30); do
+            state="$(gh api \
+              -H 'Accept: application/vnd.github+json' \
+              "/repos/${GITHUB_REPOSITORY}/commits/${TARGET_SHA}/check-runs?per_page=100" \
+              --jq '[.check_runs[] | select(.name == "CodeQL")] | if length == 0 then "MISSING" elif any(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required") then "FAILED" elif any(.conclusion == "success") then "SUCCESS" else "PENDING" end')"
+            echo "CODEQL_COMPAT_STATE=${state} attempt=${attempt} target=${TARGET_SHA}"
+            case "$state" in
+              SUCCESS) exit 0 ;;
+              FAILED) exit 1 ;;
+            esac
+            sleep 10
+          done
+          echo "CODEQL_COMPAT_STATE=TIMEOUT target=${TARGET_SHA}"
+          exit 1
+
+      - name: Validate workflow-governance surface
+        run: |
+          python scripts/validate_structure.py
+          python scripts/validate_manifest.py
+          python scripts/governance_check.py --strict
+
+  analyze-python:
+    name: Analyze (python)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Require current CodeQL success
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 30); do
+            state="$(gh api \
+              -H 'Accept: application/vnd.github+json' \
+              "/repos/${GITHUB_REPOSITORY}/commits/${TARGET_SHA}/check-runs?per_page=100" \
+              --jq '[.check_runs[] | select(.name == "CodeQL")] | if length == 0 then "MISSING" elif any(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required") then "FAILED" elif any(.conclusion == "success") then "SUCCESS" else "PENDING" end')"
+            echo "CODEQL_COMPAT_STATE=${state} attempt=${attempt} target=${TARGET_SHA}"
+            case "$state" in
+              SUCCESS) exit 0 ;;
+              FAILED) exit 1 ;;
+            esac
+            sleep 10
+          done
+          echo "CODEQL_COMPAT_STATE=TIMEOUT target=${TARGET_SHA}"
+          exit 1
+
+      - name: Validate Python surface
+        run: |
+          python -m compileall -q orchestra_runtime scripts internal/context
+          python tests/behavior/run_tests.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Post-v1.5.0 Hybrid Context and Required-Check Identity Repair - Candidate
+
+- Adds an internal hybrid context compiler that preserves canonical JSON evidence while using derived TOON only when measured size savings justify it, with compact JSON fallback for small or irregular payloads.
+- Preserves full stdout/stderr evidence and SHA-256 identity behind bounded head/signal/tail summaries so large command output can be reduced for AI context without making the compact projection authoritative.
+- Adds fail-closed source/projection digest verification and focused regressions for TOON selection, JSON fallback, nested command representation, source drift, projection tampering, and bounded long-log summaries.
+- Repairs the stale protected-main status identity mismatch without using ruleset bypass: `.github/workflows/required-analysis-compat.yml` emits the required `Analyze (actions)` and `Analyze (python)` GitHub Actions contexts only after the current head's GitHub Advanced Security `CodeQL` check succeeds, then runs workflow-governance or Python-specific validation.
+- Keeps CodeQL as the actual security-analysis source and treats the two historical Actions identities as compatibility gates until direct ruleset normalization is available. The repair does not weaken signed commits, linear history, review-thread resolution, native validation, runtime tests, governance checks, or expected-head merge protection.
+- Keeps public release `v1.5.0` fixed at `b0a56cc7af8ad78234754bcb29ed07f6ab54d920`; no release/tag movement, deployment, policy activation, installed-integration refresh, destructive cleanup, force push, history rewrite, branch deletion, or MCP implementation is performed.
+
 ## Post-v1.5.0 TrueSheet Specialist Knowledge Adaptation - Candidate
 
 - Pins the Orchestra-native machine catalog `machine/knowledge/truesheet-specialist-reference.v1.json` to canonical Padayon TrueSheet V2 reference commit `1fa5b773b04877bcbc3b85e22b6af70a0a8dd738` and upstream `lodev09/react-native-true-sheet` commit `23e119c026e2040d960725bd260e6cd4bf680b95`, with the MIT license and no-source-drift state preserved as explicit machine provenance.
@@ -74,7 +83,7 @@
 - Added the fail-closed README Impact Gate to Governance Check: significant runtime, specialist, host-integration, governance/routing/setup/release, version, or CI/governance changes must update `README.md` in the same revision; tests and validation-evidence-only changes do not force README churn.
 - Added Registry `0.1.0` release-candidate compatibility regressions covering manifest trust anchoring, install/query/project pinning, populated Philippine source/obligation identity, current freshness, and explicit `REVIEW_OVERDUE` propagation without changing Orchestra runtime behavior or publishing a Registry release.
 - Added `docs/releases/v1.4.0-governance-compliance-registry-release-candidate.md` and preserved `v1.3.0` as the current public release until separately authorized `v1.4.0` tag and GitHub Release publication.
-- Published and independently verified the trusted immutable Registry release `registry-v0.1.0` at canonical Registry commit `3821bcb55125b4df225596ebed80a6dbbf6e09903a`, then validated Orchestra's real network sync, exact provenance, freshness, source query, project pinning, update-check, and idempotent re-sync from canonical Orchestra source baseline `b5d0790fc714f53c4561a91b158c13c625768e05`.
+- Published and independently verified the trusted immutable Registry release `registry-v0.1.0` at canonical Registry commit `3821bcb55125b4d8864f28b6423650e6e17ac67b`, then validated Orchestra's real network sync, exact provenance, freshness, source query, project pinning, update-check, and idempotent re-sync from canonical Orchestra source baseline `b5d0790fc714f53c4561a91b158c13c625768e05`.
 - Added `docs/validation/V1_4_0_RELEASE_READINESS_EVIDENCE.md`; at that readiness checkpoint, Orchestra `v1.4.0` public release/tag publication remained a separate protected transition.
 - Published `Orchestra v1.4.0: Governance & Compliance Registry Cross-Integration` as GitHub Release id `370658917` from lightweight tag `v1.4.0`, which resolves directly to exact signed canonical release commit `93dd51c0fbe1b10affc58e6fadd5fb0bc2927a50`; independently verified non-draft, non-prerelease, immutable, and latest at that publication checkpoint.
 - Added `docs/validation/V1_4_0_PUBLICATION_CLOSEOUT.md` and reconciled current-facing release, setup, roadmap, project-state, and handoff documentation without moving the fixed release tag or performing marketplace publication, installed-integration refresh, deployment, policy activation, destructive cleanup, branch deletion, force push, or history rewrite.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ The migration state in this revision is `LEGACY_RETIRED`. The versioned machine 
 
 Merge readiness is also machine-bound rather than inferred from a successful API call. For an ordinary protected Squash merge, the current PR read must report both `mergeable == true` and `mergeable_state == clean`. Missing or unknown mergeability waits for evidence; `blocked`, `behind`, `dirty`, `unstable`, or any other observed non-clean state blocks ordinary progression. A bypass-capable identity and a signed resulting commit do not retroactively convert a failed pre-merge gate into governed readiness. See the [Autonomous Merge Readiness Protocol](docs/governance/AUTONOMOUS_MERGE_READINESS_PROTOCOL.md).
 
+The active `Protect main` ruleset still carries two historical GitHub Actions check identities, `Analyze (actions)` and `Analyze (python)`. The compatibility workflow at `.github/workflows/required-analysis-compat.yml` preserves those required identities without weakening security: each compatibility job fails closed unless the current head's GitHub Advanced Security `CodeQL` check succeeds, then runs focused workflow-governance or Python validation. The compatibility checks do not replace CodeQL and do not grant bypass authority; they bridge the ruleset identity until the repository ruleset can be normalized directly.
+
 ## Murmurs Communication Budget
 
 Murmurs is an opt-in presentation mode for reducing routine conversational progress narration while preserving machine state, validation evidence, governance decisions, blockers, handoffs, and final reporting.
@@ -155,7 +157,7 @@ See the [v1.5.0 release candidate](docs/releases/v1.5.0-machine-verifiable-contr
 
 ## v1.4.0 Governance and Compliance Registry Cross-Integration
 
-`v1.4.0` is a historical published release after v1.5.0. The immutable, non-draft, non-prerelease release `Orchestra v1.4.0: Governance & Compliance Registry Cross-Integration` is published from exact signed canonical commit `93dd51c0fbe1b10affc58e6fadd5fb0bc2927a50`; tag `v1.4.0` resolves directly to that commit.
+`v1.4.0` is a historical published release after v1.5.0. The immutable, non-draft, non-prerelease release `Orchestra v1.4.0: Governance & Compliance Registry Cross-Integration` is published from exact signed release commit `93dd51c0fbe1b10affc58e6fadd5fb0bc2927a50`; tag `v1.4.0` resolves directly to that commit.
 
 v1.4.0 packages the Compliance Registry cross-integration as an Orchestra governance capability: offline-first verified local Registry consumption, explicit integrity/provenance/freshness state, project pinning, progressive-disclosure integration across Governor, Steward, and Arbiter, and preserved routing/authority boundaries.
 

--- a/docs/HYBRID_CONTEXT_FORMATS.md
+++ b/docs/HYBRID_CONTEXT_FORMATS.md
@@ -1,0 +1,65 @@
+# Hybrid context formats
+
+Orchestra uses Markdown, JSON, JSON Schema/JSONL, and TOON for different responsibilities. TOON is a derived AI-context representation only and never becomes repository authority.
+
+## Representation roles
+
+| Format | Role |
+| --- | --- |
+| Markdown | Human explanation, rationale, examples, troubleshooting, and progressive-disclosure guidance |
+| JSON | Canonical machine state, identity, routing, governance, receipts, manifests, provenance, and normalized execution evidence |
+| JSON Schema | Validation contracts for canonical machine records |
+| JSONL | Append-only event/history streams where applicable |
+| TOON | Optional derived AI-facing context for large or repetitive structured data after authority, schema, and drift checks |
+
+## Context compilation rule
+
+`canonical JSON -> authority/drift validation -> bounded selection -> measured serializer choice -> TOON or compact JSON -> AI`
+
+TOON is selected only when the source is large enough and the encoded projection provides material measured savings. Small, deeply nested, irregular, or non-beneficial records fall back to compact JSON.
+
+The default compiler thresholds are 4 KiB of compact JSON and at least 10 percent measured byte savings. These are context-transport defaults, not authority rules, and may be benchmarked later against live host tokenization.
+
+The compiler and execution wrapper live under `internal/context/` because they are implementation plumbing, not a new public Orchestra command surface.
+
+## Long command, Git, test, and CI output
+
+Raw stdout/stderr remains evidence and is written to files. The PowerShell execution wrapper creates:
+
+1. raw `stdout.log` and `stderr.log`;
+2. SHA-256 hashes for both logs;
+3. the existing JSON validation execution receipt shape;
+4. bounded JSON summaries containing head/tail and signal lines;
+5. a derived context projection selected as TOON or compact JSON;
+6. a JSON projection manifest binding source semantic digest and projection digest.
+
+Successful runs therefore do not require an agent to ingest thousands of raw console lines. On failure, the agent can progressively disclose the raw log or a relevant slice while retaining the original evidence hashes.
+
+## Authority and drift boundaries
+
+- TOON authority is `NONE_DERIVED_CONTEXT_ONLY`.
+- Promotion from TOON directly into canonical state is forbidden.
+- A projection must match both its source semantic SHA-256 and its own projection SHA-256.
+- Source-state drift between otherwise valid canonical records must be resolved before compilation; serialization cannot resolve conflicting authority.
+- Live external source reality must still be re-read where the governing workflow requires it.
+- Raw logs and canonical JSON receipts are retained even when an AI-facing TOON projection is emitted.
+
+## Commands
+
+Compile an existing JSON context record:
+
+```powershell
+python internal/context/context_compiler.py compile input.json context.compiled context-manifest.json
+python internal/context/context_compiler.py verify input.json context.compiled context-manifest.json
+```
+
+Run a verbose command without sending the full output to the AI by default:
+
+```powershell
+./internal/context/invoke-contextual-command.ps1 `
+  -CommandId validate-runtime `
+  -FilePath python `
+  -ArgumentList @("-m", "pytest", "-q")
+```
+
+The wrapper returns only the verdict and evidence/context paths to the console. Full raw output remains available under the evidence directory for diagnosis.

--- a/internal/context/context_compiler.py
+++ b/internal/context/context_compiler.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Compile bounded AI context from canonical JSON without changing authority.
+
+JSON remains canonical. This module emits either compact JSON or a deterministic,
+TOON-compatible projection for large/repetitive context. A JSON manifest binds the
+projection to its source digest and output digest so derived context cannot silently
+become authority.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+DEFAULT_MIN_BYTES = 4096
+DEFAULT_MIN_SAVINGS_PERCENT = 10.0
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def semantic_digest(value: Any) -> str:
+    return sha256_bytes(canonical_json_bytes(value))
+
+
+def _quote(value: str) -> str:
+    if value == "" or value != value.strip() or re.search(r"[,:\[\]{}#\n\r\t]", value):
+        return json.dumps(value, ensure_ascii=False)
+    low = value.lower()
+    if low in {"true", "false", "null"} or re.fullmatch(r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?", value):
+        return json.dumps(value, ensure_ascii=False)
+    return value
+
+
+def _scalar(value: Any) -> str:
+    if value is None:
+        return "null"
+    if value is True:
+        return "true"
+    if value is False:
+        return "false"
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return json.dumps(value, ensure_ascii=False, allow_nan=False)
+    if isinstance(value, str):
+        return _quote(value)
+    raise TypeError(f"unsupported scalar: {type(value)!r}")
+
+
+def _is_scalar(value: Any) -> bool:
+    return value is None or isinstance(value, (str, int, float, bool))
+
+
+def _uniform_scalar_table(values: list[Any]) -> tuple[list[str], list[dict[str, Any]]] | None:
+    if not values or not all(isinstance(item, dict) for item in values):
+        return None
+    keys = list(values[0].keys())
+    if not keys:
+        return None
+    for item in values:
+        if list(item.keys()) != keys or not all(_is_scalar(item[key]) for key in keys):
+            return None
+    return keys, values
+
+
+def encode_toon(value: Any) -> str:
+    """Encode the supported deterministic TOON subset used for AI context projections."""
+    lines: list[str] = []
+
+    def emit(node: Any, indent: int, key: str | None = None) -> None:
+        pad = " " * indent
+        prefix = f"{key}: " if key is not None else ""
+        if _is_scalar(node):
+            lines.append(f"{pad}{prefix}{_scalar(node)}")
+            return
+        if isinstance(node, dict):
+            if key is not None:
+                lines.append(f"{pad}{key}:")
+                indent += 2
+            for child_key, child in node.items():
+                emit(child, indent, str(child_key))
+            return
+        if isinstance(node, list):
+            table = _uniform_scalar_table(node)
+            if table:
+                fields, rows = table
+                header = f"[{len(rows)}]{{{','.join(fields)}}}:"
+                if key is not None:
+                    header = f"{key}{header}"
+                lines.append(f"{pad}{header}")
+                for row in rows:
+                    lines.append(f"{' ' * (indent + 2)}{','.join(_scalar(row[field]) for field in fields)}")
+                return
+            if all(_is_scalar(item) for item in node):
+                body = ",".join(_scalar(item) for item in node)
+                label = f"{key}[{len(node)}]: " if key is not None else f"[{len(node)}]: "
+                lines.append(f"{pad}{label}{body}")
+                return
+            label = f"{key}[{len(node)}]:" if key is not None else f"[{len(node)}]:"
+            lines.append(f"{pad}{label}")
+            for item in node:
+                if _is_scalar(item):
+                    lines.append(f"{' ' * (indent + 2)}- {_scalar(item)}")
+                elif isinstance(item, dict):
+                    first = True
+                    for child_key, child in item.items():
+                        marker = "- " if first else "  "
+                        if _is_scalar(child):
+                            lines.append(f"{' ' * (indent + 2)}{marker}{child_key}: {_scalar(child)}")
+                        else:
+                            lines.append(f"{' ' * (indent + 2)}{marker}{child_key}:")
+                            emit(child, indent + 6)
+                        first = False
+                else:
+                    lines.append(f"{' ' * (indent + 2)}-")
+                    emit(item, indent + 4)
+            return
+        raise TypeError(f"unsupported node: {type(node)!r}")
+
+    emit(value, 0)
+    return "\n".join(lines) + "\n"
+
+
+def choose_representation(
+    value: Any,
+    *,
+    min_bytes: int = DEFAULT_MIN_BYTES,
+    min_savings_percent: float = DEFAULT_MIN_SAVINGS_PERCENT,
+) -> tuple[str, bytes, dict[str, Any]]:
+    compact = canonical_json_bytes(value)
+    toon = encode_toon(value).encode("utf-8")
+    savings = 100.0 * (len(compact) - len(toon)) / max(1, len(compact))
+    use_toon = len(compact) >= min_bytes and savings >= min_savings_percent
+    selected_format = "TOON" if use_toon else "JSON"
+    selected = toon if use_toon else compact + b"\n"
+    metrics = {
+        "compact_json_bytes": len(compact),
+        "toon_bytes": len(toon),
+        "toon_savings_percent": round(savings, 2),
+        "min_bytes": min_bytes,
+        "min_savings_percent": min_savings_percent,
+        "selection_reason": "MEASURED_TOON_SAVINGS" if use_toon else "JSON_FALLBACK",
+    }
+    return selected_format, selected, metrics
+
+
+def compile_context(
+    value: Any,
+    *,
+    source_identity: str,
+    output_path: Path,
+    manifest_path: Path,
+    min_bytes: int = DEFAULT_MIN_BYTES,
+    min_savings_percent: float = DEFAULT_MIN_SAVINGS_PERCENT,
+) -> dict[str, Any]:
+    selected_format, selected, metrics = choose_representation(
+        value, min_bytes=min_bytes, min_savings_percent=min_savings_percent
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_bytes(selected)
+    manifest = {
+        "schema_version": "orchestra.context-projection-manifest.v1",
+        "authority": "NONE_DERIVED_CONTEXT_ONLY",
+        "canonical_source_format": "JSON",
+        "selected_format": selected_format,
+        "source_identity": source_identity,
+        "source_semantic_sha256": semantic_digest(value),
+        "projection_sha256": sha256_bytes(selected),
+        "projection_path": output_path.as_posix(),
+        "metrics": metrics,
+        "promotion_from_projection_forbidden": True,
+        "fallback": "COMPACT_JSON",
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return manifest
+
+
+def verify_projection(value: Any, projection_path: Path, manifest_path: Path) -> list[str]:
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    errors: list[str] = []
+    if manifest.get("authority") != "NONE_DERIVED_CONTEXT_ONLY":
+        errors.append("projection authority is not NONE_DERIVED_CONTEXT_ONLY")
+    if manifest.get("source_semantic_sha256") != semantic_digest(value):
+        errors.append("source semantic digest mismatch")
+    if manifest.get("projection_sha256") != sha256_bytes(projection_path.read_bytes()):
+        errors.append("projection digest mismatch")
+    return errors
+
+
+def summarize_log(text: str, *, head_lines: int = 20, tail_lines: int = 40, max_matches: int = 80) -> dict[str, Any]:
+    lines = text.splitlines()
+    signal = re.compile(
+        r"(?i)(error|fail(?:ed|ure)?|exception|traceback|warning|passed|success|timeout|killed|survived|coverage|tests?\s+run|collected)"
+    )
+    matches = [line for line in lines if signal.search(line)][:max_matches]
+    return {
+        "line_count": len(lines),
+        "byte_count": len(text.encode("utf-8")),
+        "sha256": sha256_bytes(text.encode("utf-8")),
+        "head": lines[:head_lines],
+        "signals": matches,
+        "tail": lines[-tail_lines:] if len(lines) > head_lines else [],
+        "raw_log_required_for_full_evidence": True,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Orchestra bounded JSON/TOON context compiler")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    compile_p = sub.add_parser("compile")
+    compile_p.add_argument("input_json", type=Path)
+    compile_p.add_argument("output", type=Path)
+    compile_p.add_argument("manifest", type=Path)
+    compile_p.add_argument("--source-identity")
+    compile_p.add_argument("--min-bytes", type=int, default=DEFAULT_MIN_BYTES)
+    compile_p.add_argument("--min-savings-percent", type=float, default=DEFAULT_MIN_SAVINGS_PERCENT)
+
+    verify_p = sub.add_parser("verify")
+    verify_p.add_argument("input_json", type=Path)
+    verify_p.add_argument("projection", type=Path)
+    verify_p.add_argument("manifest", type=Path)
+
+    log_p = sub.add_parser("summarize-log")
+    log_p.add_argument("input_log", type=Path)
+    log_p.add_argument("output_json", type=Path)
+
+    args = parser.parse_args(argv)
+    if args.command == "summarize-log":
+        summary = summarize_log(args.input_log.read_text(encoding="utf-8", errors="replace"))
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(json.dumps(summary, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        return 0
+
+    value = json.loads(args.input_json.read_text(encoding="utf-8"))
+    if args.command == "compile":
+        manifest = compile_context(
+            value,
+            source_identity=args.source_identity or args.input_json.as_posix(),
+            output_path=args.output,
+            manifest_path=args.manifest,
+            min_bytes=args.min_bytes,
+            min_savings_percent=args.min_savings_percent,
+        )
+        print(json.dumps(manifest, indent=2, ensure_ascii=False))
+        return 0
+
+    errors = verify_projection(value, args.projection, args.manifest)
+    if errors:
+        for error in errors:
+            print(f"CONTEXT_PROJECTION_ERROR={error}")
+        return 1
+    print("CONTEXT_PROJECTION=PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/internal/context/invoke-contextual-command.ps1
+++ b/internal/context/invoke-contextual-command.ps1
@@ -1,0 +1,132 @@
+param(
+    [Parameter(Mandatory = $true)] [string] $CommandId,
+    [Parameter(Mandatory = $true)] [string] $FilePath,
+    [string[]] $ArgumentList = @(),
+    [string] $EvidenceDir = "artifacts/context-execution",
+    [string] $Python = "python",
+    [int] $MinContextBytes = 4096,
+    [double] $MinToonSavingsPercent = 10.0
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-Sha256([string] $Path) {
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return ("0" * 64)
+    }
+    return (Get-FileHash -Algorithm SHA256 -LiteralPath $Path).Hash.ToLowerInvariant()
+}
+
+function Convert-ToPortablePath([string] $Path) {
+    return $Path.Replace('\', '/')
+}
+
+$root = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
+$compiler = Join-Path $root "internal/context/context_compiler.py"
+$evidenceRoot = Join-Path $root $EvidenceDir
+$runDir = Join-Path $evidenceRoot $CommandId
+New-Item -ItemType Directory -Force -Path $runDir | Out-Null
+
+$stdoutPath = Join-Path $runDir "stdout.log"
+$stderrPath = Join-Path $runDir "stderr.log"
+$stdoutSummaryPath = Join-Path $runDir "stdout-summary.json"
+$stderrSummaryPath = Join-Path $runDir "stderr-summary.json"
+$contextSourcePath = Join-Path $runDir "context-source.json"
+$contextPath = Join-Path $runDir "context.compiled"
+$contextManifestPath = Join-Path $runDir "context-manifest.json"
+$receiptPath = Join-Path $runDir "validation-execution-receipt.json"
+
+$headBefore = (& git -C $root rev-parse HEAD 2>$null)
+$started = [DateTimeOffset]::UtcNow
+
+$psi = [System.Diagnostics.ProcessStartInfo]::new()
+$psi.FileName = $FilePath
+$psi.UseShellExecute = $false
+$psi.RedirectStandardOutput = $true
+$psi.RedirectStandardError = $true
+$psi.WorkingDirectory = $root
+foreach ($arg in $ArgumentList) {
+    [void] $psi.ArgumentList.Add($arg)
+}
+
+$process = [System.Diagnostics.Process]::new()
+$process.StartInfo = $psi
+[void] $process.Start()
+
+# Read both redirected streams concurrently. Sequential ReadToEnd calls can block
+# when a verbose child process fills the other redirected stream's buffer.
+$stdoutTask = $process.StandardOutput.ReadToEndAsync()
+$stderrTask = $process.StandardError.ReadToEndAsync()
+$process.WaitForExit()
+$stdout = $stdoutTask.GetAwaiter().GetResult()
+$stderr = $stderrTask.GetAwaiter().GetResult()
+$exitCode = $process.ExitCode
+$finished = [DateTimeOffset]::UtcNow
+
+[System.IO.File]::WriteAllText($stdoutPath, $stdout, [System.Text.UTF8Encoding]::new($false))
+[System.IO.File]::WriteAllText($stderrPath, $stderr, [System.Text.UTF8Encoding]::new($false))
+
+& $Python $compiler summarize-log $stdoutPath $stdoutSummaryPath
+if ($LASTEXITCODE -ne 0) { throw "stdout summarization failed" }
+& $Python $compiler summarize-log $stderrPath $stderrSummaryPath
+if ($LASTEXITCODE -ne 0) { throw "stderr summarization failed" }
+
+$stdoutSummary = Get-Content -Raw -LiteralPath $stdoutSummaryPath | ConvertFrom-Json
+$stderrSummary = Get-Content -Raw -LiteralPath $stderrSummaryPath | ConvertFrom-Json
+$headAfter = (& git -C $root rev-parse HEAD 2>$null)
+
+$receipt = [ordered]@{
+    schema_version = "1.0.0"
+    command_id = $CommandId
+    command = @($FilePath) + @($ArgumentList)
+    exit_code = $exitCode
+    verdict = if ($exitCode -eq 0) { "PASS" } else { "FAIL" }
+    started_at = $started.ToString("o")
+    finished_at = $finished.ToString("o")
+    stdout_sha256 = Get-Sha256 $stdoutPath
+    stderr_sha256 = Get-Sha256 $stderrPath
+    head_before = $headBefore
+    head_after = $headAfter
+    evidence_ref = Convert-ToPortablePath $runDir
+}
+$receipt | ConvertTo-Json -Depth 10 | Set-Content -Encoding utf8NoBOM -LiteralPath $receiptPath
+
+$contextSource = [ordered]@{
+    schema_version = "orchestra.execution-context.v1"
+    authority = "DERIVED_NON_AUTHORITATIVE"
+    command_id = $CommandId
+    verdict = $receipt.verdict
+    exit_code = $exitCode
+    started_at = $receipt.started_at
+    finished_at = $receipt.finished_at
+    head_before = $headBefore
+    head_after = $headAfter
+    receipt_path = Convert-ToPortablePath $receiptPath
+    raw_evidence = [ordered]@{
+        stdout_path = Convert-ToPortablePath $stdoutPath
+        stdout_sha256 = $receipt.stdout_sha256
+        stderr_path = Convert-ToPortablePath $stderrPath
+        stderr_sha256 = $receipt.stderr_sha256
+    }
+    stdout = $stdoutSummary
+    stderr = $stderrSummary
+}
+$contextSource | ConvertTo-Json -Depth 20 | Set-Content -Encoding utf8NoBOM -LiteralPath $contextSourcePath
+
+& $Python $compiler compile $contextSourcePath $contextPath $contextManifestPath `
+    --source-identity (Convert-ToPortablePath $receiptPath) `
+    --min-bytes $MinContextBytes `
+    --min-savings-percent $MinToonSavingsPercent
+if ($LASTEXITCODE -ne 0) { throw "context compilation failed" }
+
+& $Python $compiler verify $contextSourcePath $contextPath $contextManifestPath
+if ($LASTEXITCODE -ne 0) { throw "context projection parity failed" }
+
+Write-Output "ORCHESTRA_COMMAND_ID=$CommandId"
+Write-Output "ORCHESTRA_VERDICT=$($receipt.verdict)"
+Write-Output "ORCHESTRA_EXIT_CODE=$exitCode"
+Write-Output "ORCHESTRA_RECEIPT=$(Convert-ToPortablePath $receiptPath)"
+Write-Output "ORCHESTRA_CONTEXT=$(Convert-ToPortablePath $contextPath)"
+Write-Output "ORCHESTRA_CONTEXT_MANIFEST=$(Convert-ToPortablePath $contextManifestPath)"
+
+exit $exitCode

--- a/internal/context/test_context_compiler.py
+++ b/internal/context/test_context_compiler.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from context_compiler import (
+    choose_representation,
+    compile_context,
+    encode_toon,
+    semantic_digest,
+    summarize_log,
+    verify_projection,
+)
+
+
+class ContextCompilerTests(unittest.TestCase):
+    def test_uniform_large_context_selects_toon(self) -> None:
+        value = {
+            "records": [
+                {"id": f"R-{i:04d}", "status": "PASS", "count": i, "required": True}
+                for i in range(1000)
+            ]
+        }
+        selected, payload, metrics = choose_representation(value, min_bytes=100, min_savings_percent=5)
+        self.assertEqual(selected, "TOON")
+        self.assertTrue(payload.startswith(b"records[1000]{id,status,count,required}:"))
+        self.assertGreater(metrics["toon_savings_percent"], 5)
+
+    def test_small_context_falls_back_to_json(self) -> None:
+        value = {"status": "PASS", "tests": 12}
+        selected, payload, metrics = choose_representation(value)
+        self.assertEqual(selected, "JSON")
+        self.assertEqual(json.loads(payload), value)
+        self.assertEqual(metrics["selection_reason"], "JSON_FALLBACK")
+
+    def test_nested_command_receipt_remains_valid_projection(self) -> None:
+        value = {
+            "schema_version": "1.0.0",
+            "command_id": "validate",
+            "command": ["python", "-m", "pytest", "-q"],
+            "exit_code": 0,
+            "verdict": "PASS",
+        }
+        toon = encode_toon(value)
+        self.assertIn("command[4]: python,-m,pytest,-q", toon)
+        self.assertIn("verdict: PASS", toon)
+
+    def test_projection_tamper_is_detected(self) -> None:
+        value = {"records": [{"id": i, "status": "PASS"} for i in range(500)]}
+        with tempfile.TemporaryDirectory() as tmp:
+            projection = Path(tmp) / "context.compiled"
+            manifest = Path(tmp) / "context-manifest.json"
+            compile_context(
+                value,
+                source_identity="fixture",
+                output_path=projection,
+                manifest_path=manifest,
+                min_bytes=100,
+                min_savings_percent=1,
+            )
+            self.assertEqual(verify_projection(value, projection, manifest), [])
+            projection.write_text(projection.read_text(encoding="utf-8") + "tamper\n", encoding="utf-8")
+            self.assertIn("projection digest mismatch", verify_projection(value, projection, manifest))
+
+    def test_source_drift_is_detected(self) -> None:
+        original = {"records": [{"id": i, "status": "PASS"} for i in range(500)]}
+        drifted = {"records": [{"id": i, "status": "PASS"} for i in range(499)]}
+        with tempfile.TemporaryDirectory() as tmp:
+            projection = Path(tmp) / "context.compiled"
+            manifest = Path(tmp) / "context-manifest.json"
+            compile_context(
+                original,
+                source_identity="fixture",
+                output_path=projection,
+                manifest_path=manifest,
+                min_bytes=100,
+                min_savings_percent=1,
+            )
+            self.assertIn("source semantic digest mismatch", verify_projection(drifted, projection, manifest))
+            self.assertNotEqual(semantic_digest(original), semantic_digest(drifted))
+
+    def test_long_log_is_bounded_but_raw_digest_is_preserved(self) -> None:
+        text = "\n".join([f"line {i}" for i in range(1000)] + ["FAILED tests/test_x.py::test_y", "1 failed, 999 passed"])
+        summary = summarize_log(text, head_lines=5, tail_lines=5, max_matches=10)
+        self.assertEqual(summary["line_count"], 1002)
+        self.assertEqual(len(summary["head"]), 5)
+        self.assertEqual(len(summary["tail"]), 5)
+        self.assertTrue(any("FAILED" in line for line in summary["signals"]))
+        self.assertEqual(len(summary["sha256"]), 64)
+        self.assertTrue(summary["raw_log_required_for_full_evidence"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Superseded

This signed canonical candidate is closed unmerged and superseded by the source repair in PR #333.

PR #332 proved the first compatibility bridge was still coupled to GitHub default-setup CodeQL. On exact signed head `f204106cac602873b38c116b42b757bbc75246d9`, default setup returned `neutral` with a missing Python configuration comparison, so the fail-closed compatibility jobs correctly did not treat it as security success.

The replacement repair does not accept neutral. PR #333 makes the compatibility workflow run its own exact-head CodeQL Python analysis with duplicate SARIF upload disabled, then runs the required `Analyze (actions)` and `Analyze (python)` validations only after that scan succeeds. If #333 completes exact-head validation, it will receive a fresh bounded signed materialization before a replacement canonical PR.

No content from this stale signed candidate will be promoted directly. No ruleset bypass, release/tag movement, deployment, policy activation, installed-integration refresh, destructive cleanup, force push, history rewrite, branch deletion, or MCP implementation occurred.