### PR TITLE
B3.1.5: canonicalize AGY stream result normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Post-v1.6.0 Comparative Benchmark B3.1.5 Antigravity Stream-JSON Result Envelope Normalization - Candidate
+
+- Normalizes stream-json terminal result envelopes in `scripts/antigravity_benchmark_executor.py` via `normalize_stream_terminal_event` to correctly recognize wrapped Antigravity CLI 1.1.15 terminal events (`{"event": "result", "result": {"status": "SUCCESS", "usage": {...}, ...}}`).
+- Resolves measurement fields (`status`, `usage`, `response`, `conversation_id`, `duration_seconds`, `num_turns`, `cli_version`, `model`, `latency`, `coordination`) from the nested canonical result payload.
+- Enforces fail-closed validation (`INVALID_RUN` / `MEASUREMENT_CAPTURE_FAILURE`) against missing terminal events, non-object result payloads, missing/non-SUCCESS status, missing/malformed usage objects, and conflicting critical fields (`status`, `usage`, `cli_version`, `model`) between outer wrapper and nested payload.
+- Recognizes `event` field discriminators (e.g., `event = "step_update"`, `event = "init"`, `event = "tool_start"`) in progress event processing, while strictly excluding the terminal result from intermediate progress counts.
+- Preserves full original wrapper in `raw_evidence.terminal_event_envelope` (and `raw_evidence.outer_envelope`) and normalized payload in `raw_evidence.terminal_result_payload`.
+- Maintains full backwards compatibility with flat legacy terminal fixtures (`{"type": "result", "status": "SUCCESS", ...}`).
+- Records B3.2 Diagnostic Attempt 2 compatibility disposition (`INVALID_RUN` / `AGY_STREAM_RESULT_ENVELOPE_SCHEMA_MISMATCH` / `RESOURCE_CEILING_EXCEEDED`) as diagnostic compatibility evidence without committing external run directories or interpreting counters as comparative performance evidence.
+- Adds comprehensive deterministic regression tests in `tests/runtime/test_comparative_benchmark_antigravity_executor.py` with zero live model turns.
+- Updates machine discovery in `README.json`, machine binding record `machine/benchmarking/antigravity-executor-binding.v1.json`, and documentation in `docs/benchmarking/COMPARATIVE_MEASUREMENT_B3.md`.
+
 ## Post-v1.6.0 Comparative Benchmark B3.1.4 Antigravity Sparse Settings Semantic Preflight - Candidate
 
 - Refactors Antigravity host preflight in `scripts/antigravity_benchmark_executor.py` to interpret `useG1Credits` according to documented Antigravity sparse-settings semantics where system default is `false`.

