### PR TITLE
feat: add bounded adaptive specialist context A2

### DIFF
--- a/README.json
+++ b/README.json
@@ -66,6 +66,17 @@
       "runtime_integration": false,
       "a2_authorized": false,
       "authority_note": "A1 adaptive memory is local evidence and derived preference state only. It cannot grant authority, alter governance, change deterministic routing, or automatically promote inferred candidates."
+    },
+    "specialist_adaptive_context_a2": {
+      "status": "IMPLEMENTED_ON_BOUNDED_A2_CANDIDATE_BRANCH_ADVISORY_ONLY",
+      "purpose": "Opt-in read-only specialist context compiled from exact-scope A1 local state after existing route binding, authority, capability, and governance gates.",
+      "machine_sources": ["machine/adaptive/a2-context-contract.v1.json", "machine/schemas/adaptive-context.schema.json"],
+      "human_sources": ["docs/architecture/ADAPTIVE_CONTEXT_A2.md"],
+      "runtime_attachment": "POST_GOVERNANCE_PRE_OPERATION",
+      "default_runtime_executor_changed": false,
+      "canonical_route_mutation": false,
+      "a3_authorized": false,
+      "authority_note": "A2 context is advisory only. It cannot select a different route, grant authority or capability, alter governance, or promote learned patterns."
     }
   },
   "machine_scan_order": [
@@ -104,6 +115,8 @@
     "adaptive_profile_schema": "machine/schemas/adaptive-profile.schema.json",
     "adaptive_export_schema": "machine/schemas/adaptive-export.schema.json",
     "adaptive_store_meta_schema": "machine/schemas/adaptive-store-meta.schema.json",
+    "adaptive_context_a2_contract": "machine/adaptive/a2-context-contract.v1.json",
+    "adaptive_context_schema": "machine/schemas/adaptive-context.schema.json",
     "release_evidence_directory": "machine/release-evidence",
     "schemas_directory": "machine/schemas",
     "source_state_receipt_schema": "machine/schemas/source-state-receipt.schema.json",
@@ -137,7 +150,7 @@
     "required_analysis_ruleset_drift_issue": 331,
     "required_analysis_ruleset_drift_state": "OPEN_COMPATIBILITY_WORKFLOW_ACTIVE"
   },
