### PR TITLE
feat: harden Antigravity benchmark live invocation and preflight (B3.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Post-v1.6.0 Comparative Benchmark B3.1.1 Antigravity Live Invocation Hardening - Candidate
+
+- Hardens the live Antigravity CLI invocation path in `scripts/antigravity_benchmark_executor.py` to use validated print-mode syntax: `["agy", "--model", "gemini-3.7-flash-high", "-p", prompt, "--output-format", "json"]`.
+- Removes prompt passing via subprocess stdin and removes unvalidated `--no-use-g1-credits` command-line argument.
+- Implements fail-closed host preflight verifying exact CLI version (1.1.14), `settings.json` parsing, explicit `useG1Credits: false`, model pinning, and deterministic counter identity (`antigravity-cli-1.1.14:json-usage:gemini-3.7-flash-high`) before model execution.
+- Establishes explicit provenance semantics across CLI version (`PREFLIGHT_COMMAND`), model (`PINNED_COMMAND_ARGUMENT`), usage counters (`HOST_REPORTED_JSON_USAGE`), and counter ID (`ORCHESTRA_ASSIGNED_MEASUREMENT_SURFACE`).
+- Enforces quality boundaries ensuring host `SUCCESS` alone does not produce benchmark `PASS` by requiring explicit task completion, validation, and governance evidence.
+- Accurately measures response bytes from the Antigravity `response` payload field.
+- Adds comprehensive deterministic runtime test coverage in `tests/runtime/test_comparative_benchmark_antigravity_executor.py` without live model or provider execution.
+
 ## Post-v1.6.0 Comparative Benchmark B3.1 Antigravity Measurement Executor Binding - Candidate
 
 - Implements the bounded Antigravity measurement executor binding in `scripts/antigravity_benchmark_executor.py` for the Orchestra comparative benchmark harness under the canonical B0/B1/B3.0 contracts.

--- a/README.json
+++ b/README.json
@@ -187,7 +187,7 @@
     },
     "comparative_measurement_b3_1": {
       "status": "IMPLEMENTED_NON_CALIBRATED",
-      "purpose": "Bounded Antigravity measurement executor binding for the Orchestra comparative benchmark harness, supporting structured token usage mapping and deterministic counter identity provenance.",
+      "purpose": "Bounded Antigravity measurement executor binding for the Orchestra comparative benchmark harness with hardened print-mode invocation, fail-closed preflight, explicit provenance semantics, and strict outcome evaluation.",
       "program_id": "orchestra.shared-comparative-benchmark.v1",
       "executor": "scripts/antigravity_benchmark_executor.py",
       "machine_sources": ["machine/benchmarking/antigravity-executor-binding.v1.json"],
@@ -201,7 +201,7 @@
       "a5_execution_promotion": "NOT_AUTHORIZED",
       "a6_authorized": false,
       "b4_state": "BLOCKED",
-      "authority_note": "B3.1 provides the bounded Antigravity measurement executor binding only. Calibration is not executed in this unit, Murmurs benefit is not established, fresh_billable_tokens and cost remain unavailable, A5 remains shadow-only, and B4 remains blocked."
+      "authority_note": "B3.1/B3.1.1 provides the bounded Antigravity measurement executor binding only. Calibration is not executed in this unit, Murmurs benefit is not established, fresh_billable_tokens and cost remain unavailable, A5 remains shadow-only, and B4 remains blocked."
     }
   },
   "machine_scan_order": [
@@ -384,6 +384,7 @@
     "adaptive_tuner_a5": "docs/architecture/ADAPTIVE_TUNER_A5.md",
     "comparative_measurement_b0": "docs/benchmarking/COMPARATIVE_MEASUREMENT_B0.md",
     "comparative_measurement_b1": "docs/benchmarking/COMPARATIVE_MEASUREMENT_B1.md",
+    "comparative_measurement_b3": "docs/benchmarking/COMPARATIVE_MEASUREMENT_B3.md",
     "roadmap": "docs/project/ROADMAP.md",
     "changelog": "CHANGELOG.md",
     "release_docs": "docs/releases/",

--- a/docs/benchmarking/COMPARATIVE_MEASUREMENT_B3.md
+++ b/docs/benchmarking/COMPARATIVE_MEASUREMENT_B3.md
@@ -87,16 +87,62 @@ Provenance rules:
 - Paired B3 token deltas are valid only while this counter identity remains identical across `DEFAULT`, `CAVEMAN`, and `MURMURS` arms.
 - If the CLI version, model identity, usage-field semantics, provider/host, or structured-output mechanism changes, the counter identity must change and the affected paired batch must not be combined as one comparable counter population.
 
-## Execution Controls
+## Execution Controls and B3.1.1 Live Invocation Hardening
 
 The B3 Antigravity executor pins:
 
 ```text
 model: gemini-3.7-flash-high
 output_format: json
-personal_credit_fallback: disabled (useG1Credits: false)
-mode: non-interactive
+personal_credit_fallback: disabled (useG1Credits: false in ~/.gemini/antigravity-cli/settings.json)
+mode: non-interactive (print-mode interface)
 ```
+
+### Production Live-Execution Command Format (B3.1.1)
+
+The live invocation path uses the validated Antigravity print-mode command interface:
+
+```json
+[
+  "agy",
+  "--model",
+  "gemini-3.7-flash-high",
+  "-p",
+  "<PROMPT>",
+  "--output-format",
+  "json"
+]
+```
+
+Invocation invariants:
+- Prompt is delivered strictly through `-p` / `--print` argument.
+- Benchmark prompt is not supplied through subprocess stdin.
+- `shell=False` is mandatory; stdout and stderr are captured.
+- Unvalidated `--no-use-g1-credits` command argument is removed (credit policy is enforced in `settings.json`).
+- Non-zero subprocess exit codes fail closed as `MEASUREMENT_CAPTURE_FAILURE` or `HARNESS_FAILURE`.
+
+### Fail-Closed Host Preflight (B3.1.1)
+
+Before any real model invocation, the executor verifies:
+1. Resolved Antigravity CLI version (`agy --version`) is exactly `1.1.14`.
+2. `settings.json` exists and parses successfully.
+3. `useG1Credits` is explicitly `false`.
+4. Benchmark model in request control identity remains exactly `gemini-3.7-flash-high`.
+5. Expected measurement-surface counter identity remains `antigravity-cli-1.1.14:json-usage:gemini-3.7-flash-high`.
+
+If any preflight condition fails, the executor returns `INVALID_RUN` with `MEASUREMENT_CAPTURE_FAILURE` without executing a model call.
+
+### Explicit Provenance Semantics (B3.1.1)
+
+The observed Antigravity outer JSON envelope does not necessarily contain host-returned model or version fields. Provenance is preserved explicitly in raw evidence:
+- CLI version: `source = PREFLIGHT_COMMAND` (exact validated `agy --version`)
+- Model: `source = PINNED_COMMAND_ARGUMENT` (`gemini-3.7-flash-high`)
+- Usage counters: `source = HOST_REPORTED_JSON_USAGE`
+- Counter ID: `provenance = ORCHESTRA_ASSIGNED_MEASUREMENT_SURFACE` (not provider-issued)
+
+### Communication Response Bytes (B3.1.1)
+
+User-visible response bytes are measured from the `response` field of the Antigravity structured envelope (or `content` field when present), ensuring accurate communication accounting.
 
 Fail-closed invariants:
 The executor fails closed as `INVALID_RUN` with `MEASUREMENT_CAPTURE_FAILURE` (or `CORRUPTED_STARTING_STATE` / `HARNESS_FAILURE`) when:
@@ -107,18 +153,19 @@ The executor fails closed as `INVALID_RUN` with `MEASUREMENT_CAPTURE_FAILURE` (o
 5. `output_tokens` is missing or invalid;
 6. Model identity changes or mismatches the pinned model;
 7. Counter identity changes inside a paired batch;
-8. Canonical starting-state identity is corrupted.
+8. Canonical starting-state identity is corrupted;
+9. Preflight checks fail (version, settings, credit policy).
 
 ## Quality Boundary: Host Status != Task Outcome
 
 Antigravity status `SUCCESS` does NOT imply benchmark task `PASS`.
 
-The benchmark task outcome is determined independently from:
+The benchmark task outcome is determined independently from explicit independently established evidence:
 - Task completion (`task_completed`);
 - Required validation (`validation_passed`);
 - Governance preservation (`governance_valid`).
 
-When host execution succeeds but benchmark validation fails, the run is recorded as a valid execution with outcome `FAIL` (not `PASS`, and not `INVALID_RUN`).
+Missing task-completion, validation, or governance fields default to `false` and cannot manufacture a benchmark `PASS`. When host execution succeeds but benchmark validation fails, the run is recorded as a valid execution with outcome `FAIL` (not `PASS`, and not `INVALID_RUN`).
 
 ## Causal variable
 

--- a/scripts/antigravity_benchmark_executor.py
+++ b/scripts/antigravity_benchmark_executor.py
@@ -1,12 +1,18 @@
 #!/usr/bin/env python3
 """Antigravity measurement executor binding for Orchestra comparative benchmark.
 
-Provides the B3.1 executor adapter for Antigravity CLI host-native execution,
-structured usage parsing, and Orchestra-compatible benchmark result construction.
+Provides the B3.1.1 executor adapter for Antigravity CLI host-native execution,
+fail-closed preflight validation, structured usage parsing, and Orchestra-compatible
+benchmark result construction.
 
 Measurement Surface Provenance:
 - Counter ID format: "antigravity-cli-{cli_version}:json-usage:{model}"
 - Canonical default: "antigravity-cli-1.1.14:json-usage:gemini-3.7-flash-high"
+- Provenance semantics:
+  - CLI version: source = PREFLIGHT_COMMAND (exact validated `agy --version`)
+  - Model: source = PINNED_COMMAND_ARGUMENT (gemini-3.7-flash-high)
+  - Usage counters: source = HOST_REPORTED_JSON_USAGE
+  - Counter ID: provenance = ORCHESTRA_ASSIGNED_MEASUREMENT_SURFACE
 - Note: This counter ID is Orchestra-assigned provenance identifying the exact
   host-native measurement surface; it is NOT claimed to be an Antigravity/provider-issued
   identifier. Paired B3 token deltas are valid only while this identity remains
@@ -75,6 +81,157 @@ def compute_counter_id(
     It is not claimed to be a vendor/provider-issued counter ID.
     """
     return f"antigravity-cli-{cli_version}:{transport}:{model}"
+
+
+def get_default_settings_path() -> Path:
+    """Return default settings path: ~/.gemini/antigravity-cli/settings.json."""
+    return Path.home() / ".gemini" / "antigravity-cli" / "settings.json"
+
+
+def run_host_preflight(
+    request: dict[str, Any],
+    settings_path: Path | None = None,
+    version_runner_fn: Callable[[list[str]], tuple[int, str, str]] | None = None,
+) -> tuple[bool, str | None, dict[str, Any] | None, str | None]:
+    """Execute fail-closed host preflight before real model invocation.
+
+    Invariants verified:
+    1. Resolved Antigravity CLI version is exactly 1.1.14.
+    2. settings.json exists and parses successfully.
+    3. useG1Credits is explicitly False.
+    4. Benchmark model in request control_identity remains exactly gemini-3.7-flash-high.
+    5. Expected counter identity remains antigravity-cli-1.1.14:json-usage:gemini-3.7-flash-high.
+
+    Returns:
+        (is_valid, invalid_reason, detail, validated_cli_version)
+    """
+    req_control = request.get("control_identity", {})
+    req_model = req_control.get("model", PINNED_MODEL)
+    if req_model != PINNED_MODEL:
+        return (
+            False,
+            "MEASUREMENT_CAPTURE_FAILURE",
+            {
+                "error": f"request model {req_model!r} does not match pinned model {PINNED_MODEL!r}",
+                "pinned_model": PINNED_MODEL,
+                "request_model": req_model,
+            },
+            None,
+        )
+
+    target_settings = settings_path or get_default_settings_path()
+    if not target_settings.is_file():
+        return (
+            False,
+            "MEASUREMENT_CAPTURE_FAILURE",
+            {
+                "error": f"settings file not found: {target_settings}",
+                "settings_path": str(target_settings),
+            },
+            None,
+        )
+
+    try:
+        raw_settings = target_settings.read_text(encoding="utf-8")
+        settings = json.loads(raw_settings)
+    except Exception as exc:
+        return (
+            False,
+            "MEASUREMENT_CAPTURE_FAILURE",
+            {
+                "error": f"failed to parse settings.json: {exc}",
+                "settings_path": str(target_settings),
+            },
+            None,
+        )
+
+    if not isinstance(settings, dict):
+        return (
+            False,
+            "MEASUREMENT_CAPTURE_FAILURE",
+            {
+                "error": "settings.json root is not an object",
+                "settings_path": str(target_settings),
+            },
+            None,
+        )
+
+    use_g1 = settings.get("useG1Credits")
+    if use_g1 is not False or isinstance(use_g1, bool) is False:
+        return (
+            False,
+            "MEASUREMENT_CAPTURE_FAILURE",
+            {
+                "error": "useG1Credits must be explicitly false in settings.json",
+                "observed_useG1Credits": use_g1,
+                "settings_path": str(target_settings),
+            },
+            None,
+        )
+
+    version_cmd = ["agy", "--version"]
+    if version_runner_fn is not None:
+        rc, stdout, stderr = version_runner_fn(version_cmd)
+    else:
+        try:
+            completed = subprocess.run(
+                version_cmd,
+                capture_output=True,
+                text=True,
+                check=False,
+                shell=False,
+            )
+            rc, stdout, stderr = completed.returncode, completed.stdout, completed.stderr
+        except OSError as exc:
+            return (
+                False,
+                "HARNESS_FAILURE",
+                {"error": f"failed to execute agy --version: {exc}"},
+                None,
+            )
+
+    if rc != 0:
+        return (
+            False,
+            "MEASUREMENT_CAPTURE_FAILURE",
+            {
+                "error": f"agy --version returned non-zero exit code {rc}",
+                "returncode": rc,
+                "stdout": stdout,
+                "stderr": stderr,
+            },
+            None,
+        )
+
+    raw_version = stdout.strip()
+    tokens = raw_version.split()
+    resolved_version = tokens[-1] if tokens else ""
+    if resolved_version != PINNED_CLI_VERSION:
+        return (
+            False,
+            "MEASUREMENT_CAPTURE_FAILURE",
+            {
+                "error": f"resolved CLI version {resolved_version!r} does not match pinned version {PINNED_CLI_VERSION!r}",
+                "raw_version_output": raw_version,
+                "pinned_version": PINNED_CLI_VERSION,
+            },
+            None,
+        )
+
+    counter_id = compute_counter_id(cli_version=resolved_version, model=PINNED_MODEL)
+    if counter_id != DEFAULT_COUNTER_ID:
+        return (
+            False,
+            "MEASUREMENT_CAPTURE_FAILURE",
+            {
+                "error": "counter identity mismatch",
+                "observed_counter_id": counter_id,
+                "expected_counter_id": DEFAULT_COUNTER_ID,
+            },
+            None,
+        )
+
+    return True, None, None, resolved_version
 
 
 def map_antigravity_tokens(usage: dict[str, Any], counter_id: str) -> dict[str, Any]:
@@ -213,14 +370,33 @@ def evaluate_task_outcome(
 
     Quality Boundary:
     Antigravity status SUCCESS does NOT imply benchmark task PASS.
-    Task outcome is determined independently from:
-    - task completion
-    - required validation
-    - governance preservation
+    No missing task-completion, validation, or governance field may default
+    to a successful benchmark result.
+
+    Task outcome is determined strictly from explicit independently established evidence:
+    - task_completed
+    - validation_passed
+    - governance_valid
     """
-    task_completed = bool(antigravity_output.get("task_completed", task_payload.get("task_completed", True)))
-    validation_passed = bool(antigravity_output.get("validation_passed", task_payload.get("validation_passed", True)))
-    governance_valid = bool(antigravity_output.get("governance_valid", task_payload.get("governance_valid", True)))
+    raw_completed = (
+        antigravity_output.get("task_completed")
+        if "task_completed" in antigravity_output
+        else task_payload.get("task_completed")
+    )
+    raw_validation = (
+        antigravity_output.get("validation_passed")
+        if "validation_passed" in antigravity_output
+        else task_payload.get("validation_passed")
+    )
+    raw_gov = (
+        antigravity_output.get("governance_valid")
+        if "governance_valid" in antigravity_output
+        else task_payload.get("governance_valid")
+    )
+
+    task_completed = bool(raw_completed) if raw_completed is not None else False
+    validation_passed = bool(raw_validation) if raw_validation is not None else False
+    governance_valid = bool(raw_gov) if raw_gov is not None else False
 
     is_pass = task_completed and validation_passed and governance_valid
 
@@ -248,6 +424,7 @@ def parse_antigravity_output(
     raw_output: str | dict[str, Any],
     request: dict[str, Any],
     elapsed_ms: int | None = None,
+    validated_cli_version: str = PINNED_CLI_VERSION,
 ) -> dict[str, Any]:
     """Parse raw Antigravity outer envelope and construct Orchestra benchmark result."""
     task_payload = request.get("task_payload", {})
@@ -297,24 +474,47 @@ def parse_antigravity_output(
             elapsed_ms,
         )
 
-    host_model = envelope.get("model", PINNED_MODEL)
-    req_control = request.get("control_identity", {})
-    req_model = req_control.get("model", PINNED_MODEL)
-    if host_model != PINNED_MODEL or req_model != PINNED_MODEL or host_model != req_model:
+    # Check model mismatch if host returned model field
+    if "model" in envelope and envelope["model"] != PINNED_MODEL:
         return build_invalid_result(
             request,
             "MEASUREMENT_CAPTURE_FAILURE",
             {
-                "error": "model identity mismatch",
-                "host_model": host_model,
+                "error": "host returned model mismatch",
+                "host_model": envelope["model"],
+                "pinned_model": PINNED_MODEL,
+            },
+            elapsed_ms,
+        )
+
+    req_control = request.get("control_identity", {})
+    req_model = req_control.get("model", PINNED_MODEL)
+    if req_model != PINNED_MODEL:
+        return build_invalid_result(
+            request,
+            "MEASUREMENT_CAPTURE_FAILURE",
+            {
+                "error": "request model mismatch",
                 "request_model": req_model,
                 "pinned_model": PINNED_MODEL,
             },
             elapsed_ms,
         )
 
-    host_cli_version = envelope.get("cli_version", PINNED_CLI_VERSION)
-    counter_id = compute_counter_id(cli_version=host_cli_version, model=host_model)
+    # Check cli_version mismatch if host returned cli_version field
+    if "cli_version" in envelope and envelope["cli_version"] != PINNED_CLI_VERSION:
+        return build_invalid_result(
+            request,
+            "MEASUREMENT_CAPTURE_FAILURE",
+            {
+                "error": "host returned cli_version mismatch",
+                "host_cli_version": envelope["cli_version"],
+                "pinned_cli_version": PINNED_CLI_VERSION,
+            },
+            elapsed_ms,
+        )
+
+    counter_id = compute_counter_id(cli_version=validated_cli_version, model=PINNED_MODEL)
     if counter_id != DEFAULT_COUNTER_ID:
         return build_invalid_result(
             request,
@@ -369,7 +569,17 @@ def parse_antigravity_output(
     }
 
     comm_source = envelope.get("communication") or {}
-    user_visible_bytes = int(comm_source.get("user_visible_bytes", len(envelope.get("content", "").encode("utf-8")) if "content" in envelope else 0))
+    if "user_visible_bytes" in comm_source:
+        user_visible_bytes = int(comm_source["user_visible_bytes"])
+    elif "response" in envelope:
+        resp = envelope["response"]
+        user_visible_bytes = len(resp.encode("utf-8")) if isinstance(resp, str) else len(canonical_json(resp).encode("utf-8"))
+    elif "content" in envelope:
+        cont = envelope["content"]
+        user_visible_bytes = len(cont.encode("utf-8")) if isinstance(cont, str) else len(canonical_json(cont).encode("utf-8"))
+    else:
+        user_visible_bytes = 0
+
     communication = {
         "progress_messages": int(comm_source.get("progress_messages", 0)),
         "model_progress_calls": int(comm_source.get("model_progress_calls", 0)),
@@ -383,9 +593,25 @@ def parse_antigravity_output(
 
     raw_evidence = {
         "host": "Antigravity CLI",
-        "cli_version": host_cli_version,
-        "model": host_model,
+        "cli_version": validated_cli_version,
+        "cli_version_provenance": {
+            "source": "PREFLIGHT_COMMAND",
+            "value": validated_cli_version,
+        },
+        "model": PINNED_MODEL,
+        "model_provenance": {
+            "source": "PINNED_COMMAND_ARGUMENT",
+            "value": PINNED_MODEL,
+        },
+        "usage_provenance": {
+            "source": "HOST_REPORTED_JSON_USAGE",
+        },
         "counter_id": counter_id,
+        "counter_id_provenance": {
+            "identifier": counter_id,
+            "provenance": "ORCHESTRA_ASSIGNED_MEASUREMENT_SURFACE",
+            "vendor_assigned_claim": False,
+        },
         "outer_envelope": copy.deepcopy(envelope),
         "total_tokens": usage.get("total_tokens"),
         "useG1Credits": envelope.get("useG1Credits", False),
@@ -423,7 +649,9 @@ def parse_antigravity_output(
 
 def execute_request(
     request: dict[str, Any],
-    runner_fn: Callable[[list[str], str], tuple[int, str, str]] | None = None,
+    runner_fn: Callable[..., tuple[int, str, str]] | None = None,
+    settings_path: Path | None = None,
+    version_runner_fn: Callable[[list[str]], tuple[int, str, str]] | None = None,
 ) -> dict[str, Any]:
     """Execute a single comparative benchmark request with Antigravity binding."""
     if not isinstance(request, dict):
@@ -462,26 +690,44 @@ def execute_request(
     if mock_output is not None:
         return parse_antigravity_output(mock_output, request, elapsed_ms=10)
 
-    # Live Antigravity CLI execution path (disabled during non-live testing)
+    # Fail-closed host preflight before real model invocation
+    preflight_valid, pf_reason, pf_detail, validated_version = run_host_preflight(
+        request,
+        settings_path=settings_path,
+        version_runner_fn=version_runner_fn,
+    )
+    if not preflight_valid:
+        return build_invalid_result(
+            request,
+            pf_reason or "MEASUREMENT_CAPTURE_FAILURE",
+            pf_detail or {"error": "preflight failed"},
+        )
+
+    cli_version = validated_version or PINNED_CLI_VERSION
+    prompt = task_payload.get("prompt", "")
+
+    # Validated Antigravity print-mode command interface
     cmd = [
         "agy",
         "--model",
         PINNED_MODEL,
+        "-p",
+        prompt,
         "--output-format",
         "json",
-        "--no-use-g1-credits",
     ]
 
-    prompt = task_payload.get("prompt", "")
     started = time.monotonic()
 
     if runner_fn is not None:
-        returncode, stdout, stderr = runner_fn(cmd, prompt)
+        try:
+            returncode, stdout, stderr = runner_fn(cmd, prompt)
+        except TypeError:
+            returncode, stdout, stderr = runner_fn(cmd)
     else:
         try:
             completed = subprocess.run(
                 cmd,
-                input=prompt,
                 capture_output=True,
                 text=True,
                 check=False,
@@ -506,7 +752,7 @@ def execute_request(
             elapsed,
         )
 
-    return parse_antigravity_output(stdout, request, elapsed)
+    return parse_antigravity_output(stdout, request, elapsed, validated_cli_version=cli_version)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/runtime/test_comparative_benchmark_antigravity_executor.py
+++ b/tests/runtime/test_comparative_benchmark_antigravity_executor.py
@@ -98,8 +98,9 @@ def _mock_host_envelope(
     task_completed: bool = True,
     validation_passed: bool = True,
     governance_valid: bool = True,
+    response: str | None = "Sample structured response payload",
 ) -> dict[str, Any]:
-    return {
+    envelope: dict[str, Any] = {
         "status": status,
         "model": model,
         "cli_version": cli_version,
@@ -111,11 +112,23 @@ def _mock_host_envelope(
             "cache_read_tokens": cache_read_tokens,
             "total_tokens": total_tokens,
         },
-        "content": "Sample structured response payload",
         "task_completed": task_completed,
         "validation_passed": validation_passed,
         "governance_valid": governance_valid,
     }
+    if response is not None:
+        envelope["response"] = response
+    return envelope
+
+
+def _create_mock_settings(tmp_path: Path, use_g1_credits: Any = False) -> Path:
+    settings_file = tmp_path / "settings.json"
+    settings_file.parent.mkdir(parents=True, exist_ok=True)
+    data = {}
+    if use_g1_credits is not None:
+        data["useG1Credits"] = use_g1_credits
+    settings_file.write_text(json.dumps(data), encoding="utf-8")
+    return settings_file
 
 
 def test_01_valid_antigravity_usage_maps_to_host_reported_tokens() -> None:
@@ -245,14 +258,48 @@ def test_10_antigravity_success_does_not_automatically_set_task_outcome_pass() -
     assert res2["outcome"]["task_completed"] is False
 
 
-def test_11_counter_identity_is_deterministic() -> None:
+def test_11_host_success_without_independent_evidence_cannot_produce_pass() -> None:
+    # Regression test for Objective 5: Host envelope has status=SUCCESS and valid tokens,
+    # but no task_completed, validation_passed, or governance_valid fields.
+    # The executor must NOT default missing fields to True or manufacture benchmark PASS.
+    bare_envelope = {
+        "status": "SUCCESS",
+        "usage": {
+            "input_tokens": 1200,
+            "output_tokens": 350,
+            "thinking_tokens": 50,
+            "cache_read_tokens": 100,
+            "total_tokens": 1700,
+        },
+        "response": "Completed the request successfully.",
+    }
+    req = _base_request(raw_host_output=bare_envelope)
+    # Ensure task_payload contains no manufactured outcome flags
+    req["task_payload"].pop("task_completed", None)
+    req["task_payload"].pop("validation_passed", None)
+    req["task_payload"].pop("governance_valid", None)
+
+    res = executor.execute_request(req)
+    _validate_result_schema(res)
+
+    assert res["outcome"]["status"] == "FAIL"
+    assert res["outcome"]["invalid_reason"] is None
+    assert res["outcome"]["task_completed"] is False
+    assert res["outcome"]["validation_passed"] is False
+    assert res["outcome"]["governance_valid"] is False
+    assert res["tokens"]["source"] == "HOST_REPORTED"
+    assert res["tokens"]["input_tokens"] == 1200
+    assert res["tokens"]["output_tokens"] == 350
+
+
+def test_12_counter_identity_is_deterministic() -> None:
     cid1 = executor.compute_counter_id()
     cid2 = executor.compute_counter_id("1.1.14", "gemini-3.7-flash-high", "json-usage")
     assert cid1 == "antigravity-cli-1.1.14:json-usage:gemini-3.7-flash-high"
     assert cid1 == cid2 == executor.DEFAULT_COUNTER_ID
 
 
-def test_12_changed_cli_or_model_identity_changes_counter_identity() -> None:
+def test_13_changed_cli_or_model_identity_changes_counter_identity() -> None:
     base_cid = executor.DEFAULT_COUNTER_ID
 
     cid_cli_change = executor.compute_counter_id(cli_version="1.2.0")
@@ -271,8 +318,7 @@ def test_12_changed_cli_or_model_identity_changes_counter_identity() -> None:
     assert res["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
 
 
-def test_13_no_live_antigravity_invocation_occurs_during_tests() -> None:
-    # Supply a runner_fn that records if it was called; in unit test mode with mock payload, runner_fn is never invoked
+def test_14_no_live_antigravity_invocation_occurs_during_tests() -> None:
     called = []
 
     def fake_runner(cmd: list[str], prompt: str) -> tuple[int, str, str]:
@@ -285,7 +331,7 @@ def test_13_no_live_antigravity_invocation_occurs_during_tests() -> None:
     assert res["outcome"]["status"] == "PASS"
 
 
-def test_14_corrupted_starting_state_fails_closed() -> None:
+def test_15_corrupted_starting_state_fails_closed() -> None:
     req = _base_request(corrupted_starting_state=True, raw_host_output=_mock_host_envelope())
     res = executor.execute_request(req)
     _validate_result_schema(res)
@@ -301,7 +347,7 @@ def test_14_corrupted_starting_state_fails_closed() -> None:
     assert res2["outcome"]["invalid_reason"] == "CORRUPTED_STARTING_STATE"
 
 
-def test_15_model_mismatch_fails_closed() -> None:
+def test_16_model_mismatch_fails_closed() -> None:
     # Request control_identity model != pinned model
     req = _base_request(raw_host_output=_mock_host_envelope())
     req["control_identity"]["model"] = "unpinned-model-variant"
@@ -319,7 +365,247 @@ def test_15_model_mismatch_fails_closed() -> None:
     assert res2["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
 
 
-def test_16_runner_integration_with_antigravity_executor(tmp_path: Path) -> None:
+def test_17_live_argv_construction_and_no_stdin_prompt(tmp_path: Path) -> None:
+    # Tests Objective 1:
+    # Command is: ["agy", "--model", "gemini-3.7-flash-high", "-p", prompt, "--output-format", "json"]
+    # Prompt is passed via -p, prompt is not passed on stdin, --no-use-g1-credits is absent.
+    settings_file = _create_mock_settings(tmp_path, use_g1_credits=False)
+    captured_calls: list[dict[str, Any]] = []
+
+    def mock_version_runner(cmd: list[str]) -> tuple[int, str, str]:
+        return (0, "1.1.14\n", "")
+
+    def mock_model_runner(cmd: list[str], prompt: str) -> tuple[int, str, str]:
+        captured_calls.append({"cmd": cmd, "prompt": prompt})
+        envelope = _mock_host_envelope(
+            task_completed=True,
+            validation_passed=True,
+            governance_valid=True,
+        )
+        return (0, json.dumps(envelope), "")
+
+    test_prompt = "Refactor the authentication middleware."
+    req = _base_request(prompt=test_prompt)
+    res = executor.execute_request(
+        req,
+        runner_fn=mock_model_runner,
+        settings_path=settings_file,
+        version_runner_fn=mock_version_runner,
+    )
+    _validate_result_schema(res)
+
+    assert len(captured_calls) == 1
+    call_info = captured_calls[0]
+    cmd = call_info["cmd"]
+
+    expected_cmd = [
+        "agy",
+        "--model",
+        "gemini-3.7-flash-high",
+        "-p",
+        test_prompt,
+        "--output-format",
+        "json",
+    ]
+    assert cmd == expected_cmd
+    assert "-p" in cmd
+    assert cmd[cmd.index("-p") + 1] == test_prompt
+    assert "--no-use-g1-credits" not in cmd
+    assert res["outcome"]["status"] == "PASS"
+
+
+def test_18_preflight_accepts_exact_cli_version_1_1_14(tmp_path: Path) -> None:
+    # Tests Objective 2: Preflight accepts exact version 1.1.14
+    settings_file = _create_mock_settings(tmp_path, use_g1_credits=False)
+    model_called = False
+
+    def mock_version_runner(cmd: list[str]) -> tuple[int, str, str]:
+        assert cmd == ["agy", "--version"]
+        return (0, "antigravity-cli 1.1.14\n", "")
+
+    def mock_model_runner(cmd: list[str], prompt: str) -> tuple[int, str, str]:
+        nonlocal model_called
+        model_called = True
+        return (0, json.dumps(_mock_host_envelope()), "")
+
+    req = _base_request(prompt="Sample prompt")
+    res = executor.execute_request(
+        req,
+        runner_fn=mock_model_runner,
+        settings_path=settings_file,
+        version_runner_fn=mock_version_runner,
+    )
+    _validate_result_schema(res)
+
+    assert model_called is True
+    assert res["outcome"]["status"] == "PASS"
+    assert res["raw_evidence"]["cli_version"] == "1.1.14"
+
+
+def test_19_preflight_fails_closed_on_different_cli_version(tmp_path: Path) -> None:
+    # Tests Objective 2: CLI version mismatch fails closed before model invocation
+    settings_file = _create_mock_settings(tmp_path, use_g1_credits=False)
+    model_called = False
+
+    def mock_version_runner(cmd: list[str]) -> tuple[int, str, str]:
+        return (0, "1.2.0\n", "")
+
+    def mock_model_runner(cmd: list[str], prompt: str) -> tuple[int, str, str]:
+        nonlocal model_called
+        model_called = True
+        return (0, json.dumps(_mock_host_envelope()), "")
+
+    req = _base_request(prompt="Sample prompt")
+    res = executor.execute_request(
+        req,
+        runner_fn=mock_model_runner,
+        settings_path=settings_file,
+        version_runner_fn=mock_version_runner,
+    )
+    _validate_result_schema(res)
+
+    assert model_called is False
+    assert res["outcome"]["status"] == "INVALID_RUN"
+    assert res["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+    assert "1.2.0" in str(res["raw_evidence"]["detail"])
+
+
+def test_20_preflight_accepts_explicit_use_g1_credits_false(tmp_path: Path) -> None:
+    # Tests Objective 2: useG1Credits: false in settings.json passes preflight
+    settings_file = _create_mock_settings(tmp_path, use_g1_credits=False)
+    model_called = False
+
+    def mock_version_runner(cmd: list[str]) -> tuple[int, str, str]:
+        return (0, "1.1.14\n", "")
+
+    def mock_model_runner(cmd: list[str], prompt: str) -> tuple[int, str, str]:
+        nonlocal model_called
+        model_called = True
+        return (0, json.dumps(_mock_host_envelope()), "")
+
+    req = _base_request(prompt="Sample prompt")
+    res = executor.execute_request(
+        req,
+        runner_fn=mock_model_runner,
+        settings_path=settings_file,
+        version_runner_fn=mock_version_runner,
+    )
+    _validate_result_schema(res)
+
+    assert model_called is True
+    assert res["outcome"]["status"] == "PASS"
+
+
+def test_21_preflight_fails_closed_on_use_g1_credits_true(tmp_path: Path) -> None:
+    # Tests Objective 2: useG1Credits: true fails closed before model invocation
+    settings_file = _create_mock_settings(tmp_path, use_g1_credits=True)
+    model_called = False
+
+    def mock_version_runner(cmd: list[str]) -> tuple[int, str, str]:
+        return (0, "1.1.14\n", "")
+
+    def mock_model_runner(cmd: list[str], prompt: str) -> tuple[int, str, str]:
+        nonlocal model_called
+        model_called = True
+        return (0, json.dumps(_mock_host_envelope()), "")
+
+    req = _base_request(prompt="Sample prompt")
+    res = executor.execute_request(
+        req,
+        runner_fn=mock_model_runner,
+        settings_path=settings_file,
+        version_runner_fn=mock_version_runner,
+    )
+    _validate_result_schema(res)
+
+    assert model_called is False
+    assert res["outcome"]["status"] == "INVALID_RUN"
+    assert res["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+    assert "useG1Credits" in str(res["raw_evidence"]["detail"])
+
+
+def test_22_preflight_fails_closed_on_malformed_or_missing_settings(tmp_path: Path) -> None:
+    # Tests Objective 2: Missing settings file, malformed JSON, and missing useG1Credits key
+    def mock_version_runner(cmd: list[str]) -> tuple[int, str, str]:
+        return (0, "1.1.14\n", "")
+
+    # 1. Missing settings file
+    missing_settings = tmp_path / "non_existent_settings.json"
+    req1 = _base_request(prompt="Sample prompt")
+    res1 = executor.execute_request(
+        req1,
+        settings_path=missing_settings,
+        version_runner_fn=mock_version_runner,
+    )
+    _validate_result_schema(res1)
+    assert res1["outcome"]["status"] == "INVALID_RUN"
+    assert res1["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+    # 2. Malformed settings file
+    malformed_settings = tmp_path / "bad_settings.json"
+    malformed_settings.write_text("{not-valid-json", encoding="utf-8")
+    req2 = _base_request(prompt="Sample prompt")
+    res2 = executor.execute_request(
+        req2,
+        settings_path=malformed_settings,
+        version_runner_fn=mock_version_runner,
+    )
+    _validate_result_schema(res2)
+    assert res2["outcome"]["status"] == "INVALID_RUN"
+    assert res2["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+    # 3. Missing useG1Credits key (e.g. empty object)
+    missing_key_settings = _create_mock_settings(tmp_path / "sub", use_g1_credits=None)
+    req3 = _base_request(prompt="Sample prompt")
+    res3 = executor.execute_request(
+        req3,
+        settings_path=missing_key_settings,
+        version_runner_fn=mock_version_runner,
+    )
+    _validate_result_schema(res3)
+    assert res3["outcome"]["status"] == "INVALID_RUN"
+    assert res3["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+
+def test_23_provenance_semantics_explicitly_preserved() -> None:
+    # Tests Objective 3: Explicit provenance for CLI version, model, usage, and counter ID
+    envelope = _mock_host_envelope()
+    # Remove model and cli_version from envelope to ensure they are not claimed to be host-returned
+    del envelope["model"]
+    del envelope["cli_version"]
+
+    req = _base_request(raw_host_output=envelope)
+    res = executor.execute_request(req)
+    _validate_result_schema(res)
+
+    raw_ev = res["raw_evidence"]
+    assert raw_ev["cli_version_provenance"]["source"] == "PREFLIGHT_COMMAND"
+    assert raw_ev["cli_version_provenance"]["value"] == "1.1.14"
+    assert raw_ev["model_provenance"]["source"] == "PINNED_COMMAND_ARGUMENT"
+    assert raw_ev["model_provenance"]["value"] == "gemini-3.7-flash-high"
+    assert raw_ev["usage_provenance"]["source"] == "HOST_REPORTED_JSON_USAGE"
+    assert raw_ev["counter_id_provenance"]["provenance"] == "ORCHESTRA_ASSIGNED_MEASUREMENT_SURFACE"
+    assert raw_ev["counter_id_provenance"]["vendor_assigned_claim"] is False
+    assert raw_ev["counter_id_provenance"]["identifier"] == "antigravity-cli-1.1.14:json-usage:gemini-3.7-flash-high"
+
+
+def test_24_response_bytes_captured_from_response_field() -> None:
+    # Tests Objective 6: Observed Antigravity envelope uses 'response' field
+    # user_visible_bytes is calculated from 'response' field, not zero
+    response_text = "Here is the refactored code and summary."
+    envelope = _mock_host_envelope(response=response_text)
+    envelope.pop("content", None)
+
+    req = _base_request(raw_host_output=envelope)
+    res = executor.execute_request(req)
+    _validate_result_schema(res)
+
+    expected_bytes = len(response_text.encode("utf-8"))
+    assert res["communication"]["user_visible_bytes"] == expected_bytes
+    assert res["communication"]["user_visible_bytes"] > 0
+
+
+def test_25_runner_integration_with_antigravity_executor(tmp_path: Path) -> None:
     # Test runner execution with scripts/antigravity_benchmark_executor.py
     manifest_path = tmp_path / "manifest.json"
     manifest = {


### PR DESCRIPTION
### Summary

- Hardens the Antigravity benchmark measurement executor (\scripts/antigravity_benchmark_executor.py\) with validated print-mode argument format: \gy --model gemini-3.7-flash-high -p <PROMPT> --output-format json\.
- Removes unvalidated \--no-use-g1-credits\ argument and prompt delivery via subprocess stdin.
- Enforces fail-closed host preflight checking exact CLI version (1.1.14), settings.json parsing, explicit \useG1Credits: false\, model pinning, and deterministic counter identity (\ntigravity-cli-1.1.14:json-usage:gemini-3.7-flash-high\).
- Preserves explicit provenance semantics (PREFLIGHT_COMMAND, PINNED_COMMAND_ARGUMENT, HOST_REPORTED_JSON_USAGE, ORCHESTRA_ASSIGNED_MEASUREMENT_SURFACE) and measures response bytes accurately from the Antigravity \esponse\ field.
- Ensures missing task completion, validation, and governance evidence strictly defaults to \alse\ so host SUCCESS alone cannot manufacture benchmark PASS.
- Adds comprehensive deterministic runtime unit tests without live model or provider execution.