### PR TITLE
docs: freeze O7 optimized Registry consumption plan

### DIFF
--- a/README.json
+++ b/README.json
@@ -17,8 +17,8 @@
     "current_public_release_commit": "ba35764a14111518c7da729b5a4c69c6af485a9b",
     "current_public_release_state_scope": "LIVE_VERIFIED_PUBLICATION",
     "main_contains_post_release_work": true,
-    "next_release_plan": "UNSELECTED_POST_V1_6_0",
-    "next_release_plan_status": "NO_NEXT_RELEASE_SELECTED_OR_AUTHORIZED"
+    "next_release_plan": "V1_7_AFTER_CODEX_BASELINE_CLOSEOUT",
+    "next_release_plan_status": "APPROVED_SEQUENCE_NOT_YET_PUBLISHED"
   },
   "purpose": {
     "summary": "Portable orchestration runtime for structured AI-assisted software development.",
@@ -215,11 +215,13 @@
       "authority_note": "B3 records completed and validated 30-run empirical calibration and baseline evidence freeze under the Padayon-grounded task-set. Murmurs benefit remains not established from calibration sample evidence alone, token savings are evidence-derived only, fresh_billable_tokens and cost remain unavailable, personal credit fallback remains disabled, A5 remains shadow-only, and B4 remains blocked."
     },
     "comparative_measurement_codex_baseline_readiness": {
-      "status": "READINESS_ONLY_NO_LIVE_CALLS",
+      "status": "CANONICAL_READY_NO_LIVE_CALLS",
       "purpose": "Host-specific Codex CLI measurement adapter readiness for the controlled cross-host baseline without changing the frozen benchmark subject, task set, common runner, deterministic response validator, communication treatments, or accepted Antigravity evidence.",
       "executor": "scripts/codex_benchmark_executor.py",
       "machine_sources": ["machine/benchmarking/codex-executor-binding.v1.json"],
       "human_sources": ["docs/benchmarking/CODEX_BASELINE_READINESS.md"],
+      "canonical_readiness_commit": "83f0ff7d74c14b19f78d58143aadcc0a0613f13f",
+      "canonical_readiness_tree": "6e6a4f48439f6126452de1f9c65949fec4d3d7e1",
       "frozen_benchmark_subject": {
         "sha": "d95f677dbf23ab79c4698c26645ea30cea9b3019",
         "tree": "ceab55bd512ea6fde4e8e76877cbb7006d18500e"
@@ -231,13 +233,13 @@
       "taskset_digest": "fd5109b2ec94709883bd75a9b7c6c89b6cd4f9bcc9840554bbd7cbb277a931a8",
       "validator": "EXACT_JSON_CONFORMANCE_V1",
       "live_execution_authorized": false,
-      "exact_cli_version": "TO_BE_FROZEN_BY_HUMAN_GATE",
-      "exact_model": "TO_BE_FROZEN_BY_HUMAN_GATE",
-      "exact_reasoning_effort": "TO_BE_FROZEN_BY_HUMAN_GATE",
+      "exact_cli_version": "TO_BE_FROZEN_BY_LIVE_EXECUTION_GATE",
+      "exact_model": "TO_BE_FROZEN_BY_LIVE_EXECUTION_GATE",
+      "exact_reasoning_effort": "TO_BE_FROZEN_BY_LIVE_EXECUTION_GATE",
       "a5_execution_promotion": "NOT_AUTHORIZED",
       "a6_authorized": false,
       "b4_state": "BLOCKED",
-      "authority_note": "Readiness infrastructure and host-counter transport are measurement evidence plumbing only. The frozen control_identity.orchestra_revision remains d95f; Codex adapter provenance is separate and cannot become benchmark-subject authority."
+      "authority_note": "Readiness is canonical and performs zero live Codex/provider calls. Live baseline execution still requires exact host/model/reasoning/counter/workspace/resource and stop-condition freeze."
     },
     "registry_adaptive_consumption_o1_o6": {
       "status": "CANONICAL_IMPLEMENTED_VALIDATED_AND_REGISTRY_RECONCILED",
@@ -247,11 +249,36 @@
       "validation_surfaces": ["tests/runtime/test_registry_adaptive.py", "tests/runtime/test_registry_adaptive_edges.py", "tests/runtime/test_registry_joint_contract.py"],
       "human_sources": ["docs/architecture/REGISTRY_ADAPTIVE_CONSUMPTION_O1_O6.md"],
       "canonical_orchestra_implementation": {"sha": "955a4b4918e28638a50e9564d1e3ea0127ae5f73", "tree": "4cba8642eb63b38b283db67010e01f204c92780b"},
-      "registry_r1_r6_canonical": {"repository": "Baelfyre/Orchestra-Compliance-Registry", "sha": "20eb859db153f17e24c052a13765e982d51cedbf", "tree": "763be9062a0c23031c794403dc4592f5db4389b0", "implementation_merge_sha": "be297335b55aa6a3a88a473c7e7da28614e95cd2", "trusted_release": "registry-v0.2.0", "trusted_release_includes_r1_r6": false},
+      "registry_r1_r6_canonical": {"repository": "Baelfyre/Orchestra-Compliance-Registry", "sha": "20eb859db153f17e24c052a13765e982d51cedbf", "tree": "763be9062a0c23031c794403dc4592f5db4389b0", "implementation_merge_sha": "be297335b55aa6a3a88a473c7e7da28614e95cd2", "trusted_release": "registry-v0.3.0", "trusted_release_includes_r1_r6": true},
       "r5_capability_blob_sha": "978c1a6eecffe802df79e6d110a16b780ec6bd3f",
       "joint_reconciliation": "PASS",
       "legacy_v0_2_compatibility": "EXPLICIT_LOCAL_PROFILE_NO_INVENTED_REGISTRY_CAPABILITY_METADATA",
       "authority_note": "Registry capability, freshness, delta, and routing evidence cannot expand Orchestra authority, publish Registry state, bypass Conductor routing, or replace Governor/Steward/Arbiter evidence controls."
+    },
+    "registry_query_optimization_o7": {
+      "status": "APPROVED_PLANNED_NOT_IMPLEMENTED",
+      "purpose": "Consume the Registry R7 typed/indexed/projection query gateway using the smallest sufficient context while preserving O1-O6 semantics, exact Registry identities, existing compliance receipts, and fail-closed behavior.",
+      "human_sources": ["docs/architecture/REGISTRY_QUERY_OPTIMIZATION_O7.md"],
+      "implementation_order": "AFTER_CODEX_BASELINE_CLOSEOUT_AND_ORCHESTRA_V1_7_0_AND_AFTER_STABLE_REGISTRY_R7_CONTRACT",
+      "required_compatibility_floor": {"cap.query.v1": "1.0.0"},
+      "planned_optional_capabilities": ["cap.query.projection.v1", "cap.query.relationships.v1", "cap.query.indexed-read.v1", "cap.query.budget.v1", "cap.transport.mcp.v1"],
+      "preferred_transport_order": ["DIRECT_LOCAL_INDEXED_GATEWAY", "DIRECT_LOCAL_JSON_QUERY", "OPTIONAL_MCP_TRANSPORT"],
+      "projection_levels": ["MINIMAL", "SUMMARY", "EVIDENCE", "FULL"],
+      "phase_plan": [
+        "O7.0_CONSUMER_CONTRACT_FREEZE",
+        "O7.1_OPTIONAL_CAPABILITY_NEGOTIATION",
+        "O7.2_TRANSPORT_ABSTRACTION",
+        "O7.3_PROJECTION_AWARE_CONSUMPTION",
+        "O7.4_EXISTING_RECEIPT_NORMALIZATION",
+        "O7.5_DETERMINISTIC_FAILOVER",
+        "O7.6_CONTEXT_BUDGET_INTEGRATION",
+        "O7.7_JOINT_R7_O7_CONFORMANCE"
+      ],
+      "fallbacks": {"indexed_unavailable": "DIRECT_LOCAL_JSON_QUERY", "mcp_unavailable": "DIRECT_LOCAL_QUERY", "optional_capability_missing": "CURRENT_O3_PATH", "index_identity_mismatch": "REJECT_REBUILD_OR_FALLBACK", "semantic_mismatch": "FAIL_CLOSED"},
+      "frozen_invariants": ["O1_CAPABILITY_NEGOTIATION", "O2_COMPATIBILITY_FAIL_CLOSED", "O3_QUERY_SEMANTICS", "O4_QUERY_SCOPED_FRESHNESS", "O5_RELEASE_DELTA", "O6_DOMAIN_ROUTING", "CONDUCTOR_EXCLUSIVE_ROUTING", "GOVERNOR_APPLICABILITY", "STEWARD_TRACEABILITY", "ARBITER_SET_EQUALITY"],
+      "planned_release_target": "v1.8.0_AFTER_REGISTRY_R7_TRUSTED_RELEASE_AND_JOINT_CONFORMANCE",
+      "token_efficiency_claim": "NOT_CLAIMED_UNTIL_MEASURED",
+      "authority_note": "O7 is a planned read-path optimization only. MCP remains transport, the Registry index remains derived, query/projection choice cannot change compliance meaning, and no O7 path may expand authority or bypass existing evidence gates."
     }
   },
   "machine_scan_order": [
@@ -350,7 +377,7 @@
     "required_analysis_ruleset_drift_issue": 331,
     "required_analysis_ruleset_drift_state": "OPEN_COMPATIBILITY_WORKFLOW_ACTIVE"
   },