-  "architecture": {"current_overview": "docs/architecture/README.md", "detailed_authority_capability_design": "docs/project/AUTHORITY_CAPABILITY_RUNTIME_ARCHITECTURE.md", "routing_reference": "ROUTING_MAP.md", "governance_reference": "docs/governance/README.md", "compliance_registry_reference": "docs/governance/COMPLIANCE_REGISTRY_INTEGRATION.md", "compliance_protocol_runtime": "orchestra_runtime/compliance_protocol.py", "mcp_transport_reference": "docs/developer/MCP_STDIO_TRANSPORT.md", "historical_status_policy": "Phase documents may retain phase-era status wording. Current exact state comes from live machine contracts, release evidence, and Git identity."},
+  "architecture": {"current_overview": "docs/architecture/README.md", "detailed_authority_capability_design": "docs/project/AUTHORITY_CAPABILITY_RUNTIME_ARCHITECTURE.md", "routing_reference": "ROUTING_MAP.md", "governance_reference": "docs/governance/README.md", "compliance_registry_reference": "docs/governance/COMPLIANCE_REGISTRY_INTEGRATION.md", "compliance_protocol_runtime": "orchestra_runtime/compliance_protocol.py", "mcp_transport_reference": "docs/developer/MCP_STDIO_TRANSPORT.md", "adaptive_context_reference": "docs/architecture/ADAPTIVE_CONTEXT_A2.md", "historical_status_policy": "Phase documents may retain phase-era status wording. Current exact state comes from live machine contracts, release evidence, and Git identity."},
   "hosts_integrations": {
     "host_update_contract": "machine/hosts/update-contract.v1.json",
     "adapter_sdk_reference": "docs/setup/ADAPTER_SDK_PRAP.md",
@@ -201,7 +214,7 @@
     "murmurs_measurement_issue": 316,
     "murmurs_measurement_issue_state": "OPEN",
     "adaptive_governed_orchestration_issue": 340,
-    "adaptive_governed_orchestration_state": "DEFERRED_PLANNING_ONLY"
+    "adaptive_governed_orchestration_state": "A2_CANDIDATE_IMPLEMENTED_A3_PLUS_NOT_AUTHORIZED"
   },
   "documentation": {
     "documentation_map": "docs/README.md",
@@ -215,6 +228,7 @@
     "host_updates": "docs/setup/HOST_UPDATES.md",
     "hybrid_context_formats": "docs/HYBRID_CONTEXT_FORMATS.md",
     "adaptive_memory_a0_a1": "docs/architecture/ADAPTIVE_MEMORY_A0_A1.md",
+    "adaptive_context_a2": "docs/architecture/ADAPTIVE_CONTEXT_A2.md",
     "roadmap": "docs/project/ROADMAP.md",
     "changelog": "CHANGELOG.md",
     "release_docs": "docs/releases/",
@@ -240,7 +254,8 @@
     "documentation_architecture_v2": "INCLUDED_IN_V1_6_CANDIDATE",
     "documentation_and_provenance_closeout": "INCLUDED_IN_V1_6_CANDIDATE",
     "adaptive_local_memory_a1": "IMPLEMENTED_ON_BOUNDED_CANDIDATE_BRANCH_NO_RUNTIME_EFFECT",
-    "adaptive_governed_orchestration": "DEFERRED_PLANNING_ONLY_ISSUE_340",
+    "adaptive_specialist_context_a2": "IMPLEMENTED_ON_BOUNDED_CANDIDATE_BRANCH_ADVISORY_ONLY",
+    "adaptive_governed_orchestration": "A2_IMPLEMENTED_CANDIDATE_LATER_PHASES_DEFERRED_ISSUE_340",
     "murmurs_live_host_token_measurement": "DEFERRED_UNTIL_ELIGIBLE_COUNTERS_ISSUE_316"
   },
   "ai_review_guidance": {
@@ -262,6 +277,7 @@
     "treat_murmurs_as_presentation_only": true,
     "do_not_claim_murmurs_token_savings_without_comparable_host_reported_counters": true,
     "treat_adaptive_a1_memory_as_non_authorizing_local_data_not_runtime_policy": true,
+    "treat_adaptive_a2_context_as_advisory_only_after_existing_runtime_gates": true,
     "treat_v1_5_0_as_published_verified_only_when_tag_release_and_commit_identity_match": true,
     "treat_v1_6_0_source_snapshot_as_publication_authorized_not_published_until_exact_tag_release_and_commit_identity_exist": true,
     "when_evaluating_a_published_tag_or_release_prefer_live_verified_git_and_release_identity_over_prepublication_snapshot_fields": true

--- a/docs/architecture/ADAPTIVE_CONTEXT_A2.md
+++ b/docs/architecture/ADAPTIVE_CONTEXT_A2.md
@@ -1,0 +1,158 @@
+# Adaptive Specialist Context A2
+
+## Status
+
+A2 is implemented on the bounded stacked candidate branch `agent/adaptive-context-a2-20260818`.
+
+A2 depends on the exact-head validated A1 foundation at commit `a6fc709ea3ff25b10c0087093a887f815f510bbe`, tree `61e17acfa7b370814ea2f22da1550d0ebe0440c7`. A1 remains a separate draft, unmerged candidate. A2 validation does not grant merge authority for A1 or A2.
+
+A3 and later phases are not authorized by this unit.
+
+## Purpose
+
+A2 provides opt-in, read-only adaptive context to the already selected specialist. The context may help the specialist use known user preferences and bounded governed outcome evidence, but it cannot select a different specialist, expand authority, grant capabilities, alter governance, change lifecycle permissions, or promote inferred patterns.
+
+## Runtime attachment
+
+A2 does not modify the default `RuntimeExecutor`. It adds `AdaptiveRuntimeExecutor`, an opt-in subclass that uses the existing runtime operation hook.
+
+The runtime order remains:
+
+```text
+coordination validation
+  -> trusted initialization
+  -> context assembly
+  -> command parsing
+  -> deterministic routing
+  -> trusted runtime binding
+  -> authority evaluation
+  -> capability evaluation
+  -> governance validation
+  -> A2 advisory context compilation
+  -> lifecycle operation
+  -> audit/evidence/result
+```
+
+The adaptive provider is therefore not called when routing is unbound, authority is denied, capability is denied, or governance blocks execution.
+
+A2 does not attach adaptive context to delegated child executions. Supplying `adaptive_context` to delegated execution entry points fails closed. Delegated adaptive context remains deferred until a later phase explicitly defines how it intersects the delegation context contract.
+
+The operation receives a copy of the existing `RouteDecision` with `metadata.adaptive_context` attached. The route returned in the canonical `ExecutionResult` remains the original route decision and is not mutated by A2.
+
+## Invocation identity and bounds
+
+A2 adaptive compilation requires an explicit `AdaptiveInvocationContext` containing the user identity and any applicable project or task/session identity.
+
+The caller also controls finite context bounds:
+
+- `max_items`, default `16`;
+- `max_outcome_evidence`, default `8`;
+- optional `min_candidate_confidence`.
+
+A2 does not invent a universal inferred-candidate confidence threshold. If the caller supplies no threshold, inferred candidates are excluded from specialist context.
+
+`repository_refs` and `current_instruction_refs` are caller-curated references. A2 does not copy the raw prompt into the adaptive packet.
+
+## Scope isolation
+
+Every candidate pattern remains subject to the A1 scope model:
+
+1. `global_user`
+2. `project`
+3. `specialist`
+4. `task_session`
+
+The user identity must always match. Project, specialist, and task/session identifiers must match when the stored scope carries those constraints.
+
+A specialist-scoped record cannot be attached to a different specialist. A task/session record with a specialist constraint also requires that exact specialist. A task/session record without a specialist constraint remains task/session scoped and may be shared only inside that exact task/session identity.
+
+## Precedence
+
+For the same adaptive subject, A2 applies this precedence:
+
+1. explicit current user instruction;
+2. explicit scoped user preference;
+3. confirmed learned pattern;
+4. inferred candidate;
+5. deterministic default behavior.
+
+At equal precedence, the more specific matching scope wins:
+
+1. task/session;
+2. specialist;
+3. project;
+4. global user.
+
+The final deterministic tie break uses the record update timestamp and stable pattern identity.
+
+A2 does not create confirmed learned patterns. It can only consume a confirmed pattern if a separately governed process created one under a later authorized phase.
+
+## Profile and evidence integrity
+
+A2 reads the A1 machine-local store through `JsonlAdaptiveStore`.
+
+Compilation requires:
+
+- a hash-valid observation log;
+- a materialized profile using the current A1 memory rule version;
+- `profile.source_head_digest` equal to the current observation-log head.
+
+Missing, stale, or incompatible profile state results in deterministic fallback with no partial learned items.
+
+Provider failures are converted into a generic advisory fallback packet. Exception details are not copied into specialist context.
+
+## Governed outcome evidence
+
+`GOVERNED_OUTCOME_RECORDED` observations may be attached as bounded structured advisory evidence when their scope matches.
+
+Governed outcomes do not become preferences automatically and do not grant authority. A2 does not derive new performance, cost, token, or latency claims from unavailable measurements.
+
+## Privacy boundary
+
+A2 inherits the A1 storage and validation boundary:
+
+- machine-local store outside the repository by default;
+- credential-like values and sensitive key fragments rejected by A1;
+- raw conversation records are not authoritative adaptive evidence;
+- adaptive state remains user scoped;
+- deletion and expiry behavior remains owned by A1.
+
+The A2 packet adds no provider transmission or training path.
+
+## Deterministic fallback
+
+Adaptive state is optional. If no invocation context is supplied, `AdaptiveRuntimeExecutor` runs the ordinary base operation without adaptive metadata.
+
+When adaptive compilation is requested but the profile is missing, stale, incompatible, cross-user, or unavailable, the runtime supplies a bounded `DETERMINISTIC_FALLBACK` packet. Routing, authority, capability, governance, and lifecycle behavior remain unchanged.
+
+## A2 validation contract
+
+A2 validation must prove at minimum:
+
+- exact user, project, specialist, and task/session scope isolation;
+- explicit-current versus scoped versus inferred precedence;
+- specialist-scoped state cannot leak to another specialist;
+- inferred candidates require an explicit caller threshold;
+- stale profile state fails to deterministic fallback without partial adaptive items;
+- A2 packets validate against `machine/schemas/adaptive-context.schema.json`;
+- the adaptive provider is not invoked when governance blocks execution;
+- provider failure exposes only generic fallback state;
+- operation-time adaptive metadata does not mutate the canonical runtime route;
+- delegated adaptive context fails closed in A2;
+- the default `RuntimeExecutor` remains unchanged;
+- A3 behaviors are absent.
+
+## A3 stop boundary
+
+A2 must not implement:
+
+- adaptive route ranking;
+- worker or model selection;
+- strategy ranking;
+- automatic pattern promotion;
+- provider integration;
+- training;
+- recursive or test-time compute;
+- learned Tuner topology.
+
+Those remain separately governed future work under issue #340 and require fresh authorization.

--- a/machine/adaptive/a2-context-contract.v1.json
+++ b/machine/adaptive/a2-context-contract.v1.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "orchestra.adaptive-context-contract.v1",
+  "phase": "A2_SPECIALIST_CONTEXT_ADAPTATION",
+  "dependency": {
+    "a1_exit_gate_required": true,
+    "validated_a1_head": "a6fc709ea3ff25b10c0087093a887f815f510bbe",
+    "validated_a1_tree": "61e17acfa7b370814ea2f22da1550d0ebe0440c7",
+    "a1_canonical_merge_required_for_a2_branching": false
+  },
+  "authority": {
+    "mode": "READ_ONLY_ADVISORY",
+    "routing_authority_change": false,
+    "authority_change": false,
+    "capability_change": false,
+    "governance_change": false,
+    "lifecycle_authority_change": false,
+    "automatic_inferred_promotion": false,
+    "provider_integration": "NONE",
+    "training": "NONE"
+  },
+  "runtime_attachment": {
+    "implementation": "ADAPTIVE_RUNTIME_EXECUTOR_OPERATION_WRAPPER",
+    "attachment_point": "AFTER_ROUTE_BINDING_AUTHORITY_CAPABILITY_AND_GOVERNANCE_BEFORE_OPERATION",
+    "canonical_route_mutated": false,
+    "operation_receives_advisory_route_copy": true,
+    "default_runtime_executor_changed": false,
+    "blocked_governance_invokes_adaptive_provider": false,
+    "delegated_adaptive_context": "DEFERRED_IN_A2_FAIL_CLOSED"
+  },
+  "precedence": [
+    "EXPLICIT_CURRENT_INSTRUCTION",
+    "EXPLICIT_SCOPED_PREFERENCE",
+    "CONFIRMED_LEARNED_PATTERN",
+    "INFERRED_CANDIDATE",
+    "DEFAULT"
+  ],
+  "equal_precedence_scope_specificity": [
+    "task_session",
+    "specialist",
+    "project",
+    "global_user"
+  ],
+  "scope_isolation": {
+    "user_key": "EXACT",
+    "project_key": "EXACT_WHEN_SCOPED",
+    "specialist_slug": "EXACT_WHEN_SCOPED",
+    "task_session_key": "EXACT_FOR_TASK_SESSION_SCOPE"
+  },
+  "candidate_policy": {
+    "candidate_context_is_advisory": true,
+    "minimum_confidence": "CALLER_SUPPLIED_ONLY",
+    "default_when_threshold_absent": "EXCLUDE_INFERRED_CANDIDATES",
+    "a2_invents_confidence_threshold": false
+  },
+  "context_bounds": {
+    "max_items": "CALLER_SUPPLIED_WITH_FINITE_DEFAULT",
+    "max_outcome_evidence": "CALLER_SUPPLIED_WITH_FINITE_DEFAULT",
+    "raw_prompt_copied_into_adaptive_packet": false,
+    "repository_refs": "CALLER_CURATED_REFERENCES_ONLY",
+    "current_instruction_refs": "CALLER_CURATED_REFERENCES_ONLY"
+  },
+  "integrity": {
+    "observation_log_must_validate_hash_chain": true,
+    "profile_source_head_must_match_observation_head": true,
+    "memory_rule_version_must_match": true,
+    "stale_or_incompatible_profile": "DETERMINISTIC_FALLBACK"
+  },
+  "fallback": {
+    "missing_invocation_context": "BASE_RUNTIME_OPERATION_WITHOUT_ADAPTIVE_CONTEXT",
+    "missing_profile": "DETERMINISTIC_FALLBACK",
+    "stale_profile": "DETERMINISTIC_FALLBACK",
+    "provider_error": "GENERIC_DETERMINISTIC_FALLBACK_WITHOUT_EXCEPTION_DETAIL",
+    "routing_authority_on_fallback": "UNCHANGED"
+  },
+  "governed_outcomes": {
+    "source": "GOVERNED_OUTCOME_RECORDED",
+    "use": "BOUNDED_STRUCTURED_ADVISORY_EVIDENCE_ONLY",
+    "becomes_preference_automatically": false,
+    "grants_authority": false
+  },
+  "a3_boundary": {
+    "adaptive_route_ranking": "NOT_IMPLEMENTED_IN_A2",
+    "worker_or_model_selection": "NOT_IMPLEMENTED_IN_A2",
+    "strategy_ranking": "NOT_IMPLEMENTED_IN_A2",
+    "automatic_promotion": "NOT_IMPLEMENTED_IN_A2",
+    "provider_integration": "NOT_IMPLEMENTED_IN_A2",
+    "training": "NOT_IMPLEMENTED_IN_A2",
+    "recursive_or_test_time_compute": "NOT_IMPLEMENTED_IN_A2",
+    "a3_authorized": false
+  },
+  "schema": "machine/schemas/adaptive-context.schema.json",
+  "human_documentation": "docs/architecture/ADAPTIVE_CONTEXT_A2.md"
+}

