### PR TITLE
materialize: governed host update commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Post-v1.5.0 Governed Host Update Commands - Candidate
+
+- Adds `machine/hosts/update-contract.v1.json` and its canonical JSON Schema as the machine-owned Host Update contract for Codex, Antigravity, Claude Code, Cursor, Windsurf, VS Code/VSCodium, JetBrains, Zed, and Neovim.
+- Preserves the exact host maturity boundary: Codex and Antigravity are `SUPPORTED`; Claude Code, Cursor, Windsurf, VS Code/VSCodium, JetBrains, Zed, and Neovim remain `SCAFFOLD_ONLY` and instruction-only for Host Update behavior.
+- Adds a deterministic read-only Host Update planner that resolves host aliases, local package/version parity, optional observed-latest status, update instructions, post-update validation, and non-destructive recovery guidance without performing network access or installed-host mutation by default.
+- Keeps Git/local supported-host guidance fast-forward-only with a recorded pre-update revision, clean working tree, `git fetch origin`, `git pull --ff-only`, required post-update validation, and fail-closed handling for unknown hosts or validation failure.
+- Requires separate explicit authorization before any supported-host installed-integration refresh and forbids automatic installed-integration refresh, implicit marketplace promotion, release/tag publication, deployment, policy activation, destructive cleanup, branch deletion, force push, history rewrite, ruleset bypass, or MCP implementation.
+- Adds deterministic regression coverage for host-set parity, package/version parity, maturity preservation, authority non-expansion, VS Code/VSCodium alias behavior, unknown-host fail-closed behavior, status comparison, recovery safety, and rejection of an execution flag.
+- Adds Host Update setup documentation and supported-host adapter guidance while keeping public release `v1.5.0` fixed at `b0a56cc7af8ad78234754bcb29ed07f6ab54d920`.
+
 ## Post-v1.5.0 Hybrid Context and Required-Check Identity Repair - Candidate
 
 - Adds an internal hybrid context compiler that preserves canonical JSON evidence while using derived TOON only when measured size savings justify it, with compact JSON fallback for small or irregular payloads.

--- a/README.md
+++ b/README.md
@@ -315,6 +315,14 @@ Support means a validated integration surface. Scaffold-only means the repositor
 
 Repository CI and Phase C fixtures are not live installed-host evidence. Accepted R7 records are reconciled in [R7 live installed-host validation evidence](docs/validation/R7_LIVE_INSTALLED_HOST_VALIDATION_EVIDENCE.md); the fixture remains pending/empty by design. See [Compatibility](docs/setup/COMPATIBILITY.md).
 
+## Host Update Planning
+
+Host Update behavior is now defined by a versioned machine-owned contract at `machine/hosts/update-contract.v1.json`, with deterministic read-only planning exposed by `scripts/host_update.py`. Planning reports host maturity, package/version status, update instructions, post-update validation, and recovery guidance. It does not itself authorize or mutate an installed integration.
+
+Codex and Antigravity are the only `SUPPORTED` Host Update targets. Claude Code, Cursor, Windsurf, VS Code/VSCodium, JetBrains, Zed, and Neovim remain `SCAFFOLD_ONLY` and instruction-only. Unknown hosts fail closed. Supported Git/local guidance is fast-forward-only and requires post-update validation; installed-host refresh remains a separately authorized action and is never automatic.
+
+See [Host Update Contract](docs/setup/HOST_UPDATES.md) for the canonical contract, maturity matrix, planner interface, validation requirements, and recovery boundary.
+
 ## Installation
 
 Use the host-native path:
@@ -428,6 +436,7 @@ See the [v1.2.0 release notes](docs/releases/v1.2.0-governed-orchestration.md). 
 
 - [Installation](docs/setup/INSTALLATION.md)
 - [Compatibility](docs/setup/COMPATIBILITY.md)
+- [Host Update Contract](docs/setup/HOST_UPDATES.md)
 - [Validation](docs/setup/VALIDATION.md)
 - [Skill Index](SKILL_INDEX.md)
 

--- a/adapters/antigravity/README.md
+++ b/adapters/antigravity/README.md
@@ -1,5 +1,15 @@
 # Antigravity Adapter
 
-Antigravity usage depends on the local skill or plugin support available in the installed environment. This adapter does not claim automatic compatibility.
+Antigravity usage depends on the local skill or plugin support available in the installed environment. This adapter does not claim automatic marketplace discovery or installed-host mutation.
+
+## Host update planning
+
+Antigravity is a supported Host Update maturity target. Generate the deterministic read-only plan with:
+
+```text
+python scripts/host_update.py --host antigravity --json
+```
+
+The plan may describe the existing fast-forward repository update and post-update validation path, but it never reloads, refreshes, or reinstalls the active Antigravity integration. Installed-host mutation requires separate explicit authorization. See `docs/setup/HOST_UPDATES.md`.
 
 See [install-guide.md](install-guide.md) and [agent-instructions.template.md](agent-instructions.template.md).

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -1,6 +1,6 @@
 # Codex Adapter for Orchestra
 
-This adapter provides a Codex-compatible export of the current Orchestra skills. The current published GitHub Release and repository metadata are `v1.2.0`.
+This adapter provides a Codex-compatible export of the current Orchestra skills. The current published GitHub Release is `v1.5.0`; repository `main` may contain post-release candidate work without moving that immutable release.
 
 ## Purpose
 
