### PR TITLE
Materialize v1.6.0 release candidate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "orchestra",
       "source": "./",
       "description": "Governance-first specialist skill framework for routed, auditable AI coding workflows.",
-      "version": "1.5.0"
+      "version": "1.6.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra",
   "description": "Governance-first specialist skill framework for routed, auditable AI coding workflows.",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "update_check": {
     "update_check_enabled": true,
     "update_check_channel": "stable",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conductor",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "An installable AI workflow plugin that routes complex software tasks through focused specialist skills for architecture, UI/UX, documentation, diagrams, databases, QA, security, and gated resilience review.",
   "author": {
     "name": "Baelfyre",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v1.6.0 Integration & Developer Experience - Release Candidate
+
+- Normalizes all 11 repository-enforced package/version surfaces to `1.6.0` without changing host maturity, runtime authority, deployment state, or the still-published `v1.5.0` tag/Release identity.
+- Packages the verified post-v1.5 two-step signed-materialization optimization, preserving isolated signing evidence and a fresh complete protected-main validation matrix on the signed canonical PR.
+- Packages the TrueSheet specialist knowledge enrichment with pinned Padayon/upstream provenance, MIT licensing identity, selective machine reference data, and progressive-disclosure guidance for the five approved specialist owners without vendoring or runtime dependency adoption.
+- Packages hybrid context representation with JSON as canonical structured machine state and TOON only as a derived, validated, non-authoritative projection when measured context savings justify it.
+- Packages the Required Analysis Compatibility workflow that runs real exact-head CodeQL before emitting the historical `Analyze (actions)` and `Analyze (python)` contexts. Issue #331 remains open; this release does not claim direct ruleset identity normalization.
+- Packages governed Host Update commands with deterministic read-only planning, preserved host maturity, fail-closed unknown-host behavior, explicit recovery guidance, and no automatic installed-integration refresh.
+- Packages the Adapter SDK / PRAP v1 compatibility certification surface with deterministic read-only evidence while keeping certification, host maturity, transport support, and runtime authority separate.
+- Packages the repository-native Developer Portal as a discovery/indexing surface only; it is not a marketplace, registry, deployment plane, or permission source.
+- Packages MCP stdio governed tool transport v1 for protocol revision `2026-07-28`, limited to `server/discover`, `tools/list`, and `tools/call`, with fresh trusted runtime composition per accepted call and no authority expansion from MCP metadata or arguments.
+- Packages documentation architecture v2: a concise root README, general human documentation map, current architecture/governance entry points, `README.json` machine index v2, and deterministic documentation-impact validation that updates the correct human or machine surface instead of forcing blanket README churn.
+- Adds `docs/releases/v1.6.0-integration-developer-experience-release-candidate.md` and refreshes current package/release context while keeping public publication separate from package preparation.
+- Preserves Murmurs issue #316 as open with no token-savings percentage claim and preserves Adaptive Governed Orchestration issue #340 as deferred planning-only work outside v1.6.0.
+- Final release readiness remains revision-bound: historical feature validation is implementation evidence only. Publication requires a fresh exact signed candidate, complete protected validation, clean merge state, expected-head Squash merge, signed canonical identity, and independent tag/Release verification.
+
 ## Post-v1.5.0 Documentation Architecture Refactor - Candidate
 
 - Refactors the root `README.md` into a concise human landing page while preserving the existing banner, navigation style, badges, trust-boundary message, installation entry points, and release identity.

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -4,80 +4,72 @@
 Orchestra
 
 ## Project Purpose
-A governance-first specialist skill framework that routes complex AI-assisted software work through focused, auditable specialist skills, designed for compatibility across multiple IDEs and coding hosts.
+A governance-first specialist orchestration framework that routes complex AI-assisted software work through focused, auditable responsibilities across multiple IDEs and coding hosts.
 
 ## Project Type
 Open-source developer tooling and AI orchestration framework
 
 ## Current Stage
-v1.5.0 - Machine-Verifiable Control Plane and Murmurs (`PUBLISHED_VERIFIED`). Repository package/version surfaces and the current public GitHub Release are aligned to `1.5.0`. The immutable, non-draft, non-prerelease release `Orchestra v1.5.0: Machine-Verifiable Control Plane and Murmurs` is published from lightweight tag `v1.5.0`, which resolves directly to exact signed canonical release commit `b0a56cc7af8ad78234754bcb29ed07f6ab54d920`. The control-plane migration is `LEGACY_RETIRED`, fail-closed ordinary merge readiness requires `mergeable=true` and `mergeable_state=clean`, and Murmurs is canonical as an additive opt-in presentation mode with `NORMAL` as the default. MCP is not part of v1.5.0; its publication prerequisite is satisfied, but any MCP work still requires a fresh post-release priority and design decision. No marketplace publication, installed-integration refresh, deployment/production mutation, or policy activation was performed by release publication.
+v1.6.0 - Integration & Developer Experience (`RELEASE_CANDIDATE_IN_PREPARATION`). Repository package/version surfaces are being normalized to `1.6.0`, while the current public GitHub Release remains immutable `v1.5.0` at signed release commit `b0a56cc7af8ad78234754bcb29ed07f6ab54d920`. The v1.6 candidate consolidates the verified post-v1.5 signed-materialization optimization, TrueSheet specialist enrichment, hybrid JSON/TOON context policy and required-analysis compatibility, Host Update commands, Adapter SDK/PRAP certification, Developer Portal, MCP stdio governed tool transport, and documentation architecture v2. A package/version bump is not publication; v1.6 becomes public only after a separately governed tag/Release publication and independent identity verification.
 
 ## Primary Users
-Developers and maintainers who install Orchestra as a plugin, skill set, or runtime package inside a supported or scaffold-only IDE or coding host (Claude Code, Codex, Antigravity, Cursor, Windsurf, JetBrains, Zed, Neovim)
+Developers and maintainers who install Orchestra as a plugin, skill set, or runtime package inside supported or scaffold-only coding hosts.
 
 ## Data Sensitivity
-Not applicable by default. Orchestra itself does not store, process, or transmit end-user or client data. Data sensitivity depends on the downstream project a maintainer applies Orchestra to, per `docs/CONTRIBUTING.md` instructions to exclude private projects, personal data, and client details from the repository itself.
+Not applicable by default. Orchestra itself does not store or transmit downstream end-user or client data. Downstream project data sensitivity remains governed by that project's own context and policies.
 
 ## Runtime or Deployment Context
-Distributed via GitHub as a plugin or marketplace package (`.claude-plugin/`, `.codex-plugin/`) and as a Python runtime package (`orchestra_runtime/`). Consumed locally inside a developer's IDE or coding host; not deployed as a hosted service.
+Distributed through GitHub plugin/package surfaces and the local `orchestra_runtime` Python runtime. Orchestra is local developer tooling, not a hosted production service.
 
 ## Governance Level
 Recommended
 
-Guidance used for this classification:
-- Orchestra is a public, multi-agent development repository with write-permission automation surfaces such as Dagger guardrails and state-lock scripts, which is a listed risk signal above pure Advisory.
-- Orchestra does not itself handle real end-user data, client data, production business data, or destructive-by-default operations, so automatic Strict-Governed classification is not required.
-- `main` is governed by pull-request review and required status checks, which is consistent with Recommended-tier coordination needs.
-- Maintainers may raise this to Strict-Governed later if adoption, write scope, or release criticality increases.
+Orchestra is a public multi-agent development repository with write-capable automation surfaces, protected-main governance, exact-head validation, and bounded destructive-path simulation. Release work therefore uses the full governed release path even though Orchestra itself does not process production business data by default.
 
 ## Safety Boundaries
-- Dagger guardrail system enforces warning-first, then blocking, behavior for governance-sensitive actions, per `docs/CONTRIBUTING.md`.
-- State-lock mechanism guards against concurrent write collisions.
-- Scaffold-only adapters (Cursor, Windsurf, JetBrains, Zed, Neovim) must not be represented as production-ready or marketplace-published until formally graduated per `docs/project/SCAFFOLD_ADAPTER_GRADUATION_CRITERIA.md`.
-- Runtime envelopes are transport metadata, not execution authority. Correlation IDs are observational identifiers. Retrospectives are supplementary audit records. `ApprovedUnitPlan` governance decision references do not replace execution-envelope authority.
-- `OrchestraStatusProjection` is read-only and derived; it does not mutate repository state, Git refs, or governance policy. It is not a source of truth. Missing or conflicting data reports UNKNOWN. Exit codes report command execution success only and do not create governance authority.
-- `OrchestraWorktreeContract` is optional and host-capability-dependent. Worktree isolation must not be mandatory for single-agent or lightweight execution. Cleanup is `EXPLICIT_HOST_ACTION_ONLY`; no automatic deletion of dirty, unrelated, or user-owned worktrees is permitted.
-- The cross-module audit protocol coordinates specialist-owned findings and evidence; it creates no implementation, Git, merge, release, deployment, or policy authority.
-- Compliance Registry evidence is reusable governance input, not a new authority layer. Governor retains compliance/source-applicability ownership, Steward retains requirements/change-control ownership, Arbiter retains transition/evidence-freshness ownership, and Conductor/The Tuner retain routing/coordination boundaries. Registry state cannot authorize release, deployment, policy activation, destructive operations, or legal conclusions.
-- Repository simulation and GitHub CI are not live installed-host evidence. Accepted R7 evidence is recorded separately for installed Codex and Antigravity continuity and Claude Code packaging compatibility; Claude Code active runtime continuity remains unclaimed under `SCAFFOLD_ONLY` maturity.
-- Governed Autonomy Profiles are reduction-only workflow gates. `HUMAN_GOVERNED` is the safe default, children cannot exceed parents, and no profile creates release, deployment, policy, destructive, force-push, history-rewrite, or authority-expansion permission.
-- Murmurs is presentation-only. It cannot modify machine state, authority, governance, validation, blockers, handoffs, or terminal outcomes, and it must not claim token savings without comparable host-reported counters.
-- MCP remains a future transport/integration boundary and must not become a source of authority. The v1.5.0 publication prerequisite is complete, but implementation is not automatic and requires a fresh post-release priority/design gate.
-- No vendoring of external plugin code, and no claiming unsupported compatibility or compliance, per `docs/CONTRIBUTING.md`.
+- Routing is not authority.
+- Governance approval is not runtime authority.
+- Validation evidence proves outcomes but does not create permission.
+- Runtime authority and capabilities are explicit, bounded, and reduction-only.
+- Dagger live destructive execution remains blocked; resilience work is simulation/guarded unless separately promoted and authorized.
+- Host compatibility, PRAP certification, Developer Portal discovery, MCP metadata, and host maturity cannot grant runtime authority.
+- MCP is transport, not authority; v1.6 includes only the bounded stdio tools transport already merged and verified.
+- JSON remains canonical for structured machine state. TOON is derived, validated, and non-authoritative only.
+- Murmurs is presentation-only and cannot change machine state, governance, validation truth, blockers, handoffs, or terminal outcomes.
+- No Murmurs token-savings percentage is claimed without trustworthy comparable host-reported counters.
+- External references such as TrueSheet provide knowledge/provenance inputs only and do not become Orchestra governance or runtime authority.
+- No automatic installed-integration refresh, host maturity promotion, deployment, or policy activation is implied by a release.
 
 ## Validation Requirements
-- `pytest tests/runtime` must pass with the repository's enforced statement, branch, and critical-module coverage requirements.
 - `python tests/behavior/run_tests.py` must pass.
-- `python scripts/governance_check.py --strict` must pass as enforced in CI via `governance-check.yml`.
-- `python scripts/check_readme_impact.py` must pass for pull-request and push revisions; significant Orchestra runtime, specialist, host-integration, governance/routing/setup/release, version, or CI/governance changes require `README.md` in the same revision.
-- Manifest and packaging validators (`validate_claude_plugin.py`, `validate_ide_packaging.py`, `validate_manifest.py`, `validate_structure.py`) must pass.
-- Cross-layer contract validators and their behavior tests must pass for affected revisions.
-- `python scripts/validate_governed_autonomy_modes_contract.py` and its focused runtime tests must pass when autonomy-profile contracts change.
-- Published v1.5.0 release evidence records fresh exact-head runtime/coverage, workflow-sanity, P9 conformance, Mutmut, integrated Cosmic Ray, native Windows/Ubuntu/macOS, CodeQL, governance, documentation parity, package-version parity, signed canonical merge, tag identity, and GitHub Release identity.
-- `python scripts/preflight_sync_check.py` must be run against `origin/main` before starting a new local editing session, per `docs/CONTRIBUTING.md`.
+- `pytest tests/runtime` must pass with enforced statement, branch, and critical-module coverage floors.
+- `python scripts/governance_check.py --strict` must pass.
+- The documentation-impact contract must pass and require the correct human/machine surfaces for the actual changed scope.
+- All 11 release/version surfaces must match `1.6.0` before the candidate can be release-ready.
+- Required Analysis compatibility must execute real exact-head CodeQL successfully before emitting the legacy required `Analyze (actions)` / `Analyze (python)` contexts.
+- Native Windows, Ubuntu, and macOS validation must pass on the exact signed candidate.
+- Release-candidate mutation-confidence and Cosmic Ray evidence must be fresh where repository policy triggers them.
+- Ordinary governed merge readiness requires current `mergeable=true`, `mergeable_state=clean`, zero unresolved review threads, signed exact-head identity, and expected-head Squash protection.
+- Publication requires an exact `v1.6.0` tag/GitHub Release identity check against the approved signed canonical candidate.
 
 ## Known Constraints
-- Cursor, Windsurf, JetBrains, Zed, and Neovim adapters are scaffold-only and not yet published to their respective marketplaces.
-- `tests/behavior/run-tests.ps1` is intentionally maintained in parallel with `run_tests.py` as the primary validation path for Windows environments, per `docs/MATURITY.md`.
-- Direct pushes to `main` are not part of the normal workflow; changes go through a branch and pull request except for documented maintainer bypass recovery cases.
-- Installed Codex and Antigravity parity, host context-reset behavior, and Windows filesystem-specific behavior require host-local evidence in addition to repository CI.
-- Repository package metadata and the current public GitHub Release are `1.5.0`; lightweight tag `v1.5.0` resolves directly to signed release commit `b0a56cc7af8ad78234754bcb29ed07f6ab54d920`. Later `main` commits must not move that fixed release tag.
-- The Compliance Registry foundation, source/freshness pilot, deterministic packaging, immutable `registry-v0.1.0` publication, and Orchestra real network-provenance validation are complete; future Registry releases remain separately governed transitions.
-- Repository Murmurs simulation demonstrates structural progress-call reduction and outcome parity but does not prove a billing-token savings percentage.
+- Codex and Antigravity remain the supported Host Update identities. Claude Code, Cursor, Windsurf, VS Code/VSCodium, JetBrains, Zed, and Neovim remain scaffold-only unless separately graduated.
+- Issue #331 remains open: protected `main` still requires stale `Analyze (actions)` / `Analyze (python)` status identities. The compatibility workflow preserves current progression after real CodeQL succeeds, but it is not a permanent ruleset normalization.
+- Issue #316 remains open because trustworthy comparable live-host Murmurs token counters are not currently available in the validated host evidence.
+- The current public release remains `v1.5.0` until the v1.6 publication gate completes. Existing v1.5 tag/release identity must not move.
+- Repository simulation and CI evidence do not automatically prove installed-host behavior or token billing behavior.
 
 ## Known Non-Goals
-- Orchestra does not store, process, or transmit end-user or client data itself.
-- Orchestra does not aim to make `PROJECT_CONTEXT.md` universally mandatory for every project that adopts it, per `docs/governance/PROJECT_CONTEXT_ENFORCEMENT_POLICY.md`.
-- This document does not modify CI enforcement on its own.
-- A merged implementation or version bump is not a released capability until the separate tag and GitHub Release gates complete.
-- v1.5.0 does not include MCP implementation.
+- v1.6 does not implement Streamable HTTP, MCP resources, prompts, Tasks/extensions, remote authorization, or deployment.
+- v1.6 does not include Adaptive Governed Orchestration / Fugu work from issue #340.
+- v1.6 does not activate policy, deploy to production, publish scaffold hosts to marketplaces, or refresh installed integrations.
+- A merged release candidate is not itself a public release.
 
 ## Maintainer Approval Rules
-- Changes to governance level, scaffold graduation status, CI enforcement gates, merge state, or release state require their applicable pull-request and human-authorization gates.
-- Maintainer bypass is a recovery path for urgent ruleset repair, CI repair, or access recovery only, not a default development path, and must be documented afterward if it changes governance or CI behavior.
+Changes to governance, host maturity, protected rules, release state, deployment, installed refresh, destructive execution, force push/history rewrite, or branch deletion require their separately applicable authority and evidence gates.
 
 ## User or Maintainer Preferences
-Not yet decided. No project-specific maintainer preferences beyond `docs/CONTRIBUTING.md` are currently documented for this field.
+Repository changes follow bounded governed execution, exact-head validation, fail-closed evidence handling, and forward-only history preservation.
 
 ## Last Reviewed
-2026-08-16
+2026-08-17

--- a/README.json
+++ b/README.json
@@ -11,13 +11,13 @@
     "full_name": "Baelfyre/Orchestra",
     "url": "https://github.com/Baelfyre/Orchestra",
     "license": "MIT",
-    "package_version": "1.5.0",
+    "package_version": "1.6.0",
     "package_version_source": "plugin.json#/version",
     "current_public_release": "v1.5.0",
     "current_public_release_commit": "b0a56cc7af8ad78234754bcb29ed07f6ab54d920",
     "main_contains_post_release_work": true,
     "next_release_plan": "v1.6.0",
-    "next_release_plan_status": "PLANNED_AFTER_DOCUMENTATION_REFACTOR_CANONICAL_VERIFICATION"
+    "next_release_plan_status": "RELEASE_CANDIDATE_IN_PREPARATION"
   },
   "purpose": {
     "summary": "Portable orchestration runtime for structured AI-assisted software development.",
@@ -26,60 +26,16 @@
     "core_trust_boundary": "Permission and execution authority are explicit bounded inputs. Routing, host capability, governance disposition, validation evidence, compatibility certification, presentation mode, and GitHub state cannot independently grant or expand authority."
   },
   "capabilities": {
-    "specialist_orchestration": {
-      "status": "IMPLEMENTED",
-      "machine_sources": ["machine/specialists/registry.v1.json", "machine/routing/routes.v1.json"],
-      "human_sources": ["SKILL_INDEX.md", "ROUTING_MAP.md"]
-    },
-    "governed_runtime": {
-      "status": "IMPLEMENTED",
-      "machine_sources": ["machine/governance/policy.v1.json"],
-      "human_sources": ["docs/architecture/README.md", "docs/governance/GOVERNANCE_LAYER.md", "docs/project/AUTHORITY_CAPABILITY_RUNTIME_ARCHITECTURE.md"]
-    },
-    "cross_specialist_coordination": {
-      "status": "IMPLEMENTED",
-      "human_sources": ["docs/governance/TUNER_PROTOCOL.md", "ROUTING_MAP.md"]
-    },
-    "validation_and_evidence": {
-      "status": "IMPLEMENTED",
-      "machine_sources": ["machine/schemas/", "machine/release-evidence/"],
-      "human_sources": ["docs/setup/VALIDATION.md", "docs/validation/"]
-    },
-    "host_update_planning": {
-      "status": "IMPLEMENTED_READ_ONLY",
-      "machine_sources": ["machine/hosts/update-contract.v1.json"],
-      "human_sources": ["docs/setup/HOST_UPDATES.md"]
-    },
-    "adapter_sdk_and_prap_certification": {
-      "status": "IMPLEMENTED_READ_ONLY_CERTIFICATION",
-      "machine_sources": ["machine/protocol/prap-certification-contract.v1.json", "machine/schemas/prap-certification-evidence.schema.json"],
-      "human_sources": ["docs/setup/ADAPTER_SDK_PRAP.md"]
-    },
-    "developer_portal": {
-      "status": "IMPLEMENTED_DISCOVERY_ONLY",
-      "machine_sources": ["machine/developer-portal/catalog.v1.json"],
-      "human_sources": ["docs/developer/README.md"]
-    },
-    "mcp_stdio_transport": {
-      "status": "IMPLEMENTED_POST_V1_5_UNRELEASED",
-      "protocol_revision": "2026-07-28",
-      "transport": "stdio",
-      "surface": ["server/discover", "tools/list", "tools/call"],
-      "human_sources": ["docs/developer/MCP_STDIO_TRANSPORT.md"],
-      "authority_note": "MCP is transport, not authority."
-    },
-    "murmurs_presentation": {
-      "status": "IMPLEMENTED_OPT_IN",
-      "machine_sources": ["machine/presentation/murmurs-policy.v1.json", "machine/presentation/murmurs-vocabulary.v1.json"],
-      "human_sources": ["docs/project/MURMURS_COMMUNICATION_BUDGET.md"],
-      "token_savings_claim": "NOT_CLAIMED_WITHOUT_TRUSTWORTHY_COMPARABLE_LIVE_HOST_COUNTERS"
-    },
-    "hybrid_context_representation": {
-      "status": "IMPLEMENTED_POLICY",
-      "human_sources": ["docs/HYBRID_CONTEXT_FORMATS.md"],
-      "json_authority": "CANONICAL_FOR_STRUCTURED_MACHINE_STATE",
-      "toon_authority": "DERIVED_VALIDATED_NON_AUTHORITATIVE"
-    }
+    "specialist_orchestration": {"status": "IMPLEMENTED", "machine_sources": ["machine/specialists/registry.v1.json", "machine/routing/routes.v1.json"], "human_sources": ["SKILL_INDEX.md", "ROUTING_MAP.md"]},
+    "governed_runtime": {"status": "IMPLEMENTED", "machine_sources": ["machine/governance/policy.v1.json"], "human_sources": ["docs/architecture/README.md", "docs/governance/GOVERNANCE_LAYER.md", "docs/project/AUTHORITY_CAPABILITY_RUNTIME_ARCHITECTURE.md"]},
+    "cross_specialist_coordination": {"status": "IMPLEMENTED", "human_sources": ["docs/governance/TUNER_PROTOCOL.md", "ROUTING_MAP.md"]},
+    "validation_and_evidence": {"status": "IMPLEMENTED", "machine_sources": ["machine/schemas/", "machine/release-evidence/"], "human_sources": ["docs/setup/VALIDATION.md", "docs/validation/"]},
+    "host_update_planning": {"status": "INCLUDED_IN_V1_6_CANDIDATE", "machine_sources": ["machine/hosts/update-contract.v1.json"], "human_sources": ["docs/setup/HOST_UPDATES.md"]},
+    "adapter_sdk_and_prap_certification": {"status": "INCLUDED_IN_V1_6_CANDIDATE", "machine_sources": ["machine/protocol/prap-certification-contract.v1.json", "machine/schemas/prap-certification-evidence.schema.json"], "human_sources": ["docs/setup/ADAPTER_SDK_PRAP.md"]},
+    "developer_portal": {"status": "INCLUDED_IN_V1_6_CANDIDATE", "machine_sources": ["machine/developer-portal/catalog.v1.json"], "human_sources": ["docs/developer/README.md"]},
+    "mcp_stdio_transport": {"status": "INCLUDED_IN_V1_6_CANDIDATE", "protocol_revision": "2026-07-28", "transport": "stdio", "surface": ["server/discover", "tools/list", "tools/call"], "human_sources": ["docs/developer/MCP_STDIO_TRANSPORT.md"], "authority_note": "MCP is transport, not authority."},
+    "murmurs_presentation": {"status": "IMPLEMENTED_OPT_IN", "machine_sources": ["machine/presentation/murmurs-policy.v1.json", "machine/presentation/murmurs-vocabulary.v1.json"], "human_sources": ["docs/project/MURMURS_COMMUNICATION_BUDGET.md"], "token_savings_claim": "NOT_CLAIMED_WITHOUT_TRUSTWORTHY_COMPARABLE_LIVE_HOST_COUNTERS"},
+    "hybrid_context_representation": {"status": "INCLUDED_IN_V1_6_CANDIDATE", "human_sources": ["docs/HYBRID_CONTEXT_FORMATS.md"], "json_authority": "CANONICAL_FOR_STRUCTURED_MACHINE_STATE", "toon_authority": "DERIVED_VALIDATED_NON_AUTHORITATIVE"}
   },
   "machine_scan_order": [
     {"order": 1, "path": "README.json", "purpose": "AI-facing repository orientation and machine-surface discovery graph"},
@@ -129,62 +85,24 @@
     "developer_portal_catalog_schema": "machine/schemas/developer-portal-catalog.schema.json",
     "readme_machine_index_schema": "machine/schemas/readme-machine-index.schema.json"
   },
-  "specialists": {
-    "count": 14,
-    "registry_source": "machine/specialists/registry.v1.json",
-    "human_index": "SKILL_INDEX.md",
-    "routing_reference": "ROUTING_MAP.md",
-    "knowledge_root": "skills/",
-    "source_of_truth_note": "Specialist prose and reasoning guidance remain in skills/*/SKILL.md; machine routing-critical metadata is compiled and parity-validated."
-  },
+  "specialists": {"count": 14, "registry_source": "machine/specialists/registry.v1.json", "human_index": "SKILL_INDEX.md", "routing_reference": "ROUTING_MAP.md", "knowledge_root": "skills/", "source_of_truth_note": "Specialist prose and reasoning guidance remain in skills/*/SKILL.md; machine routing-critical metadata is compiled and parity-validated."},
   "governance": {
-    "human_overview": "docs/governance/GOVERNANCE_LAYER.md",
+    "human_overview": "docs/governance/README.md",
     "current_architecture_overview": "docs/architecture/README.md",
     "machine_policy": "machine/governance/policy.v1.json",
     "control_plane_stage": "LEGACY_RETIRED",
     "control_plane_stage_source": "machine/migration/control-plane.v1.json#/current_stage",
     "merge_readiness_protocol": "docs/governance/AUTONOMOUS_MERGE_READINESS_PROTOCOL.md",
-    "ordinary_merge_requirements": {
-      "mergeable": true,
-      "mergeable_state": "clean",
-      "expected_head_protection": true,
-      "governed_bypass_allowed": false
-    },
+    "ordinary_merge_requirements": {"mergeable": true, "mergeable_state": "clean", "expected_head_protection": true, "governed_bypass_allowed": false},
     "effective_authority_model": "selected_profile INTERSECTION explicit_grant INTERSECTION repository_policy INTERSECTION host_capability INTERSECTION current_phase INTERSECTION current_evidence",
     "transition_dispositions": ["AUTO_CONTINUE", "AUTO_REMEDIATE_AND_REVALIDATE", "WAIT_FOR_EVIDENCE", "WAIT_FOR_CAPACITY", "ESCALATE_HUMAN", "STOP"],
-    "protected_actions_require_separate_authority": true
+    "protected_actions_require_separate_authority": true,
+    "required_analysis_ruleset_drift_issue": 331,
+    "required_analysis_ruleset_drift_state": "OPEN_COMPATIBILITY_WORKFLOW_ACTIVE"
   },
-  "architecture": {
-    "current_overview": "docs/architecture/README.md",
-    "detailed_authority_capability_design": "docs/project/AUTHORITY_CAPABILITY_RUNTIME_ARCHITECTURE.md",
-    "routing_reference": "ROUTING_MAP.md",
-    "governance_reference": "docs/governance/GOVERNANCE_LAYER.md",
-    "compliance_registry_reference": "docs/governance/COMPLIANCE_REGISTRY_INTEGRATION.md",
-    "compliance_protocol_runtime": "orchestra_runtime/compliance_protocol.py",
-    "mcp_transport_reference": "docs/developer/MCP_STDIO_TRANSPORT.md",
-    "historical_status_policy": "Phase documents may retain phase-era status wording. Current exact state comes from live machine contracts, release evidence, and Git identity."
-  },
-  "hosts_integrations": {
-    "host_update_contract": "machine/hosts/update-contract.v1.json",
-    "adapter_sdk_reference": "docs/setup/ADAPTER_SDK_PRAP.md",
-    "prap_certification_contract": "machine/protocol/prap-certification-contract.v1.json",
-    "developer_portal": "docs/developer/README.md",
-    "developer_portal_catalog": "machine/developer-portal/catalog.v1.json",
-    "mcp_transport": "docs/developer/MCP_STDIO_TRANSPORT.md",
-    "supported_hosts": ["codex", "antigravity"],
-    "scaffold_only_hosts": ["claude-code", "cursor", "windsurf", "vscode", "vscodium", "jetbrains", "zed", "neovim"],
-    "certification_is_authority": false,
-    "host_maturity_is_authority": false,
-    "installed_refresh_automatic": false
-  },
-  "knowledge_provenance": {
-    "third_party_machine_source": "machine/provenance/third-party.v1.json",
-    "third_party_human_source": "docs/THIRD_PARTY_PROVENANCE.md",
-    "machine_knowledge_directory": "machine/knowledge",
-    "truesheet_reference": "machine/knowledge/truesheet-specialist-reference.v1.json",
-    "external_reference_authority": "KNOWLEDGE_REFERENCE_ONLY_NOT_RUNTIME_OR_GOVERNANCE_AUTHORITY",
-    "source_copy_policy": "External references do not authorize wholesale source copying; provenance and incorporation boundaries remain explicit."
-  },
+  "architecture": {"current_overview": "docs/architecture/README.md", "detailed_authority_capability_design": "docs/project/AUTHORITY_CAPABILITY_RUNTIME_ARCHITECTURE.md", "routing_reference": "ROUTING_MAP.md", "governance_reference": "docs/governance/README.md", "compliance_registry_reference": "docs/governance/COMPLIANCE_REGISTRY_INTEGRATION.md", "compliance_protocol_runtime": "orchestra_runtime/compliance_protocol.py", "mcp_transport_reference": "docs/developer/MCP_STDIO_TRANSPORT.md", "historical_status_policy": "Phase documents may retain phase-era status wording. Current exact state comes from live machine contracts, release evidence, and Git identity."},
+  "hosts_integrations": {"host_update_contract": "machine/hosts/update-contract.v1.json", "adapter_sdk_reference": "docs/setup/ADAPTER_SDK_PRAP.md", "prap_certification_contract": "machine/protocol/prap-certification-contract.v1.json", "developer_portal": "docs/developer/README.md", "developer_portal_catalog": "machine/developer-portal/catalog.v1.json", "mcp_transport": "docs/developer/MCP_STDIO_TRANSPORT.md", "supported_hosts": ["codex", "antigravity"], "scaffold_only_hosts": ["claude-code", "cursor", "windsurf", "vscode", "vscodium", "jetbrains", "zed", "neovim"], "certification_is_authority": false, "host_maturity_is_authority": false, "installed_refresh_automatic": false},
+  "knowledge_provenance": {"third_party_machine_source": "machine/provenance/third-party.v1.json", "third_party_human_source": "docs/THIRD_PARTY_PROVENANCE.md", "machine_knowledge_directory": "machine/knowledge", "truesheet_reference": "machine/knowledge/truesheet-specialist-reference.v1.json", "external_reference_authority": "KNOWLEDGE_REFERENCE_ONLY_NOT_RUNTIME_OR_GOVERNANCE_AUTHORITY", "source_copy_policy": "External references do not authorize wholesale source copying; provenance and incorporation boundaries remain explicit."},
   "validation": {
     "workflow": ".github/workflows/validate.yml",
     "behavior_suite": "tests/behavior/run_tests.py",
@@ -202,14 +120,7 @@
     "future_release_candidate_policy": "Any future release candidate requires fresh exact-head runtime, branch, critical-module, mutation, Cosmic Ray, cross-platform, CodeQL/required-analysis, governance, documentation-parity, and release-identity evidence.",
     "evidence_policy": "Runtime confidence claims must be derived from persisted machine-readable CI evidence bound to the tested checkout SHA and source-head SHA."
   },
-  "continuity": {
-    "repository_human_state": "PROJECT_STATE.md",
-    "repository_human_handoff": "SESSION_HANDOFF.md",
-    "decision_log": "DECISION_LOG.md",
-    "cross_repository_continuity_owner": "Baelfyre/Padayon",
-    "active_machine_handoff_external": "Padayon Relay v2",
-    "continuity_rule": "Repository memory and handoffs cannot promote source state without verified Git/source evidence."
-  },
+  "continuity": {"repository_human_state": "PROJECT_STATE.md", "repository_human_handoff": "SESSION_HANDOFF.md", "decision_log": "DECISION_LOG.md", "cross_repository_continuity_owner": "Baelfyre/Padayon", "active_machine_handoff_external": "Padayon Relay v2", "continuity_rule": "Repository memory and handoffs cannot promote source state without verified Git/source evidence."},
   "release_state": {
     "current_public_release": "v1.5.0",
     "release_commit": "b0a56cc7af8ad78234754bcb29ed07f6ab54d920",
@@ -217,10 +128,12 @@
     "publication_closeout": "docs/validation/V1_5_0_PUBLICATION_CLOSEOUT.md",
     "post_release_main_contains_significant_changes": true,
     "provisional_next_release": "v1.6.0",
-    "provisional_next_release_status": "PLANNED_NOT_PUBLISHED",
+    "provisional_next_release_status": "RELEASE_CANDIDATE_IN_PREPARATION",
     "v1_5_0_must_remain_immutable": true,
     "murmurs_measurement_issue": 316,
-    "murmurs_measurement_issue_state": "OPEN"
+    "murmurs_measurement_issue_state": "OPEN",
+    "adaptive_governed_orchestration_issue": 340,
+    "adaptive_governed_orchestration_state": "DEFERRED_PLANNING_ONLY"
   },
   "documentation": {
     "documentation_map": "docs/README.md",
@@ -241,24 +154,19 @@
     "validation_evidence": "docs/validation/",
     "third_party_provenance": "docs/THIRD_PARTY_PROVENANCE.md",
     "merge_readiness": "docs/governance/AUTONOMOUS_MERGE_READINESS_PROTOCOL.md",
-    "murmurs": "docs/project/MURMURS_COMMUNICATION_BUDGET.md"
+    "murmurs": "docs/project/MURMURS_COMMUNICATION_BUDGET.md",
+    "release_candidate_v1_6_0": "docs/releases/v1.6.0-integration-developer-experience-release-candidate.md"
   },
-  "representation_policy": {
-    "markdown": "Human-readable explanation, rationale, examples, and nuanced specialist guidance",
-    "json": "Canonical structured machine state, identity, routing, governance, receipts, manifests, provenance, presentation contracts, evidence, and indexes",
-    "json_schema": "Validation contract for machine-readable records",
-    "jsonl": "Append-only event/history records where incremental retrieval is preferable",
-    "toon": "Derived validated non-authoritative model-context projection only when bounded compilation provides measured context benefit",
-    "parity_rule": "When the same deterministic fact appears in more than one representation, CI must validate parity or derive the projection from one authoritative source."
-  },
+  "representation_policy": {"markdown": "Human-readable explanation, rationale, examples, and nuanced specialist guidance", "json": "Canonical structured machine state, identity, routing, governance, receipts, manifests, provenance, presentation contracts, evidence, and indexes", "json_schema": "Validation contract for machine-readable records", "jsonl": "Append-only event/history records where incremental retrieval is preferable", "toon": "Derived validated non-authoritative model-context projection only when bounded compilation provides measured context benefit", "parity_rule": "When the same deterministic fact appears in more than one representation, CI must validate parity or derive the projection from one authoritative source."},
   "maturity": {
     "current_public_release": "PUBLISHED_VERIFIED",
-    "mcp_stdio_transport": "POST_RELEASE_IMPLEMENTED_UNRELEASED",
-    "host_update_commands": "POST_RELEASE_IMPLEMENTED_UNRELEASED",
-    "adapter_sdk_prap_certification": "POST_RELEASE_IMPLEMENTED_UNRELEASED",
-    "developer_portal": "POST_RELEASE_IMPLEMENTED_UNRELEASED",
-    "truesheet_specialist_enrichment": "POST_RELEASE_IMPLEMENTED_UNRELEASED",
-    "hybrid_context_compilation": "POST_RELEASE_IMPLEMENTED_UNRELEASED",
+    "mcp_stdio_transport": "INCLUDED_IN_V1_6_CANDIDATE",
+    "host_update_commands": "INCLUDED_IN_V1_6_CANDIDATE",
+    "adapter_sdk_prap_certification": "INCLUDED_IN_V1_6_CANDIDATE",
+    "developer_portal": "INCLUDED_IN_V1_6_CANDIDATE",
+    "truesheet_specialist_enrichment": "INCLUDED_IN_V1_6_CANDIDATE",
+    "hybrid_context_compilation": "INCLUDED_IN_V1_6_CANDIDATE",
+    "documentation_architecture_v2": "INCLUDED_IN_V1_6_CANDIDATE",
     "adaptive_governed_orchestration": "DEFERRED_PLANNING_ONLY_ISSUE_340",
     "murmurs_live_host_token_measurement": "DEFERRED_UNTIL_ELIGIBLE_COUNTERS_ISSUE_316"
   },
@@ -278,6 +186,6 @@
     "treat_murmurs_as_presentation_only": true,
     "do_not_claim_murmurs_token_savings_without_comparable_host_reported_counters": true,
     "treat_v1_5_0_as_published_verified_only_when_tag_release_and_commit_identity_match": true,
-    "treat_v1_6_0_as_planned_not_published_until_exact_tag_release_and_commit_identity_exist": true
+    "treat_v1_6_0_as_release_candidate_not_published_until_exact_tag_release_and_commit_identity_exist": true
   }
 }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
     <a href="CHANGELOG.md">Changelog</a>
   </p>
   <p>