--- a/README.json
+++ b/README.json
@@ -187,7 +187,7 @@
     },
     "comparative_measurement_b3_1": {
       "status": "IMPLEMENTED_NON_CALIBRATED",
-      "purpose": "Bounded Antigravity measurement executor binding, B3.1.3 exact host version pin externalization, and B3.1.4 sparse settings semantic preflight for the Orchestra comparative benchmark harness with explicit --expected-cli-version CLI argument, exact fail-closed version matching, qualified 1.1.15 host surface, sparse useG1Credits resolution (system default false), explicit DEFAULT, CAVEMAN, and MURMURS treatments, pinned Caveman external baseline, canonical Murmurs presentation binding, stream-json transport support, hardened print-mode invocation, fail-closed preflight, explicit provenance semantics, and strict outcome evaluation.",
+      "purpose": "Bounded Antigravity measurement executor binding, B3.1.3 exact host version pin externalization, B3.1.4 sparse settings semantic preflight, and B3.1.5 stream-json result envelope normalization for the Orchestra comparative benchmark harness with explicit --expected-cli-version CLI argument, exact fail-closed version matching, qualified 1.1.15 host surface, sparse useG1Credits resolution (system default false), wrapped and flat stream result envelope normalization, dual wrapper and payload evidence retention, explicit DEFAULT, CAVEMAN, and MURMURS treatments, pinned Caveman external baseline, canonical Murmurs presentation binding, stream-json transport support, hardened print-mode invocation, fail-closed preflight, explicit provenance semantics, and strict outcome evaluation.",
       "program_id": "orchestra.shared-comparative-benchmark.v1",
       "executor": "scripts/antigravity_benchmark_executor.py",
       "communication_arms": ["DEFAULT", "CAVEMAN", "MURMURS"],
@@ -211,7 +211,7 @@
       "a5_execution_promotion": "NOT_AUTHORIZED",
       "a6_authorized": false,
       "b4_state": "BLOCKED",
-      "authority_note": "B3.1/B3.1.4 provides the bounded Antigravity measurement executor binding, exact host version pin externalization, sparse settings semantic preflight, and communication-arm operationalization only. Diagnostic and calibration are not executed in this unit, Murmurs benefit is not established, fresh_billable_tokens and cost remain unavailable, personal credit fallback remains disabled, A5 remains shadow-only, and B4 remains blocked."
+      "authority_note": "B3.1/B3.1.5 provides the bounded Antigravity measurement executor binding, exact host version pin externalization, sparse settings semantic preflight, stream-json result envelope normalization, and communication-arm operationalization only. Diagnostic and calibration are not executed in this unit, Murmurs benefit is not established, fresh_billable_tokens and cost remain unavailable, personal credit fallback remains disabled, A5 remains shadow-only, and B4 remains blocked."
     }
   },
   "machine_scan_order": [

--- a/docs/benchmarking/COMPARATIVE_MEASUREMENT_B3.md
+++ b/docs/benchmarking/COMPARATIVE_MEASUREMENT_B3.md
@@ -5,22 +5,22 @@
 ```text
 Program: Orchestra Shared Comparative Benchmark
 Phase: B3 Murmurs Isolated Comparative Experiment
-Current bounded unit: B3.1.4 Sparse Settings Semantic Preflight
-State: B3_1_4_SPARSE_SETTINGS_PREFLIGHT_IMPLEMENTED_SOURCE_ONLY
-Canonical entry: b0f14ade2ce9bb2b5b25ae7c653cb94345af5dcb
-Canonical entry tree: 4dbcb6b4ff07a410fb3e1b57e9526fb9f0c851d0
-Authoritative benchmark machine state: B0/B1/B3.1.4 executor binding
+Current bounded unit: B3.1.5 Stream Result Envelope Normalization
+State: B3_1_5_STREAM_RESULT_NORMALIZATION_IMPLEMENTED_SOURCE_ONLY
+Canonical entry: f77734aa8047a4c2c374a5702df3caacc4ec4a37
+Canonical entry tree: 2bb9bf9e59d92a1b2d79c8ba3605a1446379ff56
+Authoritative benchmark machine state: B0/B1/B3.1.5 executor binding
 Validated local Antigravity host: Antigravity CLI 1.1.15
 Measurement maturity after unit implementation: MEASUREMENT_NOT_STARTED
 Murmurs benefit: NOT ESTABLISHED
 A5 execution-effective selection: NOT AUTHORIZED
 A6: NOT AUTHORIZED
 Paid provider calls: NOT AUTHORIZED BY THIS UNIT
-Diagnostic execution: DIAGNOSTIC_READINESS_ONLY (NOT EXECUTED)
+Diagnostic execution: DIAGNOSTIC_READINESS_ONLY (NOT COMPLETED)
 Calibration execution: NOT EXECUTED
 ```
 
-B3.1.4 refactors Antigravity host preflight so `useG1Credits` is interpreted according to documented Antigravity sparse-settings semantics where system default is `false`. It resolves omitted sparse settings and explicit `false` settings to effective `false` while failing closed against explicit `true` or malformed values, keeping personal credit fallback strictly disabled during benchmark measurement. It preserves exact version qualification (1.1.15), externalized version matching, stream-json event transport, and all B3.1.2 communication treatments (`DEFAULT`, `CAVEMAN`, and `MURMURS`).
+B3.1.5 introduces deterministic stream-json terminal envelope normalization in `scripts/antigravity_benchmark_executor.py` via `normalize_stream_terminal_event`, resolving wrapped Antigravity CLI 1.1.15 terminal events (`{"event": "result", "result": {"status": "SUCCESS", "usage": {...}, ...}}`) while preserving flat legacy compatibility, fail-closed conflict handling, intermediate event discrimination, dual wrapper/payload raw evidence retention, and all previous B3.1.4 sparse settings and B3.1.3 exact host version qualification invariants.
 
 It does not execute Antigravity model turns, does not execute the 3-run diagnostic, does not execute the 30-run calibration, does not measure live token savings or benefit, does not vendor Caveman, and does not alter production runtime routing.
 
@@ -31,10 +31,10 @@ ARM OPERATIONALIZATION IMPLEMENTATION != MEASURED CALIBRATION
 PLAN-ONLY VALIDATION != MEASURED CALIBRATION
 SYNTHETIC FIXTURE != MURMURS BENEFIT EVIDENCE
 CAVEMAN PUBLISHED RESULTS != ORCHESTRA RESULTS
-MEASUREMENT_NOT_STARTED remains current after B3.1.4
+MEASUREMENT_NOT_STARTED remains current after B3.1.5
 ```
 
-The authoritative benchmark machine state incorporates the B3.1.4 executor binding record (`machine/benchmarking/antigravity-executor-binding.v1.json`) alongside the B0 contract and B1 harness. Measurement maturity remains `MEASUREMENT_NOT_STARTED` until genuine calibrated evidence is collected.
+The authoritative benchmark machine state incorporates the B3.1.5 executor binding record (`machine/benchmarking/antigravity-executor-binding.v1.json`) alongside the B0 contract and B1 harness. Measurement maturity remains `MEASUREMENT_NOT_STARTED` until genuine calibrated evidence is collected.
 
 ## B3.1.2 / B3.1.3 Communication Treatments
 
@@ -101,6 +101,53 @@ Preflight state resolution table:
 - **Key present with non-boolean value (`null`, `0`, `1`, `"false"`, `"true"`, `{}`, `[]`)**: fails closed as `INVALID_RUN` (`MEASUREMENT_CAPTURE_FAILURE`) without silent coercion.
 
 Raw and effective provenance is recorded in `raw_evidence.credit_fallback_policy` to distinguish the physical file representation from the resolved host policy.
+
+## B3.1.5 Stream-JSON Result Envelope Normalization
+
+B3.1.5 introduces deterministic stream-json terminal envelope normalization in `scripts/antigravity_benchmark_executor.py` via `normalize_stream_terminal_event`. It aligns canonical parser behavior with empirical Antigravity CLI 1.1.15 host evidence where the terminal stream event has structure `{"event": "result", "result": {"status": "SUCCESS", "usage": {...}, "response": "..."}}`.
+
+Key normalization and invariant rules:
+- **Wrapped 1.1.15 Event**: Detects `event == "result"` and canonical payload in `event["result"]`.
+- **Legacy Flat Compatibility**: Preserves flat terminal structures `{"type": "result", "status": "SUCCESS", "usage": {...}}` and flat envelopes.
+- **Dual Envelope Retention**: Preserves both the full original host wrapper in `raw_evidence.terminal_event_envelope` (and `raw_evidence.outer_envelope`) and the normalized payload in `raw_evidence.terminal_result_payload`.
+- **Intermediate Event Discrimination**: Discriminates progress events using `event` in addition to `event_kind`/`kind`/`type` (e.g. `event = "step_update"`, `event = "tool_start"`), while strictly excluding the terminal result from intermediate progress counts.
+- **Fail-Closed Conflict Handling**: Fails closed if outer wrapper and nested result contain conflicting measurement-critical fields (`status`, `usage`, `cli_version`, `model`).
+- **Fail-Closed Malformation**: Fails closed if terminal result is missing, result payload is not an object, status is missing/non-SUCCESS, usage is missing/malformed, or multiple conflicting terminal results exist in the stream.
+
+## B3.2 Diagnostic Attempt 2 Compatibility Disposition
+
+Empirical diagnostic evidence from B3.2 Attempt 2 recorded the following compatibility finding (external evidence directory remains uncommitted):
+
+```text
+B3_2_DIAGNOSTIC_ATTEMPT_2 = INVALID_RUN
+
+cause:
+AGY_STREAM_RESULT_ENVELOPE_SCHEMA_MISMATCH
+
+additional finding:
+RESOURCE_CEILING_EXCEEDED
+
+observed host counters:
+input_tokens = 142896
+output_tokens = 4692
+thinking_tokens = 2804
+cache_read_tokens = 786302
+total_tokens = 147588
+
+configured diagnostic ceiling:
+45000 total_tokens per call
+
+live_host_turns_consumed:
+1
+
+accepted_benchmark_measurements:
+0
+
+benefit evidence:
+NONE
+```
+
+The values above represent diagnostic compatibility evidence only. They are not comparative Murmurs/Caveman performance evidence.
 
 ## Quality Boundary: Host Status != Task Outcome
 

--- a/machine/benchmarking/antigravity-executor-binding.v1.json
+++ b/machine/benchmarking/antigravity-executor-binding.v1.json
@@ -1,9 +1,9 @@
 {
   "schema_version": "orchestra.antigravity-executor-binding.v1",
   "program_id": "orchestra.shared-comparative-benchmark.v1",
-  "phase": "BENCHMARK_B3_1_4_SPARSE_SETTINGS_SEMANTIC_PREFLIGHT",
+  "phase": "BENCHMARK_B3_1_5_STREAM_RESULT_NORMALIZATION",
   "status": "IMPLEMENTED_NON_CALIBRATED",
-  "canonical_entry_baseline": "b0f14ade2ce9bb2b5b25ae7c653cb94345af5dcb",
+  "canonical_entry_baseline": "f77734aa8047a4c2c374a5702df3caacc4ec4a37",
   "binding": {
     "host": "Antigravity CLI",
     "cli_version": "1.1.15",
@@ -89,7 +89,9 @@
     "fail_closed_on_use_g1_credits_true": true,
     "fail_closed_on_malformed_use_g1_credits": true,
     "sparse_settings_default_fallback_disabled": true,
+    "stream_result_normalization_enabled": true,
     "raw_outer_envelope_preserved": true,
+    "raw_terminal_result_payload_preserved": true,
     "no_metric_inference": true
   },
   "quality_boundary": {
@@ -102,11 +104,15 @@
     ]
   },
   "governance_boundaries": {
-    "b3_1_4_sparse_settings_preflight": "IMPLEMENTED_SOURCE_ONLY",
+    "b3_1_5_stream_result_normalization": "IMPLEMENTED_SOURCE_ONLY",
+    "b3_2_diagnostic_attempt_2_disposition": "INVALID_RUN",
+    "b3_2_diagnostic_attempt_2_cause": "AGY_STREAM_RESULT_ENVELOPE_SCHEMA_MISMATCH",
+    "b3_2_diagnostic_attempt_2_resource_ceiling_exceeded": true,
     "current_validated_agy_version": "1.1.15",
     "credit_fallback_effective": false,
     "b3_measurement_maturity": "MEASUREMENT_NOT_STARTED",
-    "b3_diagnostic_execution": "NOT_STARTED",
+    "b3_valid_diagnostic": "NOT_COMPLETED",
+    "b3_diagnostic_execution": "NOT_COMPLETED",
     "b3_calibration_execution": "NOT_STARTED",
     "murmurs_benefit": "NOT_ESTABLISHED",
     "murmurs_token_savings": "NOT_CLAIMED",

--- a/scripts/antigravity_benchmark_executor.py
+++ b/scripts/antigravity_benchmark_executor.py
@@ -878,6 +878,62 @@ def evaluate_task_outcome(
     return outcome, quality
 
 
+def normalize_stream_terminal_event(
+    event: dict[str, Any],
+) -> tuple[bool, str | None, dict[str, Any] | None]:
+    """Normalize wrapped or flat Antigravity stream terminal event into canonical result payload.
+
+    Supports:
+    - Current AGY 1.1.15 wrapped result:
+      {"event": "result", "result": {"status": "SUCCESS", "usage": {...}, ...}}
+    - Legacy / flat compatibility:
+      {"type": "result", "status": "SUCCESS", "usage": {...}, ...} or {"status": "SUCCESS", "usage": {...}, ...}
+
+    Fails closed if:
+    - event is not a JSON object
+    - result payload is not a JSON object
+    - missing result payload when event=result
+    - conflicting outer wrapper and nested result critical fields (status, usage, cli_version, model)
+    """
+    if not isinstance(event, dict):
+        return False, "terminal stream event is not a JSON object", None
+
+    is_wrapped = (event.get("event") == "result") or ("result" in event)
+
+    if is_wrapped:
+        if "result" not in event:
+            return False, "wrapped terminal event missing result payload", None
+        result_payload = event["result"]
+        if not isinstance(result_payload, dict):
+            return False, "nested result payload is not a JSON object", None
+
+        # Fail closed on conflicting critical fields between outer wrapper and nested payload
+        for field in ("status", "usage", "cli_version", "model"):
+            if field in event and field in result_payload:
+                if event[field] != result_payload[field]:
+                    return False, f"conflicting outer wrapper and nested result critical field: {field}", None
+
+        normalized = copy.deepcopy(result_payload)
+        for field in (
+            "cli_version",
+            "model",
+            "task_completed",
+            "validation_passed",
+            "governance_valid",
+            "latency",
+            "coordination",
+            "useG1Credits",
+        ):
+            if field in event and field not in normalized:
+                normalized[field] = copy.deepcopy(event[field])
+
+        return True, None, normalized
+
+    # Flat event compatibility
+    normalized = copy.deepcopy(event)
+    return True, None, normalized
+
+
 def parse_stream_json_output(
     raw_output: str | list[Any],
     request: dict[str, Any],
@@ -944,54 +1000,139 @@ def parse_stream_json_output(
             expected_cli_version=expected_cli_version,
         )
 
-    # Locate terminal result
-    terminal_envelope: dict[str, Any] | None = None
-    for ev in reversed(events):
-        if "usage" in ev and "status" in ev:
-            terminal_envelope = ev
-            break
-        if ev.get("type") in ("result", "terminal", "completion") and ("usage" in ev or "status" in ev):
-            terminal_envelope = ev
-            break
+    # Discover candidate terminal events
+    candidate_terminal_events: list[dict[str, Any]] = []
+    for ev in events:
+        if ev.get("event") == "result":
+            candidate_terminal_events.append(ev)
+        elif ev.get("type") in ("result", "terminal", "completion"):
+            candidate_terminal_events.append(ev)
+        elif (
+            "usage" in ev
+            and "status" in ev
+            and ev.get("event") not in ("step_update", "init", "tool_start", "tool_complete", "heartbeat")
+            and ev.get("type") not in ("step_update", "model_call")
+        ):
+            candidate_terminal_events.append(ev)
+        elif (
+            "result" in ev
+            and ev.get("event") not in ("step_update", "init", "tool_start", "tool_complete", "heartbeat")
+            and ev.get("type") not in ("step_update", "model_call")
+        ):
+            candidate_terminal_events.append(ev)
 
-    if terminal_envelope is None:
-        terminal_envelope = events[-1]
-
-    status = terminal_envelope.get("status")
-    if not isinstance(status, str) or not status.strip() or status.upper() != "SUCCESS":
+    if not candidate_terminal_events:
         return build_invalid_result(
             request,
             "MEASUREMENT_CAPTURE_FAILURE",
-            {"error": f"terminal stream status is not SUCCESS: {status}", "terminal_envelope": terminal_envelope},
+            {"error": "no terminal result event found in stream"},
             elapsed_ms,
             expected_cli_version=expected_cli_version,
         )
 
-    usage = terminal_envelope.get("usage")
+    # If multiple candidate terminal events exist, check for conflicts
+    if len(candidate_terminal_events) > 1:
+        normalized_candidates: list[dict[str, Any]] = []
+        for cand in candidate_terminal_events:
+            ok, err_msg, cand_norm = normalize_stream_terminal_event(cand)
+            if not ok or cand_norm is None:
+                return build_invalid_result(
+                    request,
+                    "MEASUREMENT_CAPTURE_FAILURE",
+                    {"error": f"invalid terminal event among candidates: {err_msg}", "candidate": cand},
+                    elapsed_ms,
+                    expected_cli_version=expected_cli_version,
+                )
+            normalized_candidates.append(cand_norm)
+
+        # Check if candidate payloads conflict on critical measurement fields
+        first_cand = normalized_candidates[0]
+        for other_cand in normalized_candidates[1:]:
+            for field in ("status", "usage", "cli_version", "model", "response"):
+                if first_cand.get(field) != other_cand.get(field):
+                    return build_invalid_result(
+                        request,
+                        "MEASUREMENT_CAPTURE_FAILURE",
+                        {
+                            "error": f"multiple conflicting terminal results in event stream for field: {field}",
+                            "candidate_count": len(candidate_terminal_events),
+                        },
+                        elapsed_ms,
+                        expected_cli_version=expected_cli_version,
+                    )
+
+    terminal_envelope = candidate_terminal_events[-1]
+    is_valid_terminal, norm_error, normalized_payload = normalize_stream_terminal_event(terminal_envelope)
+    if not is_valid_terminal or normalized_payload is None:
+        return build_invalid_result(
+            request,
+            "MEASUREMENT_CAPTURE_FAILURE",
+            {
+                "error": norm_error or "failed to normalize terminal stream event",
+                "terminal_envelope": terminal_envelope,
+            },
+            elapsed_ms,
+            expected_cli_version=expected_cli_version,
+        )
+
+    status = normalized_payload.get("status")
+    if not isinstance(status, str) or not status.strip() or status.upper() != "SUCCESS":
+        return build_invalid_result(
+            request,
+            "MEASUREMENT_CAPTURE_FAILURE",
+            {
+                "error": f"terminal stream status is not SUCCESS: {status}",
+                "terminal_envelope": terminal_envelope,
+                "terminal_result_payload": normalized_payload,
+            },
+            elapsed_ms,
+            expected_cli_version=expected_cli_version,
+        )
+
+    usage = normalized_payload.get("usage")
     if not isinstance(usage, dict):
         return build_invalid_result(
             request,
             "MEASUREMENT_CAPTURE_FAILURE",
-            {"error": "usage object missing from terminal event", "terminal_envelope": terminal_envelope},
+            {
+                "error": "usage object missing from terminal event",
+                "terminal_envelope": terminal_envelope,
+                "terminal_result_payload": normalized_payload,
+            },
             elapsed_ms,
             expected_cli_version=expected_cli_version,
         )
 
     target_expected_version = expected_cli_version or QUALIFIED_CLI_VERSION
+    host_cli_version = normalized_payload.get("cli_version") or terminal_envelope.get("cli_version")
     effective_cli_version = (
         validated_cli_version
-        or terminal_envelope.get("cli_version")
+        or host_cli_version
         or target_expected_version
     )
 
-    if "cli_version" in terminal_envelope and terminal_envelope["cli_version"] != target_expected_version:
+    if host_cli_version is not None and host_cli_version != target_expected_version:
         return build_invalid_result(
             request,
             "MEASUREMENT_CAPTURE_FAILURE",
             {
                 "error": "terminal stream cli_version mismatch",
-                "host_cli_version": terminal_envelope["cli_version"],
+                "host_cli_version": host_cli_version,
                 "expected_cli_version": target_expected_version,
+            },
+            elapsed_ms,
+            expected_cli_version=target_expected_version,
+        )
+
+    host_model = normalized_payload.get("model") or terminal_envelope.get("model")
+    if host_model is not None and host_model != PINNED_MODEL:
+        return build_invalid_result(
+            request,
+            "MEASUREMENT_CAPTURE_FAILURE",
+            {
+                "error": "terminal stream model mismatch",
+                "host_model": host_model,
+                "expected_model": PINNED_MODEL,
             },
             elapsed_ms,
             expected_cli_version=target_expected_version,
@@ -1031,7 +1172,7 @@ def parse_stream_json_output(
             expected_cli_version=target_expected_version,
         )
 
-    outcome, quality = evaluate_task_outcome(terminal_envelope, task_payload)
+    outcome, quality = evaluate_task_outcome(normalized_payload, task_payload)
 
     # Process progress events according to presentation mode
     pres_mode = binding.get("presentation_mode", "NORMAL") if binding else "NORMAL"
@@ -1039,7 +1180,14 @@ def parse_stream_json_output(
     model_progress_calls = 0
     user_visible_bytes = 0
 
-    intermediate_events = [ev for ev in events if ev is not terminal_envelope]
+    intermediate_events = [
+        ev
+        for ev in events
+        if ev is not terminal_envelope
+        and ev not in candidate_terminal_events
+        and ev.get("event") != "result"
+        and ev.get("type") not in ("result", "terminal", "completion")
+    ]
 
     if pres_mode == "MURMURS":
         root = presentation_root or repository_root()
@@ -1052,7 +1200,7 @@ def parse_stream_json_output(
             decide_presentation,
         )
         for seq_idx, ev in enumerate(intermediate_events, start=1):
-            raw_kind = ev.get("event_kind") or ev.get("kind") or ev.get("type")
+            raw_kind = ev.get("event_kind") or ev.get("kind") or ev.get("type") or ev.get("event")
             if raw_kind == "tool_start" or raw_kind == "TOOL_STARTED":
                 event_kind = PresentationEventKind.TOOL_STARTED
             elif raw_kind == "tool_complete" or raw_kind == "TOOL_COMPLETED":
@@ -1080,19 +1228,25 @@ def parse_stream_json_output(
                 user_visible_bytes += len(content.encode("utf-8"))
             elif decision.disposition.value == "SILENT":
                 pass
-            if ev.get("type") in ("step_update", "model_call") or "content" in ev:
+            if ev.get("type") in ("step_update", "model_call") or ev.get("event") in ("step_update", "model_call") or "content" in ev:
                 model_progress_calls += 1
     else:
         # NORMAL mode (DEFAULT and CAVEMAN)
         for ev in intermediate_events:
             progress_messages += 1
-            if ev.get("type") in ("step_update", "model_call") or "content" in ev:
+            if ev.get("type") in ("step_update", "model_call") or ev.get("event") in ("step_update", "model_call") or "content" in ev:
                 model_progress_calls += 1
             content = str(ev.get("content", ev.get("response", ev.get("message", ""))))
             user_visible_bytes += len(content.encode("utf-8"))
 
     # Add terminal response user_visible_bytes (terminal is always EXPLAIN)
-    terminal_resp = terminal_envelope.get("response") or terminal_envelope.get("content") or ""
+    terminal_resp = (
+        normalized_payload.get("response")
+        or normalized_payload.get("content")
+        or terminal_envelope.get("response")
+        or terminal_envelope.get("content")
+        or ""
+    )
     if isinstance(terminal_resp, str):
         user_visible_bytes += len(terminal_resp.encode("utf-8"))
     else:
@@ -1102,20 +1256,31 @@ def parse_stream_json_output(
         "progress_messages": progress_messages,
         "model_progress_calls": model_progress_calls,
         "user_visible_bytes": user_visible_bytes,
-        "context_transfer_bytes": int(terminal_envelope.get("context_transfer_bytes", 0)),
+        "context_transfer_bytes": int(
+            normalized_payload.get("context_transfer_bytes", terminal_envelope.get("context_transfer_bytes", 0))
+        ),
         "semantic_preservation_failures": 0,
         "required_information_omissions": 0,
     }
 
-    latency_source = terminal_envelope.get("latency") or {}
+    latency_source = normalized_payload.get("latency") or terminal_envelope.get("latency") or {}
+    wall_clock_ms = latency_source.get("wall_clock_ms")
+    if wall_clock_ms is None:
+        if elapsed_ms is not None:
+            wall_clock_ms = int(elapsed_ms)
+        elif "duration_seconds" in normalized_payload and isinstance(normalized_payload["duration_seconds"], (int, float)):
+            wall_clock_ms = int(normalized_payload["duration_seconds"] * 1000)
+        else:
+            wall_clock_ms = 0
+
     latency = {
-        "wall_clock_ms": int(latency_source.get("wall_clock_ms", elapsed_ms if elapsed_ms is not None else 0)),
+        "wall_clock_ms": wall_clock_ms,
         "model_execution_ms": latency_source.get("model_execution_ms"),
         "tool_execution_ms": latency_source.get("tool_execution_ms"),
         "coordination_overhead_ms": latency_source.get("coordination_overhead_ms"),
     }
 
-    coord_source = terminal_envelope.get("coordination") or {}
+    coord_source = normalized_payload.get("coordination") or terminal_envelope.get("coordination") or {}
     coordination = {
         "specialist_messages": int(coord_source.get("specialist_messages", 0)),
         "cross_specialist_messages": int(coord_source.get("cross_specialist_messages", 0)),
@@ -1131,7 +1296,9 @@ def parse_stream_json_output(
 
     effective_credit_policy = credit_policy
     if effective_credit_policy is None:
-        _, _, effective_credit_policy = resolve_use_g1_credits(terminal_envelope)
+        _, _, effective_credit_policy = resolve_use_g1_credits(
+            normalized_payload if "useG1Credits" in normalized_payload else terminal_envelope
+        )
 
     effective_binding = binding or {}
     raw_evidence = {
@@ -1171,6 +1338,8 @@ def parse_stream_json_output(
         "effective_prompt_or_policy_digest": effective_binding.get("effective_prompt_or_policy_digest", ""),
         "topology_candidate_id": request.get("arm", {}).get("topology_candidate_id"),
         "topology_digest": request.get("arm", {}).get("topology_digest"),
+        "terminal_event_envelope": copy.deepcopy(terminal_envelope),
+        "terminal_result_payload": copy.deepcopy(normalized_payload),
         "outer_envelope": copy.deepcopy(terminal_envelope),
         "stream_events": copy.deepcopy(events),
         "total_tokens": usage.get("total_tokens"),
@@ -1237,6 +1406,19 @@ def parse_antigravity_output(
 
     # Detect stream-json list
     if isinstance(raw_output, list):
+        return parse_stream_json_output(
+            raw_output,
+            request,
+            elapsed_ms=elapsed_ms,
+            expected_cli_version=expected_cli_version,
+            validated_cli_version=validated_cli_version,
+            binding=binding,
+            presentation_root=presentation_root,
+            credit_policy=credit_policy,
+        )
+
+    # Detect stream-json transport
+    if transport in ("stream-json", "stream-json-usage", PINNED_TRANSPORT_STREAM) and isinstance(raw_output, str):
         return parse_stream_json_output(
             raw_output,
             request,

--- a/tests/runtime/test_comparative_benchmark_antigravity_executor.py
+++ b/tests/runtime/test_comparative_benchmark_antigravity_executor.py
@@ -2024,3 +2024,521 @@ def test_76_stream_json_sparse_settings_provenance(tmp_path: Path) -> None:
     assert pol["effective_source"] == "SYSTEM_DEFAULT_SPARSE_PERSISTENCE"
     assert pol["key_present"] is False
     assert pol["effective_value"] is False
+
+
+def _mock_agy_1_1_15_wrapped_result(
+    status: str = "SUCCESS",
+    input_tokens: int = 142896,
+    output_tokens: int = 4692,
+    thinking_tokens: int = 2804,
+    cache_read_tokens: int = 786302,
+    total_tokens: int = 147588,
+    response: str = "diagnostic response",
+    conversation_id: str = "synthetic-test-id",
+    duration_seconds: float = 86.5398064,
+    num_turns: int = 1,
+    cli_version: str | None = None,
+    model: str | None = None,
+    task_completed: bool = True,
+    validation_passed: bool = True,
+    governance_valid: bool = True,
+) -> dict[str, Any]:
+    res: dict[str, Any] = {
+        "conversation_id": conversation_id,
+        "duration_seconds": duration_seconds,
+        "num_turns": num_turns,
+        "response": response,
+        "status": status,
+        "usage": {
+            "cache_read_tokens": cache_read_tokens,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "thinking_tokens": thinking_tokens,
+            "total_tokens": total_tokens,
+        },
+        "task_completed": task_completed,
+        "validation_passed": validation_passed,
+        "governance_valid": governance_valid,
+    }
+    if cli_version is not None:
+        res["cli_version"] = cli_version
+    if model is not None:
+        res["model"] = model
+    return {
+        "event": "result",
+        "result": res,
+    }
+
+
+def test_77_normalize_stream_terminal_event_helper_unit_tests() -> None:
+    # Helper unit tests for normalize_stream_terminal_event
+    wrapped = _mock_agy_1_1_15_wrapped_result()
+    ok, err, norm = executor.normalize_stream_terminal_event(wrapped)
+    assert ok is True
+    assert err is None
+    assert norm is not None
+    assert norm["status"] == "SUCCESS"
+    assert norm["usage"]["input_tokens"] == 142896
+    assert norm["conversation_id"] == "synthetic-test-id"
+
+    # Flat legacy event
+    flat = {"type": "result", "status": "SUCCESS", "usage": {"input_tokens": 100, "output_tokens": 50}}
+    ok, err, norm = executor.normalize_stream_terminal_event(flat)
+    assert ok is True
+    assert err is None
+    assert norm["usage"]["input_tokens"] == 100
+
+    # Non-dict event
+    ok, err, norm = executor.normalize_stream_terminal_event("not-a-dict")  # type: ignore
+    assert ok is False
+    assert "not a JSON object" in (err or "")
+
+    # Wrapped event with non-dict result payload
+    ok, err, norm = executor.normalize_stream_terminal_event({"event": "result", "result": "invalid"})
+    assert ok is False
+    assert "nested result payload is not a JSON object" in (err or "")
+
+    # Wrapped event with missing result key
+    ok, err, norm = executor.normalize_stream_terminal_event({"event": "result"})
+    assert ok is False
+    assert "missing result payload" in (err or "")
+
+    # Conflicting outer status
+    conflict_status = {
+        "event": "result",
+        "status": "FAIL",
+        "result": {"status": "SUCCESS", "usage": {"input_tokens": 100, "output_tokens": 50}},
+    }
+    ok, err, norm = executor.normalize_stream_terminal_event(conflict_status)
+    assert ok is False
+    assert "conflicting outer wrapper and nested result critical field: status" in (err or "")
+
+    # Conflicting outer usage
+    conflict_usage = {
+        "event": "result",
+        "usage": {"input_tokens": 999, "output_tokens": 1},
+        "result": {"status": "SUCCESS", "usage": {"input_tokens": 100, "output_tokens": 50}},
+    }
+    ok, err, norm = executor.normalize_stream_terminal_event(conflict_usage)
+    assert ok is False
+    assert "conflicting outer wrapper and nested result critical field: usage" in (err or "")
+
+
+def test_78_wrapped_agy_1_1_15_terminal_event_detected_and_accepted() -> None:
+    # Requirement: wrapped event=result matching AGY 1.1.15 is detected and parsed correctly
+    wrapped = _mock_agy_1_1_15_wrapped_result()
+    events = [
+        {"event": "step_update", "content": "Processing task step..."},
+        wrapped,
+    ]
+    raw_stream = "\n".join(json.dumps(ev) for ev in events)
+
+    req = _base_request(prompt="AGY 1.1.15 stream test", transport="stream-json")
+    res = executor.parse_antigravity_output(
+        raw_stream,
+        req,
+        elapsed_ms=86540,
+        expected_cli_version="1.1.15",
+        transport="stream-json-usage",
+    )
+    _validate_result_schema(res)
+
+    # 1. wrapped event=result is detected as terminal
+    assert res["outcome"]["status"] == "PASS"
+
+    # 2. nested result.status=SUCCESS is accepted
+    assert res["outcome"]["task_completed"] is True
+    assert res["outcome"]["validation_passed"] is True
+    assert res["outcome"]["governance_valid"] is True
+
+    # 3. nested usage maps to HOST_REPORTED tokens
+    tok = res["tokens"]
+    assert tok["source"] == "HOST_REPORTED"
+    assert tok["input_tokens"] == 142896
+    assert tok["output_tokens"] == 4692
+    assert tok["reasoning_tokens"] == 2804
+    assert tok["cached_input_tokens"] == 786302
+    assert tok["fresh_billable_tokens"] is None
+
+    # 4. counter identity is the qualified stream counter
+    assert tok["counter_id"] == "antigravity-cli-1.1.15:stream-json-usage:gemini-3.7-flash-high"
+
+    # 5. cache_read_tokens maps without being invented into total_tokens
+    assert res["raw_evidence"]["total_tokens"] == 147588
+
+    # 6. response contributes to user-visible output accounting
+    resp_bytes = len("diagnostic response".encode("utf-8"))
+    assert res["communication"]["user_visible_bytes"] >= resp_bytes
+
+    # 7. original wrapper is retained
+    assert "terminal_event_envelope" in res["raw_evidence"]
+    assert res["raw_evidence"]["terminal_event_envelope"]["event"] == "result"
+    assert "result" in res["raw_evidence"]["terminal_event_envelope"]
+
+    # 8. normalized result payload is retained
+    assert "terminal_result_payload" in res["raw_evidence"]
+    assert res["raw_evidence"]["terminal_result_payload"]["status"] == "SUCCESS"
+    assert res["raw_evidence"]["terminal_result_payload"]["conversation_id"] == "synthetic-test-id"
+
+
+def test_79_wrapped_stream_malformed_result_fails_closed() -> None:
+    # Requirement: malformed result value fails closed
+    req = _base_request(transport="stream-json")
+
+    # String result
+    res_str = executor.parse_stream_json_output(
+        [{"event": "result", "result": "malformed_string"}],
+        req,
+        expected_cli_version="1.1.15",
+    )
+    _validate_result_schema(res_str)
+    assert res_str["outcome"]["status"] == "INVALID_RUN"
+    assert res_str["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+    # Null result
+    res_null = executor.parse_stream_json_output(
+        [{"event": "result", "result": None}],
+        req,
+        expected_cli_version="1.1.15",
+    )
+    _validate_result_schema(res_null)
+    assert res_null["outcome"]["status"] == "INVALID_RUN"
+    assert res_null["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+    # Integer result
+    res_int = executor.parse_stream_json_output(
+        [{"event": "result", "result": 12345}],
+        req,
+        expected_cli_version="1.1.15",
+    )
+    _validate_result_schema(res_int)
+    assert res_int["outcome"]["status"] == "INVALID_RUN"
+    assert res_int["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+    # Missing result key with event=result
+    res_missing = executor.parse_stream_json_output(
+        [{"event": "result"}],
+        req,
+        expected_cli_version="1.1.15",
+    )
+    _validate_result_schema(res_missing)
+    assert res_missing["outcome"]["status"] == "INVALID_RUN"
+    assert res_missing["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+
+def test_80_wrapped_stream_missing_or_non_success_status_fails_closed() -> None:
+    # Requirement: missing nested status or non-SUCCESS nested status fails closed
+    req = _base_request(transport="stream-json")
+
+    # Missing status
+    res_missing_status = executor.parse_stream_json_output(
+        [{
+            "event": "result",
+            "result": {
+                "usage": {"input_tokens": 100, "output_tokens": 50},
+                "response": "ok",
+            },
+        }],
+        req,
+        expected_cli_version="1.1.15",
+    )
+    _validate_result_schema(res_missing_status)
+    assert res_missing_status["outcome"]["status"] == "INVALID_RUN"
+    assert res_missing_status["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+    # Non-SUCCESS status
+    res_fail_status = executor.parse_stream_json_output(
+        [{
+            "event": "result",
+            "result": {
+                "status": "ERROR",
+                "usage": {"input_tokens": 100, "output_tokens": 50},
+                "response": "failed",
+            },
+        }],
+        req,
+        expected_cli_version="1.1.15",
+    )
+    _validate_result_schema(res_fail_status)
+    assert res_fail_status["outcome"]["status"] == "INVALID_RUN"
+    assert res_fail_status["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+
+def test_81_wrapped_stream_missing_or_malformed_usage_fails_closed() -> None:
+    # Requirement: missing usage or malformed usage fails closed
+    req = _base_request(transport="stream-json")
+
+    # Missing usage
+    res_no_usage = executor.parse_stream_json_output(
+        [{
+            "event": "result",
+            "result": {
+                "status": "SUCCESS",
+                "response": "ok",
+            },
+        }],
+        req,
+        expected_cli_version="1.1.15",
+    )
+    _validate_result_schema(res_no_usage)
+    assert res_no_usage["outcome"]["status"] == "INVALID_RUN"
+    assert res_no_usage["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+    # Non-dict usage
+    res_str_usage = executor.parse_stream_json_output(
+        [{
+            "event": "result",
+            "result": {
+                "status": "SUCCESS",
+                "usage": "invalid_usage_string",
+            },
+        }],
+        req,
+        expected_cli_version="1.1.15",
+    )
+    _validate_result_schema(res_str_usage)
+    assert res_str_usage["outcome"]["status"] == "INVALID_RUN"
+    assert res_str_usage["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+    # Missing input_tokens
+    res_missing_input = executor.parse_stream_json_output(
+        [{
+            "event": "result",
+            "result": {
+                "status": "SUCCESS",
+                "usage": {"output_tokens": 50},
+            },
+        }],
+        req,
+        expected_cli_version="1.1.15",
+    )
+    _validate_result_schema(res_missing_input)
+    assert res_missing_input["outcome"]["status"] == "INVALID_RUN"
+    assert res_missing_input["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+    # Negative tokens
+    res_neg_input = executor.parse_stream_json_output(
+        [{
+            "event": "result",
+            "result": {
+                "status": "SUCCESS",
+                "usage": {"input_tokens": -1, "output_tokens": 50},
+            },
+        }],
+        req,
+        expected_cli_version="1.1.15",
+    )
+    _validate_result_schema(res_neg_input)
+    assert res_neg_input["outcome"]["status"] == "INVALID_RUN"
+    assert res_neg_input["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+
+def test_82_conflicting_outer_wrapper_and_nested_critical_values_fail_closed() -> None:
+    # Requirement: conflicting outer and nested critical values fail closed
+    req = _base_request(transport="stream-json")
+
+    # Conflicting status
+    res_status_conflict = executor.parse_stream_json_output(
+        [{
+            "event": "result",
+            "status": "FAIL",
+            "result": {
+                "status": "SUCCESS",
+                "usage": {"input_tokens": 100, "output_tokens": 50},
+            },
+        }],
+        req,
+        expected_cli_version="1.1.15",
+    )
+    _validate_result_schema(res_status_conflict)
+    assert res_status_conflict["outcome"]["status"] == "INVALID_RUN"
+    assert res_status_conflict["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+    # Conflicting usage
+    res_usage_conflict = executor.parse_stream_json_output(
+        [{
+            "event": "result",
+            "usage": {"input_tokens": 999, "output_tokens": 999},
+            "result": {
+                "status": "SUCCESS",
+                "usage": {"input_tokens": 100, "output_tokens": 50},
+            },
+        }],
+        req,
+        expected_cli_version="1.1.15",
+    )
+    _validate_result_schema(res_usage_conflict)
+    assert res_usage_conflict["outcome"]["status"] == "INVALID_RUN"
+    assert res_usage_conflict["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+    # Conflicting cli_version
+    res_ver_conflict = executor.parse_stream_json_output(
+        [{
+            "event": "result",
+            "cli_version": "1.1.14",
+            "result": {
+                "status": "SUCCESS",
+                "cli_version": "1.1.15",
+                "usage": {"input_tokens": 100, "output_tokens": 50},
+            },
+        }],
+        req,
+        expected_cli_version="1.1.15",
+    )
+    _validate_result_schema(res_ver_conflict)
+    assert res_ver_conflict["outcome"]["status"] == "INVALID_RUN"
+    assert res_ver_conflict["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+    # Conflicting model
+    res_model_conflict = executor.parse_stream_json_output(
+        [{
+            "event": "result",
+            "model": "gemini-2.5-pro",
+            "result": {
+                "status": "SUCCESS",
+                "model": "gemini-3.7-flash-high",
+                "usage": {"input_tokens": 100, "output_tokens": 50},
+            },
+        }],
+        req,
+        expected_cli_version="1.1.15",
+    )
+    _validate_result_schema(res_model_conflict)
+    assert res_model_conflict["outcome"]["status"] == "INVALID_RUN"
+    assert res_model_conflict["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+
+def test_83_matching_outer_and_nested_critical_fields_accepted() -> None:
+    # Requirement: non-conflicting outer metadata is accepted and merged without error
+    req = _base_request(transport="stream-json")
+    event = {
+        "event": "result",
+        "status": "SUCCESS",
+        "cli_version": "1.1.15",
+        "model": "gemini-3.7-flash-high",
+        "result": {
+            "status": "SUCCESS",
+            "cli_version": "1.1.15",
+            "model": "gemini-3.7-flash-high",
+            "usage": {"input_tokens": 500, "output_tokens": 100},
+            "task_completed": True,
+            "validation_passed": True,
+            "governance_valid": True,
+            "response": "All matched",
+        },
+    }
+    res = executor.parse_stream_json_output([event], req, expected_cli_version="1.1.15")
+    _validate_result_schema(res)
+    assert res["outcome"]["status"] == "PASS"
+    assert res["tokens"]["input_tokens"] == 500
+
+
+def test_84_multiple_conflicting_terminal_results_in_stream_fails_closed() -> None:
+    # Requirement: multiple conflicting terminal results fail closed
+    req = _base_request(transport="stream-json")
+    ev1 = _mock_agy_1_1_15_wrapped_result(status="SUCCESS", input_tokens=1000)
+    ev2 = _mock_agy_1_1_15_wrapped_result(status="SUCCESS", input_tokens=2000)  # different usage!
+
+    res = executor.parse_stream_json_output([ev1, ev2], req, expected_cli_version="1.1.15")
+    _validate_result_schema(res)
+    assert res["outcome"]["status"] == "INVALID_RUN"
+    assert res["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+
+
+def test_85_flat_legacy_terminal_fixture_remains_supported() -> None:
+    # Requirement: flat legacy terminal fixtures continue to be accepted
+    flat_event = {
+        "type": "result",
+        "status": "SUCCESS",
+        "cli_version": "1.1.15",
+        "model": "gemini-3.7-flash-high",
+        "usage": {
+            "input_tokens": 1500,
+            "output_tokens": 400,
+            "thinking_tokens": 120,
+            "cache_read_tokens": 300,
+            "total_tokens": 2320,
+        },
+        "task_completed": True,
+        "validation_passed": True,
+        "governance_valid": True,
+        "response": "Legacy flat response",
+    }
+    req = _base_request(transport="stream-json")
+    res = executor.parse_stream_json_output([flat_event], req, expected_cli_version="1.1.15")
+    _validate_result_schema(res)
+    assert res["outcome"]["status"] == "PASS"
+    assert res["tokens"]["input_tokens"] == 1500
+    assert res["raw_evidence"]["terminal_event_envelope"] == flat_event
+    assert res["raw_evidence"]["terminal_result_payload"]["status"] == "SUCCESS"
+
+
+def test_86_intermediate_progress_events_with_event_field_recognized() -> None:
+    # Requirement: event=step_update recognized and terminal result excluded from intermediate count
+    events = [
+        {"event": "step_update", "content": "Thinking step 1"},
+        {"event": "step_update", "content": "Thinking step 2"},
+        {"event": "tool_start", "event_kind": "TOOL_STARTED", "content": "Running tool"},
+        {"event": "tool_complete", "event_kind": "TOOL_COMPLETED", "content": "Finished tool"},
+        _mock_agy_1_1_15_wrapped_result(),
+    ]
+    raw_stream = "\n".join(json.dumps(ev) for ev in events)
+
+    req = _base_request(transport="stream-json", communication_mode="DEFAULT")
+    res = executor.parse_stream_json_output(raw_stream, req, expected_cli_version="1.1.15")
+    _validate_result_schema(res)
+
+    comm = res["communication"]
+    # 4 intermediate events, terminal result is excluded from progress_messages count
+    assert comm["progress_messages"] == 4
+    assert comm["model_progress_calls"] == 4
+    # User visible bytes include content of intermediate events + terminal response
+    assert comm["user_visible_bytes"] > len("diagnostic response".encode("utf-8"))
+
+
+def test_87_wrapped_stream_across_all_communication_treatments() -> None:
+    # Requirement: DEFAULT, CAVEMAN, MURMURS arms all work with wrapped AGY 1.1.15 stream-json output
+    wrapped = _mock_agy_1_1_15_wrapped_result()
+    events = [
+        {"event": "step_update", "event_kind": "TOOL_STARTED", "content": "Running test"},
+        {"event": "step_update", "event_kind": "TOOL_COMPLETED", "content": "Completed test"},
+        wrapped,
+    ]
+    stream_payload = "\n".join(json.dumps(ev) for ev in events)
+
+    for mode in ("DEFAULT", "CAVEMAN", "MURMURS"):
+        req = _base_request(
+            communication_mode=mode,
+            transport="stream-json",
+            caveman_policy_content=VALID_CAVEMAN_SKILL_MD if mode == "CAVEMAN" else None,
+            raw_host_output=stream_payload,
+        )
+        res = executor.execute_request(req)
+        _validate_result_schema(res)
+
+        assert res["tokens"]["source"] == "HOST_REPORTED"
+        assert res["tokens"]["counter_id"] == "antigravity-cli-1.1.15:stream-json-usage:gemini-3.7-flash-high"
+        assert res["tokens"]["input_tokens"] == 142896
+        assert res["tokens"]["cached_input_tokens"] == 786302
+        assert res["raw_evidence"]["transport"] == "stream-json-usage"
+        assert res["outcome"]["status"] == "PASS"
+
+
+def test_88_zero_live_model_calls_across_all_stream_tests() -> None:
+    # Requirement: zero tests execute a real Antigravity model turn
+    call_records: list[list[str]] = []
+
+    def tracking_runner(cmd: list[str], prompt: str = "") -> tuple[int, str, str]:
+        call_records.append(cmd)
+        return (0, json.dumps(_mock_agy_1_1_15_wrapped_result()), "")
+
+    req = _base_request(
+        raw_host_output=json.dumps(_mock_agy_1_1_15_wrapped_result()),
+        transport="stream-json",
+    )
+    res = executor.execute_request(req, runner_fn=tracking_runner)
+    _validate_result_schema(res)
+
+    # When mock output is provided, runner is never called
+    assert len(call_records) == 0
+    assert res["outcome"]["status"] == "PASS"


### PR DESCRIPTION
## Canonicalization role

Canonicalize the exact GitHub-signed B3.1.5 materialized head after separate source-head validation and bounded signed materialization.

Signed materialized head: `76d6ab1b396cf22d71679b1530eee3943c8b5f41`
Signed materialized tree: `cee417e44db96ec8425929fbeb3299d4b74b7cc9`
Expected canonical parent: `f77734aa8047a4c2c374a5702df3caacc4ec4a37`
Signature: GitHub verified / valid

Reviewed source head: `67d7c87492dc035b7cc2ada824ae92ca1a8bd62f`
Reviewed source tree: `cee417e44db96ec8425929fbeb3299d4b74b7cc9`

Source exact-head validation:
- Governance Check `32271915167` PASS
- validate `32271914993` PASS
- Required Analysis Compatibility `32271914934` PASS
- Cross-platform Validation `32271915069` PASS
- cosmic-ray-confidence `32271914995` PASS
- Cosmic Ray digest `sha256:b24a0e9c194e199ee2d8450694ec13cd4746bb8bb499b27401f909124aa6c1ef`

Signed materialization:
- PR #441
- workflow `32272881915` PASS
- evidence digest `sha256:cfbd38033f59d415421cd1f2813fc0be583824c3f5c47a60288714e0dce90dee`

Qualified AGY host remains CLI `1.1.15`, model `gemini-3.7-flash-high`.
B3.1.5 normalizes wrapped `event=result` stream-json terminal events while preserving legacy flat compatibility, fail-closed conflict checks, raw wrapper/payload provenance, sparse credit semantics, and exact host-version controls.

A fresh full validation matrix is required on this exact signed head before merge to main.

Governance remains:
- B3 measurement maturity = MEASUREMENT_NOT_STARTED
- valid 3-run diagnostic = NOT COMPLETED
- calibration = NOT STARTED
- Murmurs benefit = NOT ESTABLISHED
- Murmurs token savings = NOT CLAIMED
- A5 execution promotion = NOT AUTHORIZED
- A6 = NOT AUTHORIZED
- B4 = BLOCKED
- no deployment/release/production-runtime authority.