@@ -8,9 +8,15 @@ Codex may reject extended frontmatter fields (like `role`, `activation_level`, e
 
 This adapter exports Codex-compatible skills with only `name` and `description` in the frontmatter while preserving the original Markdown body, instructions, and progressive disclosure boundaries of the canonical skills.
 
-## Release-Candidate Boundary
+## Host update planning
 
-The `1.2.0` repository version corresponds to published annotated tag and GitHub Release `v1.2.0`. Accepted R7 live-host evidence is verified and reconciled locally in `docs/validation/R7_LIVE_INSTALLED_HOST_VALIDATION_EVIDENCE.md`; the repository simulation fixture remains pending/empty by design and is not live evidence.
+Codex is a supported Host Update maturity target. Generate the deterministic read-only plan with:
+
+```text
+python scripts/host_update.py --host codex --json
+```
+
+The plan may describe the existing fast-forward repository update and Codex validation path, but it never refreshes or reinstalls the active Codex integration. Installed-host mutation requires separate explicit authorization. See `docs/setup/HOST_UPDATES.md`.
 
 ## Note
 

--- a/docs/setup/HOST_UPDATES.md
+++ b/docs/setup/HOST_UPDATES.md
@@ -1,0 +1,53 @@
+# Host Update Contract
+
+Orchestra's host update surface is a read-only planning contract. It reports host maturity, update mechanism, deterministic instructions, post-update validation, and recovery guidance. It does not itself authorize or mutate an installed host integration.
+
+Canonical machine source:
+
+`machine/hosts/update-contract.v1.json`
+
+Schema:
+
+`machine/schemas/host-update-contract.schema.json`
+
+Planner:
+
+`python scripts/host_update.py --host <host> --json`
+
+## Maturity boundary
+
+| Host | Maturity | Planner behavior | Installed-host mutation |
+| --- | --- | --- | --- |
+| Codex | Supported | Git fast-forward plus manual host-refresh instructions | Requires separate explicit authorization |
+| Antigravity | Supported | Git fast-forward plus manual host-refresh instructions | Requires separate explicit authorization |
+| Claude Code | Scaffold-only | Instruction-only continuity guidance | Not implemented by this surface |
+| Cursor | Scaffold-only | Instruction-only packaging guidance | Not implemented |
+| Windsurf | Scaffold-only | Instruction-only packaging guidance | Not implemented |
+| VS Code / VSCodium | Scaffold-only | Instruction-only packaging guidance | Not implemented |
+| JetBrains | Scaffold-only | Instruction-only packaging guidance | Not implemented |
+| Zed | Scaffold-only | Instruction-only packaging guidance | Not implemented |
+| Neovim | Scaffold-only | Instruction-only packaging guidance | Not implemented |
+
+Unknown hosts fail closed.
+
+## Status checks
+
+The planner performs no network request. Without `--latest-version`, status is `NOT_CHECKED`. A caller that has separately obtained a trusted current release version may pass it explicitly:
+
+```text
+python scripts/host_update.py --host codex --latest-version 1.5.0 --json
+```
+
+The result is deterministic and uses only the canonical local contract plus the supplied version observation.
+
+The existing `scripts/check_for_updates.py` remains the repository's network-backed public-release checker. It does not grant update authority.
+
+## Git and recovery boundary
+
+Supported Git/local plans require a clean working tree, a recorded pre-update HEAD, `git fetch origin`, and `git pull --ff-only origin <current-branch>`. Merge, rebase, force push, history rewrite, and destructive cleanup are not part of the host-update contract.
+
+After a separately authorized repository update, the plan requires the listed canonical validations. Codex additionally validates its export surface. If fast-forward or validation fails, stop and preserve evidence. Any rollback or installed-host repair remains a separately authorized recovery action.
+
+## Installed integrations
+
+The planner never runs `scripts/refresh-installed-integrations.ps1`, exports skills into an installed host, reloads a plugin, reinstalls a marketplace package, publishes a release, or changes repository policy. Those actions remain outside the authority of this contract unless separately approved and supported by the active host/runtime.

--- a/machine/hosts/update-contract.v1.json
+++ b/machine/hosts/update-contract.v1.json
@@ -1,0 +1,161 @@
+{
+  "schema_version": "orchestra.host-update-contract.v1",
+  "contract_id": "orchestra-host-update",
+  "package_version": "1.5.0",
+  "default_behavior": "READ_ONLY_PLAN",
+  "unknown_host_policy": "FAIL_CLOSED",
+  "authority": {
+    "planning_grants_mutation_authority": false,
+    "explicit_mutation_authorization_required": true,
+    "automatic_installed_integration_refresh": false
+  },
+  "hosts": [
+    {
+      "host_id": "codex",
+      "aliases": ["codex"],
+      "maturity": "SUPPORTED",
+      "adapter_path": "adapters/codex",
+      "update_mechanism": "GIT_FAST_FORWARD_THEN_MANUAL_HOST_REFRESH",
+      "execution_support": "EXPLICIT_AUTHORIZATION_REQUIRED",
+      "automatic_installed_integration_refresh": false,
+      "plan_command": "python scripts/host_update.py --host codex --json",
+      "update_instructions": [
+        "Record the current repository HEAD and confirm the working tree is clean before any separately authorized update.",
+        "Run git fetch origin, then git pull --ff-only origin <current-branch>; do not merge, rebase, force-push, or rewrite history as part of the update flow.",
+        "Run the canonical post-update validation commands before treating the repository update as usable.",
+        "Refresh or reinstall the active Codex integration only under separate explicit authorization; this contract never performs that refresh automatically."
+      ],
+      "validation_commands": [
+        "python scripts/validate_structure.py",
+        "python scripts/validate_manifest.py",
+        "python scripts/check_stale_references.py",
+        "python scripts/governance_check.py --strict",
+        "python adapters/codex/validate_codex_export.py"
+      ],
+      "recovery_hints": [
+        "Preserve the recorded pre-update HEAD and stop on any fast-forward or validation failure.",
+        "Use an explicitly authorized recovery workflow to return to the recorded state; do not use force push, history rewrite, or destructive cleanup as an implicit rollback."
+      ]
+    },
+    {
+      "host_id": "antigravity",
+      "aliases": ["antigravity", "agy"],
+      "maturity": "SUPPORTED",
+      "adapter_path": "adapters/antigravity",
+      "update_mechanism": "GIT_FAST_FORWARD_THEN_MANUAL_HOST_REFRESH",
+      "execution_support": "EXPLICIT_AUTHORIZATION_REQUIRED",
+      "automatic_installed_integration_refresh": false,
+      "plan_command": "python scripts/host_update.py --host antigravity --json",
+      "update_instructions": [
+        "Record the current repository HEAD and confirm the working tree is clean before any separately authorized update.",
+        "Run git fetch origin, then git pull --ff-only origin <current-branch>; do not merge, rebase, force-push, or rewrite history as part of the update flow.",
+        "Run the canonical post-update validation commands before treating the repository update as usable.",
+        "Reload or reinstall the active Antigravity integration only under separate explicit authorization; this contract never performs that refresh automatically."
+      ],
+      "validation_commands": [
+        "python scripts/validate_structure.py",
+        "python scripts/validate_manifest.py",
+        "python scripts/check_stale_references.py",
+        "python scripts/governance_check.py --strict"
+      ],
+      "recovery_hints": [
+        "Preserve the recorded pre-update HEAD and stop on any fast-forward or validation failure.",
+        "Use an explicitly authorized recovery workflow to return to the recorded state; do not use force push, history rewrite, or destructive cleanup as an implicit rollback."
+      ]
+    },
+    {
+      "host_id": "claude-code",
+      "aliases": ["claude-code", "claude"],
+      "maturity": "SCAFFOLD_ONLY",
+      "adapter_path": "adapters/claude-code",
+      "update_mechanism": "INSTRUCTION_ONLY",
+      "execution_support": "INSTRUCTION_ONLY",
+      "automatic_installed_integration_refresh": false,
+      "plan_command": "python scripts/host_update.py --host claude-code --json",
+      "update_instructions": [
+        "Use this scaffold only to inspect repository update guidance for active runtime continuity.",
+        "Do not represent this scaffold as marketplace installation or live installed-host mutation capability."
+      ],
+      "validation_commands": ["python scripts/validate_claude_plugin.py"],
+      "recovery_hints": ["Stop if scaffold validation fails; no installed-host rollback is implied by this instruction-only surface."]
+    },
+    {
+      "host_id": "cursor",
+      "aliases": ["cursor"],
+      "maturity": "SCAFFOLD_ONLY",
+      "adapter_path": "adapters/cursor",
+      "update_mechanism": "INSTRUCTION_ONLY",
+      "execution_support": "INSTRUCTION_ONLY",
+      "automatic_installed_integration_refresh": false,
+      "plan_command": "python scripts/host_update.py --host cursor --json",
+      "update_instructions": ["Inspect the Cursor packaging scaffold and repository release state; no live installed-host mutation is implemented."],
+      "validation_commands": ["python scripts/validate_ide_packaging.py"],
+      "recovery_hints": ["Stop on scaffold validation failure; no installed-host rollback is implied."]
+    },
+    {
+      "host_id": "windsurf",
+      "aliases": ["windsurf"],
+      "maturity": "SCAFFOLD_ONLY",
+      "adapter_path": "adapters/windsurf",
+      "update_mechanism": "INSTRUCTION_ONLY",
+      "execution_support": "INSTRUCTION_ONLY",
+      "automatic_installed_integration_refresh": false,
+      "plan_command": "python scripts/host_update.py --host windsurf --json",
+      "update_instructions": ["Inspect the Windsurf packaging scaffold and repository release state; no live installed-host mutation is implemented."],
+      "validation_commands": ["python scripts/validate_ide_packaging.py"],
+      "recovery_hints": ["Stop on scaffold validation failure; no installed-host rollback is implied."]
+    },
+    {
+      "host_id": "vscode",
+      "aliases": ["vscode", "vscodium"],
+      "maturity": "SCAFFOLD_ONLY",
+      "adapter_path": "adapters/vscode",
+      "update_mechanism": "INSTRUCTION_ONLY",
+      "execution_support": "INSTRUCTION_ONLY",
+      "automatic_installed_integration_refresh": false,
+      "plan_command": "python scripts/host_update.py --host vscode --json",
+      "update_instructions": ["Inspect the VS Code/VSCodium packaging scaffold and repository release state; no live installed-host mutation is implemented."],
+      "validation_commands": ["python scripts/validate_ide_packaging.py"],
+      "recovery_hints": ["Stop on scaffold validation failure; no installed-host rollback is implied."]
+    },
+    {
+      "host_id": "jetbrains",
+      "aliases": ["jetbrains"],
+      "maturity": "SCAFFOLD_ONLY",
+      "adapter_path": "adapters/jetbrains",
+      "update_mechanism": "INSTRUCTION_ONLY",
+      "execution_support": "INSTRUCTION_ONLY",
+      "automatic_installed_integration_refresh": false,
+      "plan_command": "python scripts/host_update.py --host jetbrains --json",
+      "update_instructions": ["Inspect the JetBrains packaging scaffold and repository release state; no live installed-host mutation is implemented."],
+      "validation_commands": ["python scripts/validate_ide_packaging.py"],
+      "recovery_hints": ["Stop on scaffold validation failure; no installed-host rollback is implied."]
+    },
+    {
+      "host_id": "zed",
+      "aliases": ["zed"],
+      "maturity": "SCAFFOLD_ONLY",
+      "adapter_path": "adapters/zed",
+      "update_mechanism": "INSTRUCTION_ONLY",
+      "execution_support": "INSTRUCTION_ONLY",
+      "automatic_installed_integration_refresh": false,
+      "plan_command": "python scripts/host_update.py --host zed --json",
+      "update_instructions": ["Inspect the Zed packaging scaffold and repository release state; no live installed-host mutation is implemented."],
+      "validation_commands": ["python scripts/validate_ide_packaging.py"],
+      "recovery_hints": ["Stop on scaffold validation failure; no installed-host rollback is implied."]
+    },
+    {
+      "host_id": "neovim",
+      "aliases": ["neovim", "nvim"],
+      "maturity": "SCAFFOLD_ONLY",
+      "adapter_path": "adapters/neovim",
+      "update_mechanism": "INSTRUCTION_ONLY",
+      "execution_support": "INSTRUCTION_ONLY",
+      "automatic_installed_integration_refresh": false,
+      "plan_command": "python scripts/host_update.py --host neovim --json",
+      "update_instructions": ["Inspect the Neovim packaging scaffold and repository release state; no live installed-host mutation is implemented."],
+      "validation_commands": ["python scripts/validate_ide_packaging.py"],
+      "recovery_hints": ["Stop on scaffold validation failure; no installed-host rollback is implied."]
+    }
+  ]
+}

--- a/machine/schemas/host-update-contract.schema.json
+++ b/machine/schemas/host-update-contract.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Orchestra Host Update Contract v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "contract_id",
+    "package_version",
+    "default_behavior",
+    "unknown_host_policy",
+    "authority",
+    "hosts"
+  ],
+  "properties": {
+    "schema_version": {"const": "orchestra.host-update-contract.v1"},
+    "contract_id": {"const": "orchestra-host-update"},
+    "package_version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+    "default_behavior": {"const": "READ_ONLY_PLAN"},
+    "unknown_host_policy": {"const": "FAIL_CLOSED"},
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "planning_grants_mutation_authority",
+        "explicit_mutation_authorization_required",
+        "automatic_installed_integration_refresh"
+      ],
+      "properties": {
+        "planning_grants_mutation_authority": {"const": false},
+        "explicit_mutation_authorization_required": {"const": true},
+        "automatic_installed_integration_refresh": {"const": false}
+      }
+    },
+    "hosts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/host"}
+    }
+  },
+  "$defs": {
+    "nonEmptyStringArray": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "host": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "host_id",
+        "aliases",
+        "maturity",
+        "adapter_path",
+        "update_mechanism",
+        "execution_support",
+        "automatic_installed_integration_refresh",
+        "plan_command",
+        "update_instructions",
+        "validation_commands",
+        "recovery_hints"
+      ],
+      "properties": {
+        "host_id": {"type": "string", "minLength": 1},
+        "aliases": {"$ref": "#/$defs/nonEmptyStringArray"},
+        "maturity": {"enum": ["SUPPORTED", "SCAFFOLD_ONLY"]},
+        "adapter_path": {"type": "string", "pattern": "^adapters/[^/]+$"},
+        "update_mechanism": {"enum": ["GIT_FAST_FORWARD_THEN_MANUAL_HOST_REFRESH", "INSTRUCTION_ONLY"]},
+        "execution_support": {"enum": ["EXPLICIT_AUTHORIZATION_REQUIRED", "INSTRUCTION_ONLY"]},
+        "automatic_installed_integration_refresh": {"const": false},
+        "plan_command": {"type": "string", "minLength": 1},
+        "update_instructions": {"$ref": "#/$defs/nonEmptyStringArray"},
+        "validation_commands": {"$ref": "#/$defs/nonEmptyStringArray"},
+        "recovery_hints": {"$ref": "#/$defs/nonEmptyStringArray"}
+      }
+    }
+  }
+}

