### PR TITLE
B3.1.3: externalize exact Antigravity host version pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Post-v1.6.0 Comparative Benchmark B3.1.3 Exact Host Version Pin Externalization - Candidate
+
+- Externalizes the exact expected Antigravity host CLI version via `--expected-cli-version` CLI argument in `scripts/antigravity_benchmark_executor.py`, removing operational hard-coding while preserving exact fail-closed version matching.
+- Rejects loose, range, wildcard, and operator version strings (e.g., empty, latest, `>=1.1.15`, `^1.1.15`) in `validate_version_format`.
+- Qualifies Antigravity CLI 1.1.15 host surface via zero-turn structured preflight probes (`/model`, `/effort`, `/usage`, `num_turns=0`, `usage_counters=0`, `model=gemini-3.7-flash-high`).
+- Derives measurement surface counter identity dynamically from validated exact version: `antigravity-cli-1.1.15:json-usage:gemini-3.7-flash-high` and `antigravity-cli-1.1.15:stream-json-usage:gemini-3.7-flash-high`.
+- Separates provenance in `raw_evidence`: `expected_cli_version` (`EXECUTOR_ARGUMENT` / `DEFAULT_QUALIFIED_HOST`) and `observed_cli_version` (`PREFLIGHT_COMMAND` / `HOST_REPORTED_*`).
+- Preserves all B3.1.2 communication treatments (`DEFAULT`, `CAVEMAN`, `MURMURS`), stream-json transport, fail-closed settings preflight (`useG1Credits: false`), and independent task outcome evaluation.
+- Expands deterministic test suite in `tests/runtime/test_comparative_benchmark_antigravity_executor.py` with zero live model turns.
+- Updates machine discovery in `README.json`, machine binding record `machine/benchmarking/antigravity-executor-binding.v1.json`, and documentation `docs/benchmarking/COMPARATIVE_MEASUREMENT_B3.md`.
+
 ## Post-v1.6.0 Comparative Benchmark B3.1.2 Communication Arm Operationalization - Candidate
 
 - Operationalizes `DEFAULT`, `CAVEMAN`, and `MURMURS` communication treatments in `scripts/antigravity_benchmark_executor.py` into distinct, machine-verifiable benchmark treatments.

--- a/README.json
+++ b/README.json
@@ -187,7 +187,7 @@
     },
     "comparative_measurement_b3_1": {
       "status": "IMPLEMENTED_NON_CALIBRATED",
-      "purpose": "Bounded Antigravity measurement executor binding and B3.1.2 communication-arm operationalization for the Orchestra comparative benchmark harness with explicit DEFAULT, CAVEMAN, and MURMURS treatments, pinned Caveman external baseline, canonical Murmurs presentation binding, stream-json transport support, hardened print-mode invocation, fail-closed preflight, explicit provenance semantics, and strict outcome evaluation.",
+      "purpose": "Bounded Antigravity measurement executor binding and B3.1.3 exact host version pin externalization for the Orchestra comparative benchmark harness with explicit --expected-cli-version CLI argument, exact fail-closed version matching, qualified 1.1.15 host surface, explicit DEFAULT, CAVEMAN, and MURMURS treatments, pinned Caveman external baseline, canonical Murmurs presentation binding, stream-json transport support, hardened print-mode invocation, fail-closed preflight, explicit provenance semantics, and strict outcome evaluation.",
       "program_id": "orchestra.shared-comparative-benchmark.v1",
       "executor": "scripts/antigravity_benchmark_executor.py",
       "communication_arms": ["DEFAULT", "CAVEMAN", "MURMURS"],
@@ -200,8 +200,8 @@
       },
       "machine_sources": ["machine/benchmarking/antigravity-executor-binding.v1.json"],
       "human_sources": ["docs/benchmarking/COMPARATIVE_MEASUREMENT_B3.md"],
-      "canonical_json_counter_id": "antigravity-cli-1.1.14:json-usage:gemini-3.7-flash-high",
-      "canonical_stream_json_counter_id": "antigravity-cli-1.1.14:stream-json-usage:gemini-3.7-flash-high",
+      "canonical_json_counter_id": "antigravity-cli-1.1.15:json-usage:gemini-3.7-flash-high",
+      "canonical_stream_json_counter_id": "antigravity-cli-1.1.15:stream-json-usage:gemini-3.7-flash-high",
       "counter_identity_provenance": "ORCHESTRA_ASSIGNED_MEASUREMENT_SURFACE",
       "measurement_maturity": "MEASUREMENT_NOT_STARTED",
       "diagnostic_executed": false,
@@ -211,7 +211,7 @@
       "a5_execution_promotion": "NOT_AUTHORIZED",
       "a6_authorized": false,
       "b4_state": "BLOCKED",
