### PR TITLE
feat(benchmark): b3.1.4 antigravity sparse settings semantic preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Post-v1.6.0 Comparative Benchmark B3.1.4 Antigravity Sparse Settings Semantic Preflight - Candidate
+
+- Refactors Antigravity host preflight in `scripts/antigravity_benchmark_executor.py` to interpret `useG1Credits` according to documented Antigravity sparse-settings semantics where system default is `false`.
+- Introduces `resolve_use_g1_credits` deterministic helper mapping absent keys to effective `false` with `SYSTEM_DEFAULT_SPARSE_PERSISTENCE` provenance and explicit `false` to `EXPLICIT_SETTING` provenance.
+- Enforces fail-closed validation (`INVALID_RUN` / `MEASUREMENT_CAPTURE_FAILURE`) when `useG1Credits` is explicitly `true` or set to non-boolean/malformed values (`null`, `0`, `1`, `"false"`, `"true"`, `{}`, `[]`) without silent coercion.
+- Preserves the core benchmark invariant that `effective_use_g1_credits` must be `false`, keeping personal credit fallback strictly disabled during comparative measurement.
+- Preserves raw and effective provenance in `credit_fallback_policy` machine evidence across execution results.
+- Preserves all prior preflights: exact CLI version matching (1.1.15), model pinning (`gemini-3.7-flash-high`), stream-json and json counter identities, communication treatment bindings (`DEFAULT`, `CAVEMAN`, `MURMURS`), and independent task outcome evaluation.
+- Adds comprehensive deterministic runtime test coverage in `tests/runtime/test_comparative_benchmark_antigravity_executor.py` with zero live model turns.
+- Updates machine discovery in `README.json`, machine binding record `machine/benchmarking/antigravity-executor-binding.v1.json`, and documentation in `docs/benchmarking/COMPARATIVE_MEASUREMENT_B3.md`.
+
 ## Post-v1.6.0 Comparative Benchmark B3.1.3 Exact Host Version Pin Externalization - Candidate
 
 - Externalizes the exact expected Antigravity host CLI version via `--expected-cli-version` CLI argument in `scripts/antigravity_benchmark_executor.py`, removing operational hard-coding while preserving exact fail-closed version matching.