-    <img src="https://img.shields.io/badge/package_version-v1.5.0-blue" alt="Repository package version v1.5.0" />
+    <img src="https://img.shields.io/badge/package_version-v1.6.0-blue" alt="Repository package version v1.6.0" />
     <a href="https://github.com/Baelfyre/Orchestra/actions/workflows/validate.yml">
       <img src="https://github.com/Baelfyre/Orchestra/actions/workflows/validate.yml/badge.svg" alt="Repository validation status" />
     </a>
@@ -73,7 +73,7 @@ agy plugin install https://github.com/Baelfyre/Orchestra
 
 **Other hosts and local setups:** see the [Installation Guide](docs/setup/INSTALLATION.md) and [Compatibility Guide](docs/setup/COMPATIBILITY.md).
 
-The current public release is **v1.5.0**. `main` may contain verified post-release work, so use the release tag when exact published content is required.
+Repository package surfaces are prepared for **v1.6.0**. The current public GitHub Release remains **v1.5.0** until the separately governed publication gate creates and verifies the `v1.6.0` tag and release.
 
 ## Explore the framework
 

--- a/adapters/cursor/package.json
+++ b/adapters/cursor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-cursor-scaffold",
   "displayName": "Orchestra Cursor Scaffold",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "description": "Scaffold-only Cursor packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/jetbrains/package.json