-  "architecture": {"current_overview": "docs/architecture/README.md", "detailed_authority_capability_design": "docs/project/AUTHORITY_CAPABILITY_RUNTIME_ARCHITECTURE.md", "routing_reference": "ROUTING_MAP.md", "governance_reference": "docs/governance/README.md", "compliance_registry_reference": "docs/governance/COMPLIANCE_REGISTRY_INTEGRATION.md", "compliance_protocol_runtime": "orchestra_runtime/compliance_protocol.py", "mcp_transport_reference": "docs/developer/MCP_STDIO_TRANSPORT.md", "adaptive_context_reference": "docs/architecture/ADAPTIVE_CONTEXT_A2.md", "adaptive_shadow_learning_reference": "docs/architecture/ADAPTIVE_SHADOW_LEARNING_A3.md", "adaptive_shadow_implementation_reference": "docs/architecture/ADAPTIVE_SHADOW_LEARNING_A3_IMPLEMENTATION.md", "adaptive_selection_a4_reference": "docs/architecture/ADAPTIVE_SELECTION_A4.md", "adaptive_selection_a4_execution_attachment_reference": "docs/architecture/ADAPTIVE_SELECTION_A4_EXECUTION_ATTACHMENT.md", "adaptive_tuner_a5_reference": "docs/architecture/ADAPTIVE_TUNER_A5.md", "historical_status_policy": "Phase documents may retain phase-era status wording. Current exact state comes from live machine contracts, release evidence, and Git identity."},
+  "architecture": {"current_overview": "docs/architecture/README.md", "detailed_authority_capability_design": "docs/project/AUTHORITY_CAPABILITY_RUNTIME_ARCHITECTURE.md", "routing_reference": "ROUTING_MAP.md", "governance_reference": "docs/governance/README.md", "compliance_registry_reference": "docs/governance/COMPLIANCE_REGISTRY_INTEGRATION.md", "compliance_protocol_runtime": "orchestra_runtime/compliance_protocol.py", "mcp_transport_reference": "docs/developer/MCP_STDIO_TRANSPORT.md", "adaptive_context_reference": "docs/architecture/ADAPTIVE_CONTEXT_A2.md", "adaptive_shadow_learning_reference": "docs/architecture/ADAPTIVE_SHADOW_LEARNING_A3.md", "adaptive_shadow_implementation_reference": "docs/architecture/ADAPTIVE_SHADOW_LEARNING_A3_IMPLEMENTATION.md", "adaptive_selection_a4_reference": "docs/architecture/ADAPTIVE_SELECTION_A4.md", "adaptive_selection_a4_execution_attachment_reference": "docs/architecture/ADAPTIVE_SELECTION_A4_EXECUTION_ATTACHMENT.md", "adaptive_tuner_a5_reference": "docs/architecture/ADAPTIVE_TUNER_A5.md", "registry_query_optimization_o7_reference": "docs/architecture/REGISTRY_QUERY_OPTIMIZATION_O7.md", "historical_status_policy": "Phase documents may retain phase-era status wording. Current exact state comes from live machine contracts, release evidence, and Git identity."},
   "hosts_integrations": {
     "host_update_contract": "machine/hosts/update-contract.v1.json",
     "adapter_sdk_reference": "docs/setup/ADAPTER_SDK_PRAP.md",
@@ -405,10 +432,10 @@
     "release_evidence": "GITHUB_RELEASE_ID_371748233",
     "publication_closeout": "GITHUB_RELEASE_ID_371748233_PLUS_CANONICAL_COMMIT_VERIFICATION",
     "post_release_main_contains_significant_changes": true,
-    "provisional_next_release": "UNSELECTED",
-    "provisional_next_release_status": "NO_NEXT_RELEASE_SELECTED_OR_AUTHORIZED",
+    "provisional_next_release": "v1.7.0",
+    "provisional_next_release_status": "APPROVED_AFTER_CODEX_BASELINE_CLOSEOUT",
     "publication_authorized": false,
-    "publication_target": "NONE",
+    "publication_target": "NONE_UNTIL_CODEX_BASELINE_CLOSEOUT",
     "publication_identity_rule": "Any future public release becomes authoritative only when the exact tag, immutable GitHub Release, and approved signed canonical commit identity are created and independently verified.",
     "v1_5_0_must_remain_immutable": true,
     "murmurs_measurement_issue": 316,
@@ -439,6 +466,7 @@
     "comparative_measurement_b3": "docs/benchmarking/COMPARATIVE_MEASUREMENT_B3.md",
     "codex_baseline_readiness": "docs/benchmarking/CODEX_BASELINE_READINESS.md",
     "registry_adaptive_consumption_o1_o6": "docs/architecture/REGISTRY_ADAPTIVE_CONSUMPTION_O1_O6.md",
+    "registry_query_optimization_o7": "docs/architecture/REGISTRY_QUERY_OPTIMIZATION_O7.md",
     "roadmap": "docs/project/ROADMAP.md",
     "changelog": "CHANGELOG.md",
     "release_docs": "docs/releases/",
@@ -468,8 +496,9 @@
     "adaptive_governed_orchestration": "A5_CLOSED_AT_SHADOW_MATURITY_EXECUTION_PROMOTION_DEFERRED_BENEFIT_NOT_ESTABLISHED_ISSUE_340",
     "comparative_measurement_b0": "CONTRACT_FROZEN_NO_BENCHMARK_EXECUTION",
     "comparative_measurement_b1": "IMPLEMENTED_NON_PRODUCTION_NO_PROVIDER_ADAPTERS",
-    "codex_baseline_readiness": "READINESS_ONLY_NO_LIVE_CALLS",
+    "codex_baseline_readiness": "CANONICAL_READY_NO_LIVE_CALLS",
     "registry_adaptive_consumption_o1_o6": "CANONICAL_IMPLEMENTED_VALIDATED_AND_REGISTRY_RECONCILED",
+    "registry_query_optimization_o7": "APPROVED_PLANNED_NOT_IMPLEMENTED",
     "murmurs_live_host_token_measurement": "DEFERRED_UNTIL_ELIGIBLE_COUNTERS_ISSUE_316"
   },
   "ai_review_guidance": {
@@ -526,6 +555,11 @@
     "require_explicit_v0_2_legacy_profile_instead_of_inventing_missing_registry_capability_metadata": true,
     "require_query_scoped_registry_freshness_to_bind_to_the_exact_consumed_source_set": true,
     "require_unknown_registry_domains_to_escalate_instead_of_creating_or_selecting_unbounded_agents": true,
+    "treat_registry_query_o7_as_planned_not_implemented_until_canonical_runtime_evidence_exists": true,
+    "prefer_direct_local_indexed_registry_gateway_over_mcp_for_orchestra_internal_consumption_when_o7_is_implemented": true,
+    "treat_registry_mcp_as_optional_transport_not_registry_or_orchestra_authority": true,
+    "preserve_o1_o6_compliance_semantics_across_o7_projection_and_transport_paths": true,
+    "do_not_claim_o7_token_savings_until_cross_path_efficiency_measurement_exists": true,
     "treat_v1_5_0_as_published_verified_only_when_tag_release_and_commit_identity_match": true,
     "treat_v1_6_0_as_published_verified_only_when_tag_release_and_commit_identity_match": true,
     "when_evaluating_a_published_tag_or_release_prefer_live_verified_git_and_release_identity_over_prepublication_snapshot_fields": true

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ It is **not an AI model**. Models generate and review work. Orchestra determines
 | **Portable host integration** | Supports governed adapter surfaces, PRAP compatibility, host maturity contracts, and bounded MCP transport. | [Hosts & Integrations](docs/README.md#hosts-adapters-and-integrations) |
 | **Machine-readable knowledge** | Exposes structured contracts, schemas, provenance, release evidence, and an AI-first repository index. | [`README.json`](README.json) |
 
+## Token-efficient Registry consumption
+
+**O7 is approved and planned, not yet implemented.** It will let Orchestra consume projected/indexed Registry results through the smallest sufficient context while preserving the existing O1-O6 capability, freshness, receipt, Governor/Steward/Arbiter, and fail-closed semantics. Direct local indexed access is preferred; direct JSON remains the deterministic fallback and MCP remains an optional transport for external hosts.
+
+See [O7 — Optimized Registry Consumption](docs/architecture/REGISTRY_QUERY_OPTIMIZATION_O7.md) for the complete architecture and phase plan.
+
 ## How Orchestra works
 
 ```text

--- a/docs/architecture/REGISTRY_QUERY_OPTIMIZATION_O7.md
+++ b/docs/architecture/REGISTRY_QUERY_OPTIMIZATION_O7.md
@@ -1,0 +1,149 @@
+# O7 — Optimized Registry Consumption
+
+## Status
+
+`APPROVED_PLANNED_NOT_IMPLEMENTED`
+
+O7 is the approved Orchestra consumer phase for the Registry R7 token-efficient read architecture. O7 must not begin runtime implementation until the current Codex baseline program and Orchestra v1.7.0 closeout are complete, and Registry R7 has a stable contract candidate.
+
+## Objective
+
+Allow Orchestra to consume the smallest sufficient Registry context through an optional indexed/projection-aware path while preserving all existing O1-O6 compliance semantics, receipts, authority boundaries, and fail-closed behavior.
+
+## Compatibility boundary
+
+O7 is additive. Orchestra continues to require `cap.query.v1`. R7 optimization capabilities remain optional so `registry-v0.3.0` and the current direct JSON query path continue to work.
+
+Proposed optional capabilities:
+
+- `cap.query.projection.v1`
+- `cap.query.relationships.v1`
+- `cap.query.indexed-read.v1`
+- `cap.query.budget.v1`
+- `cap.transport.mcp.v1`
+
+## Architecture
+
+```text
+verified Registry release
+        |
+        +--> R7 direct local indexed gateway  <-- preferred when available
+        |
+        +--> existing direct JSON query       <-- deterministic fallback
+        |
+        `--> optional MCP transport           <-- external host/IDE path
+                    |
+                    v
+          normalized Registry result
+                    |
+                    v
+          ComplianceQueryReceipt
+                    |
+          Governor -> Steward -> Arbiter
+```
+
+MCP is not Orchestra's required internal transport. Direct local deterministic access is preferred for Orchestra; MCP primarily serves external MCP-capable IDEs, hosts, and agents.
+
+## Phase plan
+
+### O7.0 — Consumer contract freeze
+
+Freeze accepted R7 capability IDs, minimum versions, transport preferences, fallback behavior, receipt normalization, integrity failure semantics, and context-budget integration before runtime changes.
+
+### O7.1 — Optional capability negotiation
+
+Extend the existing O1 capability negotiation surface to recognize the R7 capabilities as optional. Their absence must not break the current O1-O6 path.
+
+### O7.2 — Transport abstraction
+
+Preferred order:
+
+1. direct local indexed Registry gateway;
+2. direct local JSON query;
+3. optional MCP transport when the consumer is external or MCP is explicitly selected.
+
+Transport selection cannot expand authority or alter Registry semantics.
+
+### O7.3 — Projection-aware consumption
+
+Request only the smallest sufficient projection for each workflow stage:
+
+- Conductor discovery -> `MINIMAL`;
+- Governor applicability/review -> `SUMMARY` or `EVIDENCE`;
+- Steward requirements/traceability -> `EVIDENCE`;
+- explicit audit escalation -> `FULL` only when required.
+
+Projection choice changes payload size, not source/obligation identity or governance meaning.
+
+### O7.4 — Existing receipt normalization
+
+Every transport and projection must normalize into the existing compliance evidence model. Preserve exact Registry release identity, query digest, source IDs, obligation IDs, freshness evidence, capability negotiation, and domain-routing evidence.
+
+Governor, Steward, and Arbiter continue using the existing set-equality and evidence-freshness contracts.
+
+### O7.5 — Deterministic failover
+
+- indexed gateway unavailable -> direct JSON fallback;
+- MCP unavailable -> direct local query;
+- optional capability absent -> current O3 path;
+- index identity/digest mismatch -> reject index and rebuild or fall back;
+- semantic query mismatch -> fail closed;
+- required capability incompatibility -> fail closed.
+
+No model-authored repair may override an integrity or semantic mismatch.
+
+### O7.6 — Context-budget integration
+
+Bind Registry projection selection to Orchestra's existing communication/context budget rather than creating a separate independent budget authority.
+
+Conceptually:
+
+```text
+workflow need
+   -> evidence/detail requirement
+   -> available context budget
+   -> R7 bounded projection
+   -> normalized receipt
+```
+
+### O7.7 — Joint R7/O7 conformance
+
+Establish semantic parity among direct JSON, indexed Registry query, MCP query, and Orchestra-normalized query for source IDs, obligation IDs, freshness, Registry identity, domain routing, and query/receipt semantics.
+
+Payload representations may differ in size; compliance meaning and exact canonical identities may not.
+
+## Frozen O1-O6 invariants
+
+O7 does not replace or weaken:
+
+- O1 capability negotiation;
+- O2 compatibility/fail-closed behavior;
+- O3 deterministic query selection semantics;
+- O4 query-scoped freshness;
+- O5 release-delta impact analysis;
+- O6 governed domain-to-specialist routing;
+- Conductor's exclusive routing role;
+- Governor applicability ownership;
+- Steward requirements/traceability ownership;
+- Arbiter exact-state and set-equality enforcement.
+
+## Completion gate
+
+O7 is complete only when:
+
+- current O1-O6 tests remain green;
+- Registry v0.3 fallback remains compatible;
+- R7 capability negotiation is deterministic;
+- direct/indexed/MCP semantic parity passes;
+- existing compliance receipts remain authoritative for downstream workflow state;
+- integrity mismatch fails closed;
+- context-budget behavior is bounded and deterministic;
+- token/workflow savings are measured rather than assumed.
+
+## Planned release boundary
+
+O7 is intended for an Orchestra release after Registry R7 is completed and published as an immutable trusted release. The current planning target is Orchestra `v1.8.0`; release selection remains subject to the normal governed release closeout.
+
+## Dependency
+
+Registry R7 owns the entity/read model, derived index, projections, query gateway, and MCP adapter. Orchestra must not duplicate those query semantics. See `docs/TOKEN_EFFICIENT_QUERY_ARCHITECTURE_R7.md` in `Baelfyre/Orchestra-Compliance-Registry`.


### PR DESCRIPTION
Planning/contract-only change. Adds the approved O7 optimized Registry-consumption architecture, a compact README.md section, and a detailed README.json machine plan. No O7 runtime path is implemented. Existing O1-O6 semantics remain frozen. The plan is explicitly sequenced after Codex baseline closeout / Orchestra v1.7.0 and after a stable Registry R7 contract.