--- a/README.json
+++ b/README.json
@@ -187,7 +187,7 @@
     },
     "comparative_measurement_b3_1": {
       "status": "IMPLEMENTED_NON_CALIBRATED",
-      "purpose": "Bounded Antigravity measurement executor binding and B3.1.3 exact host version pin externalization for the Orchestra comparative benchmark harness with explicit --expected-cli-version CLI argument, exact fail-closed version matching, qualified 1.1.15 host surface, explicit DEFAULT, CAVEMAN, and MURMURS treatments, pinned Caveman external baseline, canonical Murmurs presentation binding, stream-json transport support, hardened print-mode invocation, fail-closed preflight, explicit provenance semantics, and strict outcome evaluation.",
+      "purpose": "Bounded Antigravity measurement executor binding, B3.1.3 exact host version pin externalization, and B3.1.4 sparse settings semantic preflight for the Orchestra comparative benchmark harness with explicit --expected-cli-version CLI argument, exact fail-closed version matching, qualified 1.1.15 host surface, sparse useG1Credits resolution (system default false), explicit DEFAULT, CAVEMAN, and MURMURS treatments, pinned Caveman external baseline, canonical Murmurs presentation binding, stream-json transport support, hardened print-mode invocation, fail-closed preflight, explicit provenance semantics, and strict outcome evaluation.",
       "program_id": "orchestra.shared-comparative-benchmark.v1",
       "executor": "scripts/antigravity_benchmark_executor.py",
       "communication_arms": ["DEFAULT", "CAVEMAN", "MURMURS"],
@@ -211,7 +211,7 @@
       "a5_execution_promotion": "NOT_AUTHORIZED",
       "a6_authorized": false,
       "b4_state": "BLOCKED",
-      "authority_note": "B3.1/B3.1.3 provides the bounded Antigravity measurement executor binding, exact host version pin externalization, and communication-arm operationalization only. Diagnostic and calibration are not executed in this unit, Murmurs benefit is not established, fresh_billable_tokens and cost remain unavailable, A5 remains shadow-only, and B4 remains blocked."
+      "authority_note": "B3.1/B3.1.4 provides the bounded Antigravity measurement executor binding, exact host version pin externalization, sparse settings semantic preflight, and communication-arm operationalization only. Diagnostic and calibration are not executed in this unit, Murmurs benefit is not established, fresh_billable_tokens and cost remain unavailable, personal credit fallback remains disabled, A5 remains shadow-only, and B4 remains blocked."
     }
   },
   "machine_scan_order": [

--- a/docs/benchmarking/COMPARATIVE_MEASUREMENT_B3.md
+++ b/docs/benchmarking/COMPARATIVE_MEASUREMENT_B3.md
@@ -5,11 +5,11 @@
 ```text
 Program: Orchestra Shared Comparative Benchmark
 Phase: B3 Murmurs Isolated Comparative Experiment
-Current bounded unit: B3.1.3 Exact Host Version Pin Externalization
-State: B3_1_3_EXACT_HOST_VERSION_PIN_IMPLEMENTED_SOURCE_ONLY
-Canonical entry: 48007cbbbbfa6ce84747ed8b413b1d4af8ac895f
-Canonical entry tree: 62818f2a94c961725578e2297001f8692ad83444
-Authoritative benchmark machine state: B0/B1/B3.1.3 executor binding
+Current bounded unit: B3.1.4 Sparse Settings Semantic Preflight
+State: B3_1_4_SPARSE_SETTINGS_PREFLIGHT_IMPLEMENTED_SOURCE_ONLY
+Canonical entry: b0f14ade2ce9bb2b5b25ae7c653cb94345af5dcb
+Canonical entry tree: 4dbcb6b4ff07a410fb3e1b57e9526fb9f0c851d0
+Authoritative benchmark machine state: B0/B1/B3.1.4 executor binding
 Validated local Antigravity host: Antigravity CLI 1.1.15
 Measurement maturity after unit implementation: MEASUREMENT_NOT_STARTED
 Murmurs benefit: NOT ESTABLISHED
@@ -20,7 +20,7 @@ Diagnostic execution: DIAGNOSTIC_READINESS_ONLY (NOT EXECUTED)
 Calibration execution: NOT EXECUTED
 ```
 
-B3.1.3 externalizes the exact expected Antigravity host CLI version (`--expected-cli-version`), replacing the operational hard-coding of 1.1.14 while qualifying 1.1.15 via zero-turn structured preflight probes. It maintains exact fail-closed host/version identity for every comparative measurement batch and preserves the B3.1.2 communication treatments (`DEFAULT`, `CAVEMAN`, and `MURMURS`).
+B3.1.4 refactors Antigravity host preflight so `useG1Credits` is interpreted according to documented Antigravity sparse-settings semantics where system default is `false`. It resolves omitted sparse settings and explicit `false` settings to effective `false` while failing closed against explicit `true` or malformed values, keeping personal credit fallback strictly disabled during benchmark measurement. It preserves exact version qualification (1.1.15), externalized version matching, stream-json event transport, and all B3.1.2 communication treatments (`DEFAULT`, `CAVEMAN`, and `MURMURS`).
 
 It does not execute Antigravity model turns, does not execute the 3-run diagnostic, does not execute the 30-run calibration, does not measure live token savings or benefit, does not vendor Caveman, and does not alter production runtime routing.
 
@@ -31,10 +31,10 @@ ARM OPERATIONALIZATION IMPLEMENTATION != MEASURED CALIBRATION
 PLAN-ONLY VALIDATION != MEASURED CALIBRATION
 SYNTHETIC FIXTURE != MURMURS BENEFIT EVIDENCE
 CAVEMAN PUBLISHED RESULTS != ORCHESTRA RESULTS
-MEASUREMENT_NOT_STARTED remains current after B3.1.3
+MEASUREMENT_NOT_STARTED remains current after B3.1.4
 ```
 
-The authoritative benchmark machine state incorporates the B3.1.3 executor binding record (`machine/benchmarking/antigravity-executor-binding.v1.json`) alongside the B0 contract and B1 harness. Measurement maturity remains `MEASUREMENT_NOT_STARTED` until genuine calibrated evidence is collected.
+The authoritative benchmark machine state incorporates the B3.1.4 executor binding record (`machine/benchmarking/antigravity-executor-binding.v1.json`) alongside the B0 contract and B1 harness. Measurement maturity remains `MEASUREMENT_NOT_STARTED` until genuine calibrated evidence is collected.
 
 ## B3.1.2 / B3.1.3 Communication Treatments
 
@@ -85,6 +85,22 @@ Paired comparability invariants:
 - Native usage counters (`input_tokens`, `output_tokens`, `cache_read_tokens`, `thinking_tokens`) map deterministically into Orchestra token schema regardless of transport format.
 - `total_tokens` remains in `raw_evidence` only.
 - Cost remains `UNAVAILABLE`.
+
+## Sparse Settings Semantics & Credit Policy Resolution
+
+Antigravity CLI settings persistence follows sparse persistence semantics:
+1. `useG1Credits` has system default `false`.
+2. Values equal to system defaults may be omitted from `settings.json`.
+3. An omitted `useG1Credits` key and `"useG1Credits": false` both represent the exact same effective host policy: `effective_use_g1_credits = false` (credit fallback disabled).
+4. The benchmark invariant is strictly: `effective_use_g1_credits` must be `false`.
+
+Preflight state resolution table:
+- **Key absent (`settings = {}`)**: resolves to `effective_use_g1_credits = false`, passes preflight with `effective_source: SYSTEM_DEFAULT_SPARSE_PERSISTENCE`.
+- **Key explicitly false (`settings = {"useG1Credits": false}`)**: resolves to `effective_use_g1_credits = false`, passes preflight with `effective_source: EXPLICIT_SETTING`.
+- **Key explicitly true (`settings = {"useG1Credits": true}`)**: fails closed as `INVALID_RUN` (`MEASUREMENT_CAPTURE_FAILURE`) because personal credit fallback is enabled.
+- **Key present with non-boolean value (`null`, `0`, `1`, `"false"`, `"true"`, `{}`, `[]`)**: fails closed as `INVALID_RUN` (`MEASUREMENT_CAPTURE_FAILURE`) without silent coercion.
+
+Raw and effective provenance is recorded in `raw_evidence.credit_fallback_policy` to distinguish the physical file representation from the resolved host policy.
 
 ## Quality Boundary: Host Status != Task Outcome
 

--- a/machine/benchmarking/antigravity-executor-binding.v1.json
+++ b/machine/benchmarking/antigravity-executor-binding.v1.json
@@ -1,9 +1,9 @@
 {
   "schema_version": "orchestra.antigravity-executor-binding.v1",
   "program_id": "orchestra.shared-comparative-benchmark.v1",
-  "phase": "BENCHMARK_B3_1_3_EXACT_HOST_VERSION_PIN_EXTERNALIZATION",
+  "phase": "BENCHMARK_B3_1_4_SPARSE_SETTINGS_SEMANTIC_PREFLIGHT",
   "status": "IMPLEMENTED_NON_CALIBRATED",
-  "canonical_entry_baseline": "48007cbbbbfa6ce84747ed8b413b1d4af8ac895f",
+  "canonical_entry_baseline": "b0f14ade2ce9bb2b5b25ae7c653cb94345af5dcb",
   "binding": {
     "host": "Antigravity CLI",
     "cli_version": "1.1.15",
@@ -15,6 +15,9 @@
     "output_formats": ["json", "stream-json"],
     "non_interactive": true,
     "personal_credit_fallback": "disabled",
+    "use_g1_credits_effective": false,
+    "sparse_settings_persistence": true,
+    "use_g1_credits_system_default": false,
     "use_g1_credits": false,
     "executor_script": "scripts/antigravity_benchmark_executor.py",
     "qualification_method": "ZERO_TURN_STRUCTURED_PREFLIGHT_PROBES",
@@ -83,6 +86,9 @@
     "fail_closed_on_caveman_policy_mismatch": true,
     "fail_closed_on_missing_expected_cli_version": true,
     "fail_closed_on_cli_version_mismatch": true,
+    "fail_closed_on_use_g1_credits_true": true,
+    "fail_closed_on_malformed_use_g1_credits": true,
+    "sparse_settings_default_fallback_disabled": true,
     "raw_outer_envelope_preserved": true,
     "no_metric_inference": true
   },
@@ -96,8 +102,9 @@
     ]
   },
   "governance_boundaries": {
-    "b3_1_3_exact_host_version_pin": "IMPLEMENTED_SOURCE_ONLY",
+    "b3_1_4_sparse_settings_preflight": "IMPLEMENTED_SOURCE_ONLY",
     "current_validated_agy_version": "1.1.15",
+    "credit_fallback_effective": false,
     "b3_measurement_maturity": "MEASUREMENT_NOT_STARTED",
     "b3_diagnostic_execution": "NOT_STARTED",
     "b3_calibration_execution": "NOT_STARTED",

--- a/scripts/antigravity_benchmark_executor.py
+++ b/scripts/antigravity_benchmark_executor.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Antigravity measurement executor binding for Orchestra comparative benchmark.
 
-Provides the B3.1.3 executor adapter for Antigravity CLI host-native execution,
+Provides the B3.1.4 executor adapter for Antigravity CLI host-native execution,
 deterministic communication-arm binding (DEFAULT, CAVEMAN, MURMURS), fail-closed
-preflight validation, externalized exact CLI version expectation, structured
-usage parsing, stream-json event parsing, and Orchestra-compatible benchmark
-result construction.
+preflight validation with sparse settings semantic interpretation for useG1Credits,
+externalized exact CLI version expectation, structured usage parsing, stream-json
+event parsing, and Orchestra-compatible benchmark result construction.
 
 Measurement Surface Provenance:
 - Counter ID format: "antigravity-cli-{cli_version}:{transport}:{model}"
@@ -126,6 +126,87 @@ def compute_counter_id(
 def get_default_settings_path() -> Path:
     """Return default settings path: ~/.gemini/antigravity-cli/settings.json."""
     return Path.home() / ".gemini" / "antigravity-cli" / "settings.json"
+
+
+def resolve_use_g1_credits(
+    settings: Any,
+) -> tuple[bool, str | None, dict[str, Any]]:
+    """Resolve and validate useG1Credits according to Antigravity sparse-settings semantics.
+
+    Official Antigravity semantics:
+    1. `useG1Credits` has system default `false`.
+    2. `settings.json` uses sparse persistence: values equal to system defaults may be omitted.
+    3. Key absent and key explicitly `false` represent the same effective host policy:
+       `effective_use_g1_credits = false` (credit fallback disabled).
+    4. Key explicitly `true` enables personal credit fallback: fails closed as INVALID_RUN.
+    5. Key present with non-boolean values (e.g. null, 0, 1, "false", "true", {}, []) fails closed
+       without silent coercion.
+
+    Returns:
+        (is_valid, error_message, credit_fallback_policy)
+    """
+    if not isinstance(settings, dict):
+        policy = {
+            "setting_name": "useG1Credits",
+            "key_present": False,
+            "observed_value": None,
+            "effective_value": None,
+            "effective_source": "INVALID_SETTINGS_ROOT",
+            "fallback_allowed": False,
+        }
+        return False, "settings.json root is not an object", policy
+
+    if "useG1Credits" not in settings:
+        policy = {
+            "setting_name": "useG1Credits",
+            "key_present": False,
+            "observed_value": None,
+            "effective_value": False,
+            "effective_source": "SYSTEM_DEFAULT_SPARSE_PERSISTENCE",
+            "fallback_allowed": False,
+        }
+        return True, None, policy
+
+    raw_val = settings["useG1Credits"]
+    if type(raw_val) is not bool:
+        policy = {
+            "setting_name": "useG1Credits",
+            "key_present": True,
+            "observed_value": raw_val,
+            "effective_value": None,
+            "effective_source": "MALFORMED_EXPLICIT_SETTING",
+            "fallback_allowed": False,
+        }
+        return (
+            False,
+            f"useG1Credits has invalid non-boolean value in settings.json: {raw_val!r}",
+            policy,
+        )
+
+    if raw_val is True:
+        policy = {
+            "setting_name": "useG1Credits",
+            "key_present": True,
+            "observed_value": True,
+            "effective_value": True,
+            "effective_source": "EXPLICIT_SETTING",
+            "fallback_allowed": True,
+        }
+        return (
+            False,
+            "useG1Credits is explicitly true in settings.json; benchmark measurement requires personal credit fallback disabled",
+            policy,
+        )
+
+    policy = {
+        "setting_name": "useG1Credits",
+        "key_present": True,
+        "observed_value": False,
+        "effective_value": False,
+        "effective_source": "EXPLICIT_SETTING",
+        "fallback_allowed": False,
+    }
+    return True, None, policy
 
 
 def repository_root() -> Path:
@@ -469,7 +550,7 @@ def run_host_preflight(
     1. Expected CLI version is explicitly provided, non-empty, and valid format.
     2. Resolved Antigravity CLI version from `agy --version` exactly equals expected_cli_version.
     3. settings.json exists and parses successfully.
-    4. useG1Credits is explicitly False.
+    4. useG1Credits resolves to effective False under sparse settings semantics (omitted or explicit False).
     5. Benchmark model in request control_identity remains exactly gemini-3.7-flash-high.
     6. Expected counter identity matches the specified transport and version.
 
@@ -527,25 +608,15 @@ def run_host_preflight(
             None,
         )
 
-    if not isinstance(settings, dict):
+    valid_credits, credit_err, credit_policy = resolve_use_g1_credits(settings)
+    if not valid_credits:
         return (
             False,
             "MEASUREMENT_CAPTURE_FAILURE",
             {
-                "error": "settings.json root is not an object",
-                "settings_path": str(target_settings),
-            },
-            None,
-        )
-
-    use_g1 = settings.get("useG1Credits")
-    if use_g1 is not False or isinstance(use_g1, bool) is False:
-        return (
-            False,
-            "MEASUREMENT_CAPTURE_FAILURE",
-            {
-                "error": "useG1Credits must be explicitly false in settings.json",
-                "observed_useG1Credits": use_g1,
+                "error": credit_err,
+                "observed_useG1Credits": credit_policy.get("observed_value"),
+                "credit_fallback_policy": credit_policy,
                 "settings_path": str(target_settings),
             },
             None,
@@ -815,6 +886,7 @@ def parse_stream_json_output(
     validated_cli_version: str | None = None,
     binding: dict[str, Any] | None = None,
     presentation_root: Path | str | None = None,
+    credit_policy: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Parse Antigravity NDJSON event stream and compute deterministic metrics."""
     req_id = request.get("request_id", "unknown-request")
@@ -1057,6 +1129,10 @@ def parse_stream_json_output(
 
     safety = {field: False for field in SAFETY_FIELDS}
 
+    effective_credit_policy = credit_policy
+    if effective_credit_policy is None:
+        _, _, effective_credit_policy = resolve_use_g1_credits(terminal_envelope)
+
     effective_binding = binding or {}
     raw_evidence = {
         "host": "Antigravity CLI",
@@ -1098,7 +1174,8 @@ def parse_stream_json_output(
         "outer_envelope": copy.deepcopy(terminal_envelope),
         "stream_events": copy.deepcopy(events),
         "total_tokens": usage.get("total_tokens"),
-        "useG1Credits": terminal_envelope.get("useG1Credits", False),
+        "useG1Credits": effective_credit_policy.get("effective_value", False),
+        "credit_fallback_policy": copy.deepcopy(effective_credit_policy),
     }
 
     val_basis = {
@@ -1140,6 +1217,7 @@ def parse_antigravity_output(
     binding: dict[str, Any] | None = None,
     transport: str = PINNED_TRANSPORT_JSON,
     presentation_root: Path | str | None = None,
+    credit_policy: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Parse raw Antigravity output (JSON or stream-json) and construct Orchestra benchmark result."""
     # Ensure treatment binding exists
@@ -1167,6 +1245,7 @@ def parse_antigravity_output(
             validated_cli_version=validated_cli_version,
             binding=binding,
             presentation_root=presentation_root,
+            credit_policy=credit_policy,
         )
 
     # Detect multi-line stream-json string
@@ -1181,6 +1260,7 @@ def parse_antigravity_output(
                 validated_cli_version=validated_cli_version,
                 binding=binding,
                 presentation_root=presentation_root,
+                credit_policy=credit_policy,
             )
 
     task_payload = request.get("task_payload", {})
@@ -1365,6 +1445,10 @@ def parse_antigravity_output(
 
     safety = {field: False for field in SAFETY_FIELDS}
 
+    effective_credit_policy = credit_policy
+    if effective_credit_policy is None:
+        _, _, effective_credit_policy = resolve_use_g1_credits(envelope)
+
     effective_binding = binding or {}
     raw_evidence = {
         "host": "Antigravity CLI",
@@ -1405,7 +1489,8 @@ def parse_antigravity_output(
         "topology_digest": request.get("arm", {}).get("topology_digest"),
         "outer_envelope": copy.deepcopy(envelope),
         "total_tokens": usage.get("total_tokens"),
-        "useG1Credits": envelope.get("useG1Credits", False),
+        "useG1Credits": effective_credit_policy.get("effective_value", False),
+        "credit_fallback_policy": copy.deepcopy(effective_credit_policy),
     }
 
     val_basis = {
@@ -1615,6 +1700,16 @@ def execute_request(
             expected_cli_version=expected_ver,
         )
 
+    active_credit_policy = None
+    target_settings = settings_path or get_default_settings_path()
+    if target_settings.is_file():
+        try:
+            raw_settings = target_settings.read_text(encoding="utf-8")
+            parsed_settings = json.loads(raw_settings)
+            _, _, active_credit_policy = resolve_use_g1_credits(parsed_settings)
+        except Exception:
+            active_credit_policy = None
+
     return parse_antigravity_output(
         stdout,
         request,
@@ -1624,6 +1719,7 @@ def execute_request(
         binding=binding,
         transport=transport_counter,
         presentation_root=presentation_root,
+        credit_policy=active_credit_policy,
     )
 
 

--- a/tests/runtime/test_comparative_benchmark_antigravity_executor.py
+++ b/tests/runtime/test_comparative_benchmark_antigravity_executor.py
@@ -606,12 +606,13 @@ def test_22_preflight_fails_closed_on_malformed_or_missing_settings(tmp_path: Pa
     assert res2["outcome"]["status"] == "INVALID_RUN"
     assert res2["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
 
-    missing_key_settings = _create_mock_settings(tmp_path / "sub", use_g1_credits=None)
+    non_object_settings = tmp_path / "list_settings.json"
+    non_object_settings.write_text("[1, 2, 3]", encoding="utf-8")
     req3 = _base_request(prompt="Sample prompt")
     res3 = executor.execute_request(
         req3,
         expected_cli_version="1.1.15",
-        settings_path=missing_key_settings,
+        settings_path=non_object_settings,
         version_runner_fn=mock_version_runner,
     )
     _validate_result_schema(res3)
@@ -1518,3 +1519,508 @@ def test_59_host_success_alone_cannot_become_benchmark_task_pass() -> None:
     assert res["outcome"]["validation_passed"] is False
     assert res["outcome"]["governance_valid"] is False
     assert res["tokens"]["source"] == "HOST_REPORTED"
+
+
+def test_60_resolve_use_g1_credits_helper_state_table() -> None:
+    # State A: key absent -> effective false, SYSTEM_DEFAULT_SPARSE_PERSISTENCE
+    ok, err, policy = executor.resolve_use_g1_credits({})
+    assert ok is True
+    assert err is None
+    assert policy == {
+        "setting_name": "useG1Credits",
+        "key_present": False,
+        "observed_value": None,
+        "effective_value": False,
+        "effective_source": "SYSTEM_DEFAULT_SPARSE_PERSISTENCE",
+        "fallback_allowed": False,
+    }
+
+    # State B: key explicitly false -> effective false, EXPLICIT_SETTING
+    ok, err, policy = executor.resolve_use_g1_credits({"useG1Credits": False})
+    assert ok is True
+    assert err is None
+    assert policy == {
+        "setting_name": "useG1Credits",
+        "key_present": True,
+        "observed_value": False,
+        "effective_value": False,
+        "effective_source": "EXPLICIT_SETTING",
+        "fallback_allowed": False,
+    }
+
+    # State C: key explicitly true -> fails closed, fallback_allowed True
+    ok, err, policy = executor.resolve_use_g1_credits({"useG1Credits": True})
+    assert ok is False
+    assert "explicitly true" in str(err)
+    assert policy == {
+        "setting_name": "useG1Credits",
+        "key_present": True,
+        "observed_value": True,
+        "effective_value": True,
+        "effective_source": "EXPLICIT_SETTING",
+        "fallback_allowed": True,
+    }
+
+    # State D: key present with invalid/non-boolean values
+    invalid_cases = [
+        None,
+        0,
+        1,
+        "false",
+        "true",
+        {},
+        [],
+        3.14,
+    ]
+    for val in invalid_cases:
+        ok, err, policy = executor.resolve_use_g1_credits({"useG1Credits": val})
+        assert ok is False
+        assert err is not None
+        assert policy["key_present"] is True
+        assert policy["observed_value"] == val
+        assert policy["effective_value"] is None
+        assert policy["effective_source"] == "MALFORMED_EXPLICIT_SETTING"
+        assert policy["fallback_allowed"] is False
+
+    # Non-dict inputs
+    for non_dict in (None, [1, 2], "string", 42):
+        ok, err, policy = executor.resolve_use_g1_credits(non_dict)
+        assert ok is False
+        assert "not an object" in str(err)
+
+
+def test_61_preflight_passes_on_sparse_omitted_use_g1_credits(tmp_path: Path) -> None:
+    # Key absent in settings.json passes preflight and preserves sparse provenance
+    settings_file = _create_mock_settings(tmp_path, use_g1_credits=None)
+    model_called = False
+
+    def mock_version_runner(cmd: list[str]) -> tuple[int, str, str]:
+        return (0, "1.1.15\n", "")
+
+    def mock_model_runner(cmd: list[str], prompt: str) -> tuple[int, str, str]:
+        nonlocal model_called
+        model_called = True
+        return (0, json.dumps(_mock_host_envelope()), "")
+
+    req = _base_request(prompt="Sparse settings verification")
+    res = executor.execute_request(
+        req,
+        expected_cli_version="1.1.15",
+        runner_fn=mock_model_runner,
+        settings_path=settings_file,
+        version_runner_fn=mock_version_runner,
+    )
+    _validate_result_schema(res)
+
+    assert model_called is True
+    assert res["outcome"]["status"] == "PASS"
+    raw_ev = res["raw_evidence"]
+    assert raw_ev["useG1Credits"] is False
+    assert raw_ev["credit_fallback_policy"] == {
+        "setting_name": "useG1Credits",
+        "key_present": False,
+        "observed_value": None,
+        "effective_value": False,
+        "effective_source": "SYSTEM_DEFAULT_SPARSE_PERSISTENCE",
+        "fallback_allowed": False,
+    }
+
+
+def test_62_preflight_passes_on_explicit_false_use_g1_credits(tmp_path: Path) -> None:
+    # Explicit false in settings.json passes preflight and preserves explicit provenance
+    settings_file = _create_mock_settings(tmp_path, use_g1_credits=False)
+    model_called = False
+
+    def mock_version_runner(cmd: list[str]) -> tuple[int, str, str]:
+        return (0, "1.1.15\n", "")
+
+    def mock_model_runner(cmd: list[str], prompt: str) -> tuple[int, str, str]:
+        nonlocal model_called
+        model_called = True
+        return (0, json.dumps(_mock_host_envelope()), "")
+
+    req = _base_request(prompt="Explicit false verification")
+    res = executor.execute_request(
+        req,
+        expected_cli_version="1.1.15",
+        runner_fn=mock_model_runner,
+        settings_path=settings_file,
+        version_runner_fn=mock_version_runner,
+    )
+    _validate_result_schema(res)
+
+    assert model_called is True
+    assert res["outcome"]["status"] == "PASS"
+    raw_ev = res["raw_evidence"]
+    assert raw_ev["useG1Credits"] is False
+    assert raw_ev["credit_fallback_policy"] == {
+        "setting_name": "useG1Credits",
+        "key_present": True,
+        "observed_value": False,
+        "effective_value": False,
+        "effective_source": "EXPLICIT_SETTING",
+        "fallback_allowed": False,
+    }
+
+
+def test_63_preflight_fails_closed_on_explicit_true_use_g1_credits(tmp_path: Path) -> None:
+    # Explicit true in settings.json fails closed as INVALID_RUN / MEASUREMENT_CAPTURE_FAILURE
+    settings_file = _create_mock_settings(tmp_path, use_g1_credits=True)
+    model_called = False
+
+    def mock_version_runner(cmd: list[str]) -> tuple[int, str, str]:
+        return (0, "1.1.15\n", "")
+
+    def mock_model_runner(cmd: list[str], prompt: str) -> tuple[int, str, str]:
+        nonlocal model_called
+        model_called = True
+        return (0, json.dumps(_mock_host_envelope()), "")
+
+    req = _base_request(prompt="Explicit true verification")
+    res = executor.execute_request(
+        req,
+        expected_cli_version="1.1.15",
+        runner_fn=mock_model_runner,
+        settings_path=settings_file,
+        version_runner_fn=mock_version_runner,
+    )
+    _validate_result_schema(res)
+
+    assert model_called is False
+    assert res["outcome"]["status"] == "INVALID_RUN"
+    assert res["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+    detail = res["raw_evidence"]["detail"]
+    assert detail["credit_fallback_policy"]["fallback_allowed"] is True
+    assert detail["credit_fallback_policy"]["effective_value"] is True
+    assert detail["credit_fallback_policy"]["key_present"] is True
+
+
+def test_64_preflight_fails_closed_on_null_use_g1_credits(tmp_path: Path) -> None:
+    # JSON null (None in Python) fails closed without coercion
+    settings_file = tmp_path / "settings_null.json"
+    settings_file.write_text(json.dumps({"useG1Credits": None}), encoding="utf-8")
+    model_called = False
+
+    def mock_version_runner(cmd: list[str]) -> tuple[int, str, str]:
+        return (0, "1.1.15\n", "")
+
+    def mock_model_runner(cmd: list[str], prompt: str) -> tuple[int, str, str]:
+        nonlocal model_called
+        model_called = True
+        return (0, json.dumps(_mock_host_envelope()), "")
+
+    req = _base_request(prompt="Null check")
+    res = executor.execute_request(
+        req,
+        expected_cli_version="1.1.15",
+        runner_fn=mock_model_runner,
+        settings_path=settings_file,
+        version_runner_fn=mock_version_runner,
+    )
+    _validate_result_schema(res)
+
+    assert model_called is False
+    assert res["outcome"]["status"] == "INVALID_RUN"
+    assert res["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+
+def test_65_preflight_fails_closed_on_numeric_0_use_g1_credits(tmp_path: Path) -> None:
+    # Numeric 0 fails closed (not coerced to False)
+    settings_file = tmp_path / "settings_zero.json"
+    settings_file.write_text(json.dumps({"useG1Credits": 0}), encoding="utf-8")
+    model_called = False
+
+    def mock_version_runner(cmd: list[str]) -> tuple[int, str, str]:
+        return (0, "1.1.15\n", "")
+
+    def mock_model_runner(cmd: list[str], prompt: str) -> tuple[int, str, str]:
+        nonlocal model_called
+        model_called = True
+        return (0, json.dumps(_mock_host_envelope()), "")
+
+    req = _base_request()
+    res = executor.execute_request(
+        req,
+        expected_cli_version="1.1.15",
+        runner_fn=mock_model_runner,
+        settings_path=settings_file,
+        version_runner_fn=mock_version_runner,
+    )
+    _validate_result_schema(res)
+    assert model_called is False
+    assert res["outcome"]["status"] == "INVALID_RUN"
+    assert res["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+
+def test_66_preflight_fails_closed_on_numeric_1_use_g1_credits(tmp_path: Path) -> None:
+    # Numeric 1 fails closed (not coerced to True)
+    settings_file = tmp_path / "settings_one.json"
+    settings_file.write_text(json.dumps({"useG1Credits": 1}), encoding="utf-8")
+    model_called = False
+
+    def mock_version_runner(cmd: list[str]) -> tuple[int, str, str]:
+        return (0, "1.1.15\n", "")
+
+    def mock_model_runner(cmd: list[str], prompt: str) -> tuple[int, str, str]:
+        nonlocal model_called
+        model_called = True
+        return (0, json.dumps(_mock_host_envelope()), "")
+
+    req = _base_request()
+    res = executor.execute_request(
+        req,
+        expected_cli_version="1.1.15",
+        runner_fn=mock_model_runner,
+        settings_path=settings_file,
+        version_runner_fn=mock_version_runner,
+    )
+    _validate_result_schema(res)
+    assert model_called is False
+    assert res["outcome"]["status"] == "INVALID_RUN"
+    assert res["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+
+def test_67_preflight_fails_closed_on_string_false_use_g1_credits(tmp_path: Path) -> None:
+    # String "false" fails closed (not coerced to False)
+    settings_file = tmp_path / "settings_str_false.json"
+    settings_file.write_text(json.dumps({"useG1Credits": "false"}), encoding="utf-8")
+    model_called = False
+
+    def mock_version_runner(cmd: list[str]) -> tuple[int, str, str]:
+        return (0, "1.1.15\n", "")
+
+    def mock_model_runner(cmd: list[str], prompt: str) -> tuple[int, str, str]:
+        nonlocal model_called
+        model_called = True
+        return (0, json.dumps(_mock_host_envelope()), "")
+
+    req = _base_request()
+    res = executor.execute_request(
+        req,
+        expected_cli_version="1.1.15",
+        runner_fn=mock_model_runner,
+        settings_path=settings_file,
+        version_runner_fn=mock_version_runner,
+    )
+    _validate_result_schema(res)
+    assert model_called is False
+    assert res["outcome"]["status"] == "INVALID_RUN"
+    assert res["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+
+def test_68_preflight_fails_closed_on_string_true_use_g1_credits(tmp_path: Path) -> None:
+    # String "true" fails closed (not coerced to True)
+    settings_file = tmp_path / "settings_str_true.json"
+    settings_file.write_text(json.dumps({"useG1Credits": "true"}), encoding="utf-8")
+    model_called = False
+
+    def mock_version_runner(cmd: list[str]) -> tuple[int, str, str]:
+        return (0, "1.1.15\n", "")
+
+    def mock_model_runner(cmd: list[str], prompt: str) -> tuple[int, str, str]:
+        nonlocal model_called
+        model_called = True
+        return (0, json.dumps(_mock_host_envelope()), "")
+
+    req = _base_request()
+    res = executor.execute_request(
+        req,
+        expected_cli_version="1.1.15",
+        runner_fn=mock_model_runner,
+        settings_path=settings_file,
+        version_runner_fn=mock_version_runner,
+    )
+    _validate_result_schema(res)
+    assert model_called is False
+    assert res["outcome"]["status"] == "INVALID_RUN"
+    assert res["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+
+def test_69_preflight_fails_closed_on_object_or_list_use_g1_credits(tmp_path: Path) -> None:
+    # Object or list value fails closed
+    def mock_version_runner(cmd: list[str]) -> tuple[int, str, str]:
+        return (0, "1.1.15\n", "")
+
+    for val in ({}, [1, 2]):
+        sf = tmp_path / f"settings_{type(val).__name__}.json"
+        sf.write_text(json.dumps({"useG1Credits": val}), encoding="utf-8")
+        req = _base_request()
+        res = executor.execute_request(
+            req,
+            expected_cli_version="1.1.15",
+            settings_path=sf,
+            version_runner_fn=mock_version_runner,
+        )
+        _validate_result_schema(res)
+        assert res["outcome"]["status"] == "INVALID_RUN"
+        assert res["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+
+def test_70_missing_settings_file_fails_closed(tmp_path: Path) -> None:
+    # Non-existent settings.json file fails closed
+    missing_file = tmp_path / "does_not_exist" / "settings.json"
+    req = _base_request()
+    res = executor.execute_request(
+        req,
+        expected_cli_version="1.1.15",
+        settings_path=missing_file,
+        version_runner_fn=lambda cmd: (0, "1.1.15\n", ""),
+    )
+    _validate_result_schema(res)
+    assert res["outcome"]["status"] == "INVALID_RUN"
+    assert res["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+
+def test_71_malformed_json_settings_file_fails_closed(tmp_path: Path) -> None:
+    # Malformed JSON syntax in settings.json fails closed
+    bad_file = tmp_path / "bad.json"
+    bad_file.write_text("{ unclosed json", encoding="utf-8")
+    req = _base_request()
+    res = executor.execute_request(
+        req,
+        expected_cli_version="1.1.15",
+        settings_path=bad_file,
+        version_runner_fn=lambda cmd: (0, "1.1.15\n", ""),
+    )
+    _validate_result_schema(res)
+    assert res["outcome"]["status"] == "INVALID_RUN"
+    assert res["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+
+def test_72_exact_cli_version_mismatch_fails_closed_before_model_invocation(tmp_path: Path) -> None:
+    # CLI version mismatch fails closed before model execution
+    settings_file = _create_mock_settings(tmp_path, use_g1_credits=None)
+    model_called = False
+
+    def mock_model_runner(cmd: list[str], prompt: str) -> tuple[int, str, str]:
+        nonlocal model_called
+        model_called = True
+        return (0, json.dumps(_mock_host_envelope()), "")
+
+    req = _base_request()
+    res = executor.execute_request(
+        req,
+        expected_cli_version="1.1.15",
+        runner_fn=mock_model_runner,
+        settings_path=settings_file,
+        version_runner_fn=lambda cmd: (0, "antigravity-cli 1.1.16\n", ""),
+    )
+    _validate_result_schema(res)
+    assert model_called is False
+    assert res["outcome"]["status"] == "INVALID_RUN"
+    assert res["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+
+def test_73_model_mismatch_fails_closed_before_model_invocation(tmp_path: Path) -> None:
+    # Model mismatch fails closed
+    settings_file = _create_mock_settings(tmp_path, use_g1_credits=None)
+    req = _base_request()
+    req["control_identity"]["model"] = "gemini-2.5-pro"
+    res = executor.execute_request(
+        req,
+        expected_cli_version="1.1.15",
+        settings_path=settings_file,
+        version_runner_fn=lambda cmd: (0, "1.1.15\n", ""),
+    )
+    _validate_result_schema(res)
+    assert res["outcome"]["status"] == "INVALID_RUN"
+    assert res["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+
+def test_74_counter_identity_invariants_preserved() -> None:
+    # Counter identities remain deterministic and exact
+    json_counter = executor.compute_counter_id(cli_version="1.1.15", transport="json-usage")
+    stream_counter = executor.compute_counter_id(cli_version="1.1.15", transport="stream-json-usage")
+    assert json_counter == "antigravity-cli-1.1.15:json-usage:gemini-3.7-flash-high"
+    assert stream_counter == "antigravity-cli-1.1.15:stream-json-usage:gemini-3.7-flash-high"
+
+
+def test_75_provenance_distinguishes_explicit_setting_from_system_default_sparse(tmp_path: Path) -> None:
+    # Provenance semantics distinguish EXPLICIT_SETTING from SYSTEM_DEFAULT_SPARSE_PERSISTENCE
+    settings_sparse = tmp_path / "sparse.json"
+    settings_sparse.write_text("{}", encoding="utf-8")
+
+    settings_explicit = tmp_path / "explicit.json"
+    settings_explicit.write_text(json.dumps({"useG1Credits": False}), encoding="utf-8")
+
+    def mock_version_runner(cmd: list[str]) -> tuple[int, str, str]:
+        return (0, "1.1.15\n", "")
+
+    def mock_model_runner(cmd: list[str], prompt: str) -> tuple[int, str, str]:
+        return (0, json.dumps(_mock_host_envelope()), "")
+
+    res_sparse = executor.execute_request(
+        _base_request(prompt="sparse test"),
+        expected_cli_version="1.1.15",
+        runner_fn=mock_model_runner,
+        settings_path=settings_sparse,
+        version_runner_fn=mock_version_runner,
+    )
+    res_explicit = executor.execute_request(
+        _base_request(prompt="explicit test"),
+        expected_cli_version="1.1.15",
+        runner_fn=mock_model_runner,
+        settings_path=settings_explicit,
+        version_runner_fn=mock_version_runner,
+    )
+
+    _validate_result_schema(res_sparse)
+    _validate_result_schema(res_explicit)
+
+    pol_sparse = res_sparse["raw_evidence"]["credit_fallback_policy"]
+    pol_explicit = res_explicit["raw_evidence"]["credit_fallback_policy"]
+
+    assert pol_sparse["effective_source"] == "SYSTEM_DEFAULT_SPARSE_PERSISTENCE"
+    assert pol_sparse["key_present"] is False
+    assert pol_sparse["observed_value"] is None
+    assert pol_sparse["effective_value"] is False
+
+    assert pol_explicit["effective_source"] == "EXPLICIT_SETTING"
+    assert pol_explicit["key_present"] is True
+    assert pol_explicit["observed_value"] is False
+    assert pol_explicit["effective_value"] is False
+
+
+def test_76_stream_json_sparse_settings_provenance(tmp_path: Path) -> None:
+    # Stream-json transport preserves sparse settings provenance
+    settings_file = tmp_path / "sparse_stream.json"
+    settings_file.write_text("{}", encoding="utf-8")
+
+    events = [
+        {"type": "step_update", "content": "Working..."},
+        {
+            "type": "result",
+            "status": "SUCCESS",
+            "cli_version": "1.1.15",
+            "usage": {"input_tokens": 1200, "output_tokens": 300, "thinking_tokens": 50, "cache_read_tokens": 100, "total_tokens": 1650},
+            "task_completed": True,
+            "validation_passed": True,
+            "governance_valid": True,
+            "response": "Done with task",
+        },
+    ]
+    raw_stream = "\n".join(json.dumps(ev) for ev in events)
+
+    def mock_version_runner(cmd: list[str]) -> tuple[int, str, str]:
+        return (0, "1.1.15\n", "")
+
+    def mock_model_runner(cmd: list[str], prompt: str) -> tuple[int, str, str]:
+        return (0, raw_stream, "")
+
+    req = _base_request(prompt="Stream sparse test", transport="stream-json")
+    res = executor.execute_request(
+        req,
+        expected_cli_version="1.1.15",
+        runner_fn=mock_model_runner,
+        settings_path=settings_file,
+        version_runner_fn=mock_version_runner,
+        transport="stream-json",
+    )
+    _validate_result_schema(res)
+
+    assert res["outcome"]["status"] == "PASS"
+    assert res["tokens"]["counter_id"] == "antigravity-cli-1.1.15:stream-json-usage:gemini-3.7-flash-high"
+    pol = res["raw_evidence"]["credit_fallback_policy"]
+    assert pol["effective_source"] == "SYSTEM_DEFAULT_SPARSE_PERSISTENCE"
+    assert pol["key_present"] is False
+    assert pol["effective_value"] is False


### PR DESCRIPTION
## Summary

Implements **B3.1.4 Antigravity Sparse Settings Semantic Preflight** for the Orchestra comparative benchmark harness.

### Key Changes
- Refactors Antigravity host preflight in \scripts/antigravity_benchmark_executor.py\ to interpret \useG1Credits\ according to documented Antigravity sparse-settings semantics where system default is \alse\.
- Introduces \esolve_use_g1_credits\ deterministic helper mapping absent keys to effective \alse\ with \SYSTEM_DEFAULT_SPARSE_PERSISTENCE\ provenance and explicit \alse\ to \EXPLICIT_SETTING\ provenance.
- Enforces fail-closed validation (\INVALID_RUN\ / \MEASUREMENT_CAPTURE_FAILURE\) when \useG1Credits\ is explicitly \	rue\ or set to non-boolean/malformed values (\
ull\, \