+++ b/adapters/jetbrains/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-jetbrains-scaffold",
   "displayName": "Orchestra JetBrains Scaffold",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "description": "Scaffold-only JetBrains packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/jetbrains/plugin.xml
+++ b/adapters/jetbrains/plugin.xml
@@ -2,7 +2,7 @@
   <id>com.baelfyre.orchestra.scaffold</id>
   <name>Orchestra JetBrains Scaffold</name>
   <vendor>Baelfyre</vendor>
-  <version>1.5.0</version>
+  <version>1.6.0</version>
   <description>Scaffold-only JetBrains packaging metadata for Orchestra runtime adapter integration.</description>
   <depends>com.intellij.modules.platform</depends>
   <extensions defaultExtensionNs="com.intellij">

--- a/adapters/neovim/package.json
+++ b/adapters/neovim/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-neovim-scaffold",
   "displayName": "Orchestra Neovim Scaffold",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "description": "Scaffold-only Neovim packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/vscode/package.json
+++ b/adapters/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-vscode-scaffold",
   "displayName": "Orchestra VS Code Scaffold",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "description": "Scaffold-only VS Code packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/windsurf/package.json
+++ b/adapters/windsurf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-windsurf-scaffold",
   "displayName": "Orchestra Windsurf Scaffold",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "description": "Scaffold-only Windsurf packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/zed/package.json
