### PR TITLE
Materialize MCP stdio governed tool transport v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Post-v1.5.0 MCP stdio Governed Tool Transport - Candidate
+
+- Adds the first bounded MCP integration for protocol revision `2026-07-28`, using stdio only and exposing `server/discover`, `tools/list`, and `tools/call`.
+- Maps MCP tools to a deterministic intersection of an existing PRAP adapter command surface and Orchestra's trusted runtime policy; no parallel adapter registry, authority model, or permission source is introduced.
+- Creates a fresh trusted runtime composition per accepted tool call and preserves existing route binding, authority, runtime-capability, governance, lifecycle, operation, and audit ordering.
+- Restricts MCP tool arguments to a single `prompt` field with `additionalProperties: false`; client MCP metadata and arbitrary tool metadata cannot inject Orchestra governance validation, authority, or runtime-capability grants.
+- Adds `scripts/mcp_server.py`, focused runtime regressions, and developer/Adapter SDK documentation while keeping stdout protocol-only and diagnostics on stderr.
+- Keeps Streamable HTTP, resources, prompts, Tasks/extensions, deployment, policy activation, installed-integration refresh, host-maturity promotion, issue #316 closure, and token-savings claims outside this unit.
+- Keeps public release `v1.5.0` fixed at `b0a56cc7af8ad78234754bcb29ed07f6ab54d920`; this is a post-release candidate and does not move or republish the release.
 
 ## Post-v1.5.0 Developer Portal - Candidate
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ See [Compliance Registry Integration](docs/governance/COMPLIANCE_REGISTRY_INTEGR
 
 ## Developer Portal
 
-The repository-native [Developer Portal](docs/developer/README.md) is the discovery index for stabilized adapter, PRAP certification, host maturity, specialist, governance, and validation contracts. Its machine catalog is `machine/developer-portal/catalog.v1.json`. The portal is documentation and discovery only: it cannot grant authority, promote hosts, publish marketplace content, deploy, refresh integrations, move releases, or implement MCP.
+The repository-native [Developer Portal](docs/developer/README.md) is the discovery index for stabilized adapter, PRAP certification, host maturity, specialist, governance, and validation contracts. Its machine catalog is `machine/developer-portal/catalog.v1.json`. The portal remains documentation and discovery only: it cannot grant authority, promote hosts, publish marketplace content, deploy, refresh integrations, move releases, or authorize the separately governed MCP transport.
 
 ## Adapter SDK and PRAP v1 Compatibility Certification
 
@@ -93,7 +93,15 @@ Orchestra's post-v1.5 Adapter SDK formalizes the existing PRAP v1 boundary inste
 
 PRAP compatibility is deliberately separate from host maturity. A certification pass validates declared adapter metadata and compatibility, but it cannot promote a scaffold host, grant runtime authority or capabilities, mutate a repository or installed integration, or imply marketplace availability. Host Update maturity continues to come only from `machine/hosts/update-contract.v1.json`: Codex and Antigravity remain `SUPPORTED`; Claude Code, Cursor, Windsurf, VS Code/VSCodium, JetBrains, Zed, and Neovim remain `SCAFFOLD_ONLY`.
 
-See [Adapter SDK and PRAP v1 Compatibility Certification](docs/setup/ADAPTER_SDK_PRAP.md). MCP remains deferred to the final integration phase and, if later justified, must map to this stabilized protocol boundary rather than replace it or become an authority layer.
+See [Adapter SDK and PRAP v1 Compatibility Certification](docs/setup/ADAPTER_SDK_PRAP.md). The post-v1.5 MCP candidate maps to this stabilized protocol boundary rather than replacing it or becoming an authority layer.
+
+## MCP stdio governed tool transport
+
+The first bounded MCP integration candidate targets protocol revision `2026-07-28` over stdio and exposes only `server/discover`, `tools/list`, and `tools/call`. Start the local transport with `python scripts/mcp_server.py --adapter codex`, or select another existing Orchestra adapter identity without changing its PRAP or host-maturity status.
+
+MCP tools are a deterministic projection of commands that are both exposed by the selected existing adapter and present in Orchestra's trusted runtime policy. Each tool accepts a single `prompt` field with no arbitrary additional metadata, and each accepted call creates a fresh trusted `RuntimeExecutor` composition so existing route binding, authority, runtime-capability, governance, lifecycle, operation, and audit ordering remain authoritative. MCP client metadata, discovery information, tool names, and tool arguments cannot grant or expand Orchestra authority.
+
+This unit does not add Streamable HTTP, resources, prompts, Tasks/extensions, remote authorization, deployment, policy activation, installed-integration refresh, host-maturity promotion, issue #316 closure, or token-savings claims. The current public release remains fixed at `v1.5.0`; this is a post-release candidate only. See [MCP stdio governed tool transport](docs/developer/MCP_STDIO_TRANSPORT.md).
 
 ## How Orchestra Works
 
@@ -167,7 +175,7 @@ v1.5.0 packages the completed machine-verifiable control-plane re-foundation, th
 
 The final publication boundary recorded 1,058 passing runtime tests, 98.47% statement coverage, and 95.36% branch coverage, together with the required critical-module, workflow-sanity, P9 conformance, Mutmut, integrated Cosmic Ray, native Windows/Ubuntu/macOS, CodeQL, governance, package/version, Registry compatibility, signed canonical merge, tag-identity, and release-identity evidence.
 
-See the [v1.5.0 release candidate](docs/releases/v1.5.0-machine-verifiable-control-plane-murmurs-release-candidate.md), [v1.5.0 release-readiness evidence](docs/validation/V1_5_0_RELEASE_READINESS_EVIDENCE.md), and [v1.5.0 publication closeout](docs/validation/V1_5_0_PUBLICATION_CLOSEOUT.md). MCP was intentionally excluded from v1.5.0. Publication satisfies its sequencing prerequisite only; any MCP work still requires a fresh post-release priority and design decision.
+See the [v1.5.0 release candidate](docs/releases/v1.5.0-machine-verifiable-control-plane-murmurs-release-candidate.md), [v1.5.0 release-readiness evidence](docs/validation/V1_5_0_RELEASE_READINESS_EVIDENCE.md), and [v1.5.0 publication closeout](docs/validation/V1_5_0_PUBLICATION_CLOSEOUT.md). MCP was intentionally excluded from v1.5.0. The later MCP stdio candidate is a separately governed post-release integration and does not move or republish the fixed v1.5.0 release.
 
 ## v1.4.0 Governance and Compliance Registry Cross-Integration
 
@@ -290,7 +298,7 @@ The Tuner's coordination runtime records specialist-owned contracts, dependencie
 ## Roles and Specialist Responsibilities
 
 | Role | Primary responsibility | Key boundary |
-|---|---|---|
+| --- | --- | --- |
 | The Steward | Business alignment, requirements traceability, scope, change control, acceptance criteria | Does not decide legal or technical implementation details |
 | The Governor | Legal/compliance governance, source/applicability verification, privacy-obligation, IP and licensing review | Does not provide legal advice or grant runtime authority |
 | Conductor | Routing and ordered specialist handoffs | Routes work but does not implement it |
@@ -313,7 +321,7 @@ Artificer remains a maintainer-only internal repository-evolution surface. It is
 Support means a validated integration surface. Scaffold-only means the repository contains a thin runtime adapter and packaging or instruction scaffold, not a published marketplace product.
 
 | Host | Maturity | Notes |
-|---|---|---|
+| --- | --- | --- |
 | Codex | Supported | Marketplace-first installation with repo-local fallback; R7 same-host and cross-host continuity evidence is verified and merged. |
 | Claude Code | Scaffold-only | Marketplace metadata, namespaced plugin skills, and R7-H package/contract compatibility; active runtime continuity is not claimed. |
 | Antigravity | Supported | Native `agy` plugin path; R7 same-host and cross-host continuity evidence is verified and merged. |
@@ -436,6 +444,7 @@ See the [v1.2.0 release notes](docs/releases/v1.2.0-governed-orchestration.md). 
 - The current coordination runtime is in-memory and does not add persistent collaboration storage, SQLite, migrations, RPC, or host-process orchestration.
 - Orchestra does not create remote workers, background agents, or distributed orchestration infrastructure.
 - Compatibility mode is explicit, finite, and intended for bounded existing routes.
+- The current MCP candidate is stdio-only and tools-only; it does not provide Streamable HTTP, resources, prompts, Tasks/extensions, remote authorization, deployment, or host promotion.
 - Cursor, Windsurf, VS Code/VSCodium, JetBrains, Zed, and Neovim remain scaffold-only.
 - Repository simulation is not live installed-host evidence. Accepted R7 evidence is `MERGED_VERIFIED`; the simulated fixture remains pending/empty by design.
 - Orchestra is developer tooling and a local runtime. It does not store or transmit downstream project data by default.
@@ -451,6 +460,7 @@ See the [v1.2.0 release notes](docs/releases/v1.2.0-governed-orchestration.md). 
 - [Installation](docs/setup/INSTALLATION.md)
 - [Compatibility](docs/setup/COMPATIBILITY.md)
 - [Host Update Contract](docs/setup/HOST_UPDATES.md)
+- [MCP stdio governed tool transport](docs/developer/MCP_STDIO_TRANSPORT.md)
 - [Validation](docs/setup/VALIDATION.md)
 - [Skill Index](SKILL_INDEX.md)
 

--- a/docs/developer/MCP_STDIO_TRANSPORT.md
+++ b/docs/developer/MCP_STDIO_TRANSPORT.md
@@ -1,0 +1,84 @@
+# MCP stdio governed tool transport
+
+Status: post-v1.5 candidate under Orchestra issue #349.
+
+## Scope
+
+Orchestra's first MCP integration targets protocol revision `2026-07-28` and the standard stdio transport. The bounded surface is deliberately limited to:
+
+- `server/discover`
+- `tools/list`
+- `tools/call`
+
+Streamable HTTP, resources, prompts, Tasks/extensions, deployment, policy activation, and installed-integration refresh are outside this unit.
+
+The server entry point is:
+
+```text
+python scripts/mcp_server.py --adapter codex
+```
+
+`--adapter` selects an existing Orchestra PRAP adapter identity. MCP does not add a new PRAP adapter identity or promote host maturity.
+
+## Current protocol model
+
+MCP `2026-07-28` uses a stateless request model. Orchestra does not implement the retired `initialize` / `initialized` handshake or MCP protocol sessions in this transport. Requests must declare `io.modelcontextprotocol/protocolVersion` in `_meta`; unsupported versions fail with the MCP unsupported-protocol-version error.
+
+`server/discover` advertises only the protocol revision and tools capability implemented by this bounded server. `tools/list` returns a deterministic projection of commands that are both exposed by the selected existing adapter and present in the current trusted runtime policy. Tool definitions accept one field only, `prompt`, with `additionalProperties: false`.
+
+## Authority boundary
+
+MCP is transport, not authority.
+
+A tool call:
+
+1. creates a fresh Orchestra trusted compatibility composition and runtime executor;
+2. selects the requested MCP tool only when it is currently projected by both the backing adapter and runtime policy;
+3. wraps the existing PRAP adapter with an exact-command transport view;
+4. enters `RuntimeExecutor.execute` with transport-identification metadata only;
+5. preserves the existing binding, authority, runtime-capability, governance, lifecycle, operation, and audit sequence.
+
+MCP request `_meta` is validated for protocol compatibility but is not forwarded as runtime authority or governance metadata. Tool arguments cannot supply `governance_validated`, `destructive_validated`, `dry_run`, authority grants, runtime capability grants, or arbitrary metadata. Routes that already require trusted governance validation therefore remain blocked unless a separately trusted Orchestra integration supplies that validation through an existing authorized boundary.
+
+PRAP `AdapterCapabilities`, MCP client identity, MCP client capabilities, tool names, tool arguments, discovery data, compatibility certification, host maturity, and successful validation do not grant Orchestra runtime authority.
+
+## stdio safety
+
+The server reads one UTF-8 JSON-RPC message per input line and writes one compact JSON-RPC response per output line. Protocol output is written to stdout only. Internal diagnostics use stderr so logging cannot corrupt MCP framing.
+
+Unknown tools and malformed tool arguments are protocol-level errors. Existing Orchestra runtime denials are returned as tool execution errors without changing their authority meaning.
+
+## Validation expectations
+
+The focused runtime tests cover:
+
+- current protocol discovery;
+- deterministic tool ordering and runtime-policy projection;
+- exact-command routing independent of prompt triggers;
+- a fresh trusted runtime per tool call;
+- protocol-version and reserved `_meta` validation;
+- unknown tools and malformed argument fail-closed behavior;
+- rejection of client-supplied governance metadata;
+- existing governed-route blocking;
+- runtime-contract failure translation;
+- parse/internal-error handling and stdout/stderr separation.
+
+The signed canonical PR must still pass Orchestra's complete protected-main validation matrix on its exact head. Signed-materialization evidence is transport evidence only and is not reusable as canonical merge readiness.
+
+## Non-goals
+
+This unit does not:
+
+- create an MCP-specific authority or permission model;
+- replace PRAP or the Adapter SDK;
+- change the Developer Portal into a hosted control plane;
+- expose resources or prompts;
+- implement Tasks or Multi Round-Trip Requests;
+- add Streamable HTTP or network listeners;
+- add OAuth or remote authorization;
+- deploy anything;
+- activate policy;
+- refresh installed integrations;
+- change host maturity;
+- close Murmurs issue #316;
+- claim token savings.

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -8,12 +8,13 @@ The Developer Portal is Orchestra's repository-native discovery surface for deve
 | --- | --- |
 | Understand or build an adapter | `docs/setup/ADAPTER_SDK_PRAP.md`, `machine/protocol/prap-certification-contract.v1.json`, `machine/specialists/registry.v1.json` |
 | Produce PRAP compatibility evidence | `scripts/certify_adapter.py`, `machine/protocol/prap-certification-contract.v1.json`, `machine/schemas/prap-certification-evidence.schema.json` |
+| Integrate through MCP stdio | `docs/developer/MCP_STDIO_TRANSPORT.md`, `orchestra_runtime/mcp_transport.py`, `scripts/mcp_server.py` |
 | Check host maturity | `machine/hosts/update-contract.v1.json`, `docs/setup/HOST_UPDATES.md` |
 | Understand specialist / Downstream Role boundaries | `machine/specialists/registry.v1.json`, `docs/project/AUTHORITY_CAPABILITY_RUNTIME_ARCHITECTURE.md` |
 | Review governance | `machine/governance/policy.v1.json`, `docs/governance/GOVERNANCE_LAYER.md` |
 | Validate changes | `docs/setup/VALIDATION.md` |
 
-The machine-readable index for these entry points is `machine/developer-portal/catalog.v1.json`. Its schema is `machine/schemas/developer-portal-catalog.schema.json`.
+The machine-readable index for the established portal entry points is `machine/developer-portal/catalog.v1.json`. Its schema is `machine/schemas/developer-portal-catalog.schema.json`. The bounded MCP transport is a later integration phase and does not make the portal catalog authoritative for MCP execution.
 
 ## Adapter journey
 
@@ -24,6 +25,15 @@ The machine-readable index for these entry points is `machine/developer-portal/c
 5. Treat certification and host maturity as separate dimensions. Certification cannot promote a scaffold host.
 6. Run repository validation before proposing a governed source change.
 
+## MCP integration journey
+
+1. Read `docs/developer/MCP_STDIO_TRANSPORT.md` and the existing Adapter SDK/PRAP authority boundary.
+2. Start the bounded server with `python scripts/mcp_server.py --adapter <existing-adapter-id>`.
+3. Treat the selected adapter as the existing PRAP/runtime identity. MCP does not register a new adapter or promote host maturity.
+4. Use only the implemented `server/discover`, `tools/list`, and `tools/call` surface for protocol revision `2026-07-28`.
+5. Treat MCP request metadata and tool arguments as untrusted for Orchestra authority or governance expansion.
+6. Keep Streamable HTTP, resources, prompts, Tasks/extensions, deployment, policy activation, and installed-integration refresh outside this bounded transport.
+
 ## Specialist extension journey
 
 The machine specialist registry at `machine/specialists/registry.v1.json` owns specialist identity. The Developer Portal does not create new specialists, change ownership, or convert Downstream Roles into authority sources. Read the authority/capability/runtime architecture and governance policy before proposing a specialist extension.
@@ -32,14 +42,16 @@ Third-party discovery or publication is intentionally outside this phase. The Th
 
 ## Governance and authority boundary
 
-Portal links point to authoritative machine contracts where authority exists; the catalog does not duplicate or supersede those contracts. Portal discovery, documentation, validation success, certification success, packaging metadata, and GitHub mergeability do not grant runtime authority or capabilities.
+Portal links point to authoritative machine contracts where authority exists; the catalog does not duplicate or supersede those contracts. Portal discovery, documentation, validation success, certification success, packaging metadata, MCP discovery, and GitHub mergeability do not grant runtime authority or capabilities.
 
-The Developer Portal cannot activate policy, deploy or mutate production, refresh installed integrations, move releases or tags, promote host maturity, publish marketplace content, perform destructive cleanup, rewrite history, or implement MCP.
+The Developer Portal cannot activate policy, deploy or mutate production, refresh installed integrations, move releases or tags, promote host maturity, publish marketplace content, perform destructive cleanup, or rewrite history. The separately governed MCP transport cannot turn the portal into an authority source.
 
-## Future transport boundary
+## MCP transport boundary
 
-MCP remains the final integration phase. If later implemented under separate authority, it must map to the stabilized Adapter SDK/PRAP boundary and existing governance contracts. The Developer Portal does not define an MCP transport, server, tool registry, or permission model.
+The post-v1.5 MCP candidate is a stdio-only transport that maps protocol revision `2026-07-28` to Orchestra's existing trusted Adapter SDK/PRAP/runtime boundary. It projects current runtime-bound commands as tools and delegates accepted calls to a fresh existing trusted runtime composition. It does not define a new permission model or bypass binding, authority, runtime-capability, governance, lifecycle, or audit controls.
+
+The first bounded unit does not add Streamable HTTP, resources, prompts, Tasks/extensions, deployment, policy activation, installed-integration refresh, host-maturity promotion, or token-savings claims. See `docs/developer/MCP_STDIO_TRANSPORT.md`.
 
 ## Public release boundary
 
-The current public release remains `v1.5.0` at `b0a56cc7af8ad78234754bcb29ed07f6ab54d920`. This portal phase does not move or republish that release.
+The current public release remains `v1.5.0` at `b0a56cc7af8ad78234754bcb29ed07f6ab54d920`. This post-release candidate does not move or republish that release.

--- a/docs/setup/ADAPTER_SDK_PRAP.md
+++ b/docs/setup/ADAPTER_SDK_PRAP.md
@@ -42,6 +42,10 @@ PRAP `AdapterCapabilities` describe adapter interface characteristics. They are 
 
 Adapter metadata, packaging metadata, validation success, and compatibility evidence cannot expand authority. Existing trusted runtime composition and authority controls remain separate.
 
-## Future transports
+## MCP transport mapping
 
-MCP remains a future transport-integration concern. If a later governed phase justifies MCP implementation, MCP must map stabilized Orchestra capabilities to this Adapter SDK/PRAP boundary. It must not replace PRAP, become an authority source, or reinterpret certification as permission.
+The post-v1.5 MCP candidate adds a bounded stdio transport for MCP protocol revision `2026-07-28`. It does not create a parallel adapter protocol. The MCP server selects an existing Orchestra adapter through `AdapterFactory`, projects only commands that are both exposed by that adapter and present in the current trusted runtime policy, and routes every accepted tool call through a fresh existing `RuntimeExecutor` composition.
+
+MCP therefore remains transport rather than authority. MCP client metadata, MCP capabilities, tool names, tool arguments, discovery responses, PRAP certification, and Host Update maturity cannot grant runtime authority or runtime capability. Client-supplied tool arguments cannot inject Orchestra governance-validation metadata.
+
+The first bounded transport exposes only `server/discover`, `tools/list`, and `tools/call` over stdio. Streamable HTTP, resources, prompts, Tasks/extensions, deployment, policy activation, and installed-integration refresh remain outside this unit. See `docs/developer/MCP_STDIO_TRANSPORT.md`.

--- a/orchestra_runtime/mcp_transport.py
+++ b/orchestra_runtime/mcp_transport.py
@@ -1,0 +1,372 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+import json
+from pathlib import Path
+import sys
+from typing import TextIO
+from uuid import uuid4
+
+from .factories import AdapterFactory
+from .interfaces import IIDEAdapter
+from .models import Command, ExecutionResult
+from .repositories import ManifestRepository, SkillSourceRepository
+from .services import (
+    ContextAssembler,
+    GovernanceValidator,
+    InMemoryAuditSink,
+    RouterService,
+    RuntimeExecutor,
+    SkillRegistry,
+    build_compatibility_composition,
+)
+from .errors import RuntimeContractError
+
+
+MCP_PROTOCOL_VERSION = "2026-07-28"
+MCP_PROTOCOL_VERSION_META_KEY = "io.modelcontextprotocol/protocolVersion"
+MCP_CLIENT_INFO_META_KEY = "io.modelcontextprotocol/clientInfo"
+MCP_CLIENT_CAPABILITIES_META_KEY = "io.modelcontextprotocol/clientCapabilities"
+MCP_SERVER_INFO_META_KEY = "io.modelcontextprotocol/serverInfo"
+
+JSONRPC_PARSE_ERROR = -32700
+JSONRPC_INVALID_REQUEST = -32600
+JSONRPC_METHOD_NOT_FOUND = -32601
+JSONRPC_INVALID_PARAMS = -32602
+JSONRPC_INTERNAL_ERROR = -32603
+MCP_UNSUPPORTED_PROTOCOL_VERSION = -32022
+
+
+class McpProtocolError(Exception):
+    def __init__(self, code: int, message: str, data: dict[str, object] | None = None) -> None:
+        super().__init__(message)
+        self.code = int(code)
+        self.message = str(message)
+        self.data = dict(data or {})
+
+
+class _ExactCommandAdapter(IIDEAdapter):
+    """Transport-only adapter view that preserves the selected PRAP adapter identity."""
+
+    def __init__(self, backing: IIDEAdapter, command_name: str) -> None:
+        self._backing = backing
+        self._command_name = str(command_name).strip()
+
+    @property
+    def adapter_name(self) -> str:
+        return self._backing.adapter_name
+
+    def provide_context(self, prompt: str, metadata: dict | None = None):
+        return self._backing.provide_context(prompt, metadata)
+
+    def expose_commands(self) -> tuple[str, ...]:
+        return self._backing.expose_commands()
+
+    def parse_command(self, prompt: str, metadata: dict | None = None) -> Command:
+        return Command(
+            name=self._command_name,
+            raw_input=prompt,
+            adapter_name=self.adapter_name,
+            metadata=dict(metadata or {}),
+        )
+
+
+RuntimeFactory = Callable[[], tuple[RuntimeExecutor, IIDEAdapter]]
+
+
+class McpToolTransport:
+    """MCP 2026-07-28 stdio transport over Orchestra's existing trusted runtime."""
+
+    def __init__(
+        self,
+        runtime_factory: RuntimeFactory,
+        *,
+        server_name: str = "orchestra",
+        server_version: str,
+        error_stream: TextIO | None = None,
+    ) -> None:
+        if not callable(runtime_factory):
+            raise TypeError("runtime_factory must be callable")
+        name = str(server_name).strip()
+        version = str(server_version).strip()
+        if not name or not version:
+            raise ValueError("server_name and server_version must be non-empty")
+        self._runtime_factory = runtime_factory
+        self._server_name = name
+        self._server_version = version
+        self._error_stream = error_stream or sys.stderr
+
+    @property
+    def server_info(self) -> dict[str, str]:
+        return {"name": self._server_name, "version": self._server_version}
+
+    def _response_meta(self) -> dict[str, object]:
+        return {MCP_SERVER_INFO_META_KEY: self.server_info}
+
+    @staticmethod
+    def _request_id(message: object) -> object:
+        if isinstance(message, dict) and "id" in message:
+            return message["id"]
+        return None
+
+    def _validate_request(self, message: object) -> tuple[object, str, dict[str, object]]:
+        if not isinstance(message, dict) or message.get("jsonrpc") != "2.0":
+            raise McpProtocolError(JSONRPC_INVALID_REQUEST, "Invalid Request")
+        if "id" not in message:
+            raise McpProtocolError(JSONRPC_INVALID_REQUEST, "MCP stdio transport accepts requests only")
+        method = message.get("method")
+        params = message.get("params", {})
+        if not isinstance(method, str) or not method.strip():
+            raise McpProtocolError(JSONRPC_INVALID_REQUEST, "Invalid Request")
+        if not isinstance(params, dict):
+            raise McpProtocolError(JSONRPC_INVALID_PARAMS, "Request params must be an object")
+        self._validate_meta(params)
+        return message["id"], method, params
+
+    @staticmethod
+    def _validate_optional_implementation(value: object, field_name: str) -> None:
+        if value is None:
+            return
+        if not isinstance(value, dict):
+            raise McpProtocolError(JSONRPC_INVALID_PARAMS, f"{field_name} must be an object")
+        name = value.get("name")
+        version = value.get("version")
+        if not isinstance(name, str) or not name.strip() or not isinstance(version, str) or not version.strip():
+            raise McpProtocolError(JSONRPC_INVALID_PARAMS, f"{field_name} must include non-empty name and version")
+
+    def _validate_meta(self, params: dict[str, object]) -> None:
+        meta = params.get("_meta")
+        if not isinstance(meta, dict):
+            raise McpProtocolError(JSONRPC_INVALID_PARAMS, "Request _meta is required")
+        requested = meta.get(MCP_PROTOCOL_VERSION_META_KEY)
+        if not isinstance(requested, str) or not requested.strip():
+            raise McpProtocolError(JSONRPC_INVALID_PARAMS, "Request protocol version is required")
+        if requested != MCP_PROTOCOL_VERSION:
+            raise McpProtocolError(
+                MCP_UNSUPPORTED_PROTOCOL_VERSION,
+                "Unsupported protocol version",
+                {"requested": requested, "supported": [MCP_PROTOCOL_VERSION]},
+            )
+        self._validate_optional_implementation(meta.get(MCP_CLIENT_INFO_META_KEY), "clientInfo")
+        capabilities = meta.get(MCP_CLIENT_CAPABILITIES_META_KEY)
+        if capabilities is not None and not isinstance(capabilities, dict):
+            raise McpProtocolError(JSONRPC_INVALID_PARAMS, "clientCapabilities must be an object")
+
+    def _project_tools(self, executor: RuntimeExecutor, adapter: IIDEAdapter) -> list[dict[str, object]]:
+        available = set(adapter.expose_commands())
+        projected: dict[str, str] = {}
+        for binding in executor.composition.policy.bindings:
+            if binding.command_name not in available:
+                continue
+            existing = projected.get(binding.command_name)
+            if existing is not None and existing != binding.skill_slug:
+                raise RuntimeError(f"ambiguous runtime binding for command '{binding.command_name}'")
+            projected[binding.command_name] = binding.skill_slug
+
+        return [
+            {
+                "name": command_name,
+                "title": f"Orchestra: {command_name}",
+                "description": (
+                    f"Route the '{command_name}' Orchestra command through the existing trusted "
+                    f"runtime binding for specialist '{projected[command_name]}'."
+                ),
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "description": "Task input supplied to the selected Orchestra command.",
+                        }
+                    },
+                    "required": ["prompt"],
+                    "additionalProperties": False,
+                },
+            }
+            for command_name in sorted(projected)
+        ]
+
+    def discover(self) -> dict[str, object]:
+        return {
+            "resultType": "complete",
+            "supportedVersions": [MCP_PROTOCOL_VERSION],
+            "capabilities": {"tools": {}},
+            "instructions": (
+                "Orchestra exposes existing governed runtime commands as MCP tools. "
+                "MCP metadata and tool arguments do not grant runtime authority or governance approval."
+            ),
+            "_meta": self._response_meta(),
+        }
+
+    def list_tools(self) -> dict[str, object]:
+        executor, adapter = self._runtime_factory()
+        return {
+            "resultType": "complete",
+            "tools": self._project_tools(executor, adapter),
+            "ttlMs": 0,
+            "cacheScope": "private",
+            "_meta": self._response_meta(),
+        }
+
+    @staticmethod
+    def _parse_tool_call(params: dict[str, object], allowed_names: set[str]) -> tuple[str, str]:
+        name = params.get("name")
+        arguments = params.get("arguments")
+        if not isinstance(name, str) or name not in allowed_names:
+            raise McpProtocolError(JSONRPC_INVALID_PARAMS, "Unknown tool")
+        if not isinstance(arguments, dict):
+            raise McpProtocolError(JSONRPC_INVALID_PARAMS, "Tool arguments must be an object")
+        if set(arguments) != {"prompt"}:
+            raise McpProtocolError(JSONRPC_INVALID_PARAMS, "Tool arguments must contain only 'prompt'")
+        prompt = arguments.get("prompt")
+        if not isinstance(prompt, str) or not prompt.strip():
+            raise McpProtocolError(JSONRPC_INVALID_PARAMS, "Tool argument 'prompt' must be a non-empty string")
+        return name, prompt
+
+    def _tool_result(self, result: ExecutionResult) -> dict[str, object]:
+        return {
+            "resultType": "complete",
+            "content": [{"type": "text", "text": result.output}],
+            "isError": not result.success,
+            "_meta": self._response_meta(),
+        }
+
+    def call_tool(self, params: dict[str, object]) -> dict[str, object]:
+        executor, adapter = self._runtime_factory()
+        tools = self._project_tools(executor, adapter)
+        name, prompt = self._parse_tool_call(params, {str(item["name"]) for item in tools})
+        exact_adapter = _ExactCommandAdapter(adapter, name)
+        try:
+            result = executor.execute(
+                exact_adapter,
+                prompt,
+                {
+                    "orchestra.transport": "mcp",
+                    "orchestra.mcp.tool": name,
+                },
+            )
+        except RuntimeContractError as exc:
+            return {
+                "resultType": "complete",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": f"Orchestra runtime rejected the request ({exc.reason_code}).",
+                    }
+                ],
+                "isError": True,
+                "_meta": self._response_meta(),
+            }
+        return self._tool_result(result)
+
+    def handle_message(self, message: object) -> dict[str, object]:
+        request_id = self._request_id(message)
+        try:
+            request_id, method, params = self._validate_request(message)
+            if method == "server/discover":
+                result = self.discover()
+            elif method == "tools/list":
+                cursor = params.get("cursor")
+                if cursor not in {None, ""}:
+                    raise McpProtocolError(JSONRPC_INVALID_PARAMS, "Pagination cursors are not supported")
+                result = self.list_tools()
+            elif method == "tools/call":
+                result = self.call_tool(params)
+            else:
+                raise McpProtocolError(JSONRPC_METHOD_NOT_FOUND, "Method not found")
+            return {"jsonrpc": "2.0", "id": request_id, "result": result}
+        except McpProtocolError as exc:
+            error: dict[str, object] = {"code": exc.code, "message": exc.message}
+            if exc.data:
+                error["data"] = exc.data
+            return {"jsonrpc": "2.0", "id": request_id, "error": error}
+
+    def handle_line(self, line: str) -> dict[str, object]:
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError:
+            return {
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": JSONRPC_PARSE_ERROR, "message": "Parse error"},
+            }
+        return self.handle_message(message)
+
+    def serve_stdio(
+        self,
+        input_stream: TextIO | None = None,
+        output_stream: TextIO | None = None,
+    ) -> int:
+        source = input_stream or sys.stdin
+        sink = output_stream or sys.stdout
+        for raw_line in source:
+            if not raw_line.strip():
+                continue
+            try:
+                response = self.handle_line(raw_line)
+            except Exception as exc:
+                print(
+                    f"ORCHESTRA_MCP_INTERNAL_ERROR={type(exc).__name__}",
+                    file=self._error_stream,
+                    flush=True,
+                )
+                response = {
+                    "jsonrpc": "2.0",
+                    "id": None,
+                    "error": {"code": JSONRPC_INTERNAL_ERROR, "message": "Internal error"},
+                }
+            sink.write(json.dumps(response, separators=(",", ":"), ensure_ascii=False) + "\n")
+            sink.flush()
+        return 0
+
+
+def build_mcp_runtime_factory(
+    repo_root: Path | str,
+    *,
+    backing_adapter: str = "codex",
+) -> RuntimeFactory:
+    root = Path(repo_root).resolve()
+    adapter_name = str(backing_adapter).strip().casefold()
+    if not adapter_name:
+        raise ValueError("backing_adapter must be non-empty")
+
+    def factory() -> tuple[RuntimeExecutor, IIDEAdapter]:
+        manifest_repository = ManifestRepository(root)
+        skill_repository = SkillSourceRepository(root)
+        skill_registry = SkillRegistry(manifest_repository, skill_repository)
+        audit_sink = InMemoryAuditSink()
+        composition = build_compatibility_composition(
+            skill_registry,
+            audit_sink,
+            run_id=f"mcp-{uuid4().hex}",
+        )
+        executor = RuntimeExecutor(
+            skill_registry,
+            RouterService(skill_registry),
+            GovernanceValidator(),
+            ContextAssembler(manifest_repository),
+            composition,
+        )
+        adapter = AdapterFactory.create(adapter_name, root)
+        return executor, adapter
+
+    return factory
+
+
+def build_mcp_stdio_transport(
+    repo_root: Path | str,
+    *,
+    backing_adapter: str = "codex",
+    error_stream: TextIO | None = None,
+) -> McpToolTransport:
+    root = Path(repo_root).resolve()
+    manifest = ManifestRepository(root).load_manifest()
+    server_version = str(manifest.get("version", "")).strip()
+    if not server_version:
+        raise ValueError("plugin.json must declare a non-empty version")
+    return McpToolTransport(
+        build_mcp_runtime_factory(root, backing_adapter=backing_adapter),
+        server_name="orchestra",
+        server_version=server_version,
+        error_stream=error_stream,
+    )

--- a/scripts/mcp_server.py
+++ b/scripts/mcp_server.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from orchestra_runtime.mcp_transport import build_mcp_stdio_transport
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="orchestra-mcp-stdio",
+        description="Serve Orchestra's governed MCP 2026-07-28 tool transport over stdio.",
+    )
+    parser.add_argument(
+        "--adapter",
+        default="codex",
+        help="Existing Orchestra PRAP adapter identity used as the runtime backing adapter (default: codex).",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        transport = build_mcp_stdio_transport(ROOT, backing_adapter=args.adapter)
+    except (OSError, ValueError) as exc:
+        print(f"ORCHESTRA_MCP_STARTUP=FAIL:{exc}", file=sys.stderr)
+        return 2
+    return transport.serve_stdio()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/runtime/test_mcp_transport.py
+++ b/tests/runtime/test_mcp_transport.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from io import StringIO
+import json
+from pathlib import Path
+
+import pytest
+
+from orchestra_runtime.mcp_transport import (
+    JSONRPC_INTERNAL_ERROR,
+    JSONRPC_INVALID_PARAMS,
+    JSONRPC_INVALID_REQUEST,
+    JSONRPC_METHOD_NOT_FOUND,
+    JSONRPC_PARSE_ERROR,
+    MCP_PROTOCOL_VERSION,
+    MCP_PROTOCOL_VERSION_META_KEY,
+    MCP_SERVER_INFO_META_KEY,
+    MCP_UNSUPPORTED_PROTOCOL_VERSION,
+    McpToolTransport,
+    build_mcp_runtime_factory,
+    build_mcp_stdio_transport,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _meta(version: str = MCP_PROTOCOL_VERSION) -> dict[str, object]:
+    return {
+        MCP_PROTOCOL_VERSION_META_KEY: version,
+        "io.modelcontextprotocol/clientInfo": {"name": "pytest", "version": "1"},
+        "io.modelcontextprotocol/clientCapabilities": {},
+    }
+
+
+def _request(method: str, params: dict[str, object] | None = None, request_id: object = 1) -> dict[str, object]:
+    payload = dict(params or {})
+    payload.setdefault("_meta", _meta())
+    return {"jsonrpc": "2.0", "id": request_id, "method": method, "params": payload}
+
+
+def _transport() -> McpToolTransport:
+    return build_mcp_stdio_transport(ROOT, backing_adapter="codex")
+
+
+def test_discover_is_modern_stateless_tools_only() -> None:
+    response = _transport().handle_message(_request("server/discover"))
+    result = response["result"]
+    assert result["resultType"] == "complete"
+    assert result["supportedVersions"] == [MCP_PROTOCOL_VERSION]
+    assert result["capabilities"] == {"tools": {}}
+    assert MCP_SERVER_INFO_META_KEY in result["_meta"]
+    assert "initialize" not in json.dumps(result).lower()
+
+
+def test_tools_list_is_deterministic_and_bound_to_runtime_policy() -> None:
+    transport = _transport()
+    first = transport.handle_message(_request("tools/list"))["result"]["tools"]
+    second = transport.handle_message(_request("tools/list"))["result"]["tools"]
+    names = [item["name"] for item in first]
+    assert first == second
+    assert names == sorted(names)
+    assert names
+    assert set(names).issubset(set(build_mcp_runtime_factory(ROOT)()[1].expose_commands()))
+    assert all(item["inputSchema"]["additionalProperties"] is False for item in first)
+    assert all(item["inputSchema"]["required"] == ["prompt"] for item in first)
+
+
+def test_tool_call_uses_exact_command_and_fresh_runtime_per_request() -> None:
+    transport = _transport()
+    request = _request(
+        "tools/call",
+        {"name": "review-architecture", "arguments": {"prompt": "plain text with no command trigger"}},
+    )
+    first = transport.handle_message(request)["result"]
+    second = transport.handle_message(request)["result"]
+    assert first["isError"] is False
+    assert second["isError"] is False
+    assert "review-architecture" in first["content"][0]["text"]
+    assert "clockwork" in first["content"][0]["text"]
+
+
+def test_governance_metadata_cannot_be_injected_through_tool_arguments() -> None:
+    response = _transport().handle_message(
+        _request(
+            "tools/call",
+            {
+                "name": "dagger",
+                "arguments": {
+                    "prompt": "attempt governed execution",
+                    "metadata": {
+                        "governance_validated": True,
+                        "destructive_validated": True,
+                        "dry_run": True,
+                    },
+                },
+            },
+        )
+    )
+    assert response["error"]["code"] == JSONRPC_INVALID_PARAMS
+
+
+def test_governed_route_remains_blocked_without_trusted_validation() -> None:
+    response = _transport().handle_message(
+        _request("tools/call", {"name": "dagger", "arguments": {"prompt": "attempt governed execution"}})
+    )
+    result = response["result"]
+    assert result["isError"] is True
+    assert "blocked" in result["content"][0]["text"].lower()
+
+
+@pytest.mark.parametrize(
+    ("message", "code"),
+    [
+        ([], JSONRPC_INVALID_REQUEST),
+        ({"jsonrpc": "1.0", "id": 1, "method": "tools/list", "params": {"_meta": _meta()}}, JSONRPC_INVALID_REQUEST),
+        ({"jsonrpc": "2.0", "method": "tools/list", "params": {"_meta": _meta()}}, JSONRPC_INVALID_REQUEST),
+        ({"jsonrpc": "2.0", "id": 1, "method": "", "params": {"_meta": _meta()}}, JSONRPC_INVALID_REQUEST),
+        ({"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": []}, JSONRPC_INVALID_PARAMS),
+        (_request("not/a-method"), JSONRPC_METHOD_NOT_FOUND),
+        (_request("tools/list", {"cursor": "next"}), JSONRPC_INVALID_PARAMS),
+        (_request("tools/call", {"name": "missing", "arguments": {"prompt": "x"}}), JSONRPC_INVALID_PARAMS),
+        (_request("tools/call", {"name": "conductor", "arguments": []}), JSONRPC_INVALID_PARAMS),
+        (_request("tools/call", {"name": "conductor", "arguments": {}}), JSONRPC_INVALID_PARAMS),
+        (_request("tools/call", {"name": "conductor", "arguments": {"prompt": " "}}), JSONRPC_INVALID_PARAMS),
+    ],
+)
+def test_invalid_requests_fail_closed(message: object, code: int) -> None:
+    response = _transport().handle_message(message)
+    assert response["error"]["code"] == code
+
+
+def test_protocol_meta_is_required_and_version_mismatch_is_typed() -> None:
+    missing = {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
+    missing_response = _transport().handle_message(missing)
+    assert missing_response["error"]["code"] == JSONRPC_INVALID_PARAMS
+
+    malformed = _request("tools/list")
+    malformed["params"]["_meta"] = []
+    malformed_response = _transport().handle_message(malformed)
+    assert malformed_response["error"]["code"] == JSONRPC_INVALID_PARAMS
+
+    unsupported = _request("tools/list")
+    unsupported["params"]["_meta"] = _meta("2099-01-01")
+    unsupported_response = _transport().handle_message(unsupported)
+    assert unsupported_response["error"]["code"] == MCP_UNSUPPORTED_PROTOCOL_VERSION
+    assert unsupported_response["error"]["data"] == {
+        "requested": "2099-01-01",
+        "supported": [MCP_PROTOCOL_VERSION],
+    }
+
+
+@pytest.mark.parametrize(
+    "meta_update",
+    [
+        {"io.modelcontextprotocol/protocolVersion": 20260728},
+        {"io.modelcontextprotocol/clientInfo": "pytest"},
+        {"io.modelcontextprotocol/clientInfo": {"name": "", "version": "1"}},
+        {"io.modelcontextprotocol/clientCapabilities": []},
+    ],
+)
+def test_reserved_meta_shapes_are_validated(meta_update: dict[str, object]) -> None:
+    request = _request("tools/list")
+    request["params"]["_meta"].update(meta_update)
+    response = _transport().handle_message(request)
+    assert response["error"]["code"] == JSONRPC_INVALID_PARAMS
+
+
+def test_client_info_is_optional_for_final_2026_revision() -> None:
+    request = _request("tools/list")
+    request["params"]["_meta"].pop("io.modelcontextprotocol/clientInfo")
+    response = _transport().handle_message(request)
+    assert "result" in response
+
+
+def test_empty_cursor_is_accepted() -> None:
+    response = _transport().handle_message(_request("tools/list", {"cursor": ""}))
+    assert "result" in response
+
+
+def test_runtime_contract_failure_is_a_tool_execution_error() -> None:
+    factory = build_mcp_runtime_factory(ROOT)
+
+    def broken_factory():
+        executor, adapter = factory()
+        executor._lifecycle_snapshots[executor.composition.run_identity.run_id] = executor.composition.lifecycle_controller.initialize(
+            executor.composition.run_identity.run_id
+        )
+        return executor, adapter
+
+    response = McpToolTransport(broken_factory, server_version="1.5.0").handle_message(
+        _request("tools/call", {"name": "conductor", "arguments": {"prompt": "x"}})
+    )
+    result = response["result"]
+    assert result["isError"] is True
+    assert "RUN_ALREADY_INITIALIZED" in result["content"][0]["text"]
+
+
+def test_stdio_parse_error_and_internal_error_stay_protocol_safe() -> None:
+    transport = _transport()
+    assert transport.handle_line("{")["error"]["code"] == JSONRPC_PARSE_ERROR
+
+    stderr = StringIO()
+
+    def exploding_factory():
+        raise RuntimeError("do not leak")
+
+    server = McpToolTransport(exploding_factory, server_version="1.5.0", error_stream=stderr)
+    stdout = StringIO()
+    exit_code = server.serve_stdio(
+        StringIO(json.dumps(_request("tools/list")) + "\n\n"),
+        stdout,
+    )
+    payload = json.loads(stdout.getvalue())
+    assert exit_code == 0
+    assert payload["error"]["code"] == JSONRPC_INTERNAL_ERROR
+    assert "do not leak" not in stdout.getvalue()
+    assert "RuntimeError" in stderr.getvalue()
+
+
+def test_constructor_and_factory_reject_invalid_configuration(tmp_path: Path) -> None:
+    with pytest.raises(TypeError):
+        McpToolTransport(None, server_version="1")  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        McpToolTransport(lambda: None, server_name="", server_version="1")  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        build_mcp_runtime_factory(ROOT, backing_adapter="")
+
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "plugin.json").write_text('{"version": ""}', encoding="utf-8")
+    with pytest.raises(ValueError):
+        build_mcp_stdio_transport(root)


### PR DESCRIPTION
Tracks #349.

## Transport purpose

This pull request is the bounded signing lane for the API-authored `MCP_STDIO_GOVERNED_TOOL_TRANSPORT_V1` source candidate. It is not a canonical merge-readiness PR and does not target `main`.

## Exact source identity

- Canonical parent: `cf6415d8b030dd0645ba40e68673f3bf912ea66e`
- Source head: `94a86e3db05141ec63cba9f9d9419eb2f249c645`
- Reviewed source tree: `6fc5d44c93e071c2941f76fa1a2712be89856c36`
- Changed paths: 8

## Bounded implementation

- MCP protocol revision `2026-07-28`
- stdio only
- `server/discover`, `tools/list`, `tools/call`
- deterministic projection of an existing PRAP adapter command surface and trusted runtime policy
- fresh trusted runtime composition for each accepted call
- no client-supplied authority, runtime-capability, or governance-validation expansion

## Excluded

No Streamable HTTP, resources, prompts, Tasks/extensions, deployment, production mutation, policy activation, installed-integration refresh, host promotion, issue #316 closure, token-savings claim, force push, history rewrite, or branch cleanup.

The `signed-materialization` workflow must validate the exact source head and reviewed tree before any Squash materialization.