--- a/machine/schemas/adaptive-context.schema.json
+++ b/machine/schemas/adaptive-context.schema.json
@@ -1,0 +1,187 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://orchestra.local/schemas/adaptive-context.schema.json",
+  "title": "Orchestra Adaptive Specialist Context v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "specialist_slug",
+    "command_name",
+    "status",
+    "reason_code",
+    "advisory_only",
+    "repository_refs",
+    "current_instruction_refs",
+    "items",
+    "outcome_evidence"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "orchestra.adaptive-context.v1"
+    },
+    "specialist_slug": {
+      "type": "string",
+      "minLength": 1
+    },
+    "command_name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "status": {
+      "enum": [
+        "ADVISORY",
+        "DETERMINISTIC_FALLBACK"
+      ]
+    },
+    "reason_code": {
+      "type": "string",
+      "minLength": 1
+    },
+    "advisory_only": {
+      "const": true
+    },
+    "repository_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "current_instruction_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "subject_key",
+          "value",
+          "scope",
+          "status",
+          "evidence_class",
+          "evidence_refs",
+          "confidence",
+          "precedence"
+        ],
+        "properties": {
+          "subject_key": {
+            "type": "string",
+            "minLength": 1
+          },
+          "value": {},
+          "scope": {
+            "$ref": "#/$defs/scope"
+          },
+          "status": {
+            "enum": [
+              "candidate",
+              "confirmed"
+            ]
+          },
+          "evidence_class": {
+            "enum": [
+              "EXPLICIT_CURRENT_INSTRUCTION",
+              "EXPLICIT_SCOPED_PREFERENCE",
+              "INFERRED_CANDIDATE"
+            ]
+          },
+          "evidence_refs": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "uniqueItems": true
+          },
+          "confidence": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "precedence": {
+            "enum": [
+              "EXPLICIT_CURRENT_INSTRUCTION",
+              "EXPLICIT_SCOPED_PREFERENCE",
+              "CONFIRMED_LEARNED_PATTERN",
+              "INFERRED_CANDIDATE"
+            ]
+          }
+        }
+      }
+    },
+    "outcome_evidence": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "source_ref",
+          "scope",
+          "occurred_at",
+          "payload"
+        ],
+        "properties": {
+          "source_ref": {
+            "type": "string",
+            "minLength": 1
+          },
+          "scope": {
+            "$ref": "#/$defs/scope"
+          },
+          "occurred_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "payload": {
+            "type": "object"
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "scope_type",
+        "user_key"
+      ],
+      "properties": {
+        "scope_type": {
+          "enum": [
+            "global_user",
+            "project",
+            "specialist",
+            "task_session"
+          ]
+        },
+        "user_key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "project_key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "specialist_slug": {
+          "type": "string",
+          "minLength": 1
+        },
+        "task_session_key": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/orchestra_runtime/adaptive/context.py
+++ b/orchestra_runtime/adaptive/context.py
@@ -1,0 +1,471 @@
+from __future__ import annotations
+
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from ..delegation import DelegationRequest, DelegationResolution
+from ..models import RouteDecision, ValidationResult
+from ..services import RuntimeExecutor, RuntimeOperationResult
+from .models import (
+    AdaptivePattern,
+    AdaptiveProfile,
+    AdaptiveScope,
+    ADAPTIVE_MEMORY_RULE_VERSION,
+    safe_json_object,
+)
+from .store import JsonlAdaptiveStore
+
+ADAPTIVE_CONTEXT_SCHEMA_VERSION = "orchestra.adaptive-context.v1"
+
+_PRECEDENCE = {
+    "EXPLICIT_CURRENT_INSTRUCTION": (4, "EXPLICIT_CURRENT_INSTRUCTION"),
+    "EXPLICIT_SCOPED_PREFERENCE": (3, "EXPLICIT_SCOPED_PREFERENCE"),
+    "CONFIRMED_LEARNED_PATTERN": (2, "CONFIRMED_LEARNED_PATTERN"),
+    "INFERRED_CANDIDATE": (1, "INFERRED_CANDIDATE"),
+}
+_SCOPE_RANK = {
+    "global_user": 0,
+    "project": 1,
+    "specialist": 2,
+    "task_session": 3,
+}
+
+
+def _text(value: object, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+    text = value.strip()
+    if not text:
+        raise ValueError(f"{field_name} must be non-empty")
+    return text
+
+
+def _stable_refs(values: tuple[str, ...] | list[str]) -> tuple[str, ...]:
+    refs = tuple(sorted({_text(value, "reference") for value in values}))
+    return refs
+
+
+@dataclass(frozen=True, slots=True)
+class AdaptiveInvocationContext:
+    user_key: str
+    project_key: str | None = None
+    task_session_key: str | None = None
+    repository_refs: tuple[str, ...] = ()
+    current_instruction_refs: tuple[str, ...] = ()
+    max_items: int = 16
+    max_outcome_evidence: int = 8
+    min_candidate_confidence: float | None = None
+
+    def __post_init__(self) -> None:
+        user_key = _text(self.user_key, "user_key")
+        project_key = None if self.project_key is None else _text(self.project_key, "project_key")
+        task_key = None if self.task_session_key is None else _text(self.task_session_key, "task_session_key")
+        if isinstance(self.max_items, bool) or not isinstance(self.max_items, int) or self.max_items <= 0:
+            raise ValueError("max_items must be a positive integer")
+        if (
+            isinstance(self.max_outcome_evidence, bool)
+            or not isinstance(self.max_outcome_evidence, int)
+            or self.max_outcome_evidence < 0
+        ):
+            raise ValueError("max_outcome_evidence must be a non-negative integer")
+        threshold = self.min_candidate_confidence
+        if threshold is not None:
+            if isinstance(threshold, bool) or not isinstance(threshold, (int, float)):
+                raise TypeError("min_candidate_confidence must be numeric when provided")
+            threshold = float(threshold)
+            if not 0.0 <= threshold <= 1.0:
+                raise ValueError("min_candidate_confidence must be between 0 and 1")
+        repository_refs = _stable_refs(list(self.repository_refs))
+        instruction_refs = _stable_refs(list(self.current_instruction_refs))
+        safe_json_object(
+            {
+                "repository_refs": list(repository_refs),
+                "current_instruction_refs": list(instruction_refs),
+            },
+            "adaptive_invocation",
+        )
+        object.__setattr__(self, "user_key", user_key)
+        object.__setattr__(self, "project_key", project_key)
+        object.__setattr__(self, "task_session_key", task_key)
+        object.__setattr__(self, "repository_refs", repository_refs)
+        object.__setattr__(self, "current_instruction_refs", instruction_refs)
+        object.__setattr__(self, "min_candidate_confidence", threshold)
+
+
+@dataclass(frozen=True, slots=True)
+class AdaptiveContextItem:
+    subject_key: str
+    value: Any
+    scope: AdaptiveScope
+    status: str
+    evidence_class: str
+    evidence_refs: tuple[str, ...]
+    confidence: float
+    precedence: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "subject_key": self.subject_key,
+            "value": self.value,
+            "scope": self.scope.to_dict(),
+            "status": self.status,
+            "evidence_class": self.evidence_class,
+            "evidence_refs": list(self.evidence_refs),
+            "confidence": self.confidence,
+            "precedence": self.precedence,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AdaptiveOutcomeEvidence:
+    source_ref: str
+    scope: AdaptiveScope
+    occurred_at: str
+    payload: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source_ref": self.source_ref,
+            "scope": self.scope.to_dict(),
+            "occurred_at": self.occurred_at,
+            "payload": dict(self.payload),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AdaptiveContextPacket:
+    specialist_slug: str
+    command_name: str
+    status: str
+    reason_code: str
+    items: tuple[AdaptiveContextItem, ...] = ()
+    outcome_evidence: tuple[AdaptiveOutcomeEvidence, ...] = ()
+    repository_refs: tuple[str, ...] = ()
+    current_instruction_refs: tuple[str, ...] = ()
+    schema_version: str = ADAPTIVE_CONTEXT_SCHEMA_VERSION
+    advisory_only: bool = True
+
+    def __post_init__(self) -> None:
+        if self.schema_version != ADAPTIVE_CONTEXT_SCHEMA_VERSION:
+            raise ValueError(f"unsupported adaptive context schema '{self.schema_version}'")
+        specialist = _text(self.specialist_slug, "specialist_slug").casefold()
+        command = _text(self.command_name, "command_name").casefold()
+        status = _text(self.status, "status").upper()
+        if status not in {"ADVISORY", "DETERMINISTIC_FALLBACK"}:
+            raise ValueError("adaptive context status must be ADVISORY or DETERMINISTIC_FALLBACK")
+        reason = _text(self.reason_code, "reason_code")
+        if self.advisory_only is not True:
+            raise ValueError("A2 adaptive context must remain advisory_only")
+        object.__setattr__(self, "specialist_slug", specialist)
+        object.__setattr__(self, "command_name", command)
+        object.__setattr__(self, "status", status)
+        object.__setattr__(self, "reason_code", reason)
+        object.__setattr__(self, "items", tuple(self.items))
+        object.__setattr__(self, "outcome_evidence", tuple(self.outcome_evidence))
+        object.__setattr__(self, "repository_refs", _stable_refs(list(self.repository_refs)))
+        object.__setattr__(
+            self,
+            "current_instruction_refs",
+            _stable_refs(list(self.current_instruction_refs)),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "specialist_slug": self.specialist_slug,
+            "command_name": self.command_name,
+            "status": self.status,
+            "reason_code": self.reason_code,
+            "advisory_only": self.advisory_only,
+            "repository_refs": list(self.repository_refs),
+            "current_instruction_refs": list(self.current_instruction_refs),
+            "items": [item.to_dict() for item in self.items],
+            "outcome_evidence": [item.to_dict() for item in self.outcome_evidence],
+        }
+
+
+class AdaptiveContextProvider(Protocol):
+    def compile(
+        self,
+        decision: RouteDecision,
+        validation: ValidationResult,
+        invocation: AdaptiveInvocationContext,
+    ) -> AdaptiveContextPacket: ...
+
+
+def fallback_packet(
+    decision: RouteDecision,
+    invocation: AdaptiveInvocationContext,
+    reason_code: str,
+) -> AdaptiveContextPacket:
+    return AdaptiveContextPacket(
+        specialist_slug=decision.skill_slug,
+        command_name=decision.command_name,
+        status="DETERMINISTIC_FALLBACK",
+        reason_code=reason_code,
+        repository_refs=invocation.repository_refs,
+        current_instruction_refs=invocation.current_instruction_refs,
+    )
+
+
+class StoreBackedAdaptiveContextProvider:
+    """Compile bounded read-only A2 context from the validated A1 local store."""
+
+    def __init__(self, store: JsonlAdaptiveStore):
+        if not isinstance(store, JsonlAdaptiveStore):
+            raise TypeError("store must be JsonlAdaptiveStore")
+        self._store = store
+
+    def compile(
+        self,
+        decision: RouteDecision,
+        validation: ValidationResult,
+        invocation: AdaptiveInvocationContext,
+    ) -> AdaptiveContextPacket:
+        if not validation.allowed:
+            return fallback_packet(decision, invocation, "GOVERNANCE_NOT_APPROVED")
+        if invocation.user_key != self._store.user_key:
+            return fallback_packet(decision, invocation, "USER_SCOPE_MISMATCH")
+
+        observations = self._store.load_observations()
+        profile = self._store.load_profile()
+        if profile is None:
+            return fallback_packet(decision, invocation, "NO_VALID_PROFILE")
+        if not self._profile_is_current(profile, observations):
+            return fallback_packet(decision, invocation, "STALE_OR_INCOMPATIBLE_PROFILE")
+
+        selected = self._select_patterns(profile, decision.skill_slug, invocation)
+        outcomes = self._select_outcomes(observations, decision.skill_slug, invocation)
+        return AdaptiveContextPacket(
+            specialist_slug=decision.skill_slug,
+            command_name=decision.command_name,
+            status="ADVISORY",
+            reason_code="A2_CONTEXT_COMPILED",
+            items=selected[: invocation.max_items],
+            outcome_evidence=outcomes[: invocation.max_outcome_evidence],
+            repository_refs=invocation.repository_refs,
+            current_instruction_refs=invocation.current_instruction_refs,
+        )
+
+    @staticmethod
+    def _profile_is_current(
+        profile: AdaptiveProfile,
+        observations: tuple,
+    ) -> bool:
+        if profile.memory_rule_version != ADAPTIVE_MEMORY_RULE_VERSION:
+            return False
+        expected_head = None if not observations else observations[-1].digest
+        return profile.source_head_digest == expected_head
+
+    def _select_patterns(
+        self,
+        profile: AdaptiveProfile,
+        specialist_slug: str,
+        invocation: AdaptiveInvocationContext,
+    ) -> tuple[AdaptiveContextItem, ...]:
+        winners: dict[str, tuple[tuple[int, int, str, str], AdaptiveContextItem]] = {}
+        for pattern in profile.patterns:
+            if not self._scope_matches(pattern.scope, specialist_slug, invocation):
+                continue
+            classification = self._classify_pattern(pattern, invocation)
+            if classification is None:
+                continue
+            precedence_rank, precedence_label = _PRECEDENCE[classification]
+            item = AdaptiveContextItem(
+                subject_key=pattern.subject_key,
+                value=pattern.value,
+                scope=pattern.scope,
+                status=pattern.status,
+                evidence_class=pattern.evidence_class,
+                evidence_refs=pattern.evidence_refs,
+                confidence=pattern.confidence,
+                precedence=precedence_label,
+            )
+            rank = (
+                precedence_rank,
+                _SCOPE_RANK[pattern.scope.scope_type],
+                pattern.updated_at,
+                pattern.pattern_id,
+            )
+            current = winners.get(pattern.subject_key)
+            if current is None or rank > current[0]:
+                winners[pattern.subject_key] = (rank, item)
+        return tuple(
+            item
+            for _, item in sorted(
+                winners.values(),
+                key=lambda pair: (-pair[0][0], -pair[0][1], pair[1].subject_key),
+            )
+        )
+
+    @staticmethod
+    def _classify_pattern(
+        pattern: AdaptivePattern,
+        invocation: AdaptiveInvocationContext,
+    ) -> str | None:
+        if pattern.status in {"deprecated", "rejected"}:
+            return None
+        if pattern.evidence_class == "EXPLICIT_CURRENT_INSTRUCTION":
+            return "EXPLICIT_CURRENT_INSTRUCTION"
+        if pattern.evidence_class == "EXPLICIT_SCOPED_PREFERENCE":
+            return "EXPLICIT_SCOPED_PREFERENCE"
+        if pattern.evidence_class == "INFERRED_CANDIDATE":
+            if pattern.status == "confirmed":
+                return "CONFIRMED_LEARNED_PATTERN"
+            if pattern.status != "candidate":
+                return None
+            threshold = invocation.min_candidate_confidence
+            if threshold is None or pattern.confidence < threshold:
+                return None
+            return "INFERRED_CANDIDATE"
+        return None
+
+    def _select_outcomes(
+        self,
+        observations: tuple,
+        specialist_slug: str,
+        invocation: AdaptiveInvocationContext,
+    ) -> tuple[AdaptiveOutcomeEvidence, ...]:
+        outcomes = []
+        for observation in observations:
+            if observation.event_type != "GOVERNED_OUTCOME_RECORDED":
+                continue
+            if not self._scope_matches(observation.scope, specialist_slug, invocation):
+                continue
+            outcomes.append(
+                AdaptiveOutcomeEvidence(
+                    source_ref=observation.source_ref,
+                    scope=observation.scope,
+                    occurred_at=observation.occurred_at,
+                    payload=dict(observation.payload),
+                )
+            )
+        return tuple(
+            sorted(
+                outcomes,
+                key=lambda item: (item.occurred_at, item.source_ref),
+                reverse=True,
+            )
+        )
+
+    @staticmethod
+    def _scope_matches(
+        scope: AdaptiveScope,
+        specialist_slug: str,
+        invocation: AdaptiveInvocationContext,
+    ) -> bool:
+        if scope.user_key != invocation.user_key:
+            return False
+        if scope.project_key is not None and scope.project_key != invocation.project_key:
+            return False
+        if scope.specialist_slug is not None and scope.specialist_slug != specialist_slug.casefold():
+            return False
+        if scope.scope_type == "task_session" and scope.task_session_key != invocation.task_session_key:
+            return False
+        return True
+
+
+class AdaptiveRuntimeExecutor(RuntimeExecutor):
+    """Opt-in A2 executor that adds advisory context only at the operation boundary."""
+
+    def __init__(
+        self,
+        *args,
+        adaptive_provider: AdaptiveContextProvider,
+        **kwargs,
+    ):
+        if adaptive_provider is None or not hasattr(adaptive_provider, "compile"):
+            raise TypeError("adaptive_provider must implement compile")
+        super().__init__(*args, **kwargs)
+        self._adaptive_provider = adaptive_provider
+        self._base_operation = self._operation
+        self._adaptive_invocation: ContextVar[AdaptiveInvocationContext | None] = ContextVar(
+            "orchestra_adaptive_invocation",
+            default=None,
+        )
+        self._operation = self._adaptive_operation
+
+    def execute(
+        self,
+        adapter,
+        prompt: str,
+        metadata: dict | None = None,
+        *,
+        coordination_session=None,
+        adaptive_context: AdaptiveInvocationContext | None = None,
+    ):
+        token = self._adaptive_invocation.set(adaptive_context)
+        try:
+            return super().execute(
+                adapter,
+                prompt,
+                metadata,
+                coordination_session=coordination_session,
+            )
+        finally:
+            self._adaptive_invocation.reset(token)
+
+    def execute_delegation_request(
+        self,
+        adapter,
+        prompt: str,
+        request: DelegationRequest,
+        metadata: dict | None = None,
+        *,
+        coordination_session=None,
+        adaptive_context: AdaptiveInvocationContext | None = None,
+    ):
+        if adaptive_context is not None:
+            raise ValueError("A2 adaptive context is not enabled for delegated execution")
+        return super().execute_delegation_request(
+            adapter,
+            prompt,
+            request,
+            metadata,
+            coordination_session=coordination_session,
+        )
+
+    def execute_delegated(
+        self,
+        adapter,
+        prompt: str,
+        resolution: DelegationResolution,
+        metadata: dict | None = None,
+        *,
+        coordination_session=None,
+        adaptive_context: AdaptiveInvocationContext | None = None,
+    ):
+        if adaptive_context is not None:
+            raise ValueError("A2 adaptive context is not enabled for delegated execution")
+        return super().execute_delegated(
+            adapter,
+            prompt,
+            resolution,
+            metadata,
+            coordination_session=coordination_session,
+        )
+
+    def _adaptive_operation(
+        self,
+        adapter_name: str,
+        decision: RouteDecision,
+        validation: ValidationResult,
+    ) -> RuntimeOperationResult:
+        invocation = self._adaptive_invocation.get()
+        if invocation is None:
+            return self._base_operation(adapter_name, decision, validation)
+        try:
+            packet = self._adaptive_provider.compile(decision, validation, invocation)
+        except Exception:
+            packet = fallback_packet(decision, invocation, "ADAPTIVE_CONTEXT_UNAVAILABLE")
+        metadata = dict(decision.metadata)
+        metadata["adaptive_context"] = packet.to_dict()
+        advisory_decision = RouteDecision(
+            command_name=decision.command_name,
+            skill_slug=decision.skill_slug,
+            governance_required=decision.governance_required,
+            reason=decision.reason,
+            metadata=metadata,
+        )
+        return self._base_operation(adapter_name, advisory_decision, validation)

--- a/tests/runtime/test_adaptive_context.py
+++ b/tests/runtime/test_adaptive_context.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, FormatChecker
+
+from orchestra_runtime.adaptive.context import (
+    AdaptiveInvocationContext,
+    AdaptiveRuntimeExecutor,
+    StoreBackedAdaptiveContextProvider,
+)
+from orchestra_runtime.adaptive.models import AdaptiveScope
+from orchestra_runtime.adaptive.observations import append_explicit_preference, append_inferred_candidate
+from orchestra_runtime.adaptive.profile import materialize_profile
+from orchestra_runtime.adaptive.store import JsonlAdaptiveStore
+from orchestra_runtime.factories import AdapterFactory
+from orchestra_runtime.lifecycle import LifecycleState
+from orchestra_runtime.models import RouteDecision, ValidationResult
+from orchestra_runtime.repositories import ManifestRepository, SkillSourceRepository
+from orchestra_runtime.services import (
+    ContextAssembler,
+    GovernanceValidator,
+    InMemoryAuditSink,
+    RouterService,
+    RuntimeOperationResult,
+    SkillRegistry,
+    build_compatibility_composition,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+USER = "fixture-user"
+PROJECT = "Baelfyre/Orchestra"
+TIMES = tuple(f"2026-08-18T00:0{i}:00Z" for i in range(8))
+
+
+def scope(kind: str, *, specialist: str | None = None) -> AdaptiveScope:
+    return AdaptiveScope(
+        kind,
+        USER,
+        project_key=None if kind == "global_user" else PROJECT,
+        specialist_slug=specialist,
+        task_session_key="task-1" if kind == "task_session" else None,
+    )
+
+
+def route(slug: str) -> RouteDecision:
+    return RouteDecision(slug, slug, False, "test route")
+
+
+def seed_store(tmp_path: Path) -> JsonlAdaptiveStore:
+    store = JsonlAdaptiveStore(USER, root=tmp_path / "adaptive")
+    records = (
+        (scope("project"), "project-compact", False, "project"),
+        (scope("specialist", specialist="scribe"), "scribe-compact", False, "scribe"),
+        (scope("task_session", specialist="scribe"), "task-compact", True, "current"),
+    )
+    for index, (record_scope, value, current, source) in enumerate(records):
+        append_explicit_preference(
+            store,
+            scope=record_scope,
+            subject_key="docs.response_style",
+            value=value,
+            occurred_at=TIMES[index],
+            source_ref=f"test:{source}",
+            current_instruction=current,
+        )
+    append_inferred_candidate(
+        store,
+        scope=scope("project"),
+        subject_key="docs.example_density",
+        value="low",
+        confidence=0.7,
+        evidence_refs=("test:evidence",),
+        occurred_at=TIMES[3],
+        source_ref="test:candidate",
+    )
+    for index, (record_scope, source) in enumerate(
+        (
+            (scope("specialist", specialist="scribe"), "scribe"),
+            (scope("project"), "project"),
+        ),
+        start=4,
+    ):
+        store.append(
+            event_type="GOVERNED_OUTCOME_RECORDED",
+            scope=record_scope,
+            subject_key="workflow.phase_outcome",
+            evidence_class="GOVERNED_OUTCOME",
+            source_type="orchestra_phase_retrospective",
+            source_ref=f"retrospective:{source}",
+            occurred_at=TIMES[index],
+            payload={"phase_id": "A2", "phase_status": "accepted"},
+        )
+    profile = materialize_profile(USER, store.load_observations(), generated_at=TIMES[6])
+    store.write_profile(profile)
+    return store
+
+
+def build_executor(store, *, operation=None, governance=None, provider=None, run_id="a2-test"):
+    manifests = ManifestRepository(ROOT)
+    skills = SkillRegistry(manifests, SkillSourceRepository(ROOT))
+    return AdaptiveRuntimeExecutor(
+        skills,
+        RouterService(skills),
+        governance or GovernanceValidator(),
+        ContextAssembler(manifests),
+        build_compatibility_composition(skills, InMemoryAuditSink(), run_id=run_id),
+        operation=operation,
+        adaptive_provider=provider or StoreBackedAdaptiveContextProvider(store),
+    )
+
+
+def test_a2_precedence_scope_isolation_and_candidate_threshold(tmp_path: Path):
+    provider = StoreBackedAdaptiveContextProvider(seed_store(tmp_path))
+    validation = ValidationResult(True, "APPROVED")
+    scribe = provider.compile(
+        route("scribe"),
+        validation,
+        AdaptiveInvocationContext(
+            USER,
+            project_key=PROJECT,
+            task_session_key="task-1",
+            min_candidate_confidence=0.6,
+        ),
+    )
+    items = {item.subject_key: item for item in scribe.items}
+    assert items["docs.response_style"].value == "task-compact"
+    assert items["docs.response_style"].precedence == "EXPLICIT_CURRENT_INSTRUCTION"
+    assert items["docs.example_density"].precedence == "INFERRED_CANDIDATE"
+    assert {item.source_ref for item in scribe.outcome_evidence} == {
+        "retrospective:scribe",
+        "retrospective:project",
+    }
+
+    beatrice = provider.compile(
+        route("beatrice"),
+        validation,
+        AdaptiveInvocationContext(USER, project_key=PROJECT, task_session_key="task-1"),
+    )
+    other = {item.subject_key: item for item in beatrice.items}
+    assert other["docs.response_style"].value == "project-compact"
+    assert "docs.example_density" not in other
+    assert all(item.scope.specialist_slug != "scribe" for item in beatrice.items)
+    assert {item.source_ref for item in beatrice.outcome_evidence} == {"retrospective:project"}
+
+
+def test_a2_privacy_stale_profile_and_schema(tmp_path: Path):
+    with pytest.raises(ValueError, match="credential-like"):
+        AdaptiveInvocationContext(
+            USER,
+            project_key=PROJECT,
+            repository_refs=("Bearer abcdefghijklmnopqrstuvwxyz0123456789",),
+        )
+
+    store = seed_store(tmp_path)
+    provider = StoreBackedAdaptiveContextProvider(store)
+    packet = provider.compile(
+        route("scribe"),
+        ValidationResult(True, "APPROVED"),
+        AdaptiveInvocationContext(USER, project_key=PROJECT, min_candidate_confidence=0.6),
+    )
+    schema = json.loads((ROOT / "machine/schemas/adaptive-context.schema.json").read_text())
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema, format_checker=FormatChecker()).validate(packet.to_dict())
+
+    append_explicit_preference(
+        store,
+        scope=scope("project"),
+        subject_key="docs.detail_level",
+        value="bounded",
+        occurred_at=TIMES[7],
+        source_ref="test:later",
+    )
+    stale = provider.compile(
+        route("scribe"),
+        ValidationResult(True, "APPROVED"),
+        AdaptiveInvocationContext(USER, project_key=PROJECT),
+    )
+    assert stale.status == "DETERMINISTIC_FALLBACK"
+    assert stale.reason_code == "STALE_OR_INCOMPATIBLE_PROFILE"
+    assert stale.items == ()
+    assert stale.outcome_evidence == ()
+
+
+def test_a2_runtime_attaches_only_after_governance_and_preserves_route(tmp_path: Path):
+    store = seed_store(tmp_path)
+    captured = {}
+
+    def operation(adapter_name, decision, validation):
+        captured["packet"] = decision.metadata["adaptive_context"]
+        return RuntimeOperationResult(LifecycleState.COMPLETED, "completed", "TEST_COMPLETED")
+
+    executor = build_executor(store, operation=operation, run_id="a2-route")
+    result = executor.execute(
+        AdapterFactory.create("codex", ROOT),
+        "@Orchestra rerun the prompt",
+        adaptive_context=AdaptiveInvocationContext(USER, project_key=PROJECT),
+    )
+    assert result.success is True
+    assert captured["packet"]["advisory_only"] is True
+    assert result.route.skill_slug == "conductor"
+    assert "adaptive_context" not in result.route.metadata
+    assert result.authority_decision_id and result.capability_decision_id
+
+    class SpyProvider:
+        calls = 0
+
+        def compile(self, decision, validation, invocation):
+            self.calls += 1
+            raise AssertionError("provider must not run")
+
+    class BlockingGovernance:
+        def validate(self, decision, context):
+            return ValidationResult(False, "BLOCKED_PENDING_VALIDATION", ("blocked",), ("test",))
+
+    spy = SpyProvider()
+    blocked = build_executor(
+        store,
+        governance=BlockingGovernance(),
+        provider=spy,
+        run_id="a2-blocked",
+    ).execute(
+        AdapterFactory.create("codex", ROOT),
+        "@Orchestra rerun the prompt",
+        adaptive_context=AdaptiveInvocationContext(USER, project_key=PROJECT),
+    )
+    assert blocked.success is False
+    assert spy.calls == 0
+
+
+def test_a2_provider_failure_and_delegation_boundary(tmp_path: Path):
+    store = seed_store(tmp_path)
+    captured = {}
+
+    class FailingProvider:
+        def compile(self, decision, validation, invocation):
+            raise RuntimeError("private-secret-diagnostic")
+
+    def operation(adapter_name, decision, validation):
+        captured["packet"] = decision.metadata["adaptive_context"]
+        return RuntimeOperationResult(LifecycleState.COMPLETED, "completed", "TEST_COMPLETED")
+
+    executor = build_executor(
+        store,
+        operation=operation,
+        provider=FailingProvider(),
+        run_id="a2-fallback",
+    )
+    result = executor.execute(
+        AdapterFactory.create("codex", ROOT),
+        "@Orchestra rerun the prompt",
+        adaptive_context=AdaptiveInvocationContext(USER, project_key=PROJECT),
+    )
+    assert result.success is True
+    assert captured["packet"]["reason_code"] == "ADAPTIVE_CONTEXT_UNAVAILABLE"
+    assert "private-secret-diagnostic" not in json.dumps(captured["packet"])
+
+    with pytest.raises(ValueError, match="not enabled for delegated execution"):
+        executor.execute_delegated(
+            AdapterFactory.create("codex", ROOT),
+            "@Orchestra rerun the prompt",
+            None,  # type: ignore[arg-type]
+            adaptive_context=AdaptiveInvocationContext(USER, project_key=PROJECT),
+        )

--- a/tests/runtime/test_adaptive_context_edges.py
+++ b/tests/runtime/test_adaptive_context_edges.py
@@ -1,0 +1,410 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from orchestra_runtime.adaptive.context import (
+    AdaptiveContextPacket,
+    AdaptiveInvocationContext,
+    AdaptiveRuntimeExecutor,
+    StoreBackedAdaptiveContextProvider,
+)
+from orchestra_runtime.adaptive.models import (
+    AdaptivePattern,
+    AdaptiveProfile,
+    AdaptiveScope,
+    ADAPTIVE_MEMORY_RULE_VERSION,
+)
+from orchestra_runtime.adaptive.observations import append_explicit_preference
+from orchestra_runtime.adaptive.store import JsonlAdaptiveStore
+from orchestra_runtime.factories import AdapterFactory
+from orchestra_runtime.lifecycle import LifecycleState
+from orchestra_runtime.models import RouteDecision, ValidationResult
+from orchestra_runtime.repositories import ManifestRepository, SkillSourceRepository
+from orchestra_runtime.services import (
+    ContextAssembler,
+    GovernanceValidator,
+    InMemoryAuditSink,
+    RouterService,
+    RuntimeOperationResult,
+    SkillRegistry,
+    build_compatibility_composition,
+)
+
+USER = "fixture-user"
+PROJECT = "Baelfyre/Orchestra"
+T0 = "2026-08-18T01:00:00Z"
+T1 = "2026-08-18T01:01:00Z"
+
+
+def route(slug: str = "scribe") -> RouteDecision:
+    return RouteDecision(slug, slug, False, "edge route")
+
+
+def project_scope(user: str = USER, project: str = PROJECT) -> AdaptiveScope:
+    return AdaptiveScope("project", user, project_key=project)
+
+
+def pattern(
+    *,
+    pattern_id: str,
+    scope: AdaptiveScope | None = None,
+    subject: str = "docs.response_style",
+    value: str = "compact",
+    status: str = "candidate",
+    evidence_class: str = "INFERRED_CANDIDATE",
+    confidence: float = 0.5,
+    updated_at: str = T0,
+) -> AdaptivePattern:
+    return AdaptivePattern(
+        pattern_id=pattern_id,
+        scope=scope or project_scope(),
+        subject_key=subject,
+        value=value,
+        status=status,
+        evidence_class=evidence_class,
+        evidence_refs=(f"edge:{pattern_id}",),
+        observation_count=1,
+        confidence=confidence,
+        created_at=T0,
+        updated_at=updated_at,
+    )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "error_type", "match"),
+    (
+        ({"user_key": 3}, TypeError, "user_key must be a string"),
+        ({"user_key": " "}, ValueError, "user_key must be non-empty"),
+        ({"user_key": USER, "project_key": 3}, TypeError, "project_key must be a string"),
+        ({"user_key": USER, "task_session_key": " "}, ValueError, "task_session_key must be non-empty"),
+        ({"user_key": USER, "max_items": True}, ValueError, "max_items must be a positive integer"),
+        ({"user_key": USER, "max_items": "16"}, ValueError, "max_items must be a positive integer"),
+        ({"user_key": USER, "max_items": 0}, ValueError, "max_items must be a positive integer"),
+        ({"user_key": USER, "max_outcome_evidence": True}, ValueError, "max_outcome_evidence must be a non-negative integer"),
+        ({"user_key": USER, "max_outcome_evidence": "8"}, ValueError, "max_outcome_evidence must be a non-negative integer"),
+        ({"user_key": USER, "max_outcome_evidence": -1}, ValueError, "max_outcome_evidence must be a non-negative integer"),
+        ({"user_key": USER, "min_candidate_confidence": True}, TypeError, "min_candidate_confidence must be numeric"),
+        ({"user_key": USER, "min_candidate_confidence": "0.5"}, TypeError, "min_candidate_confidence must be numeric"),
+        ({"user_key": USER, "min_candidate_confidence": -0.1}, ValueError, "min_candidate_confidence must be between 0 and 1"),
+        ({"user_key": USER, "min_candidate_confidence": 1.1}, ValueError, "min_candidate_confidence must be between 0 and 1"),
+    ),
+)
+def test_a2_invocation_validation_edges(kwargs, error_type, match):
+    with pytest.raises(error_type, match=match):
+        AdaptiveInvocationContext(**kwargs)
+
+
+def test_a2_invocation_normalizes_valid_bounds_and_refs():
+    invocation = AdaptiveInvocationContext(
+        USER,
+        project_key=PROJECT,
+        max_items=1,
+        max_outcome_evidence=0,
+        min_candidate_confidence=0,
+        repository_refs=("repo:b", "repo:a", "repo:a"),
+        current_instruction_refs=("instruction:b", "instruction:a"),
+    )
+    assert invocation.repository_refs == ("repo:a", "repo:b")
+    assert invocation.current_instruction_refs == ("instruction:a", "instruction:b")
+    assert invocation.min_candidate_confidence == 0.0
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "error_type", "match"),
+    (
+        ({"schema_version": "bad"}, ValueError, "unsupported adaptive context schema"),
+        ({"specialist_slug": " "}, ValueError, "specialist_slug must be non-empty"),
+        ({"command_name": 3}, TypeError, "command_name must be a string"),
+        ({"status": "ACTIVE"}, ValueError, "status must be ADVISORY or DETERMINISTIC_FALLBACK"),
+        ({"reason_code": " "}, ValueError, "reason_code must be non-empty"),
+        ({"advisory_only": False}, ValueError, "must remain advisory_only"),
+    ),
+)
+def test_a2_packet_validation_edges(kwargs, error_type, match):
+    values = {
+        "specialist_slug": "scribe",
+        "command_name": "scribe",
+        "status": "ADVISORY",
+        "reason_code": "EDGE_OK",
+    }
+    values.update(kwargs)
+    with pytest.raises(error_type, match=match):
+        AdaptiveContextPacket(**values)
+
+
+def test_a2_packet_normalizes_identifiers_and_reference_sets():
+    packet = AdaptiveContextPacket(
+        " Scribe ",
+        " Scribe ",
+        "advisory",
+        "EDGE_OK",
+        repository_refs=("repo:b", "repo:a", "repo:a"),
+        current_instruction_refs=("instruction:b", "instruction:a"),
+    )
+    assert packet.specialist_slug == "scribe"
+    assert packet.command_name == "scribe"
+    assert packet.status == "ADVISORY"
+    assert packet.repository_refs == ("repo:a", "repo:b")
+    assert packet.current_instruction_refs == ("instruction:a", "instruction:b")
+
+
+def test_a2_provider_constructor_and_fallback_edges(tmp_path: Path):
+    with pytest.raises(TypeError, match="store must be JsonlAdaptiveStore"):
+        StoreBackedAdaptiveContextProvider(object())  # type: ignore[arg-type]
+
+    store = JsonlAdaptiveStore(USER, root=tmp_path / "adaptive")
+    provider = StoreBackedAdaptiveContextProvider(store)
+    invocation = AdaptiveInvocationContext(USER, project_key=PROJECT)
+
+    blocked = provider.compile(
+        route(),
+        ValidationResult(False, "BLOCKED", ("edge",), ("edge-rule",)),
+        invocation,
+    )
+    assert blocked.reason_code == "GOVERNANCE_NOT_APPROVED"
+
+    mismatch = provider.compile(
+        route(),
+        ValidationResult(True, "APPROVED"),
+        AdaptiveInvocationContext("other-user", project_key=PROJECT),
+    )
+    assert mismatch.reason_code == "USER_SCOPE_MISMATCH"
+
+    no_profile = provider.compile(
+        route(),
+        ValidationResult(True, "APPROVED"),
+        invocation,
+    )
+    assert no_profile.reason_code == "NO_VALID_PROFILE"
+
+
+def test_a2_profile_current_edges():
+    current = AdaptiveProfile(
+        profile_id="profile-current",
+        user_key=USER,
+        generated_at=T0,
+        patterns=(),
+        source_head_digest=None,
+    )
+    incompatible = AdaptiveProfile(
+        profile_id="profile-incompatible",
+        user_key=USER,
+        generated_at=T0,
+        patterns=(),
+        source_head_digest=None,
+        memory_rule_version="orchestra.adaptive-memory-rules.v999",
+    )
+    assert StoreBackedAdaptiveContextProvider._profile_is_current(current, ()) is True
+    assert StoreBackedAdaptiveContextProvider._profile_is_current(incompatible, ()) is False
+    assert current.memory_rule_version == ADAPTIVE_MEMORY_RULE_VERSION
+
+
+@pytest.mark.parametrize(
+    ("record", "threshold", "expected"),
+    (
+        (pattern(pattern_id="deprecated", status="deprecated", confidence=0.5), 0.0, None),
+        (pattern(pattern_id="rejected", status="rejected", confidence=0.5), 0.0, None),
+        (
+            pattern(
+                pattern_id="explicit-current",
+                scope=AdaptiveScope("task_session", USER, project_key=PROJECT, task_session_key="task-1"),
+                status="confirmed",
+                evidence_class="EXPLICIT_CURRENT_INSTRUCTION",
+                confidence=1.0,
+            ),
+            None,
+            "EXPLICIT_CURRENT_INSTRUCTION",
+        ),
+        (
+            pattern(
+                pattern_id="explicit-scoped",
+                status="confirmed",
+                evidence_class="EXPLICIT_SCOPED_PREFERENCE",
+                confidence=1.0,
+            ),
+            None,
+            "EXPLICIT_SCOPED_PREFERENCE",
+        ),
+        (
+            pattern(
+                pattern_id="confirmed-learned",
+                status="confirmed",
+                evidence_class="INFERRED_CANDIDATE",
+                confidence=0.8,
+            ),
+            None,
+            "CONFIRMED_LEARNED_PATTERN",
+        ),
+        (pattern(pattern_id="candidate-no-threshold", confidence=0.8), None, None),
+        (pattern(pattern_id="candidate-below-threshold", confidence=0.4), 0.5, None),
+        (pattern(pattern_id="candidate-allowed", confidence=0.8), 0.5, "INFERRED_CANDIDATE"),
+        (
+            pattern(
+                pattern_id="feedback",
+                status="confirmed",
+                evidence_class="USER_FEEDBACK",
+                confidence=0.5,
+            ),
+            None,
+            None,
+        ),
+    ),
+)
+def test_a2_pattern_classification_edges(record, threshold, expected):
+    invocation = AdaptiveInvocationContext(
+        USER,
+        project_key=PROJECT,
+        task_session_key="task-1",
+        min_candidate_confidence=threshold,
+    )
+    assert StoreBackedAdaptiveContextProvider._classify_pattern(record, invocation) == expected
+
+
+def test_a2_pattern_lower_precedence_does_not_replace_existing_winner(tmp_path: Path):
+    store = JsonlAdaptiveStore(USER, root=tmp_path / "adaptive")
+    provider = StoreBackedAdaptiveContextProvider(store)
+    explicit = pattern(
+        pattern_id="explicit",
+        scope=AdaptiveScope("global_user", USER),
+        status="confirmed",
+        evidence_class="EXPLICIT_SCOPED_PREFERENCE",
+        confidence=1.0,
+        value="explicit",
+    )
+    candidate = pattern(
+        pattern_id="candidate",
+        scope=project_scope(),
+        confidence=0.9,
+        updated_at=T1,
+        value="candidate",
+    )
+    profile = AdaptiveProfile(
+        profile_id="profile-precedence",
+        user_key=USER,
+        generated_at=T1,
+        patterns=(explicit, candidate),
+        source_head_digest=None,
+    )
+    selected = provider._select_patterns(
+        profile,
+        "scribe",
+        AdaptiveInvocationContext(USER, project_key=PROJECT, min_candidate_confidence=0.5),
+    )
+    assert len(selected) == 1
+    assert selected[0].value == "explicit"
+
+
+@pytest.mark.parametrize(
+    ("record_scope", "specialist", "invocation", "expected"),
+    (
+        (project_scope("other-user"), "scribe", AdaptiveInvocationContext(USER, project_key=PROJECT), False),
+        (project_scope(USER, "Baelfyre/Other"), "scribe", AdaptiveInvocationContext(USER, project_key=PROJECT), False),
+        (
+            AdaptiveScope("specialist", USER, project_key=PROJECT, specialist_slug="scribe"),
+            "beatrice",
+            AdaptiveInvocationContext(USER, project_key=PROJECT),
+            False,
+        ),
+        (
+            AdaptiveScope("task_session", USER, project_key=PROJECT, task_session_key="task-1"),
+            "scribe",
+            AdaptiveInvocationContext(USER, project_key=PROJECT, task_session_key="task-2"),
+            False,
+        ),
+        (
+            AdaptiveScope("task_session", USER, project_key=PROJECT, task_session_key="task-1"),
+            "scribe",
+            AdaptiveInvocationContext(USER, project_key=PROJECT, task_session_key="task-1"),
+            True,
+        ),
+    ),
+)
+def test_a2_scope_match_edges(record_scope, specialist, invocation, expected):
+    assert StoreBackedAdaptiveContextProvider._scope_matches(record_scope, specialist, invocation) is expected
+
+
+def test_a2_current_profile_head_and_outcome_zero_bound(tmp_path: Path):
+    store = JsonlAdaptiveStore(USER, root=tmp_path / "adaptive")
+    append_explicit_preference(
+        store,
+        scope=project_scope(),
+        subject_key="docs.response_style",
+        value="compact",
+        occurred_at=T0,
+        source_ref="edge:explicit",
+    )
+    observations = store.load_observations()
+    profile = AdaptiveProfile(
+        profile_id="profile-head",
+        user_key=USER,
+        generated_at=T1,
+        patterns=(
+            pattern(
+                pattern_id="explicit-head",
+                status="confirmed",
+                evidence_class="EXPLICIT_SCOPED_PREFERENCE",
+                confidence=1.0,
+            ),
+        ),
+        source_head_digest=observations[-1].digest,
+    )
+    store.write_profile(profile)
+    packet = StoreBackedAdaptiveContextProvider(store).compile(
+        route(),
+        ValidationResult(True, "APPROVED"),
+        AdaptiveInvocationContext(USER, project_key=PROJECT, max_items=1, max_outcome_evidence=0),
+    )
+    assert packet.status == "ADVISORY"
+    assert len(packet.items) == 1
+    assert packet.outcome_evidence == ()
+
+
+def build_edge_executor(tmp_path: Path, *, operation=None, provider=None, run_id="a2-edge-runtime"):
+    root = Path(__file__).resolve().parents[2]
+    store = JsonlAdaptiveStore(USER, root=tmp_path / "runtime-adaptive")
+    manifests = ManifestRepository(root)
+    skills = SkillRegistry(manifests, SkillSourceRepository(root))
+    return AdaptiveRuntimeExecutor(
+        skills,
+        RouterService(skills),
+        GovernanceValidator(),
+        ContextAssembler(manifests),
+        build_compatibility_composition(skills, InMemoryAuditSink(), run_id=run_id),
+        operation=operation,
+        adaptive_provider=provider or StoreBackedAdaptiveContextProvider(store),
+    )
+
+
+def test_a2_executor_provider_contract_rejects_missing_compiler():
+    with pytest.raises(TypeError, match="adaptive_provider must implement compile"):
+        AdaptiveRuntimeExecutor(None, None, None, None, None, adaptive_provider=None)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="adaptive_provider must implement compile"):
+        AdaptiveRuntimeExecutor(None, None, None, None, None, adaptive_provider=object())  # type: ignore[arg-type]
+
+
+def test_a2_executor_without_invocation_uses_base_operation(tmp_path: Path):
+    captured = {}
+
+    def operation(adapter_name, decision, validation):
+        captured["metadata"] = dict(decision.metadata)
+        return RuntimeOperationResult(LifecycleState.COMPLETED, "completed", "EDGE_COMPLETED")
+
+    root = Path(__file__).resolve().parents[2]
+    executor = build_edge_executor(tmp_path, operation=operation, run_id="a2-edge-base-operation")
+    result = executor.execute(AdapterFactory.create("codex", root), "@Orchestra rerun the prompt")
+    assert result.success is True
+    assert "adaptive_context" not in captured["metadata"]
+
+
+def test_a2_delegation_request_with_context_fails_before_base_validation(tmp_path: Path):
+    root = Path(__file__).resolve().parents[2]
+    executor = build_edge_executor(tmp_path, run_id="a2-edge-delegation-request")
+    with pytest.raises(ValueError, match="not enabled for delegated execution"):
+        executor.execute_delegation_request(
+            AdapterFactory.create("codex", root),
+            "@Orchestra rerun the prompt",
+            None,  # type: ignore[arg-type]
+            adaptive_context=AdaptiveInvocationContext(USER, project_key=PROJECT),
+        )