+++ b/adapters/zed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-zed-scaffold",
   "displayName": "Orchestra Zed Scaffold",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "description": "Scaffold-only Zed packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/docs/releases/v1.6.0-integration-developer-experience-release-candidate.md
+++ b/docs/releases/v1.6.0-integration-developer-experience-release-candidate.md
@@ -1,0 +1,112 @@
+# Orchestra v1.6.0: Integration & Developer Experience
+
+Status: `RELEASE_CANDIDATE_IN_PREPARATION`
+
+Tracking issue: #359
+
+## Summary
+
+`v1.6.0` packages the significant work completed after the `v1.5.0` Machine-Verifiable Control Plane and Murmurs release. The release does not replace Orchestra's governance or authority architecture. It makes the stabilized control plane easier to integrate with, extend, update, document, and consume through machine-readable contracts.
+
+The current public release remains `v1.5.0` at `b0a56cc7af8ad78234754bcb29ed07f6ab54d920` until a separately governed publication gate creates and independently verifies the `v1.6.0` tag and GitHub Release.
+
+## Highlights
+
+### Faster governed API-authored changes
+
+Orchestra now uses a two-step signed-materialization boundary for API-authored source. The intermediate `materialize/**` PR proves exact source/tree identity and produces a signed Squash commit, but grants no canonical merge readiness. The resulting signed commit then opens a fresh PR to `main` and must pass the full protected-main matrix independently.
+
+This removes the former third PR without weakening exact-head validation, signature requirements, clean mergeability, review-thread resolution, expected-head Squash protection, or post-merge verification.
+
+### Better specialist knowledge with explicit provenance
+
+The TrueSheet specialist enrichment adds an Orchestra-native machine reference plus progressive-disclosure guidance for Cloak, Ponytail, Clockwork, Overseer, and Scribe. The reference pins Padayon and upstream source identity, license, feature IDs, specialist ownership, and incorporation boundaries.
+
+The enrichment adapts concepts and patterns without vendoring TrueSheet, copying its runtime, or converting external material into Orchestra authority.
+
+### Hybrid context representation
+
+The internal hybrid context compiler keeps canonical structured state in JSON and may derive TOON only when bounded compilation produces a measured context-size benefit. Small or irregular records may remain compact JSON. Source and projection identity are validated fail-closed.
+
+The rule remains:
+
+`JSON = canonical structured state`
+
+`TOON = derived validated context projection only`
+
+### Required Analysis compatibility without pretending ruleset drift is fixed
+
+Current GitHub security analysis produces CodeQL while the protected-main ruleset still requires historical `Analyze (actions)` and `Analyze (python)` contexts. Orchestra's Required Analysis Compatibility workflow runs actual exact-head CodeQL analysis first and emits those compatibility contexts only after the analysis succeeds.
+
+Issue #331 remains open. `v1.6.0` does **not** claim that the underlying ruleset check-identity drift has been permanently normalized. The compatibility workflow preserves current protected-branch progression without weakening security analysis or invoking a ruleset bypass.
+
+### Governed Host Update commands
+
+A machine-owned Host Update contract and deterministic read-only planner now cover Orchestra's known host identities. The planner reports local package/version state, host maturity, update instructions, required validation, and safe recovery guidance.
+
+Unknown hosts fail closed. Installed-integration refresh is never automatic and still requires separate authority.
+
+Host maturity remains unchanged:
+
+- Codex and Antigravity: `SUPPORTED`
+- Claude Code, Cursor, Windsurf, VS Code/VSCodium, JetBrains, Zed, and Neovim: `SCAFFOLD_ONLY`
+
+### Adapter SDK and PRAP v1 certification
+
+The existing PRAP v1 boundary is now exposed through the stable `orchestra_runtime.protocol.sdk` surface, with deterministic read-only compatibility certification and machine-readable certification contracts/evidence.
+
+Certification proves declared compatibility against the current contract. It does not grant runtime authority, capabilities, host maturity, marketplace availability, deployment permission, or installed refresh authority.
+
+### Repository-native Developer Portal
+
+The Developer Portal provides one discovery surface for adapter development, PRAP certification, host maturity, specialist boundaries, governance, and validation. A machine catalog supports deterministic discovery without copying or superseding the authoritative contracts it references.
+
+The portal is documentation and indexing only. It is not a marketplace, package registry, deployment plane, or permission source.
+
+### MCP stdio governed tool transport v1
+
+The first bounded MCP integration targets protocol revision `2026-07-28` over stdio and exposes only:
+
+- `server/discover`
+- `tools/list`
+- `tools/call`
+
+Tool discovery is the deterministic intersection of an existing PRAP adapter command surface and Orchestra's trusted runtime policy. Each accepted call creates a fresh trusted runtime composition and preserves binding, authority, runtime-capability, governance, lifecycle, operation, and audit ordering.
+
+MCP metadata, client identity, tool arguments, PRAP compatibility, and host maturity cannot grant Orchestra authority.
+
+Streamable HTTP, resources, prompts, Tasks/extensions, remote authorization, deployment, policy activation, and installed-host refresh remain outside this release.
+
+### Documentation architecture v2
+
+The root README is now a concise landing page rather than a framework encyclopedia. Detailed human material is indexed through `docs/README.md`, with current architecture and governance entry points that distinguish live machine contracts from historical phase documents.
+
+`README.json` is now `orchestra.readme-machine-index.v2`, providing AI systems a structured discovery graph across architecture, capabilities, specialists, routing, governance, hosts, PRAP, MCP, knowledge/provenance, validation/evidence, continuity, release state, maturity, and human references.
+
+The documentation-impact gate was also refined so meaningful changes update the documentation surface they actually affect instead of forcing unrelated README churn:
+
+- public identity/headline change -> root README;
+- machine contract/discovery change -> `README.json`;
+- domain behavior change -> detailed documentation;
+- significant repository behavior -> changelog.
+
+## Validation boundary
+
+Release-candidate evidence is revision-bound. Final v1.6 readiness will be recorded only after the exact signed candidate passes the repository's protected matrix, including runtime/coverage, governance, Required Analysis/CodeQL, native Windows/Ubuntu/macOS validation, documentation parity, version-surface parity, and mutation-confidence campaigns where applicable.
+
+Historical green runs from the post-v1.5 feature branches are implementation evidence, not release authorization for the final candidate.
+
+## Preserved boundaries and known open work
+
+- `v1.5.0` remains immutable and must not be moved or rewritten.
+- Issue #331 remains open for direct protected-ruleset status-context normalization.
+- Murmurs live-host measurement issue #316 remains open. No token-savings percentage is claimed without trustworthy comparable counters.
+- Adaptive Governed Orchestration / Fugu issue #340 remains planning-only and is not part of v1.6.0.
+- No deployment or production mutation is part of this release.
+- No policy activation is part of this release.
+- No installed-integration refresh or host maturity promotion is part of this release.
+- No force push, history rewrite, branch deletion, or ruleset bypass is authorized by this release.
+
+## Publication gate
+
+A package/version bump and merged release candidate are not a public release. Publication requires exact final candidate identity, green governed validation, a separately created `v1.6.0` tag and GitHub Release, and independent verification that the tag and release resolve to the approved signed canonical commit.

