### PR TITLE
docs: reconcile canonical Registry-Orchestra alignment state

### DIFF
--- a/README.json
+++ b/README.json
@@ -215,15 +215,18 @@
       "authority_note": "B3 records completed and validated 30-run empirical calibration and baseline evidence freeze under the Padayon-grounded task-set. Murmurs benefit remains not established from calibration sample evidence alone, token savings are evidence-derived only, fresh_billable_tokens and cost remain unavailable, personal credit fallback remains disabled, A5 remains shadow-only, and B4 remains blocked."
     },
     "registry_adaptive_consumption_o1_o6": {
-      "status": "IMPLEMENTED_CANDIDATE_PENDING_EXACT_HEAD_VALIDATION",
+      "status": "CANONICAL_IMPLEMENTED_VALIDATED_AND_REGISTRY_RECONCILED",
       "purpose": "Negotiated Registry capability consumption, explicit trusted Registry v0.2.0 compatibility, multi-jurisdiction query selection, query-scoped freshness, release-delta impact analysis, and governed domain-to-specialist resolution.",
       "runtime_surface": "orchestra_runtime/registry_adaptive.py",
       "cli_surface": "scripts/compliance_registry_adaptive.py",
       "validation_surfaces": ["tests/runtime/test_registry_adaptive.py", "tests/runtime/test_registry_adaptive_edges.py", "tests/runtime/test_registry_joint_contract.py"],
       "human_sources": ["docs/architecture/REGISTRY_ADAPTIVE_CONSUMPTION_O1_O6.md"],
-      "registry_r5_r6_candidate": "Baelfyre/Orchestra-Compliance-Registry PR #24",
-      "legacy_v0_2_compatibility": "EXPLICIT_LOCAL_PROFILE_NO_INVENTED_REGISTRY_R5_METADATA",
-      "authority_note": "Registry capability, freshness, delta, and routing evidence cannot expand Orchestra authority, merge or publish Registry state, bypass Conductor routing, or replace Governor/Steward/Arbiter evidence controls."
+      "canonical_orchestra_implementation": {"sha": "955a4b4918e28638a50e9564d1e3ea0127ae5f73", "tree": "4cba8642eb63b38b283db67010e01f204c92780b"},
+      "registry_r1_r6_canonical": {"repository": "Baelfyre/Orchestra-Compliance-Registry", "sha": "20eb859db153f17e24c052a13765e982d51cedbf", "tree": "763be9062a0c23031c794403dc4592f5db4389b0", "implementation_merge_sha": "be297335b55aa6a3a88a473c7e7da28614e95cd2", "trusted_release": "registry-v0.2.0", "trusted_release_includes_r1_r6": false},
+      "r5_capability_blob_sha": "978c1a6eecffe802df79e6d110a16b780ec6bd3f",
+      "joint_reconciliation": "PASS",
+      "legacy_v0_2_compatibility": "EXPLICIT_LOCAL_PROFILE_NO_INVENTED_REGISTRY_CAPABILITY_METADATA",
+      "authority_note": "Registry capability, freshness, delta, and routing evidence cannot expand Orchestra authority, publish Registry state, bypass Conductor routing, or replace Governor/Steward/Arbiter evidence controls."
     }
   },
   "machine_scan_order": [
@@ -438,7 +441,7 @@
     "adaptive_governed_orchestration": "A5_CLOSED_AT_SHADOW_MATURITY_EXECUTION_PROMOTION_DEFERRED_BENEFIT_NOT_ESTABLISHED_ISSUE_340",
     "comparative_measurement_b0": "CONTRACT_FROZEN_NO_BENCHMARK_EXECUTION",
     "comparative_measurement_b1": "IMPLEMENTED_NON_PRODUCTION_NO_PROVIDER_ADAPTERS",
-    "registry_adaptive_consumption_o1_o6": "IMPLEMENTED_CANDIDATE_PENDING_EXACT_HEAD_VALIDATION",
+    "registry_adaptive_consumption_o1_o6": "CANONICAL_IMPLEMENTED_VALIDATED_AND_REGISTRY_RECONCILED",
     "murmurs_live_host_token_measurement": "DEFERRED_UNTIL_ELIGIBLE_COUNTERS_ISSUE_316"
   },
   "ai_review_guidance": {

--- a/docs/architecture/REGISTRY_ADAPTIVE_CONSUMPTION_O1_O6.md
+++ b/docs/architecture/REGISTRY_ADAPTIVE_CONSUMPTION_O1_O6.md
@@ -2,7 +2,11 @@
 
 ## Status
 
-Candidate implementation after the frozen Antigravity B3 closeout. This program does not reopen B3, merge Registry PR #23, publish a Registry release, promote A5, authorize A6, unblock B4, deploy, or grant Registry evidence any execution authority.
+O1-O6 are canonical on Orchestra `main` from implementation merge `955a4b4918e28638a50e9564d1e3ea0127ae5f73` / tree `4cba8642eb63b38b283db67010e01f204c92780b`. Registry R1-R6 are also canonical and current-facing state is reconciled at `20eb859db153f17e24c052a13765e982d51cedbf` / tree `763be9062a0c23031c794403dc4592f5db4389b0`.
+
+The cross-repository R5 capability interface was verified by exact Git blob identity: Registry `registry/capabilities.json` and Orchestra `tests/fixtures/compliance-registry/r5-capabilities.json` both use blob `978c1a6eecffe802df79e6d110a16b780ec6bd3f`. The immutable trusted Registry release remains `registry-v0.2.0`; it predates R1-R6 and is not changed or republished by this alignment.
+
+This program does not reopen B3, promote A5, authorize A6, unblock B4, deploy, publish a Registry release, or grant Registry evidence any execution authority.
 
 ## Architecture
 
@@ -91,4 +95,4 @@ This supplements, rather than replaces, the existing compliance query and consum
 
 ## Joint Contract Fixture
 
-`tests/fixtures/compliance-registry/r5-capabilities.json` is an exact copy of the R5 candidate capability manifest used for the cross-repository interface test. Joint tests cover current v0.2 fallback, required/optional capability behavior, multi-jurisdiction selection, scoped freshness, breaking and compatible deltas, specialist resolution, unresolved domains, and authority-expansion rejection.
+`tests/fixtures/compliance-registry/r5-capabilities.json` is the exact R5 capability manifest used for the cross-repository interface test. Its Git blob is identical to canonical Registry `registry/capabilities.json` at the reconciled R1-R6 state. Joint tests cover current v0.2 fallback, required/optional capability behavior, multi-jurisdiction selection, scoped freshness, breaking and compatible deltas, specialist resolution, unresolved domains, and authority-expansion rejection.


### PR DESCRIPTION
Post-canonicalization current-state reconciliation only.

Orchestra O1-O6 implementation is already canonical:
- implementation SHA `955a4b4918e28638a50e9564d1e3ea0127ae5f73`
- implementation tree `4cba8642eb63b38b283db67010e01f204c92780b`

Registry R1-R6 current canonical state:
- SHA `20eb859db153f17e24c052a13765e982d51cedbf`
- tree `763be9062a0c23031c794403dc4592f5db4389b0`
- implementation merge `be297335b55aa6a3a88a473c7e7da28614e95cd2`
- trusted release remains `registry-v0.2.0` and does not include R1-R6

Cross-repository capability parity:
- Registry `registry/capabilities.json` blob `978c1a6eecffe802df79e6d110a16b780ec6bd3f`
- Orchestra `tests/fixtures/compliance-registry/r5-capabilities.json` same exact blob
- joint reconciliation: PASS

This PR changes only current-facing O1-O6 architecture/status documentation and README.json machine discovery state. It preserves all B3 measurement evidence and frozen benchmark identities, does not change runtime behavior, does not publish a Registry or Orchestra release, does not promote A5, authorize A6, unblock B4, deploy, force push, rewrite history, or delete branches.