--- a/orchestra_runtime/host_updates.py
+++ b/orchestra_runtime/host_updates.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+HOST_UPDATE_CONTRACT_SCHEMA_VERSION = "orchestra.host-update-contract.v1"
+HOST_UPDATE_PLAN_SCHEMA_VERSION = "orchestra.host-update-plan.v1"
+SUPPORTED_HOSTS = frozenset({"codex", "antigravity"})
+SCAFFOLD_ONLY_HOSTS = frozenset(
+    {"claude-code", "cursor", "windsurf", "vscode", "jetbrains", "zed", "neovim"}
+)
+_EXPECTED_HOSTS = SUPPORTED_HOSTS | SCAFFOLD_ONLY_HOSTS
+_CONTRACT_PATH = Path("machine") / "hosts" / "update-contract.v1.json"
+_SEMVER_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$")
+
+
+class HostUpdateError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class HostUpdatePlan:
+    schema_version: str
+    contract_schema_version: str
+    requested_host: str
+    host_id: str
+    package_version: str
+    latest_version: str | None
+    update_status: str
+    maturity: str
+    update_mechanism: str
+    default_behavior: str
+    execution_support: str
+    execution_authorized: bool
+    execution_requires_separate_authorization: bool
+    automatic_installed_integration_refresh: bool
+    adapter_path: str
+    plan_command: str
+    update_instructions: tuple[str, ...]
+    validation_commands: tuple[str, ...]
+    recovery_hints: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        for key in ("update_instructions", "validation_commands", "recovery_hints"):
+            payload[key] = list(payload[key])
+        return payload
+
+
+def repository_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def _root(root: Path | str | None) -> Path:
+    return repository_root() if root is None else Path(root)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise HostUpdateError(f"HOST_UPDATE_CONTRACT_MISSING:{path}") from exc
+    except json.JSONDecodeError as exc:
+        raise HostUpdateError(f"HOST_UPDATE_CONTRACT_INVALID_JSON:{path}:{exc}") from exc
+    if not isinstance(value, dict):
+        raise HostUpdateError("HOST_UPDATE_CONTRACT_INVALID:root must be an object")
+    return value
+
+
+def _nonempty_string(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise HostUpdateError(f"HOST_UPDATE_CONTRACT_INVALID:{field}")
+    return value.strip()
+
+
+def _string_list(value: object, field: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or not value:
+        raise HostUpdateError(f"HOST_UPDATE_CONTRACT_INVALID:{field}")
+    items = tuple(_nonempty_string(item, field) for item in value)
+    if len(set(items)) != len(items):
+        raise HostUpdateError(f"HOST_UPDATE_CONTRACT_INVALID:{field}:duplicates")
+    return items
+
+
+def _parse_semver(value: str) -> tuple[int, int, int]:
+    match = _SEMVER_RE.fullmatch(value.strip())
+    if match is None:
+        raise HostUpdateError(f"HOST_UPDATE_VERSION_INVALID:{value}")
+    return tuple(int(part) for part in match.groups())
+
+
+def _package_version(repo_root: Path) -> str:
+    payload = _load_json(repo_root / "plugin.json")
+    return _nonempty_string(payload.get("version"), "plugin.version")
+
+
+def load_host_update_contract(root: Path | str | None = None) -> dict[str, Any]:
+    repo_root = _root(root)
+    contract = _load_json(repo_root / _CONTRACT_PATH)
+    if contract.get("schema_version") != HOST_UPDATE_CONTRACT_SCHEMA_VERSION:
+        raise HostUpdateError("HOST_UPDATE_CONTRACT_SCHEMA_UNSUPPORTED")
+    if contract.get("default_behavior") != "READ_ONLY_PLAN":
+        raise HostUpdateError("HOST_UPDATE_CONTRACT_INVALID:default_behavior")
+    if contract.get("unknown_host_policy") != "FAIL_CLOSED":
+        raise HostUpdateError("HOST_UPDATE_CONTRACT_INVALID:unknown_host_policy")
+
+    package_version = _nonempty_string(contract.get("package_version"), "package_version")
+    _parse_semver(package_version)
+    if package_version != _package_version(repo_root):
+        raise HostUpdateError("HOST_UPDATE_PACKAGE_VERSION_MISMATCH")
+
+    authority = contract.get("authority")
+    if not isinstance(authority, dict):
+        raise HostUpdateError("HOST_UPDATE_CONTRACT_INVALID:authority")
+    required_authority = {
+        "planning_grants_mutation_authority": False,
+        "explicit_mutation_authorization_required": True,
+        "automatic_installed_integration_refresh": False,
+    }
+    for key, expected in required_authority.items():
+        if authority.get(key) is not expected:
+            raise HostUpdateError(f"HOST_UPDATE_AUTHORITY_INVARIANT:{key}")
+
+    hosts = contract.get("hosts")
+    if not isinstance(hosts, list) or not hosts:
+        raise HostUpdateError("HOST_UPDATE_CONTRACT_INVALID:hosts")
+
+    host_ids: set[str] = set()
+    aliases: set[str] = set()
+    for index, raw in enumerate(hosts):
+        if not isinstance(raw, dict):
+            raise HostUpdateError(f"HOST_UPDATE_CONTRACT_INVALID:hosts[{index}]")
+        host_id = _nonempty_string(raw.get("host_id"), f"hosts[{index}].host_id")
+        if host_id in host_ids:
+            raise HostUpdateError(f"HOST_UPDATE_CONTRACT_INVALID:duplicate_host:{host_id}")
+        host_ids.add(host_id)
+
+        maturity = raw.get("maturity")
+        if host_id in SUPPORTED_HOSTS and maturity != "SUPPORTED":
+            raise HostUpdateError(f"HOST_UPDATE_MATURITY_DRIFT:{host_id}")
+        if host_id in SCAFFOLD_ONLY_HOSTS and maturity != "SCAFFOLD_ONLY":
+            raise HostUpdateError(f"HOST_UPDATE_MATURITY_DRIFT:{host_id}")
+
+        execution_support = raw.get("execution_support")
+        if maturity == "SUPPORTED" and execution_support != "EXPLICIT_AUTHORIZATION_REQUIRED":
+            raise HostUpdateError(f"HOST_UPDATE_EXECUTION_BOUNDARY_DRIFT:{host_id}")
+        if maturity == "SCAFFOLD_ONLY" and execution_support != "INSTRUCTION_ONLY":
+            raise HostUpdateError(f"HOST_UPDATE_EXECUTION_BOUNDARY_DRIFT:{host_id}")
+        if raw.get("automatic_installed_integration_refresh") is not False:
+            raise HostUpdateError(f"HOST_UPDATE_AUTO_REFRESH_FORBIDDEN:{host_id}")
+
+        _nonempty_string(raw.get("adapter_path"), f"hosts[{index}].adapter_path")
+        _nonempty_string(raw.get("update_mechanism"), f"hosts[{index}].update_mechanism")
+        _nonempty_string(raw.get("plan_command"), f"hosts[{index}].plan_command")
+        _string_list(raw.get("update_instructions"), f"hosts[{index}].update_instructions")
+        _string_list(raw.get("validation_commands"), f"hosts[{index}].validation_commands")
+        _string_list(raw.get("recovery_hints"), f"hosts[{index}].recovery_hints")
+
+        record_aliases = _string_list(raw.get("aliases"), f"hosts[{index}].aliases")
+        if host_id not in record_aliases:
+            raise HostUpdateError(f"HOST_UPDATE_CONTRACT_INVALID:canonical_alias_missing:{host_id}")
+        for alias in record_aliases:
+            normalized = alias.lower()
+            if normalized in aliases:
+                raise HostUpdateError(f"HOST_UPDATE_CONTRACT_INVALID:duplicate_alias:{normalized}")
+            aliases.add(normalized)
+
+    if host_ids != _EXPECTED_HOSTS:
+        missing = sorted(_EXPECTED_HOSTS - host_ids)
+        extra = sorted(host_ids - _EXPECTED_HOSTS)
+        raise HostUpdateError(f"HOST_UPDATE_HOST_SET_MISMATCH:missing={missing}:extra={extra}")
+    return contract
+
+
+def _host_index(contract: dict[str, Any]) -> tuple[dict[str, dict[str, Any]], dict[str, str]]:
+    by_id: dict[str, dict[str, Any]] = {}
+    aliases: dict[str, str] = {}
+    for record in contract["hosts"]:
+        host_id = str(record["host_id"])
+        by_id[host_id] = record
+        for alias in record["aliases"]:
+            aliases[str(alias).lower()] = host_id
+    return by_id, aliases
+
+
+def resolve_host_update_record(host: str, root: Path | str | None = None) -> dict[str, Any]:
+    requested = _nonempty_string(host, "host").lower()
+    contract = load_host_update_contract(root)
+    by_id, aliases = _host_index(contract)
+    host_id = aliases.get(requested)
+    if host_id is None:
+        raise HostUpdateError(f"UNKNOWN_HOST_FAIL_CLOSED:{requested}")
+    return dict(by_id[host_id])
+
+
+def _update_status(current: str, latest: str | None) -> tuple[str, str | None]:
+    if latest is None:
+        return "NOT_CHECKED", None
+    current_value = _parse_semver(current)
+    latest_value = _parse_semver(latest)
+    normalized_latest = latest.removeprefix("v")
+    if latest_value > current_value:
+        return "UPDATE_AVAILABLE", normalized_latest
+    if latest_value == current_value:
+        return "UP_TO_DATE", normalized_latest
+    return "LOCAL_AHEAD", normalized_latest
+
+
+def build_host_update_plan(
+    host: str,
+    *,
+    latest_version: str | None = None,
+    root: Path | str | None = None,
+) -> HostUpdatePlan:
+    repo_root = _root(root)
+    contract = load_host_update_contract(repo_root)
+    by_id, aliases = _host_index(contract)
+    requested = _nonempty_string(host, "host").lower()
+    host_id = aliases.get(requested)
+    if host_id is None:
+        raise HostUpdateError(f"UNKNOWN_HOST_FAIL_CLOSED:{requested}")
+    record = by_id[host_id]
+    current_version = str(contract["package_version"])
+    status, normalized_latest = _update_status(current_version, latest_version)
+    execution_support = str(record["execution_support"])
+
+    return HostUpdatePlan(
+        schema_version=HOST_UPDATE_PLAN_SCHEMA_VERSION,
+        contract_schema_version=HOST_UPDATE_CONTRACT_SCHEMA_VERSION,
+        requested_host=requested,
+        host_id=host_id,
+        package_version=current_version,
+        latest_version=normalized_latest,
+        update_status=status,
+        maturity=str(record["maturity"]),
+        update_mechanism=str(record["update_mechanism"]),
+        default_behavior="READ_ONLY_PLAN",
+        execution_support=execution_support,
+        execution_authorized=False,
+        execution_requires_separate_authorization=(execution_support == "EXPLICIT_AUTHORIZATION_REQUIRED"),
+        automatic_installed_integration_refresh=False,
+        adapter_path=str(record["adapter_path"]),
+        plan_command=str(record["plan_command"]),
+        update_instructions=tuple(str(item) for item in record["update_instructions"]),
+        validation_commands=tuple(str(item) for item in record["validation_commands"]),
+        recovery_hints=tuple(str(item) for item in record["recovery_hints"]),
+    )

--- a/scripts/host_update.py
+++ b/scripts/host_update.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from orchestra_runtime.host_updates import HostUpdateError, build_host_update_plan
+
+
+def _print_human(plan: dict[str, object]) -> None:
+    print(f"Host: {plan['host_id']} ({plan['maturity']})")
+    print(f"Package version: {plan['package_version']}")
+    print(f"Update status: {plan['update_status']}")
+    if plan.get("latest_version"):
+        print(f"Latest version: {plan['latest_version']}")
+    print(f"Update mechanism: {plan['update_mechanism']}")
+    print("Behavior: READ_ONLY_PLAN")
+    print("Execution authorized: false")
+    print("Automatic installed-integration refresh: false")
+    print("Instructions:")
+    for item in plan["update_instructions"]:
+        print(f"  - {item}")
+    print("Validation:")
+    for item in plan["validation_commands"]:
+        print(f"  - {item}")
+    print("Recovery:")
+    for item in plan["recovery_hints"]:
+        print(f"  - {item}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="orchestra-host-update",
+        description="Resolve a deterministic read-only host update plan. This command never mutates an installed integration.",
+    )
+    parser.add_argument("--host", required=True, help="Host id or declared alias")
+    parser.add_argument("--latest-version", help="Optional observed latest Orchestra version for deterministic status comparison")
+    parser.add_argument("--json", action="store_true", help="Emit the machine-readable plan")
+    args = parser.parse_args(argv)
+
+    try:
+        plan = build_host_update_plan(args.host, latest_version=args.latest_version, root=ROOT).to_dict()
+    except HostUpdateError as exc:
+        print(f"ORCHESTRA_HOST_UPDATE=FAIL:{exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(plan, indent=2, sort_keys=True))
+    else:
+        _print_human(plan)
+    print("ORCHESTRA_HOST_UPDATE=READ_ONLY_PLAN", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/runtime/test_host_updates.py
+++ b/tests/runtime/test_host_updates.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from orchestra_runtime.host_updates import (
+    HostUpdateError,
+    SCAFFOLD_ONLY_HOSTS,
+    SUPPORTED_HOSTS,
+    build_host_update_plan,
+    load_host_update_contract,
+    resolve_host_update_record,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_contract_preserves_exact_host_maturity_boundary_and_version_parity() -> None:
+    contract = load_host_update_contract(ROOT)
+    plugin = json.loads((ROOT / "plugin.json").read_text(encoding="utf-8"))
+    by_id = {record["host_id"]: record for record in contract["hosts"]}
+
+    assert contract["package_version"] == plugin["version"]
+    assert {host for host, record in by_id.items() if record["maturity"] == "SUPPORTED"} == SUPPORTED_HOSTS
+    assert {host for host, record in by_id.items() if record["maturity"] == "SCAFFOLD_ONLY"} == SCAFFOLD_ONLY_HOSTS
+    assert set(by_id) == SUPPORTED_HOSTS | SCAFFOLD_ONLY_HOSTS
+
+
+def test_supported_hosts_are_plan_only_until_separate_authority_exists() -> None:
+    for host in sorted(SUPPORTED_HOSTS):
+        plan = build_host_update_plan(host, root=ROOT)
+        assert plan.default_behavior == "READ_ONLY_PLAN"
+        assert plan.execution_support == "EXPLICIT_AUTHORIZATION_REQUIRED"
+        assert plan.execution_authorized is False
+        assert plan.execution_requires_separate_authorization is True
+        assert plan.automatic_installed_integration_refresh is False
+        assert plan.update_mechanism == "GIT_FAST_FORWARD_THEN_MANUAL_HOST_REFRESH"
+        assert any("git pull --ff-only" in item for item in plan.update_instructions)
+        assert all("force push" not in item.lower() for item in plan.update_instructions)
+
+
+def test_scaffold_hosts_remain_instruction_only_and_cannot_imply_live_mutation() -> None:
+    for host in sorted(SCAFFOLD_ONLY_HOSTS):
+        plan = build_host_update_plan(host, root=ROOT)
+        assert plan.maturity == "SCAFFOLD_ONLY"
+        assert plan.execution_support == "INSTRUCTION_ONLY"
+        assert plan.execution_authorized is False
+        assert plan.execution_requires_separate_authorization is False
+        assert plan.automatic_installed_integration_refresh is False
+        assert plan.update_mechanism == "INSTRUCTION_ONLY"
+
+
+def test_vscodium_alias_resolves_to_vscode_without_promoting_maturity() -> None:
+    plan = build_host_update_plan("vscodium", root=ROOT)
+    assert plan.requested_host == "vscodium"
+    assert plan.host_id == "vscode"
+    assert plan.maturity == "SCAFFOLD_ONLY"
+    assert plan.execution_support == "INSTRUCTION_ONLY"
+
+
+def test_unknown_host_fails_closed() -> None:
+    with pytest.raises(HostUpdateError, match="UNKNOWN_HOST_FAIL_CLOSED"):
+        resolve_host_update_record("imaginary-marketplace-host", ROOT)
+
+
+def test_update_status_is_deterministic_without_network_or_mutation() -> None:
+    available = build_host_update_plan("codex", latest_version="v1.6.0", root=ROOT)
+    current = build_host_update_plan("codex", latest_version="1.5.0", root=ROOT)
+    ahead = build_host_update_plan("codex", latest_version="1.4.0", root=ROOT)
+    unchecked = build_host_update_plan("codex", root=ROOT)
+
+    assert available.update_status == "UPDATE_AVAILABLE"
+    assert current.update_status == "UP_TO_DATE"
+    assert ahead.update_status == "LOCAL_AHEAD"
+    assert unchecked.update_status == "NOT_CHECKED"
+
+
+def test_supported_git_recovery_contract_is_non_destructive_and_validation_bound() -> None:
+    contract = load_host_update_contract(ROOT)
+    for record in contract["hosts"]:
+        if record["host_id"] not in SUPPORTED_HOSTS:
+            continue
+        joined_hints = " ".join(record["recovery_hints"]).lower()
+        joined_validation = " ".join(record["validation_commands"])
+        assert "reset --hard" not in joined_hints
+        assert "force push" in joined_hints
+        assert "governance_check.py --strict" in joined_validation
+
+
+def test_cli_emits_machine_plan_and_has_no_execute_flag() -> None:
+    command = [
+        sys.executable,
+        str(ROOT / "scripts" / "host_update.py"),
+        "--host",
+        "antigravity",
+        "--latest-version",
+        "1.5.0",
+        "--json",
+    ]
+    completed = subprocess.run(command, cwd=ROOT, capture_output=True, text=True, check=False)
+    assert completed.returncode == 0
+    payload = json.loads(completed.stdout)
+    assert payload["host_id"] == "antigravity"
+    assert payload["update_status"] == "UP_TO_DATE"
+    assert payload["execution_authorized"] is False
+    assert payload["automatic_installed_integration_refresh"] is False
+    assert "ORCHESTRA_HOST_UPDATE=READ_ONLY_PLAN" in completed.stderr
+
+    rejected = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "host_update.py"), "--host", "codex", "--execute"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert rejected.returncode != 0
+    assert "unrecognized arguments: --execute" in rejected.stderr

--- a/tests/runtime/test_host_updates.py
+++ b/tests/runtime/test_host_updates.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import json
 import subprocess
 import sys
@@ -13,10 +14,36 @@ from orchestra_runtime.host_updates import (
     SUPPORTED_HOSTS,
     build_host_update_plan,
     load_host_update_contract,
+    repository_root,
     resolve_host_update_record,
 )
 
 ROOT = Path(__file__).resolve().parents[2]
+
+
+def _canonical_contract() -> dict[str, object]:
+    return copy.deepcopy(load_host_update_contract(ROOT))
+
+
+def _write_contract_repo(
+    tmp_path: Path,
+    contract: object,
+    *,
+    plugin_version: object = "1.5.0",
+) -> Path:
+    contract_path = tmp_path / "machine" / "hosts" / "update-contract.v1.json"
+    contract_path.parent.mkdir(parents=True, exist_ok=True)
+    contract_path.write_text(json.dumps(contract), encoding="utf-8")
+    (tmp_path / "plugin.json").write_text(
+        json.dumps({"version": plugin_version}), encoding="utf-8"
+    )
+    return tmp_path
+
+
+def _host(contract: dict[str, object], host_id: str) -> dict[str, object]:
+    hosts = contract["hosts"]
+    assert isinstance(hosts, list)
+    return next(record for record in hosts if isinstance(record, dict) and record["host_id"] == host_id)
 
 
 def test_contract_preserves_exact_host_maturity_boundary_and_version_parity() -> None:
@@ -28,11 +55,13 @@ def test_contract_preserves_exact_host_maturity_boundary_and_version_parity() ->
     assert {host for host, record in by_id.items() if record["maturity"] == "SUPPORTED"} == SUPPORTED_HOSTS
     assert {host for host, record in by_id.items() if record["maturity"] == "SCAFFOLD_ONLY"} == SCAFFOLD_ONLY_HOSTS
     assert set(by_id) == SUPPORTED_HOSTS | SCAFFOLD_ONLY_HOSTS
+    assert repository_root() == ROOT
 
 
 def test_supported_hosts_are_plan_only_until_separate_authority_exists() -> None:
     for host in sorted(SUPPORTED_HOSTS):
         plan = build_host_update_plan(host, root=ROOT)
+        payload = plan.to_dict()
         assert plan.default_behavior == "READ_ONLY_PLAN"
         assert plan.execution_support == "EXPLICIT_AUTHORIZATION_REQUIRED"
         assert plan.execution_authorized is False
@@ -41,6 +70,9 @@ def test_supported_hosts_are_plan_only_until_separate_authority_exists() -> None
         assert plan.update_mechanism == "GIT_FAST_FORWARD_THEN_MANUAL_HOST_REFRESH"
         assert any("git pull --ff-only" in item for item in plan.update_instructions)
         assert all("force push" not in item.lower() for item in plan.update_instructions)
+        assert isinstance(payload["update_instructions"], list)
+        assert isinstance(payload["validation_commands"], list)
+        assert isinstance(payload["recovery_hints"], list)
 
 
 def test_scaffold_hosts_remain_instruction_only_and_cannot_imply_live_mutation() -> None:
@@ -55,16 +87,22 @@ def test_scaffold_hosts_remain_instruction_only_and_cannot_imply_live_mutation()
 
 
 def test_vscodium_alias_resolves_to_vscode_without_promoting_maturity() -> None:
-    plan = build_host_update_plan("vscodium", root=ROOT)
+    plan = build_host_update_plan("VSCODIUM", root=ROOT)
+    record = resolve_host_update_record("VSCODIUM", ROOT)
     assert plan.requested_host == "vscodium"
     assert plan.host_id == "vscode"
     assert plan.maturity == "SCAFFOLD_ONLY"
     assert plan.execution_support == "INSTRUCTION_ONLY"
+    assert record["host_id"] == "vscode"
 
 
-def test_unknown_host_fails_closed() -> None:
+def test_unknown_host_fails_closed_for_record_and_plan() -> None:
     with pytest.raises(HostUpdateError, match="UNKNOWN_HOST_FAIL_CLOSED"):
         resolve_host_update_record("imaginary-marketplace-host", ROOT)
+    with pytest.raises(HostUpdateError, match="UNKNOWN_HOST_FAIL_CLOSED"):
+        build_host_update_plan("imaginary-marketplace-host", root=ROOT)
+    with pytest.raises(HostUpdateError, match="HOST_UPDATE_CONTRACT_INVALID:host"):
+        build_host_update_plan("  ", root=ROOT)
 
 
 def test_update_status_is_deterministic_without_network_or_mutation() -> None:
@@ -74,9 +112,12 @@ def test_update_status_is_deterministic_without_network_or_mutation() -> None:
     unchecked = build_host_update_plan("codex", root=ROOT)
 
     assert available.update_status == "UPDATE_AVAILABLE"
+    assert available.latest_version == "1.6.0"
     assert current.update_status == "UP_TO_DATE"
     assert ahead.update_status == "LOCAL_AHEAD"
     assert unchecked.update_status == "NOT_CHECKED"
+    with pytest.raises(HostUpdateError, match="HOST_UPDATE_VERSION_INVALID"):
+        build_host_update_plan("codex", latest_version="latest", root=ROOT)
 
 
 def test_supported_git_recovery_contract_is_non_destructive_and_validation_bound() -> None:
@@ -89,6 +130,154 @@ def test_supported_git_recovery_contract_is_non_destructive_and_validation_bound
         assert "reset --hard" not in joined_hints
         assert "force push" in joined_hints
         assert "governance_check.py --strict" in joined_validation
+
+
+def test_contract_read_failures_are_fail_closed(tmp_path: Path) -> None:
+    with pytest.raises(HostUpdateError, match="HOST_UPDATE_CONTRACT_MISSING"):
+        load_host_update_contract(tmp_path)
+
+    contract_path = tmp_path / "machine" / "hosts" / "update-contract.v1.json"
+    contract_path.parent.mkdir(parents=True)
+    contract_path.write_text("{not-json", encoding="utf-8")
+    with pytest.raises(HostUpdateError, match="HOST_UPDATE_CONTRACT_INVALID_JSON"):
+        load_host_update_contract(tmp_path)
+
+    contract_path.write_text("[]", encoding="utf-8")
+    with pytest.raises(HostUpdateError, match="root must be an object"):
+        load_host_update_contract(tmp_path)
+
+
+def test_contract_top_level_identity_and_version_fail_closed(tmp_path: Path) -> None:
+    cases = [
+        ("schema_version", "other.v1", "HOST_UPDATE_CONTRACT_SCHEMA_UNSUPPORTED"),
+        ("default_behavior", "EXECUTE", "HOST_UPDATE_CONTRACT_INVALID:default_behavior"),
+        ("unknown_host_policy", "ALLOW", "HOST_UPDATE_CONTRACT_INVALID:unknown_host_policy"),
+        ("package_version", "not-semver", "HOST_UPDATE_VERSION_INVALID"),
+    ]
+    for field, value, match in cases:
+        contract = _canonical_contract()
+        contract[field] = value
+        _write_contract_repo(tmp_path, contract)
+        with pytest.raises(HostUpdateError, match=match):
+            load_host_update_contract(tmp_path)
+
+    contract = _canonical_contract()
+    _write_contract_repo(tmp_path, contract, plugin_version="1.5.1")
+    with pytest.raises(HostUpdateError, match="HOST_UPDATE_PACKAGE_VERSION_MISMATCH"):
+        load_host_update_contract(tmp_path)
+
+    contract = _canonical_contract()
+    _write_contract_repo(tmp_path, contract, plugin_version="")
+    with pytest.raises(HostUpdateError, match="HOST_UPDATE_CONTRACT_INVALID:plugin.version"):
+        load_host_update_contract(tmp_path)
+
+
+def test_contract_authority_invariants_fail_closed(tmp_path: Path) -> None:
+    contract = _canonical_contract()
+    contract["authority"] = []
+    _write_contract_repo(tmp_path, contract)
+    with pytest.raises(HostUpdateError, match="HOST_UPDATE_CONTRACT_INVALID:authority"):
+        load_host_update_contract(tmp_path)
+
+    for field, invalid in (
+        ("planning_grants_mutation_authority", True),
+        ("explicit_mutation_authorization_required", False),
+        ("automatic_installed_integration_refresh", True),
+    ):
+        contract = _canonical_contract()
+        authority = contract["authority"]
+        assert isinstance(authority, dict)
+        authority[field] = invalid
+        _write_contract_repo(tmp_path, contract)
+        with pytest.raises(HostUpdateError, match=f"HOST_UPDATE_AUTHORITY_INVARIANT:{field}"):
+            load_host_update_contract(tmp_path)
+
+
+def test_contract_host_container_and_identity_fail_closed(tmp_path: Path) -> None:
+    for invalid_hosts in (None, [], ["not-an-object"]):
+        contract = _canonical_contract()
+        contract["hosts"] = invalid_hosts
+        _write_contract_repo(tmp_path, contract)
+        pattern = "HOST_UPDATE_CONTRACT_INVALID:hosts"
+        with pytest.raises(HostUpdateError, match=pattern):
+            load_host_update_contract(tmp_path)
+
+    contract = _canonical_contract()
+    hosts = contract["hosts"]
+    assert isinstance(hosts, list)
+    hosts.append(copy.deepcopy(hosts[0]))
+    _write_contract_repo(tmp_path, contract)
+    with pytest.raises(HostUpdateError, match="duplicate_host:codex"):
+        load_host_update_contract(tmp_path)
+
+
+def test_contract_host_maturity_and_execution_boundaries_fail_closed(tmp_path: Path) -> None:
+    mutations = [
+        ("codex", "maturity", "SCAFFOLD_ONLY", "HOST_UPDATE_MATURITY_DRIFT:codex"),
+        ("cursor", "maturity", "SUPPORTED", "HOST_UPDATE_MATURITY_DRIFT:cursor"),
+        ("codex", "execution_support", "INSTRUCTION_ONLY", "HOST_UPDATE_EXECUTION_BOUNDARY_DRIFT:codex"),
+        ("cursor", "execution_support", "EXPLICIT_AUTHORIZATION_REQUIRED", "HOST_UPDATE_EXECUTION_BOUNDARY_DRIFT:cursor"),
+        ("codex", "automatic_installed_integration_refresh", True, "HOST_UPDATE_AUTO_REFRESH_FORBIDDEN:codex"),
+    ]
+    for host_id, field, value, match in mutations:
+        contract = _canonical_contract()
+        _host(contract, host_id)[field] = value
+        _write_contract_repo(tmp_path, contract)
+        with pytest.raises(HostUpdateError, match=match):
+            load_host_update_contract(tmp_path)
+
+
+def test_contract_required_host_fields_and_lists_fail_closed(tmp_path: Path) -> None:
+    for field in ("adapter_path", "update_mechanism", "plan_command"):
+        contract = _canonical_contract()
+        _host(contract, "codex")[field] = "  "
+        _write_contract_repo(tmp_path, contract)
+        with pytest.raises(HostUpdateError, match="HOST_UPDATE_CONTRACT_INVALID"):
+            load_host_update_contract(tmp_path)
+
+    for field, value in (
+        ("update_instructions", []),
+        ("validation_commands", ["same", "same"]),
+        ("recovery_hints", [""]),
+    ):
+        contract = _canonical_contract()
+        _host(contract, "codex")[field] = value
+        _write_contract_repo(tmp_path, contract)
+        with pytest.raises(HostUpdateError, match="HOST_UPDATE_CONTRACT_INVALID"):
+            load_host_update_contract(tmp_path)
+
+
+def test_contract_alias_and_host_set_integrity_fail_closed(tmp_path: Path) -> None:
+    contract = _canonical_contract()
+    _host(contract, "codex")["aliases"] = ["codex-alias"]
+    _write_contract_repo(tmp_path, contract)
+    with pytest.raises(HostUpdateError, match="canonical_alias_missing:codex"):
+        load_host_update_contract(tmp_path)
+
+    contract = _canonical_contract()
+    _host(contract, "cursor")["aliases"] = ["cursor", "CODEX"]
+    _write_contract_repo(tmp_path, contract)
+    with pytest.raises(HostUpdateError, match="duplicate_alias:codex"):
+        load_host_update_contract(tmp_path)
+
+    contract = _canonical_contract()
+    hosts = contract["hosts"]
+    assert isinstance(hosts, list)
+    hosts[:] = [record for record in hosts if isinstance(record, dict) and record["host_id"] != "zed"]
+    _write_contract_repo(tmp_path, contract)
+    with pytest.raises(HostUpdateError, match="HOST_UPDATE_HOST_SET_MISMATCH"):
+        load_host_update_contract(tmp_path)
+
+    contract = _canonical_contract()
+    extra = copy.deepcopy(_host(contract, "cursor"))
+    extra["host_id"] = "extra-host"
+    extra["aliases"] = ["extra-host"]
+    hosts = contract["hosts"]
+    assert isinstance(hosts, list)
+    hosts.append(extra)
+    _write_contract_repo(tmp_path, contract)
+    with pytest.raises(HostUpdateError, match="HOST_UPDATE_HOST_SET_MISMATCH"):
+        load_host_update_contract(tmp_path)
 
 
 def test_cli_emits_machine_plan_and_has_no_execute_flag() -> None:
@@ -119,3 +308,16 @@ def test_cli_emits_machine_plan_and_has_no_execute_flag() -> None:
     )
     assert rejected.returncode != 0
     assert "unrecognized arguments: --execute" in rejected.stderr
+
+
+def test_cli_unknown_host_fails_closed() -> None:
+    completed = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "host_update.py"), "--host", "unknown-host", "--json"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 2
+    assert completed.stdout == ""
+    assert "UNKNOWN_HOST_FAIL_CLOSED" in completed.stderr


### PR DESCRIPTION
Bounded signed-materialization transport only for Orchestra issue #336.

Frozen source head: `e710ceb87b0843f79c545e21432981817fa7eec0`
Frozen reviewed source tree: `da3ce2856771a314cb64f7da4da9507ecc2ca277`
Canonical/materialization base: `e32361b21a3ba42421778948ac66a025a6642b9d`
Source-validation PR: #337

The exact source head passed Governance Check, full validate/runtime, Required Analysis Compatibility including self-contained CodeQL and both required Analyze identities, and native Windows/Ubuntu/macOS validation while targeting canonical `main`. Runtime evidence records 1,064 passing tests, 98.50% statement coverage, and 95.48% branch coverage after bounded coverage remediation; `orchestra_runtime/host_updates.py` is 100% statement/branch covered.

This PR is signing transport only. It creates no canonical merge readiness, project-state promotion, release, deployment, policy, bypass, installed-integration, destructive, branch-deletion, force-push, history-rewrite, or MCP authority. The resulting GitHub-signed Squash commit must have exact reviewed-tree parity and canonical parent parity before a fresh signed canonical PR to `main` is opened and independently validated.