--- a/plugin.json
+++ b/plugin.json
@@ -47,7 +47,9 @@
       "activation_level": "Governor",
       "depends_on": "None",
       "icon_path": "assets/icons/the-steward.ico",
-      "output_formats": ["Governance Review"]
+      "output_formats": [
+        "Governance Review"
+      ]
     },
     {
       "primary_use": "Legal compliance validation, privacy risk review, IP and copyright review, open-source license compatibility, Terms of Service and Privacy Policy impact, audit documentation, security governance",
@@ -60,7 +62,9 @@
       "activation_level": "Governor",
       "depends_on": "None",
       "icon_path": "assets/icons/the-governor.ico",
-      "output_formats": ["Governance Review"]
+      "output_formats": [
+        "Governance Review"
+      ]
     },
     {
       "primary_use": "Continuity review, validation-state review, branch and merge readiness, source-of-truth checks, handoff readiness, access/visibility closeout",
@@ -73,7 +77,10 @@
       "activation_level": "Governance",
       "depends_on": "conductor",
       "icon_path": "assets/icons/arbiter.ico",
-      "output_formats": ["Continuity Review", "Governance Effectiveness Review"]
+      "output_formats": [
+        "Continuity Review",
+        "Governance Effectiveness Review"
+      ]
     },
     {
       "primary_use": "QA strategy, test planning, validation gates, release readiness, CI/CD validation, persona validation",
@@ -86,7 +93,11 @@
       "activation_level": "Specialist",
       "depends_on": "None",
       "icon_path": "assets/icons/overseer.ico",
-      "output_formats": ["Caveman", "Full QA Review", "Delegated Unit Evidence"]
+      "output_formats": [
+        "Caveman",
+        "Full QA Review",
+        "Delegated Unit Evidence"
+      ]
     },
     {
       "primary_use": "Project orientation, multi-skill routing, workflow planning, access/visibility routing",
@@ -99,7 +110,10 @@
       "activation_level": "Commander",
       "depends_on": "None",
       "icon_path": "assets/icons/conductor.ico",
-      "output_formats": ["Routing Plan", "Prompts"]
+      "output_formats": [
+        "Routing Plan",
+        "Prompts"
+      ]
     },
     {
       "primary_use": "Cross-domain dependency mapping, specialist-contract assembly, ownership completeness, contradiction detection, invalidation, and specialist re-entry recommendations",
@@ -112,7 +126,12 @@
       "activation_level": "Specialist",
       "depends_on": "conductor",
       "icon_path": "assets/icons/conductor.ico",
-      "output_formats": ["Collaboration Review", "Cross-Layer Contract Packet", "Contradiction Report", "Re-entry Recommendation"]
+      "output_formats": [
+        "Collaboration Review",
+        "Cross-Layer Contract Packet",
+        "Contradiction Report",
+        "Re-entry Recommendation"
+      ]
     },
     {
       "primary_use": "Security policy, RBAC, authorization, authentication risk, privacy, secrets, visibility/access-control",
@@ -125,7 +144,10 @@
       "activation_level": "Specialist",
       "depends_on": "None",
       "icon_path": "assets/icons/cipher.ico",
-      "output_formats": ["Caveman", "Full Security Review"]
+      "output_formats": [
+        "Caveman",
+        "Full Security Review"
+      ]
     },
     {
       "primary_use": "UI, UX, accessibility, visual hierarchy, responsive layout, interaction design",
@@ -138,7 +160,11 @@
       "activation_level": "Specialist",
       "depends_on": "None",
       "icon_path": "assets/icons/cloak.ico",
-      "output_formats": ["QUICK_UI_HANDOFF", "DOCUMENT_REVIEW", "FORMAL_UI_AUDIT"]
+      "output_formats": [
+        "QUICK_UI_HANDOFF",
+        "DOCUMENT_REVIEW",
+        "FORMAL_UI_AUDIT"
+      ]
     },
     {
       "primary_use": "Chaos scenarios, resilience weaknesses, failure-paths, negative tests, guardrail gaps",
@@ -151,7 +177,9 @@
       "activation_level": "Gated",
       "depends_on": "conductor",
       "icon_path": "assets/icons/dagger.ico",
-      "output_formats": ["Caveman"]
+      "output_formats": [
+        "Caveman"
+      ]
     },
     {
       "primary_use": "SQL schemas, NoSQL documents, JSON, ORM, migrations, constraints, indexes, normalization",
@@ -164,7 +192,10 @@
       "activation_level": "Specialist",
       "depends_on": "None",
       "icon_path": "assets/icons/chronicler.ico",
-      "output_formats": ["Caveman", "Normalization Output"]
+      "output_formats": [
+        "Caveman",
+        "Normalization Output"
+      ]
     },
     {
       "primary_use": "Visual modeling, UML, ERD, architecture, workflow, data-flow diagrams via Mermaid/PlantUML",
@@ -177,7 +208,10 @@
       "activation_level": "Specialist",
       "depends_on": "None",
       "icon_path": "assets/icons/weaver.ico",
-      "output_formats": ["Mermaid", "PlantUML"]
+      "output_formats": [
+        "Mermaid",
+        "PlantUML"
+      ]
     },
     {
       "primary_use": "Documentation prose, READMEs, setup guides, release notes, SDLC, technical summaries",
@@ -190,7 +224,11 @@
       "activation_level": "Specialist",
       "depends_on": "None",
       "icon_path": "assets/icons/scribe.ico",
-      "output_formats": ["Mode 1", "Mode 2", "Mode 3"]
+      "output_formats": [
+        "Mode 1",
+        "Mode 2",
+        "Mode 3"
+      ]
     },
     {
       "primary_use": "OOP architecture, layered architecture, system design, refactoring",
@@ -203,7 +241,10 @@
       "activation_level": "Specialist",
       "depends_on": "None",
       "icon_path": "assets/icons/clockwork.ico",
-      "output_formats": ["Compact", "Full"]
+      "output_formats": [
+        "Compact",
+        "Full"
+      ]
     },
     {
       "primary_use": "Implementation, code editing, validation",
@@ -216,7 +257,11 @@
       "activation_level": "Specialist",
       "depends_on": "None",
       "icon_path": "assets/icons/ponytail.ico",
-      "output_formats": ["IMPLEMENTATION_PLAN", "CODE_REVIEW", "QUICK_FIX"]
+      "output_formats": [
+        "IMPLEMENTATION_PLAN",
+        "CODE_REVIEW",
+        "QUICK_FIX"
+      ]
     }
   ]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "name": "conductor",
   "display_name": "Orchestra",
   "description": "An installable AI workflow plugin that routes tasks through focused specialist skills. See SKILL_INDEX.md and ROUTING_MAP.md for detailed routing behavior.",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "license": "MIT",
   "repository": "https://github.com/Baelfyre/Orchestra",
   "icon_path": "assets/icons/conductor.ico",