-      "authority_note": "B3.1/B3.1.2 provides the bounded Antigravity measurement executor binding and communication-arm operationalization only. Diagnostic and calibration are not executed in this unit, Murmurs benefit is not established, fresh_billable_tokens and cost remain unavailable, A5 remains shadow-only, and B4 remains blocked."
+      "authority_note": "B3.1/B3.1.3 provides the bounded Antigravity measurement executor binding, exact host version pin externalization, and communication-arm operationalization only. Diagnostic and calibration are not executed in this unit, Murmurs benefit is not established, fresh_billable_tokens and cost remain unavailable, A5 remains shadow-only, and B4 remains blocked."
     }
   },
   "machine_scan_order": [

--- a/docs/benchmarking/COMPARATIVE_MEASUREMENT_B3.md
+++ b/docs/benchmarking/COMPARATIVE_MEASUREMENT_B3.md
@@ -5,11 +5,12 @@
 ```text
 Program: Orchestra Shared Comparative Benchmark
 Phase: B3 Murmurs Isolated Comparative Experiment
-Current bounded unit: B3.1.2 Communication Arm Operationalization
-State: B3_1_2_COMMUNICATION_ARM_OPERATIONALIZATION_IMPLEMENTED
-Canonical entry: dfeb94ee8dccd1e812b7e2c2a5ae8ae1c40b5874
-Canonical entry tree: ba672942a93dcf945a51dac104d990b672ee897b
-Authoritative benchmark machine state: B0/B1/B3.1.2 executor binding
+Current bounded unit: B3.1.3 Exact Host Version Pin Externalization
+State: B3_1_3_EXACT_HOST_VERSION_PIN_IMPLEMENTED_SOURCE_ONLY
+Canonical entry: 48007cbbbbfa6ce84747ed8b413b1d4af8ac895f
+Canonical entry tree: 62818f2a94c961725578e2297001f8692ad83444
+Authoritative benchmark machine state: B0/B1/B3.1.3 executor binding
+Validated local Antigravity host: Antigravity CLI 1.1.15
 Measurement maturity after unit implementation: MEASUREMENT_NOT_STARTED
 Murmurs benefit: NOT ESTABLISHED
 A5 execution-effective selection: NOT AUTHORIZED
@@ -19,7 +20,7 @@ Diagnostic execution: DIAGNOSTIC_READINESS_ONLY (NOT EXECUTED)
 Calibration execution: NOT EXECUTED
 ```
 
-B3.1.2 implements the communication arm operationalization needed for the Orchestra comparative benchmark harness, making `DEFAULT`, `CAVEMAN`, and `MURMURS` genuinely distinct and machine-verifiable before diagnostic or calibration execution.
+B3.1.3 externalizes the exact expected Antigravity host CLI version (`--expected-cli-version`), replacing the operational hard-coding of 1.1.14 while qualifying 1.1.15 via zero-turn structured preflight probes. It maintains exact fail-closed host/version identity for every comparative measurement batch and preserves the B3.1.2 communication treatments (`DEFAULT`, `CAVEMAN`, and `MURMURS`).
 
 It does not execute Antigravity model turns, does not execute the 3-run diagnostic, does not execute the 30-run calibration, does not measure live token savings or benefit, does not vendor Caveman, and does not alter production runtime routing.
 
@@ -30,12 +31,12 @@ ARM OPERATIONALIZATION IMPLEMENTATION != MEASURED CALIBRATION
 PLAN-ONLY VALIDATION != MEASURED CALIBRATION
 SYNTHETIC FIXTURE != MURMURS BENEFIT EVIDENCE
 CAVEMAN PUBLISHED RESULTS != ORCHESTRA RESULTS
-MEASUREMENT_NOT_STARTED remains current after B3.1.2
+MEASUREMENT_NOT_STARTED remains current after B3.1.3
 ```
 
-The authoritative benchmark machine state incorporates the B3.1.2 executor binding record (`machine/benchmarking/antigravity-executor-binding.v1.json`) alongside the B0 contract and B1 harness. Measurement maturity remains `MEASUREMENT_NOT_STARTED` until genuine calibrated evidence is collected.
+The authoritative benchmark machine state incorporates the B3.1.3 executor binding record (`machine/benchmarking/antigravity-executor-binding.v1.json`) alongside the B0 contract and B1 harness. Measurement maturity remains `MEASUREMENT_NOT_STARTED` until genuine calibrated evidence is collected.
 
-## B3.1.2 Communication Treatments
+## B3.1.2 / B3.1.3 Communication Treatments
 
 The three communication arms are deterministically bound by the executor:
 
@@ -74,8 +75,8 @@ Under B3 comparative measurement:
 The executor supports host-native structured JSON and NDJSON event streaming (`stream-json`):
 
 ```text
-Canonical json counter:        antigravity-cli-1.1.14:json-usage:gemini-3.7-flash-high
-Canonical stream-json counter: antigravity-cli-1.1.14:stream-json-usage:gemini-3.7-flash-high
+Canonical json counter:        antigravity-cli-1.1.15:json-usage:gemini-3.7-flash-high
+Canonical stream-json counter: antigravity-cli-1.1.15:stream-json-usage:gemini-3.7-flash-high
 ```
 
 Paired comparability invariants:

--- a/machine/benchmarking/antigravity-executor-binding.v1.json
+++ b/machine/benchmarking/antigravity-executor-binding.v1.json
@@ -1,12 +1,14 @@
 {
   "schema_version": "orchestra.antigravity-executor-binding.v1",
   "program_id": "orchestra.shared-comparative-benchmark.v1",
-  "phase": "BENCHMARK_B3_1_2_COMMUNICATION_ARM_OPERATIONALIZATION",
+  "phase": "BENCHMARK_B3_1_3_EXACT_HOST_VERSION_PIN_EXTERNALIZATION",
   "status": "IMPLEMENTED_NON_CALIBRATED",
-  "canonical_entry_baseline": "dfeb94ee8dccd1e812b7e2c2a5ae8ae1c40b5874",
+  "canonical_entry_baseline": "48007cbbbbfa6ce84747ed8b413b1d4af8ac895f",
   "binding": {
     "host": "Antigravity CLI",
-    "cli_version": "1.1.14",
+    "cli_version": "1.1.15",
+    "validated_cli_version": "1.1.15",
+    "expected_cli_version_externalized": true,
     "model": "gemini-3.7-flash-high",
     "supported_transports": ["json-usage", "stream-json-usage"],
     "default_transport": "json-usage",
@@ -14,7 +16,15 @@
     "non_interactive": true,
     "personal_credit_fallback": "disabled",
     "use_g1_credits": false,
-    "executor_script": "scripts/antigravity_benchmark_executor.py"
+    "executor_script": "scripts/antigravity_benchmark_executor.py",
+    "qualification_method": "ZERO_TURN_STRUCTURED_PREFLIGHT_PROBES",
+    "qualification_evidence": {
+      "structured_command_probes": ["/model", "/effort", "/usage"],
+      "num_turns": 0,
+      "usage_counters": 0,
+      "model": "gemini-3.7-flash-high",
+      "status": "QUALIFIED"
+    }
   },
   "communication_arms": {
     "default": {
@@ -45,8 +55,8 @@
     }
   },
   "counter_identity": {
-    "canonical_json_counter_id": "antigravity-cli-1.1.14:json-usage:gemini-3.7-flash-high",
-    "canonical_stream_json_counter_id": "antigravity-cli-1.1.14:stream-json-usage:gemini-3.7-flash-high",
+    "canonical_json_counter_id": "antigravity-cli-1.1.15:json-usage:gemini-3.7-flash-high",
+    "canonical_stream_json_counter_id": "antigravity-cli-1.1.15:stream-json-usage:gemini-3.7-flash-high",
     "provenance": "ORCHESTRA_ASSIGNED_MEASUREMENT_SURFACE",
     "vendor_assigned_claim": false,
     "paired_comparability_rule": "IDENTICAL_COUNTER_IDENTITY_REQUIRED_ACROSS_ALL_ARMS"
@@ -71,6 +81,8 @@
     "fail_closed_on_counter_identity_drift": true,
     "fail_closed_on_corrupted_starting_state": true,
     "fail_closed_on_caveman_policy_mismatch": true,
+    "fail_closed_on_missing_expected_cli_version": true,
+    "fail_closed_on_cli_version_mismatch": true,
     "raw_outer_envelope_preserved": true,
     "no_metric_inference": true
   },
@@ -84,9 +96,13 @@
     ]
   },
   "governance_boundaries": {
-    "b3_1_2_communication_arm_operationalization": "IMPLEMENTED",
+    "b3_1_3_exact_host_version_pin": "IMPLEMENTED_SOURCE_ONLY",
+    "current_validated_agy_version": "1.1.15",
     "b3_measurement_maturity": "MEASUREMENT_NOT_STARTED",
+    "b3_diagnostic_execution": "NOT_STARTED",
+    "b3_calibration_execution": "NOT_STARTED",
     "murmurs_benefit": "NOT_ESTABLISHED",
+    "murmurs_token_savings": "NOT_CLAIMED",
     "a5_benefit": "NOT_ESTABLISHED",
     "a5_execution_promotion": "NOT_AUTHORIZED",
     "a6_authorized": false,

--- a/scripts/antigravity_benchmark_executor.py
+++ b/scripts/antigravity_benchmark_executor.py
@@ -1,17 +1,19 @@
 #!/usr/bin/env python3
 """Antigravity measurement executor binding for Orchestra comparative benchmark.
 
-Provides the B3.1.2 executor adapter for Antigravity CLI host-native execution,
+Provides the B3.1.3 executor adapter for Antigravity CLI host-native execution,
 deterministic communication-arm binding (DEFAULT, CAVEMAN, MURMURS), fail-closed
-preflight validation, structured usage parsing, stream-json event parsing, and
-Orchestra-compatible benchmark result construction.
+preflight validation, externalized exact CLI version expectation, structured
+usage parsing, stream-json event parsing, and Orchestra-compatible benchmark
+result construction.
 
 Measurement Surface Provenance:
 - Counter ID format: "antigravity-cli-{cli_version}:{transport}:{model}"
-- Canonical default (json): "antigravity-cli-1.1.14:json-usage:gemini-3.7-flash-high"
-- Canonical stream (stream-json): "antigravity-cli-1.1.14:stream-json-usage:gemini-3.7-flash-high"
+- Canonical default (json): "antigravity-cli-1.1.15:json-usage:gemini-3.7-flash-high"
+- Canonical stream (stream-json): "antigravity-cli-1.1.15:stream-json-usage:gemini-3.7-flash-high"
 - Provenance semantics:
-  - CLI version: source = PREFLIGHT_COMMAND (exact validated `agy --version`)
+  - Expected CLI version: source = EXECUTOR_ARGUMENT (--expected-cli-version)
+  - Observed CLI version: source = PREFLIGHT_COMMAND (exact validated `agy --version`)
   - Model: source = PINNED_COMMAND_ARGUMENT (gemini-3.7-flash-high)
   - Usage counters: source = HOST_REPORTED_JSON_USAGE or HOST_REPORTED_STREAM_JSON_USAGE
   - Counter ID: provenance = ORCHESTRA_ASSIGNED_MEASUREMENT_SURFACE
@@ -37,6 +39,7 @@ import copy
 import hashlib
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -51,13 +54,28 @@ EXECUTOR_RESULT_VERSION = "orchestra.comparative-benchmark-executor-result.v1"
 EXECUTOR_REQUEST_VERSION = "orchestra.comparative-benchmark-executor-request.v1"
 PROGRAM_ID = "orchestra.shared-comparative-benchmark.v1"
 
-PINNED_CLI_VERSION = "1.1.14"
+QUALIFIED_CLI_VERSION = "1.1.15"
+PINNED_CLI_VERSION = QUALIFIED_CLI_VERSION
 PINNED_MODEL = "gemini-3.7-flash-high"
 PINNED_TRANSPORT_JSON = "json-usage"
 PINNED_TRANSPORT_STREAM = "stream-json-usage"
 PINNED_TRANSPORT = PINNED_TRANSPORT_JSON
-DEFAULT_COUNTER_ID = f"antigravity-cli-{PINNED_CLI_VERSION}:{PINNED_TRANSPORT_JSON}:{PINNED_MODEL}"
-STREAM_JSON_COUNTER_ID = f"antigravity-cli-{PINNED_CLI_VERSION}:{PINNED_TRANSPORT_STREAM}:{PINNED_MODEL}"
+DEFAULT_COUNTER_ID = f"antigravity-cli-{QUALIFIED_CLI_VERSION}:{PINNED_TRANSPORT_JSON}:{PINNED_MODEL}"
+STREAM_JSON_COUNTER_ID = f"antigravity-cli-{QUALIFIED_CLI_VERSION}:{PINNED_TRANSPORT_STREAM}:{PINNED_MODEL}"
+
+VERSION_PATTERN = re.compile(r"^\d+\.\d+\.\d+(?:[-.][0-9A-Za-z]+)*$")
+
+
+def validate_version_format(version: Any) -> bool:
+    """Validate that version string is an exact semantic version without ranges, operators, or wildcards."""
+    if not isinstance(version, str):
+        return False
+    v = version.strip()
+    if not v:
+        return False
+    if any(op in v for op in (">", "<", "=", "~", "^", "*", "latest", "LATEST")):
+        return False
+    return bool(VERSION_PATTERN.match(v))
 
 PINNED_CAVEMAN_REPO = "JuliusBrussee/caveman"
 PINNED_CAVEMAN_REVISION = "ae405e872270acc57484693612ae038b16c8f6cd"
@@ -440,6 +458,7 @@ def bind_communication_treatment(
 
 def run_host_preflight(
     request: dict[str, Any],
+    expected_cli_version: str | None = None,
     settings_path: Path | None = None,
     version_runner_fn: Callable[[list[str]], tuple[int, str, str]] | None = None,
     transport: str = PINNED_TRANSPORT,
@@ -447,15 +466,27 @@ def run_host_preflight(
     """Execute fail-closed host preflight before real model invocation.
 
     Invariants verified:
-    1. Resolved Antigravity CLI version is exactly 1.1.14.
-    2. settings.json exists and parses successfully.
-    3. useG1Credits is explicitly False.
-    4. Benchmark model in request control_identity remains exactly gemini-3.7-flash-high.
-    5. Expected counter identity matches the specified transport.
+    1. Expected CLI version is explicitly provided, non-empty, and valid format.
+    2. Resolved Antigravity CLI version from `agy --version` exactly equals expected_cli_version.
+    3. settings.json exists and parses successfully.
+    4. useG1Credits is explicitly False.
+    5. Benchmark model in request control_identity remains exactly gemini-3.7-flash-high.
+    6. Expected counter identity matches the specified transport and version.
 
     Returns:
         (is_valid, invalid_reason, detail, validated_cli_version)
     """
+    if expected_cli_version is None or not validate_version_format(expected_cli_version):
+        return (
+            False,
+            "MEASUREMENT_CAPTURE_FAILURE",
+            {
+                "error": f"invalid or missing expected_cli_version: {expected_cli_version!r}",
+                "expected_cli_version": expected_cli_version,
+            },
+            None,
+        )
+
     req_control = request.get("control_identity", {})
     req_model = req_control.get("model", PINNED_MODEL)
     if req_model != PINNED_MODEL:
@@ -557,19 +588,20 @@ def run_host_preflight(
     raw_version = stdout.strip()
     tokens = raw_version.split()
     resolved_version = tokens[-1] if tokens else ""
-    if resolved_version != PINNED_CLI_VERSION:
+    if resolved_version != expected_cli_version:
         return (
             False,
             "MEASUREMENT_CAPTURE_FAILURE",
             {
-                "error": f"resolved CLI version {resolved_version!r} does not match pinned version {PINNED_CLI_VERSION!r}",
+                "error": f"resolved CLI version {resolved_version!r} does not match expected version {expected_cli_version!r}",
                 "raw_version_output": raw_version,
-                "pinned_version": PINNED_CLI_VERSION,
+                "expected_version": expected_cli_version,
+                "observed_version": resolved_version,
             },
             None,
         )
 
-    expected_counter = compute_counter_id(cli_version=PINNED_CLI_VERSION, model=PINNED_MODEL, transport=transport)
+    expected_counter = compute_counter_id(cli_version=expected_cli_version, model=PINNED_MODEL, transport=transport)
     counter_id = compute_counter_id(cli_version=resolved_version, model=PINNED_MODEL, transport=transport)
     if counter_id != expected_counter:
         return (
@@ -644,16 +676,19 @@ def build_invalid_result(
     reason: str,
     detail: dict[str, Any],
     elapsed_ms: int | None = None,
+    expected_cli_version: str | None = None,
 ) -> dict[str, Any]:
     """Build fail-closed INVALID_RUN executor result matching schema."""
     req_id = request.get("request_id", "unknown-request")
-    unavailable_evidence = {
+    unavailable_evidence: dict[str, Any] = {
         "request_id": req_id,
         "invalid_reason": reason,
         "detail": detail,
         "validation_executed": False,
         "governance_evaluated": False,
     }
+    if expected_cli_version is not None:
+        unavailable_evidence["expected_cli_version"] = expected_cli_version
     unavailable_digest = digest_json(unavailable_evidence)
     return {
         "schema_version": EXECUTOR_RESULT_VERSION,
@@ -776,7 +811,8 @@ def parse_stream_json_output(
     raw_output: str | list[Any],
     request: dict[str, Any],
     elapsed_ms: int | None = None,
-    validated_cli_version: str = PINNED_CLI_VERSION,
+    expected_cli_version: str | None = None,
+    validated_cli_version: str | None = None,
     binding: dict[str, Any] | None = None,
     presentation_root: Path | str | None = None,
 ) -> dict[str, Any]:
@@ -793,6 +829,7 @@ def parse_stream_json_output(
                     "MEASUREMENT_CAPTURE_FAILURE",
                     {"error": "stream event is not an object", "event": item},
                     elapsed_ms,
+                    expected_cli_version=expected_cli_version,
                 )
             events.append(item)
     elif isinstance(raw_output, str):
@@ -806,6 +843,7 @@ def parse_stream_json_output(
                     "MEASUREMENT_CAPTURE_FAILURE",
                     {"error": f"stream JSON decode error on line {idx + 1}: {exc}", "line": line},
                     elapsed_ms,
+                    expected_cli_version=expected_cli_version,
                 )
             if not isinstance(ev, dict):
                 return build_invalid_result(
@@ -813,6 +851,7 @@ def parse_stream_json_output(
                     "MEASUREMENT_CAPTURE_FAILURE",
                     {"error": f"stream line {idx + 1} is not a JSON object", "line": line},
                     elapsed_ms,
+                    expected_cli_version=expected_cli_version,
                 )
             events.append(ev)
     else:
@@ -821,6 +860,7 @@ def parse_stream_json_output(
             "MEASUREMENT_CAPTURE_FAILURE",
             {"error": f"unsupported stream output type: {type(raw_output).__name__}"},
             elapsed_ms,
+            expected_cli_version=expected_cli_version,
         )
 
     if not events:
@@ -829,6 +869,7 @@ def parse_stream_json_output(
             "MEASUREMENT_CAPTURE_FAILURE",
             {"error": "empty event stream"},
             elapsed_ms,
+            expected_cli_version=expected_cli_version,
         )
 
     # Locate terminal result
@@ -851,6 +892,7 @@ def parse_stream_json_output(
             "MEASUREMENT_CAPTURE_FAILURE",
             {"error": f"terminal stream status is not SUCCESS: {status}", "terminal_envelope": terminal_envelope},
             elapsed_ms,
+            expected_cli_version=expected_cli_version,
         )
 
     usage = terminal_envelope.get("usage")
@@ -860,23 +902,50 @@ def parse_stream_json_output(
             "MEASUREMENT_CAPTURE_FAILURE",
             {"error": "usage object missing from terminal event", "terminal_envelope": terminal_envelope},
             elapsed_ms,
+            expected_cli_version=expected_cli_version,
+        )
+
+    target_expected_version = expected_cli_version or QUALIFIED_CLI_VERSION
+    effective_cli_version = (
+        validated_cli_version
+        or terminal_envelope.get("cli_version")
+        or target_expected_version
+    )
+
+    if "cli_version" in terminal_envelope and terminal_envelope["cli_version"] != target_expected_version:
+        return build_invalid_result(
+            request,
+            "MEASUREMENT_CAPTURE_FAILURE",
+            {
+                "error": "terminal stream cli_version mismatch",
+                "host_cli_version": terminal_envelope["cli_version"],
+                "expected_cli_version": target_expected_version,
+            },
+            elapsed_ms,
+            expected_cli_version=target_expected_version,
         )
 
     counter_id = compute_counter_id(
-        cli_version=validated_cli_version,
+        cli_version=effective_cli_version,
         model=PINNED_MODEL,
         transport=PINNED_TRANSPORT_STREAM,
     )
-    if counter_id != STREAM_JSON_COUNTER_ID:
+    expected_counter = compute_counter_id(
+        cli_version=target_expected_version,
+        model=PINNED_MODEL,
+        transport=PINNED_TRANSPORT_STREAM,
+    )
+    if counter_id != expected_counter:
         return build_invalid_result(
             request,
             "MEASUREMENT_CAPTURE_FAILURE",
             {
                 "error": "stream-json counter identity changed inside paired batch",
                 "observed_counter_id": counter_id,
-                "expected_counter_id": STREAM_JSON_COUNTER_ID,
+                "expected_counter_id": expected_counter,
             },
             elapsed_ms,
+            expected_cli_version=target_expected_version,
         )
 
     try:
@@ -887,6 +956,7 @@ def parse_stream_json_output(
             "MEASUREMENT_CAPTURE_FAILURE",
             {"error": f"stream usage mapping failed: {exc}", "usage": usage},
             elapsed_ms,
+            expected_cli_version=target_expected_version,
         )
 
     outcome, quality = evaluate_task_outcome(terminal_envelope, task_payload)
@@ -990,10 +1060,16 @@ def parse_stream_json_output(
     effective_binding = binding or {}
     raw_evidence = {
         "host": "Antigravity CLI",
-        "cli_version": validated_cli_version,
+        "expected_cli_version": target_expected_version,
+        "expected_cli_version_provenance": {
+            "source": "EXECUTOR_ARGUMENT" if expected_cli_version else "DEFAULT_QUALIFIED_HOST",
+            "value": target_expected_version,
+        },
+        "observed_cli_version": effective_cli_version,
+        "cli_version": effective_cli_version,
         "cli_version_provenance": {
-            "source": "PREFLIGHT_COMMAND",
-            "value": validated_cli_version,
+            "source": "PREFLIGHT_COMMAND" if validated_cli_version else "HOST_REPORTED_STREAM_JSON_USAGE",
+            "value": effective_cli_version,
         },
         "model": PINNED_MODEL,
         "model_provenance": {
@@ -1059,9 +1135,10 @@ def parse_antigravity_output(
     raw_output: str | dict[str, Any] | list[dict[str, Any]],
     request: dict[str, Any],
     elapsed_ms: int | None = None,
-    validated_cli_version: str = PINNED_CLI_VERSION,
+    expected_cli_version: str | None = None,
+    validated_cli_version: str | None = None,
     binding: dict[str, Any] | None = None,
-    transport: str = PINNED_TRANSPORT,
+    transport: str = PINNED_TRANSPORT_JSON,
     presentation_root: Path | str | None = None,
 ) -> dict[str, Any]:
     """Parse raw Antigravity output (JSON or stream-json) and construct Orchestra benchmark result."""
@@ -1076,6 +1153,7 @@ def parse_antigravity_output(
                 b_reason or "MEASUREMENT_CAPTURE_FAILURE",
                 b_detail or {"error": "communication treatment binding failed"},
                 elapsed_ms,
+                expected_cli_version=expected_cli_version,
             )
         binding = resolved_binding
 
@@ -1085,6 +1163,7 @@ def parse_antigravity_output(
             raw_output,
             request,
             elapsed_ms=elapsed_ms,
+            expected_cli_version=expected_cli_version,
             validated_cli_version=validated_cli_version,
             binding=binding,
             presentation_root=presentation_root,
@@ -1098,6 +1177,7 @@ def parse_antigravity_output(
                 raw_output,
                 request,
                 elapsed_ms=elapsed_ms,
+                expected_cli_version=expected_cli_version,
                 validated_cli_version=validated_cli_version,
                 binding=binding,
                 presentation_root=presentation_root,
@@ -1114,6 +1194,7 @@ def parse_antigravity_output(
                 "MEASUREMENT_CAPTURE_FAILURE",
                 {"error": f"outer JSON decode failure: {exc}", "raw_stdout": raw_output},
                 elapsed_ms,
+                expected_cli_version=expected_cli_version,
             )
     elif isinstance(raw_output, dict):
         envelope = raw_output
@@ -1123,6 +1204,7 @@ def parse_antigravity_output(
             "MEASUREMENT_CAPTURE_FAILURE",
             {"error": f"unsupported output type: {type(raw_output).__name__}"},
             elapsed_ms,
+            expected_cli_version=expected_cli_version,
         )
 
     if not isinstance(envelope, dict):
@@ -1131,6 +1213,7 @@ def parse_antigravity_output(
             "MEASUREMENT_CAPTURE_FAILURE",
             {"error": "outer JSON is not an object", "raw_output": envelope},
             elapsed_ms,
+            expected_cli_version=expected_cli_version,
         )
 
     status = envelope.get("status")
@@ -1140,6 +1223,7 @@ def parse_antigravity_output(
             "MEASUREMENT_CAPTURE_FAILURE",
             {"error": "missing or non-string status in outer envelope", "outer_envelope": envelope},
             elapsed_ms,
+            expected_cli_version=expected_cli_version,
         )
 
     if status.upper() != "SUCCESS":
@@ -1148,6 +1232,7 @@ def parse_antigravity_output(
             "MEASUREMENT_CAPTURE_FAILURE",
             {"error": f"host execution status is not usable: {status}", "outer_envelope": envelope},
             elapsed_ms,
+            expected_cli_version=expected_cli_version,
         )
 
     if "model" in envelope and envelope["model"] != PINNED_MODEL:
@@ -1160,6 +1245,7 @@ def parse_antigravity_output(
                 "pinned_model": PINNED_MODEL,
             },
             elapsed_ms,
+            expected_cli_version=expected_cli_version,
         )
 
     req_control = request.get("control_identity", {})
@@ -1174,22 +1260,32 @@ def parse_antigravity_output(
                 "pinned_model": PINNED_MODEL,
             },
             elapsed_ms,
+            expected_cli_version=expected_cli_version,
         )
 
-    if "cli_version" in envelope and envelope["cli_version"] != PINNED_CLI_VERSION:
+    target_expected_version = expected_cli_version or QUALIFIED_CLI_VERSION
+    host_cli_version = envelope.get("cli_version")
+    effective_cli_version = (
+        validated_cli_version
+        or host_cli_version
+        or target_expected_version
+    )
+
+    if host_cli_version is not None and host_cli_version != target_expected_version:
         return build_invalid_result(
             request,
             "MEASUREMENT_CAPTURE_FAILURE",
             {
                 "error": "host returned cli_version mismatch",
-                "host_cli_version": envelope["cli_version"],
-                "pinned_cli_version": PINNED_CLI_VERSION,
+                "host_cli_version": host_cli_version,
+                "expected_cli_version": target_expected_version,
             },
             elapsed_ms,
+            expected_cli_version=target_expected_version,
         )
 
-    expected_counter = compute_counter_id(cli_version=PINNED_CLI_VERSION, model=PINNED_MODEL, transport=transport)
-    counter_id = compute_counter_id(cli_version=validated_cli_version, model=PINNED_MODEL, transport=transport)
+    expected_counter = compute_counter_id(cli_version=target_expected_version, model=PINNED_MODEL, transport=transport)
+    counter_id = compute_counter_id(cli_version=effective_cli_version, model=PINNED_MODEL, transport=transport)
     if counter_id != expected_counter:
         return build_invalid_result(
             request,
@@ -1200,6 +1296,7 @@ def parse_antigravity_output(
                 "expected_counter_id": expected_counter,
             },
             elapsed_ms,
+            expected_cli_version=target_expected_version,
         )
 
     usage = envelope.get("usage")
@@ -1209,6 +1306,7 @@ def parse_antigravity_output(
             "MEASUREMENT_CAPTURE_FAILURE",
             {"error": "native usage object is missing from outer envelope", "outer_envelope": envelope},
             elapsed_ms,
+            expected_cli_version=target_expected_version,
         )
 
     try:
@@ -1219,6 +1317,7 @@ def parse_antigravity_output(
             "MEASUREMENT_CAPTURE_FAILURE",
             {"error": f"usage mapping failed: {exc}", "usage": usage},
             elapsed_ms,
+            expected_cli_version=target_expected_version,
         )
 
     outcome, quality = evaluate_task_outcome(envelope, task_payload)
@@ -1269,10 +1368,16 @@ def parse_antigravity_output(
     effective_binding = binding or {}
     raw_evidence = {
         "host": "Antigravity CLI",
-        "cli_version": validated_cli_version,
+        "expected_cli_version": target_expected_version,
+        "expected_cli_version_provenance": {
+            "source": "EXECUTOR_ARGUMENT" if expected_cli_version else "DEFAULT_QUALIFIED_HOST",
+            "value": target_expected_version,
+        },
+        "observed_cli_version": effective_cli_version,
+        "cli_version": effective_cli_version,
         "cli_version_provenance": {
-            "source": "PREFLIGHT_COMMAND",
-            "value": validated_cli_version,
+            "source": "PREFLIGHT_COMMAND" if validated_cli_version else "HOST_REPORTED_JSON_USAGE",
+            "value": effective_cli_version,
         },
         "model": PINNED_MODEL,
         "model_provenance": {
@@ -1335,6 +1440,7 @@ def parse_antigravity_output(
 
 def execute_request(
     request: dict[str, Any],
+    expected_cli_version: str | None = None,
     runner_fn: Callable[..., tuple[int, str, str]] | None = None,
     settings_path: Path | None = None,
     version_runner_fn: Callable[[list[str]], tuple[int, str, str]] | None = None,
@@ -1373,6 +1479,25 @@ def execute_request(
             },
         )
 
+    expected_ver = (
+        expected_cli_version
+        or task_payload.get("expected_cli_version")
+        or req_control.get("expected_cli_version")
+        or request.get("expected_cli_version")
+        or os.environ.get("ORCHESTRA_EXPECTED_CLI_VERSION")
+        or os.environ.get("ANTIGRAVITY_EXPECTED_CLI_VERSION")
+    )
+    if expected_ver is not None and not validate_version_format(expected_ver):
+        return build_invalid_result(
+            request,
+            "MEASUREMENT_CAPTURE_FAILURE",
+            {
+                "error": f"invalid expected_cli_version format: {expected_ver!r}",
+                "expected_cli_version": expected_ver,
+            },
+            expected_cli_version=expected_ver,
+        )
+
     # Deterministically bind and preflight communication treatment
     is_valid, inv_reason, inv_detail, binding = bind_communication_treatment(
         request,
@@ -1386,6 +1511,7 @@ def execute_request(
             request,
             inv_reason or "MEASUREMENT_CAPTURE_FAILURE",
             inv_detail or {"error": "communication arm binding failed"},
+            expected_cli_version=expected_ver,
         )
 
     # Determine transport format and counter type
@@ -1407,14 +1533,25 @@ def execute_request(
             mock_output,
             request,
             elapsed_ms=10,
+            expected_cli_version=expected_ver,
             binding=binding,
             transport=transport_counter,
             presentation_root=presentation_root,
         )
 
+    # Live execution requires an explicitly supplied expected CLI version
+    if not expected_ver:
+        return build_invalid_result(
+            request,
+            "MEASUREMENT_CAPTURE_FAILURE",
+            {"error": "expected_cli_version is required for live execution but was not supplied"},
+            expected_cli_version=None,
+        )
+
     # Fail-closed host preflight before real model invocation
     preflight_valid, pf_reason, pf_detail, validated_version = run_host_preflight(
         request,
+        expected_cli_version=expected_ver,
         settings_path=settings_path,
         version_runner_fn=version_runner_fn,
         transport=transport_counter,
@@ -1424,9 +1561,10 @@ def execute_request(
             request,
             pf_reason or "MEASUREMENT_CAPTURE_FAILURE",
             pf_detail or {"error": "preflight failed"},
+            expected_cli_version=expected_ver,
         )
 
-    cli_version = validated_version or PINNED_CLI_VERSION
+    cli_version = validated_version or expected_ver
     effective_prompt = binding["effective_prompt"]
 
     # Validated Antigravity print-mode command interface
@@ -1464,6 +1602,7 @@ def execute_request(
                 "HARNESS_FAILURE",
                 {"error": f"failed to launch Antigravity CLI: {exc}"},
                 elapsed,
+                expected_cli_version=expected_ver,
             )
 
     elapsed = int((time.monotonic() - started) * 1000)
@@ -1473,12 +1612,14 @@ def execute_request(
             "MEASUREMENT_CAPTURE_FAILURE",
             {"returncode": returncode, "stdout": stdout, "stderr": stderr},
             elapsed,
+            expected_cli_version=expected_ver,
         )
 
     return parse_antigravity_output(
         stdout,
         request,
         elapsed,
+        expected_cli_version=expected_ver,
         validated_cli_version=cli_version,
         binding=binding,
         transport=transport_counter,
@@ -1489,6 +1630,7 @@ def execute_request(
 def main(argv: list[str] | None = None) -> int:
     """CLI entrypoint reading one JSON request on stdin and writing JSON result on stdout."""
     parser = argparse.ArgumentParser(description="Antigravity measurement executor binding for Orchestra benchmark.")
+    parser.add_argument("--expected-cli-version", type=str, default=None, help="Exact expected Antigravity CLI version (e.g. 1.1.15)")
     parser.add_argument("--request-file", type=Path, help="Optional request JSON file (default: stdin)")
     parser.add_argument("--output-file", type=Path, help="Optional output JSON file (default: stdout)")
     args = parser.parse_args(argv)
@@ -1500,14 +1642,19 @@ def main(argv: list[str] | None = None) -> int:
             raw_req = sys.stdin.read()
         request = json.loads(raw_req)
     except Exception as exc:
-        err_res = build_invalid_result({}, "HARNESS_FAILURE", {"error": f"cannot read/parse request JSON: {exc}"})
+        err_res = build_invalid_result(
+            {},
+            "HARNESS_FAILURE",
+            {"error": f"cannot read/parse request JSON: {exc}"},
+            expected_cli_version=args.expected_cli_version,
+        )
         if args.output_file:
             args.output_file.write_text(json.dumps(err_res, indent=2) + "\n", encoding="utf-8")
         else:
             print(json.dumps(err_res, indent=2))
         return 0
 
-    result = execute_request(request)
+    result = execute_request(request, expected_cli_version=args.expected_cli_version)
     out_str = json.dumps(result, indent=2) + "\n"
 
     if args.output_file:

--- a/tests/runtime/test_comparative_benchmark_antigravity_executor.py
+++ b/tests/runtime/test_comparative_benchmark_antigravity_executor.py
@@ -161,7 +161,7 @@ def _mock_host_envelope(
     cache_read_tokens: int = 300,
     total_tokens: int = 2320,
     model: str = "gemini-3.7-flash-high",
-    cli_version: str = "1.1.14",
+    cli_version: str = "1.1.15",
     task_completed: bool = True,
     validation_passed: bool = True,
     governance_valid: bool = True,
@@ -204,7 +204,7 @@ def test_01_valid_antigravity_usage_maps_to_host_reported_tokens() -> None:
     _validate_result_schema(res)
 
     assert res["tokens"]["source"] == "HOST_REPORTED"
-    assert res["tokens"]["counter_id"] == "antigravity-cli-1.1.14:json-usage:gemini-3.7-flash-high"
+    assert res["tokens"]["counter_id"] == "antigravity-cli-1.1.15:json-usage:gemini-3.7-flash-high"
     assert res["tokens"]["input_tokens"] == 1000
     assert res["tokens"]["output_tokens"] == 250
 
@@ -353,8 +353,8 @@ def test_11_host_success_without_independent_evidence_cannot_produce_pass() -> N
 
 def test_12_counter_identity_is_deterministic() -> None:
     cid1 = executor.compute_counter_id()
-    cid2 = executor.compute_counter_id("1.1.14", "gemini-3.7-flash-high", "json-usage")
-    assert cid1 == "antigravity-cli-1.1.14:json-usage:gemini-3.7-flash-high"
+    cid2 = executor.compute_counter_id("1.1.15", "gemini-3.7-flash-high", "json-usage")
+    assert cid1 == "antigravity-cli-1.1.15:json-usage:gemini-3.7-flash-high"
     assert cid1 == cid2 == executor.DEFAULT_COUNTER_ID
 
 
@@ -367,7 +367,7 @@ def test_13_changed_cli_or_model_identity_changes_counter_identity() -> None:
 
     cid_model_change = executor.compute_counter_id(model="gemini-2.5-pro")
     assert cid_model_change != base_cid
-    assert cid_model_change == "antigravity-cli-1.1.14:json-usage:gemini-2.5-pro"
+    assert cid_model_change == "antigravity-cli-1.1.15:json-usage:gemini-2.5-pro"
 
     envelope_drift = _mock_host_envelope(cli_version="1.2.0")
     res = executor.execute_request(_base_request(raw_host_output=envelope_drift))
@@ -425,7 +425,7 @@ def test_17_live_argv_construction_and_no_stdin_prompt(tmp_path: Path) -> None:
     captured_calls: list[dict[str, Any]] = []
 
     def mock_version_runner(cmd: list[str]) -> tuple[int, str, str]:
-        return (0, "1.1.14\n", "")
+        return (0, "1.1.15\n", "")
 
     def mock_model_runner(cmd: list[str], prompt: str) -> tuple[int, str, str]:
         captured_calls.append({"cmd": cmd, "prompt": prompt})
@@ -440,6 +440,7 @@ def test_17_live_argv_construction_and_no_stdin_prompt(tmp_path: Path) -> None:
     req = _base_request(prompt=test_prompt)
     res = executor.execute_request(
         req,
+        expected_cli_version="1.1.15",
         runner_fn=mock_model_runner,
         settings_path=settings_file,
         version_runner_fn=mock_version_runner,
@@ -466,13 +467,13 @@ def test_17_live_argv_construction_and_no_stdin_prompt(tmp_path: Path) -> None:
     assert res["outcome"]["status"] == "PASS"
 
 
-def test_18_preflight_accepts_exact_cli_version_1_1_14(tmp_path: Path) -> None:
+def test_18_preflight_accepts_exact_cli_version_1_1_15(tmp_path: Path) -> None:
     settings_file = _create_mock_settings(tmp_path, use_g1_credits=False)
     model_called = False
 
     def mock_version_runner(cmd: list[str]) -> tuple[int, str, str]:
         assert cmd == ["agy", "--version"]
-        return (0, "antigravity-cli 1.1.14\n", "")
+        return (0, "antigravity-cli 1.1.15\n", "")
 
     def mock_model_runner(cmd: list[str], prompt: str) -> tuple[int, str, str]:
         nonlocal model_called
@@ -482,6 +483,7 @@ def test_18_preflight_accepts_exact_cli_version_1_1_14(tmp_path: Path) -> None:
     req = _base_request(prompt="Sample prompt")
     res = executor.execute_request(
         req,
+        expected_cli_version="1.1.15",
         runner_fn=mock_model_runner,
         settings_path=settings_file,
         version_runner_fn=mock_version_runner,
@@ -490,7 +492,7 @@ def test_18_preflight_accepts_exact_cli_version_1_1_14(tmp_path: Path) -> None:
 
     assert model_called is True
     assert res["outcome"]["status"] == "PASS"
-    assert res["raw_evidence"]["cli_version"] == "1.1.14"
+    assert res["raw_evidence"]["cli_version"] == "1.1.15"
 
 
 def test_19_preflight_fails_closed_on_different_cli_version(tmp_path: Path) -> None:
@@ -508,6 +510,7 @@ def test_19_preflight_fails_closed_on_different_cli_version(tmp_path: Path) -> N
     req = _base_request(prompt="Sample prompt")
     res = executor.execute_request(
         req,
+        expected_cli_version="1.1.15",
         runner_fn=mock_model_runner,
         settings_path=settings_file,
         version_runner_fn=mock_version_runner,
@@ -525,7 +528,7 @@ def test_20_preflight_accepts_explicit_use_g1_credits_false(tmp_path: Path) -> N
     model_called = False
 
     def mock_version_runner(cmd: list[str]) -> tuple[int, str, str]:
-        return (0, "1.1.14\n", "")
+        return (0, "1.1.15\n", "")
 
     def mock_model_runner(cmd: list[str], prompt: str) -> tuple[int, str, str]:
         nonlocal model_called
@@ -535,6 +538,7 @@ def test_20_preflight_accepts_explicit_use_g1_credits_false(tmp_path: Path) -> N
     req = _base_request(prompt="Sample prompt")
     res = executor.execute_request(
         req,
+        expected_cli_version="1.1.15",
         runner_fn=mock_model_runner,
         settings_path=settings_file,
         version_runner_fn=mock_version_runner,
@@ -550,7 +554,7 @@ def test_21_preflight_fails_closed_on_use_g1_credits_true(tmp_path: Path) -> Non
     model_called = False
 
     def mock_version_runner(cmd: list[str]) -> tuple[int, str, str]:
-        return (0, "1.1.14\n", "")
+        return (0, "1.1.15\n", "")
 
     def mock_model_runner(cmd: list[str], prompt: str) -> tuple[int, str, str]:
         nonlocal model_called
@@ -560,6 +564,7 @@ def test_21_preflight_fails_closed_on_use_g1_credits_true(tmp_path: Path) -> Non
     req = _base_request(prompt="Sample prompt")
     res = executor.execute_request(
         req,
+        expected_cli_version="1.1.15",
         runner_fn=mock_model_runner,
         settings_path=settings_file,
         version_runner_fn=mock_version_runner,
@@ -574,12 +579,13 @@ def test_21_preflight_fails_closed_on_use_g1_credits_true(tmp_path: Path) -> Non
 
 def test_22_preflight_fails_closed_on_malformed_or_missing_settings(tmp_path: Path) -> None:
     def mock_version_runner(cmd: list[str]) -> tuple[int, str, str]:
-        return (0, "1.1.14\n", "")
+        return (0, "1.1.15\n", "")
 
     missing_settings = tmp_path / "non_existent_settings.json"
     req1 = _base_request(prompt="Sample prompt")
     res1 = executor.execute_request(
         req1,
+        expected_cli_version="1.1.15",
         settings_path=missing_settings,
         version_runner_fn=mock_version_runner,
     )
@@ -592,6 +598,7 @@ def test_22_preflight_fails_closed_on_malformed_or_missing_settings(tmp_path: Pa
     req2 = _base_request(prompt="Sample prompt")
     res2 = executor.execute_request(
         req2,
+        expected_cli_version="1.1.15",
         settings_path=malformed_settings,
         version_runner_fn=mock_version_runner,
     )
@@ -603,6 +610,7 @@ def test_22_preflight_fails_closed_on_malformed_or_missing_settings(tmp_path: Pa
     req3 = _base_request(prompt="Sample prompt")
     res3 = executor.execute_request(
         req3,
+        expected_cli_version="1.1.15",
         settings_path=missing_key_settings,
         version_runner_fn=mock_version_runner,
     )
@@ -621,14 +629,17 @@ def test_23_provenance_semantics_explicitly_preserved() -> None:
     _validate_result_schema(res)
 
     raw_ev = res["raw_evidence"]
-    assert raw_ev["cli_version_provenance"]["source"] == "PREFLIGHT_COMMAND"
-    assert raw_ev["cli_version_provenance"]["value"] == "1.1.14"
+    assert raw_ev["expected_cli_version"] == "1.1.15"
+    assert raw_ev["expected_cli_version_provenance"]["source"] == "DEFAULT_QUALIFIED_HOST"
+    assert raw_ev["observed_cli_version"] == "1.1.15"
+    assert raw_ev["cli_version_provenance"]["source"] == "HOST_REPORTED_JSON_USAGE"
+    assert raw_ev["cli_version_provenance"]["value"] == "1.1.15"
     assert raw_ev["model_provenance"]["source"] == "PINNED_COMMAND_ARGUMENT"
     assert raw_ev["model_provenance"]["value"] == "gemini-3.7-flash-high"
     assert raw_ev["usage_provenance"]["source"] == "HOST_REPORTED_JSON_USAGE"
     assert raw_ev["counter_id_provenance"]["provenance"] == "ORCHESTRA_ASSIGNED_MEASUREMENT_SURFACE"
     assert raw_ev["counter_id_provenance"]["vendor_assigned_claim"] is False
-    assert raw_ev["counter_id_provenance"]["identifier"] == "antigravity-cli-1.1.14:json-usage:gemini-3.7-flash-high"
+    assert raw_ev["counter_id_provenance"]["identifier"] == "antigravity-cli-1.1.15:json-usage:gemini-3.7-flash-high"
 
 
 def test_24_response_bytes_captured_from_response_field() -> None:
@@ -718,7 +729,7 @@ def test_25_runner_integration_with_antigravity_executor(tmp_path: Path) -> None
         schema = _load_schema("comparative-benchmark-run.schema.json")
         jsonschema.Draft202012Validator(schema).validate(run_record)
         assert run_record["tokens"]["source"] == "HOST_REPORTED"
-        assert run_record["tokens"]["counter_id"] == "antigravity-cli-1.1.14:json-usage:gemini-3.7-flash-high"
+        assert run_record["tokens"]["counter_id"] == "antigravity-cli-1.1.15:json-usage:gemini-3.7-flash-high"
         assert run_record["tokens"]["fresh_billable_tokens"] is None
         assert run_record["outcome"]["status"] == "PASS"
 
@@ -1039,7 +1050,7 @@ def test_41_stream_json_transport_supported_across_arms() -> None:
         _validate_result_schema(res)
 
         assert res["tokens"]["source"] == "HOST_REPORTED"
-        assert res["tokens"]["counter_id"] == "antigravity-cli-1.1.14:stream-json-usage:gemini-3.7-flash-high"
+        assert res["tokens"]["counter_id"] == "antigravity-cli-1.1.15:stream-json-usage:gemini-3.7-flash-high"
         assert res["raw_evidence"]["transport"] == "stream-json-usage"
         assert res["outcome"]["status"] == "PASS"
 
@@ -1087,7 +1098,7 @@ def test_43_stream_json_terminal_native_usage_counters_map_correctly() -> None:
 
     tok = res["tokens"]
     assert tok["source"] == "HOST_REPORTED"
-    assert tok["counter_id"] == "antigravity-cli-1.1.14:stream-json-usage:gemini-3.7-flash-high"
+    assert tok["counter_id"] == "antigravity-cli-1.1.15:stream-json-usage:gemini-3.7-flash-high"
     assert tok["input_tokens"] == 1400
     assert tok["output_tokens"] == 350
     assert tok["reasoning_tokens"] == 110
@@ -1101,8 +1112,8 @@ def test_44_json_and_stream_json_counter_identities_cannot_be_mixed(tmp_path: Pa
     cid_json = executor.compute_counter_id(transport="json-usage")
     cid_stream = executor.compute_counter_id(transport="stream-json-usage")
     assert cid_json != cid_stream
-    assert cid_json == "antigravity-cli-1.1.14:json-usage:gemini-3.7-flash-high"
-    assert cid_stream == "antigravity-cli-1.1.14:stream-json-usage:gemini-3.7-flash-high"
+    assert cid_json == "antigravity-cli-1.1.15:json-usage:gemini-3.7-flash-high"
+    assert cid_stream == "antigravity-cli-1.1.15:stream-json-usage:gemini-3.7-flash-high"
 
     # Runner cross-run invariant check fails if counter_id differs across runs
     manifest_path = tmp_path / "mixed_manifest.json"
@@ -1213,3 +1224,297 @@ def test_45_final_task_outcome_still_requires_independent_evidence() -> None:
         _validate_result_schema(res2)
         assert res2["outcome"]["status"] == "FAIL"
         assert res2["outcome"]["governance_valid"] is False
+
+
+# B3.1.3 Exact Host Version Pin Externalization Tests (14 Invariants)
+
+
+def test_46_preflight_passes_on_exact_expected_version_1_1_15(tmp_path: Path) -> None:
+    # Invariant 1: expected 1.1.15 + observed 1.1.15 passes preflight
+    settings_file = _create_mock_settings(tmp_path, use_g1_credits=False)
+    req = _base_request()
+    valid, reason, detail, ver = executor.run_host_preflight(
+        req,
+        expected_cli_version="1.1.15",
+        settings_path=settings_file,
+        version_runner_fn=lambda cmd: (0, "antigravity-cli 1.1.15\n", ""),
+    )
+    assert valid is True
+    assert reason is None
+    assert detail is None
+    assert ver == "1.1.15"
+
+
+def test_47_preflight_fails_closed_before_model_call_on_newer_version_1_1_16(tmp_path: Path) -> None:
+    # Invariant 2: expected 1.1.15 + observed 1.1.16 fails before model invocation
+    settings_file = _create_mock_settings(tmp_path, use_g1_credits=False)
+    req = _base_request()
+    valid, reason, detail, ver = executor.run_host_preflight(
+        req,
+        expected_cli_version="1.1.15",
+        settings_path=settings_file,
+        version_runner_fn=lambda cmd: (0, "antigravity-cli 1.1.16\n", ""),
+    )
+    assert valid is False
+    assert reason == "MEASUREMENT_CAPTURE_FAILURE"
+    assert "1.1.16" in str(detail)
+    assert ver is None
+
+
+def test_48_preflight_fails_closed_before_model_call_on_older_version_1_1_14(tmp_path: Path) -> None:
+    # Invariant 3: expected 1.1.15 + observed 1.1.14 fails before model invocation
+    settings_file = _create_mock_settings(tmp_path, use_g1_credits=False)
+    req = _base_request()
+    valid, reason, detail, ver = executor.run_host_preflight(
+        req,
+        expected_cli_version="1.1.15",
+        settings_path=settings_file,
+        version_runner_fn=lambda cmd: (0, "antigravity-cli 1.1.14\n", ""),
+    )
+    assert valid is False
+    assert reason == "MEASUREMENT_CAPTURE_FAILURE"
+    assert "1.1.14" in str(detail)
+    assert ver is None
+
+
+def test_49_live_execution_fails_closed_when_expected_version_missing() -> None:
+    # Invariant 4: missing expected version at CLI live execution fails closed
+    req = _base_request()
+    res = executor.execute_request(req)
+    _validate_result_schema(res)
+    assert res["outcome"]["status"] == "INVALID_RUN"
+    assert res["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+    assert "expected_cli_version" in str(res["raw_evidence"]["detail"])
+
+
+def test_50_empty_or_whitespace_expected_version_rejected(tmp_path: Path) -> None:
+    # Invariant 5: empty / whitespace expected version is rejected
+    settings_file = _create_mock_settings(tmp_path, use_g1_credits=False)
+    assert executor.validate_version_format("") is False
+    assert executor.validate_version_format("   ") is False
+    assert executor.validate_version_format(None) is False
+
+    req = _base_request()
+    res = executor.execute_request(
+        req,
+        expected_cli_version="   ",
+        settings_path=settings_file,
+        version_runner_fn=lambda cmd: (0, "1.1.15\n", ""),
+    )
+    _validate_result_schema(res)
+    assert res["outcome"]["status"] == "INVALID_RUN"
+    assert res["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+
+def test_51_malformed_expected_version_range_and_operators_rejected(tmp_path: Path) -> None:
+    # Invariant 6: malformed expected version (ranges, >=1.1.15, latest) is rejected
+    invalid_versions = [
+        ">=1.1.15",
+        "^1.1.15",
+        "~1.1.15",
+        "1.1.x",
+        "1.1.*",
+        "latest",
+        "LATEST",
+        "=1.1.15",
+        "1.1.15 - 1.1.16",
+    ]
+    settings_file = _create_mock_settings(tmp_path, use_g1_credits=False)
+    for bad_ver in invalid_versions:
+        assert executor.validate_version_format(bad_ver) is False
+        req = _base_request()
+        res = executor.execute_request(
+            req,
+            expected_cli_version=bad_ver,
+            settings_path=settings_file,
+            version_runner_fn=lambda cmd: (0, f"{bad_ver}\n", ""),
+        )
+        _validate_result_schema(res)
+        assert res["outcome"]["status"] == "INVALID_RUN"
+        assert res["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+
+def test_52_json_counter_identity_derives_from_exact_validated_version() -> None:
+    # Invariant 7: json counter identity derives from exact expected/validated version
+    cid_15 = executor.compute_counter_id(cli_version="1.1.15", transport="json-usage")
+    assert cid_15 == "antigravity-cli-1.1.15:json-usage:gemini-3.7-flash-high"
+
+    cid_14 = executor.compute_counter_id(cli_version="1.1.14", transport="json-usage")
+    assert cid_14 == "antigravity-cli-1.1.14:json-usage:gemini-3.7-flash-high"
+    assert cid_15 != cid_14
+
+
+def test_53_stream_json_counter_identity_derives_from_exact_validated_version() -> None:
+    # Invariant 8: stream-json counter identity derives from exact expected/validated version
+    cid_stream_15 = executor.compute_counter_id(cli_version="1.1.15", transport="stream-json-usage")
+    assert cid_stream_15 == "antigravity-cli-1.1.15:stream-json-usage:gemini-3.7-flash-high"
+
+    cid_stream_14 = executor.compute_counter_id(cli_version="1.1.14", transport="stream-json-usage")
+    assert cid_stream_14 == "antigravity-cli-1.1.14:stream-json-usage:gemini-3.7-flash-high"
+    assert cid_stream_15 != cid_stream_14
+
+
+def test_54_raw_evidence_records_dual_provenance_for_expected_and_observed_version(tmp_path: Path) -> None:
+    # Invariant 9: dual provenance (expected_cli_version + observed_cli_version) preserved
+    settings_file = _create_mock_settings(tmp_path, use_g1_credits=False)
+
+    def mock_version_runner(cmd: list[str]) -> tuple[int, str, str]:
+        return (0, "antigravity-cli 1.1.15\n", "")
+
+    def mock_model_runner(cmd: list[str], prompt: str) -> tuple[int, str, str]:
+        return (0, json.dumps(_mock_host_envelope(cli_version="1.1.15")), "")
+
+    req = _base_request()
+    res = executor.execute_request(
+        req,
+        expected_cli_version="1.1.15",
+        runner_fn=mock_model_runner,
+        settings_path=settings_file,
+        version_runner_fn=mock_version_runner,
+    )
+    _validate_result_schema(res)
+
+    raw_ev = res["raw_evidence"]
+    assert raw_ev["expected_cli_version"] == "1.1.15"
+    assert raw_ev["expected_cli_version_provenance"]["source"] == "EXECUTOR_ARGUMENT"
+    assert raw_ev["expected_cli_version_provenance"]["value"] == "1.1.15"
+    assert raw_ev["observed_cli_version"] == "1.1.15"
+    assert raw_ev["cli_version_provenance"]["source"] == "PREFLIGHT_COMMAND"
+    assert raw_ev["cli_version_provenance"]["value"] == "1.1.15"
+
+
+def test_55_counter_identity_drift_inside_paired_arms_fails_closed(tmp_path: Path) -> None:
+    # Invariant 10: counter identity cannot silently drift inside paired arms
+    manifest_path = tmp_path / "drift_manifest.json"
+    manifest = {
+        "schema_version": "orchestra.comparative-benchmark-manifest.v1",
+        "program_id": "orchestra.shared-comparative-benchmark.v1",
+        "experiment_id": "fixture-b3-drift",
+        "experiment_kind": "MURMURS_ISOLATED",
+        "stage": "CALIBRATION",
+        "randomization_seed": 12345,
+        "repetitions_per_arm": 1,
+        "executor_timeout_seconds": 30,
+        "common_control_identity": {
+            "orchestra_revision": "06ede6bde3aa7682194950ba9130ba52e4fb0ea5",
+            "repository_revision": "test-repo-rev",
+            "starting_state_digest": DIGEST,
+            "task_prompt_digest": DIGEST,
+            "system_instruction_digest": DIGEST,
+            "provider": "antigravity",
+            "model": "gemini-3.7-flash-high",
+            "model_revision": None,
+            "reasoning_setting": "default",
+            "temperature": 0.0,
+            "tool_access_digest": DIGEST,
+            "specialist_set_digest": DIGEST,
+            "required_specialist_set_digest": DIGEST,
+            "authority_digest": DIGEST,
+            "governance_digest": DIGEST,
+            "validation_contract_digest": DIGEST,
+            "environment_digest": DIGEST,
+            "retry_policy_digest": DIGEST,
+            "resource_budget_digest": DIGEST,
+        },
+        "arms": [
+            {"arm_id": "default", "topology_candidate_id": "fixed-top", "topology_class": "FIXED_DETERMINISTIC", "topology_digest": DIGEST, "communication_mode": "DEFAULT"},
+            {"arm_id": "caveman", "topology_candidate_id": "fixed-top", "topology_class": "FIXED_DETERMINISTIC", "topology_digest": DIGEST, "communication_mode": "CAVEMAN"},
+        ],
+        "tasks": [
+            {
+                "task_id": "task-01",
+                "task_class": "SINGLE_DOMAIN",
+                "starting_state_digest": DIGEST,
+                "task_prompt_digest": DIGEST,
+                "task_payload": {
+                    "raw_host_output": _mock_host_envelope(input_tokens=1000, output_tokens=200),
+                },
+            }
+        ],
+        "a5_evaluation": None,
+        "murmurs_evaluation": {"same_counter_identity_for_token_delta": True},
+        "interaction_evaluation": None,
+        "preregistration_digest": None,
+        "benefit_thresholds": None,
+    }
+
+    run_v15 = {
+        "task_id": "task-01",
+        "repetition_index": 1,
+        "outcome": {"status": "PASS"},
+        "tokens": {"source": "HOST_REPORTED", "counter_id": "antigravity-cli-1.1.15:json-usage:gemini-3.7-flash-high"},
+        "a5_shadow_observation": None,
+    }
+    run_v14 = {
+        "task_id": "task-01",
+        "repetition_index": 1,
+        "outcome": {"status": "PASS"},
+        "tokens": {"source": "HOST_REPORTED", "counter_id": "antigravity-cli-1.1.14:json-usage:gemini-3.7-flash-high"},
+        "a5_shadow_observation": None,
+    }
+    with pytest.raises(Exception, match="MURMURS_ISOLATED requires identical counter_id"):
+        runner.enforce_cross_run_invariants(manifest, [run_v15, run_v14])
+
+
+def test_56_historical_1_1_14_fixture_supported_when_expected_version_explicitly_set() -> None:
+    # Invariant 11: historical 1.1.14 fixture behavior supported by passing expected_cli_version="1.1.14" explicitly
+    envelope_14 = _mock_host_envelope(cli_version="1.1.14", input_tokens=1100, output_tokens=220)
+    req = _base_request(raw_host_output=envelope_14)
+    res = executor.execute_request(req, expected_cli_version="1.1.14")
+    _validate_result_schema(res)
+
+    assert res["outcome"]["status"] == "PASS"
+    assert res["tokens"]["counter_id"] == "antigravity-cli-1.1.14:json-usage:gemini-3.7-flash-high"
+    assert res["raw_evidence"]["expected_cli_version"] == "1.1.14"
+    assert res["raw_evidence"]["observed_cli_version"] == "1.1.14"
+
+
+def test_57_zero_live_antigravity_model_turns_in_test_suite() -> None:
+    # Invariant 12: zero live AGY model turns in tests
+    call_log: list[str] = []
+
+    def mock_model_runner(cmd: list[str], prompt: str) -> tuple[int, str, str]:
+        call_log.append("called")
+        return (0, json.dumps(_mock_host_envelope()), "")
+
+    # Mock output bypasses live subprocess entirely
+    req = _base_request(raw_host_output=_mock_host_envelope())
+    res = executor.execute_request(req, runner_fn=mock_model_runner)
+    assert len(call_log) == 0
+    assert res["outcome"]["status"] == "PASS"
+
+
+def test_58_all_b3_1_2_communication_treatments_remain_green_with_1_1_15() -> None:
+    # Invariant 13: all B3.1.2 treatment tests remain green
+    for mode in ("DEFAULT", "CAVEMAN", "MURMURS"):
+        req = _base_request(
+            communication_mode=mode,
+            caveman_policy_content=VALID_CAVEMAN_SKILL_MD if mode == "CAVEMAN" else None,
+            raw_host_output=_mock_host_envelope(cli_version="1.1.15"),
+        )
+        res = executor.execute_request(req, expected_cli_version="1.1.15")
+        _validate_result_schema(res)
+        assert res["outcome"]["status"] == "PASS"
+        assert res["raw_evidence"]["communication_mode"] == mode
+        assert res["tokens"]["counter_id"] == "antigravity-cli-1.1.15:json-usage:gemini-3.7-flash-high"
+
+
+def test_59_host_success_alone_cannot_become_benchmark_task_pass() -> None:
+    # Invariant 14: host SUCCESS alone cannot become benchmark task PASS
+    bare_success = {
+        "status": "SUCCESS",
+        "cli_version": "1.1.15",
+        "model": "gemini-3.7-flash-high",
+        "usage": {
+            "input_tokens": 1000,
+            "output_tokens": 200,
+        },
+    }
+    req = _base_request(raw_host_output=bare_success)
+    res = executor.execute_request(req, expected_cli_version="1.1.15")
+    _validate_result_schema(res)
+    assert res["outcome"]["status"] == "FAIL"
+    assert res["outcome"]["task_completed"] is False
+    assert res["outcome"]["validation_passed"] is False
+    assert res["outcome"]["governance_valid"] is False
+    assert res["tokens"]["source"] == "HOST_REPORTED"


### PR DESCRIPTION
## Governance State

`	ext
B3_1_3_EXACT_HOST_VERSION_PIN = IMPLEMENTED_SOURCE_ONLY
CURRENT_VALIDATED_AGY_VERSION = 1.1.15

B3_MEASUREMENT_MATURITY = MEASUREMENT_NOT_STARTED
B3_DIAGNOSTIC_EXECUTION = NOT_STARTED
B3_CALIBRATION_EXECUTION = NOT_STARTED

MURMURS_BENEFIT = NOT_ESTABLISHED
MURMURS_TOKEN_SAVINGS = NOT_CLAIMED

A5_BENEFIT = NOT_ESTABLISHED
A5_EXECUTION_PROMOTION = NOT_AUTHORIZED
A6 = NOT_AUTHORIZED
B4 = BLOCKED
`

## Qualified Measurement Surfaces

- ntigravity-cli-1.1.15:json-usage:gemini-3.7-flash-high
- ntigravity-cli-1.1.15:stream-json-usage:gemini-3.7-flash-high

Note: Counter IDs are Orchestra-assigned measurement-surface provenance, not provider-issued identifiers.

## Summary

- Externalizes the exact expected Antigravity host CLI version via --expected-cli-version CLI argument in scripts/antigravity_benchmark_executor.py.
- Rejects loose, range, wildcard, and operator version strings.
- Qualifies Antigravity CLI 1.1.15 host surface via zero-turn structured preflight probes (/model, /effort, /usage, 
um_turns=0, usage_counters=0, model=gemini-3.7-flash-high).
- Preserves all B3.1.2 communication treatments (DEFAULT, CAVEMAN, MURMURS).
- Fully covered by deterministic runtime tests with zero live model turns.