### PR DESCRIPTION
## Scope

Implements the separately authorized A2 specialist-context adaptation only, stacked directly on the exact validated A1 head `a6fc709ea3ff25b10c0087093a887f815f510bbe`.

- adds an opt-in read-only adaptive context compiler over validated A1 local state
- preserves explicit-current, scoped-preference, confirmed-pattern, inferred-candidate, and deterministic fallback precedence
- enforces exact user/project/specialist/task-session scope matching
- attaches advisory context only after existing route binding, authority, capability, and governance gates, immediately before the operation hook
- preserves the canonical `RouteDecision`; only an operation-local copy receives `metadata.adaptive_context`
- leaves the default `RuntimeExecutor` unchanged
- fails closed for delegated adaptive context in A2
- adds focused scope, privacy, stale-profile, schema, governance-order, route-integrity, provider-fallback, and delegation-boundary regressions

## Explicit boundary

A1 remains a separate draft, unmerged candidate. This stacked A2 PR does not merge or modify PR #368 and does not make A1 canonical.

A3 and later phases remain out of scope. This PR does not implement adaptive route ranking, worker/model selection, strategy ranking, automatic learned-pattern promotion, provider integration, training, recursive/test-time compute, learned Tuner topology, authority changes, capability changes, governance changes, or lifecycle-authority changes.

## Validation

This draft PR is the CI validation vehicle for the exact A2 head. Do not merge or mark ready for review until all exact-head validation gates are green and a separate protected human decision is made.