@@ -47,9 +47,7 @@
       "activation_level": "Governor",
       "depends_on": "None",
       "icon_path": "assets/icons/the-steward.ico",
-      "output_formats": [
-        "Governance Review"
-      ]
+      "output_formats": ["Governance Review"]
     },
     {
       "primary_use": "Legal compliance validation, privacy risk review, IP and copyright review, open-source license compatibility, Terms of Service and Privacy Policy impact, audit documentation, security governance",
@@ -62,9 +60,7 @@
       "activation_level": "Governor",
       "depends_on": "None",
       "icon_path": "assets/icons/the-governor.ico",
-      "output_formats": [
-        "Governance Review"
-      ]
+      "output_formats": ["Governance Review"]
     },
     {
       "primary_use": "Continuity review, validation-state review, branch and merge readiness, source-of-truth checks, handoff readiness, access/visibility closeout",
@@ -77,10 +73,7 @@
       "activation_level": "Governance",
       "depends_on": "conductor",
       "icon_path": "assets/icons/arbiter.ico",
-      "output_formats": [
-        "Continuity Review",
-        "Governance Effectiveness Review"
-      ]
+      "output_formats": ["Continuity Review", "Governance Effectiveness Review"]
     },
     {
       "primary_use": "QA strategy, test planning, validation gates, release readiness, CI/CD validation, persona validation",
@@ -93,11 +86,7 @@
       "activation_level": "Specialist",
       "depends_on": "None",
       "icon_path": "assets/icons/overseer.ico",
-      "output_formats": [
-        "Caveman",
-        "Full QA Review",
-        "Delegated Unit Evidence"
-      ]
+      "output_formats": ["Caveman", "Full QA Review", "Delegated Unit Evidence"]
     },
     {
       "primary_use": "Project orientation, multi-skill routing, workflow planning, access/visibility routing",
@@ -110,10 +99,7 @@
       "activation_level": "Commander",
       "depends_on": "None",
       "icon_path": "assets/icons/conductor.ico",
-      "output_formats": [
-        "Routing Plan",
-        "Prompts"
-      ]
+      "output_formats": ["Routing Plan", "Prompts"]
     },
     {
       "primary_use": "Cross-domain dependency mapping, specialist-contract assembly, ownership completeness, contradiction detection, invalidation, and specialist re-entry recommendations",
@@ -126,12 +112,7 @@
       "activation_level": "Specialist",
       "depends_on": "conductor",
       "icon_path": "assets/icons/conductor.ico",
-      "output_formats": [
-        "Collaboration Review",
-        "Cross-Layer Contract Packet",
-        "Contradiction Report",
-        "Re-entry Recommendation"
-      ]
+      "output_formats": ["Collaboration Review", "Cross-Layer Contract Packet", "Contradiction Report", "Re-entry Recommendation"]
     },
     {
       "primary_use": "Security policy, RBAC, authorization, authentication risk, privacy, secrets, visibility/access-control",
@@ -144,10 +125,7 @@
       "activation_level": "Specialist",
       "depends_on": "None",
       "icon_path": "assets/icons/cipher.ico",
-      "output_formats": [
-        "Caveman",
-        "Full Security Review"
-      ]
+      "output_formats": ["Caveman", "Full Security Review"]
     },
     {
       "primary_use": "UI, UX, accessibility, visual hierarchy, responsive layout, interaction design",
@@ -160,11 +138,7 @@
       "activation_level": "Specialist",
       "depends_on": "None",
       "icon_path": "assets/icons/cloak.ico",
-      "output_formats": [
-        "QUICK_UI_HANDOFF",
-        "DOCUMENT_REVIEW",
-        "FORMAL_UI_AUDIT"
-      ]
+      "output_formats": ["QUICK_UI_HANDOFF", "DOCUMENT_REVIEW", "FORMAL_UI_AUDIT"]
     },
     {
       "primary_use": "Chaos scenarios, resilience weaknesses, failure-paths, negative tests, guardrail gaps",
@@ -177,9 +151,7 @@
       "activation_level": "Gated",
       "depends_on": "conductor",
       "icon_path": "assets/icons/dagger.ico",
-      "output_formats": [
-        "Caveman"
-      ]
+      "output_formats": ["Caveman"]
     },
     {
       "primary_use": "SQL schemas, NoSQL documents, JSON, ORM, migrations, constraints, indexes, normalization",
@@ -192,10 +164,7 @@
       "activation_level": "Specialist",
       "depends_on": "None",
       "icon_path": "assets/icons/chronicler.ico",
-      "output_formats": [
-        "Caveman",
-        "Normalization Output"
-      ]
+      "output_formats": ["Caveman", "Normalization Output"]
     },
     {
       "primary_use": "Visual modeling, UML, ERD, architecture, workflow, data-flow diagrams via Mermaid/PlantUML",
@@ -208,10 +177,7 @@
       "activation_level": "Specialist",
       "depends_on": "None",
       "icon_path": "assets/icons/weaver.ico",
-      "output_formats": [
-        "Mermaid",
-        "PlantUML"
-      ]
+      "output_formats": ["Mermaid", "PlantUML"]
     },
     {
       "primary_use": "Documentation prose, READMEs, setup guides, release notes, SDLC, technical summaries",
@@ -224,11 +190,7 @@
       "activation_level": "Specialist",
       "depends_on": "None",
       "icon_path": "assets/icons/scribe.ico",
-      "output_formats": [
-        "Mode 1",
-        "Mode 2",
-        "Mode 3"
-      ]
+      "output_formats": ["Mode 1", "Mode 2", "Mode 3"]
     },
     {
       "primary_use": "OOP architecture, layered architecture, system design, refactoring",
@@ -241,10 +203,7 @@
       "activation_level": "Specialist",
       "depends_on": "None",
       "icon_path": "assets/icons/clockwork.ico",
-      "output_formats": [
-        "Compact",
-        "Full"
-      ]
+      "output_formats": ["Compact", "Full"]
     },
     {
       "primary_use": "Implementation, code editing, validation",
@@ -257,11 +216,7 @@
       "activation_level": "Specialist",
       "depends_on": "None",
       "icon_path": "assets/icons/ponytail.ico",
-      "output_formats": [
-        "IMPLEMENTATION_PLAN",
-        "CODE_REVIEW",
-        "QUICK_FIX"
-      ]
+      "output_formats": ["IMPLEMENTATION_PLAN", "CODE_REVIEW", "QUICK_FIX"]
     }
   ]
 }

--- a/tests/runtime/test_release_version_surfaces.py
+++ b/tests/runtime/test_release_version_surfaces.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[2]
-EXPECTED_VERSION = "1.5.0"
+EXPECTED_VERSION = "1.6.0"
 
 JSON_VERSION_SURFACES = (
     "plugin.json",


### PR DESCRIPTION
Tracks #359.

## Signing transport only

This PR materializes the API-authored `v1.6.0` release candidate into a GitHub-signed commit. It does not target `main` and grants no canonical release readiness by itself.

## Exact source identity

- Canonical parent: `bfcf1b5141a42dd7214a94dff6956248e42f2ecb`
- Release source head: `02d473bae17742846f0af262bed796e74b9eac56`
- Release source tree: `3abcdd20ccb3b86f24af8cf1cbb0d4c4af735804`
- Source is 18 commits ahead and 0 behind the canonical parent.
- Changed paths: 17.

## Candidate scope

- synchronize all 11 enforced package/version surfaces to `1.6.0`;
- preserve public `v1.5.0` identity until separate publication;
- add consolidated v1.6 release notes and changelog entry covering all significant post-v1.5 changes;
- record issue #331 as open compatibility/ruleset drift rather than falsely closed;
- preserve Murmurs #316 open with no token-savings percentage;
- preserve Fugu/Adaptive Governed Orchestration #340 outside v1.6 scope.

## Protected boundaries

Signing transport only. No canonical merge readiness, tag or GitHub Release publication, deployment, production mutation, policy activation, installed-integration refresh, ruleset bypass, force push, history rewrite, or branch cleanup.

The signed-materialization workflow must validate this exact source head and tree. The resulting signed commit must then open a fresh PR to `main` and pass the complete protected-main release matrix independently.