### PR TITLE
bench: enable real B2 A5 topology execution

### DIFF
--- a/CHANGELOG.B2_1_SOURCE_NOTE.tmp
+++ b/CHANGELOG.B2_1_SOURCE_NOTE.tmp
@@ -1,0 +1,1 @@
+B2.1 source validation marker only. This temporary file should not survive source closeout; it is intentionally not part of the planned scope.

--- a/CHANGELOG.B2_1_SOURCE_NOTE.tmp
+++ b/CHANGELOG.B2_1_SOURCE_NOTE.tmp
@@ -1,1 +1,0 @@
-B2.1 source validation marker only. This temporary file should not survive source closeout; it is intentionally not part of the planned scope.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Post-v1.6.0 Comparative Benchmark B2.1 A5 Topology Execution Enablement - Candidate
+
+- Adds a benchmark-only A5 topology executor in `scripts/a5_topology_benchmark_executor.py` so isolated B2 measurement can enact real sequential topology differences instead of merely carrying topology IDs as provenance.
+- Restricts this calibration surface to already-eligible sequential candidates that preserve the exact required-specialist set while varying only `Clockwork -> Overseer` versus `Overseer -> Clockwork`, followed by one identical fixed finalization step; parallel execution remains rejected.
+- Fails closed on candidate/envelope digest drift, non-`DEFAULT` communication, required-specialist drift, invalid Git workspace, CLI/model/reasoning identity drift, disallowed Codex tool events, and per-run token-ceiling breach.
+- Adds deterministic zero-live-call regression coverage plus human/machine execution-enablement records and README machine-index parity; A5 shadow ranking remains non-authorizing and the shared benchmark harness independently schedules every arm.
+- Authorizes no B2 live model calls, A5 execution promotion, Conductor or `RuntimeExecutor` production attachment, A6-A8, B4, release publication, deployment, policy activation, installed-integration refresh, destructive cleanup, branch deletion, force push, or history rewrite.
+
 ## Post-v1.6.0 Comparative Benchmark Codex Prebaseline Workspace and Exit Classification Remediation - Candidate
 
 - Requires a live Codex benchmark workspace to pass `git -C <workspace> rev-parse --is-inside-work-tree` before `codex exec`; a non-Git live workspace fails closed as `CORRUPTED_STARTING_STATE` before the Codex process is invoked, while synthetic `raw_jsonl` tests remain exempt because they launch no live process.

--- a/README.json
+++ b/README.json
@@ -185,6 +185,22 @@
       "a6_authorized": false,
       "authority_note": "B1 is evidence infrastructure only. It executes configured non-production benchmark arms, cannot let A5 select or suppress arms, does not establish A5 or Murmurs benefit, and grants no production runtime or promotion authority."
     },
+    "comparative_measurement_b2_1": {
+      "status": "B2_1_TOPOLOGY_EXECUTION_ENABLEMENT_SOURCE_CANDIDATE_ZERO_LIVE_CALLS",
+      "purpose": "Benchmark-only sequential A5 topology execution adapter for scientifically valid isolated B2 measurement, without attaching A5 to production dispatch or RuntimeExecutor execution.",
+      "program_id": "orchestra.shared-comparative-benchmark.v1",
+      "executor": "scripts/a5_topology_benchmark_executor.py",
+      "machine_sources": ["machine/benchmarking/b2-a5-topology-executor-binding.v1.json"],
+      "human_sources": ["docs/benchmarking/COMPARATIVE_MEASUREMENT_B2.md", "docs/benchmarking/B2_A5_TOPOLOGY_EXECUTION_ENABLEMENT.md"],
+      "communication_mode": "DEFAULT",
+      "supported_stage_mode": "SEQUENTIAL",
+      "parallel_execution_authorized": false,
+      "topology_effective": false,
+      "shadow_influenced_execution": false,
+      "live_execution_authorized": false,
+      "next_gate": "B2_2_REAL_CALIBRATION_FREEZE_AND_ZERO_CALL_PREFLIGHT",
+      "authority_note": "B2.1 enables non-production topology measurement only. The shared harness selects every configured arm independently, A5 remains shadow-only, parallel execution is rejected, and no live model call or runtime promotion is authorized by this source candidate."
+    },
     "comparative_measurement_b3_1": {
       "status": "CALIBRATION_COMPLETED_AND_VALIDATED",
       "purpose": "Bounded Antigravity measurement executor binding, B3.1.3 exact host version pin externalization, B3.1.4 sparse settings semantic preflight, B3.1.5 stream-json result envelope normalization, B3.1.6 explicit headless workspace binding, B3.2 Diagnostic Attempt 4 valid evidence closeout, B3.2.1 Padayon-grounded calibration task-set and deterministic outcome validation, and B3 30-run calibration execution and evidence freeze for the Orchestra comparative benchmark harness with explicit --expected-cli-version and --workspace-dir CLI arguments, verified native CLI --add-dir workspace binding, exact fail-closed version and workspace matching, qualified 1.1.15 host surface, sparse useG1Credits resolution (system default false), wrapped and flat stream result envelope normalization, dual wrapper and payload evidence retention, explicit DEFAULT, CAVEMAN, and MURMURS treatments, pinned Caveman external baseline, canonical Murmurs presentation binding, stream-json transport support, hardened print-mode invocation, fail-closed preflight, explicit provenance semantics, verified Attempt 4 instrumentation diagnostic evidence (3/3 accepted runs), Padayon-grounded calibration task-set V1 (5 tasks), deterministic EXACT_JSON_CONFORMANCE_V1 outcome validator (30/30 passed), and completed empirical calibration baseline freeze (877,582 cumulative tokens <= 1,200,000 ceiling).",
@@ -283,7 +299,7 @@
       "authority_note": "O7 is a planned read-path optimization only. MCP remains transport, the Registry index remains derived, query/projection choice cannot change compliance meaning, and no O7 path may expand authority or bypass existing evidence gates."
     },
     "comparative_measurement_codex_c2_portability_r1": {
-      "status": "C2R1_EXECUTION_COMPLETE_RECONCILIATION_CANDIDATE",
+      "status": "C2R1_EXECUTION_COMPLETE_RECONCILED_CANONICAL",
       "purpose": "Completed Codex C2R1 machine-JSON calibration reconciliation, preserving the primary 29 accepted + 1 invalid provider-outage record and the separately labeled supplemental recovery sensitivity observation.",
       "program_id": "orchestra.shared-comparative-benchmark.v1",
       "experiment_id": "b3-codex-machine-json-prompt-extension-v1",
@@ -298,7 +314,7 @@
       "live_authorization_record": "machine/benchmarking/codex-c2-portability-r1-live-execution-authorization.v1.json",
       "live_authorization_status": "CONSUMED_FOR_COMPLETED_PRIMARY_EXECUTION",
       "live_execution_authorized": false,
-      "next_gate": "C2R1_RECONCILIATION_VALIDATION_AND_CANONICALIZATION",
+      "next_gate": "B2_BENCHMARK_COMPLETION_SEQUENCE",
       "authority_note": "C2R1 completed its governed primary execution with 29 accepted runs and one preserved provider-outage invalid observation. A separately authorized supplemental recovery passed but does not replace the primary invalid run. The result remains calibration evidence only and grants no C3, A5 promotion, A6, B4, release, deployment, or policy authority."
     }
   },
@@ -359,6 +375,7 @@
     "comparative_benchmark_run_schema": "machine/schemas/comparative-benchmark-run.schema.json",
     "comparative_benchmark_experiment_schema": "machine/schemas/comparative-benchmark-experiment.schema.json",
     "comparative_benchmark_harness_implementation": "machine/benchmarking/shared-benchmark-harness-implementation.v1.json",
+    "comparative_benchmark_b2_topology_executor_binding": "machine/benchmarking/b2-a5-topology-executor-binding.v1.json",
     "comparative_benchmark_manifest_schema": "machine/schemas/comparative-benchmark-manifest.schema.json",
     "comparative_benchmark_executor_request_schema": "machine/schemas/comparative-benchmark-executor-request.schema.json",
     "comparative_benchmark_executor_result_schema": "machine/schemas/comparative-benchmark-executor-result.schema.json",
@@ -489,6 +506,7 @@
     "adaptive_tuner_a5": "docs/architecture/ADAPTIVE_TUNER_A5.md",
     "comparative_measurement_b0": "docs/benchmarking/COMPARATIVE_MEASUREMENT_B0.md",
     "comparative_measurement_b1": "docs/benchmarking/COMPARATIVE_MEASUREMENT_B1.md",
+    "comparative_measurement_b2_execution_enablement": "docs/benchmarking/B2_A5_TOPOLOGY_EXECUTION_ENABLEMENT.md",
     "comparative_measurement_b3": "docs/benchmarking/COMPARATIVE_MEASUREMENT_B3.md",
     "codex_baseline_readiness": "docs/benchmarking/CODEX_BASELINE_READINESS.md",
     "codex_prebaseline_remediation": "docs/benchmarking/CODEX_PREBASELINE_REMEDIATION.md",
@@ -526,12 +544,13 @@
     "adaptive_governed_orchestration": "A5_CLOSED_AT_SHADOW_MATURITY_EXECUTION_PROMOTION_DEFERRED_BENEFIT_NOT_ESTABLISHED_ISSUE_340",
     "comparative_measurement_b0": "CONTRACT_FROZEN_NO_BENCHMARK_EXECUTION",
     "comparative_measurement_b1": "IMPLEMENTED_NON_PRODUCTION_NO_PROVIDER_ADAPTERS",
+    "comparative_measurement_b2": "B2_1_TOPOLOGY_EXECUTION_ENABLEMENT_SOURCE_CANDIDATE_ZERO_LIVE_CALLS",
     "codex_baseline_readiness": "LIVE_DIAGNOSTIC_QUALIFIED_PREBASELINE_REMEDIATION_PENDING_VALIDATION",
     "codex_c1_cross_provider_reconciliation": "C1_COMPLETE_RECONCILED_CALIBRATION_ONLY",
     "registry_adaptive_consumption_o1_o6": "CANONICAL_IMPLEMENTED_VALIDATED_AND_REGISTRY_RECONCILED",
     "registry_query_optimization_o7": "APPROVED_PLANNED_NOT_IMPLEMENTED",
     "murmurs_live_host_token_measurement": "DEFERRED_UNTIL_ELIGIBLE_COUNTERS_ISSUE_316",
-    "codex_c2_portability_r1": "C2R1_EXECUTION_COMPLETE_RECONCILIATION_CANDIDATE"
+    "codex_c2_portability_r1": "C2R1_EXECUTION_COMPLETE_RECONCILED_CANONICAL"
   },
   "ai_review_guidance": {
     "preferred_entrypoint": "README.json",
@@ -586,6 +605,8 @@
     "treat_b1_harness_as_non_production_evidence_infrastructure": true,
     "do_not_treat_synthetic_b1_fixture_measurements_as_benefit_evidence": true,
     "require_explicit_resource_ceiling_before_paid_live_benchmark_execution": true,
+    "do_not_treat_b2_topology_identity_as_execution_without_the_benchmark_topology_adapter": true,
+    "preserve_b2_a5_shadow_ranking_as_non_authorizing_and_separate_from_arm_scheduling": true,
     "preserve_d95f_as_frozen_cross_host_benchmark_subject_identity": true,
     "treat_e182_as_common_measurement_core_baseline_not_benchmark_subject": true,
     "record_codex_host_adapter_revision_separately_from_control_identity_orchestra_revision": true,

--- a/docs/benchmarking/B2_A5_TOPOLOGY_EXECUTION_ENABLEMENT.md
+++ b/docs/benchmarking/B2_A5_TOPOLOGY_EXECUTION_ENABLEMENT.md
@@ -1,0 +1,215 @@
+# B2.1 A5 Topology Execution Enablement
+
+## Status
+
+```text
+Program: Orchestra Shared Comparative Benchmark
+Phase: B2 A5 Isolated Comparative Experiment
+Unit: B2.1 Topology Execution Enablement
+State: SOURCE_CANDIDATE_ZERO_LIVE_CALLS
+Canonical entry: fee39a1feae254dae0de54d21663bed4cc3f1fd2
+Canonical entry tree: 4ac379e9f05290f3e282cc66dee46e35ef4a157e
+A5 execution-effective selection: NOT AUTHORIZED
+A6/A7/A8: NOT AUTHORIZED
+B4: BLOCKED
+Live B2 model calls: 0
+```
+
+B2.1 fixes an experimental-validity gap discovered after the B2.0 plan-only freeze. The shared harness can schedule A5 topology arms, but the existing Antigravity and Codex communication executors do not enact those topology fields. They retain `topology_candidate_id` and `topology_digest` in provenance while performing the same single-model task execution.
+
+Therefore:
+
+```text
+DIFFERENT TOPOLOGY LABELS != DIFFERENT TOPOLOGY EXECUTION
+PROVENANCE FIELD != EXECUTION MECHANIC
+B2 PLAN-ONLY FIXTURE != REAL A5 ELIGIBILITY
+A5 SHADOW RANKING != BENCHMARK ARM SELECTION
+```
+
+Running B2 with the existing B3 executors would create a false experiment. B2.1 adds a non-production topology executor so later B2 evidence can change only the frozen coordination-order variable while leaving A5 non-effective in production.
+
+## Experimental mechanic
+
+B2.1 supports one deliberately narrow topology dimension:
+
+- required specialists: `Clockwork` and `Overseer`;
+- communication: `DEFAULT` only;
+- stage mode: sequential only;
+- one required specialist per stage;
+- candidate difference: specialist stage order and resulting prior-advisory transfer;
+- fixed finalizer: identical and outside the topology variable.
+
+The intended first calibration candidates are:
+
+```text
+Candidate A
+Clockwork -> Overseer -> fixed finalizer
+
+Candidate B
+Overseer -> Clockwork -> fixed finalizer
+```
+
+These names describe the target calibration design only. B2.1 does **not** itself declare them eligible. The later B2.2 freeze must supply a validated canonical A5 eligibility envelope proving the exact candidate identities are already permitted for the benchmark session.
+
+Parallel execution is intentionally excluded from B2.1. Although A5 schemas can describe a `PARALLEL` stage, the canonical A5 boundary explicitly does not create parallel execution capability. B2.1 fails closed on every parallel candidate instead of using a benchmark adapter to smuggle new runtime capability into the experiment.
+
+## Specialist projections
+
+B2.1 uses compact, versioned benchmark projections instead of embedding entire specialist skill files into every model prompt.
+
+### Clockwork projection
+
+Scope: architecture, dependency direction, structural constraints, ordering risks, and implementation boundaries.
+
+### Overseer projection
+
+Scope: validation sufficiency, evidence integrity, failure conditions, governance preservation, and testable acceptance criteria.
+
+Both projections are advisory and non-authorizing. They are not replacements for canonical specialist runtime instructions, do not grant ownership or authority, and exist only to isolate the coordination-order variable without making full skill-file size a prompt-cost confound.
+
+Machine-pinned projection digests are recorded in `machine/benchmarking/b2-a5-topology-executor-binding.v1.json`.
+
+## Execution sequence
+
+For one benchmark run:
+
+1. Validate the executor request and `A5_ISOLATED` experiment identity.
+2. Load one canonical A5 eligibility envelope.
+3. Require the manifest eligibility digest and candidate-set order to equal that envelope exactly.
+4. Require the requested candidate to exist in the envelope and its canonical digest to match the arm.
+5. Require `DEFAULT` communication and the complete `Clockwork + Overseer` required-specialist set.
+6. Reject any parallel/multi-specialist stage.
+7. Execute stage 1 as one bounded read-only Codex call.
+8. Execute stage 2 as one bounded read-only Codex call, supplying stage 1's advisory output.
+9. Execute one identical fixed finalizer call with both advisories sorted by canonical specialist name.
+10. Validate the final response using `EXACT_JSON_CONFORMANCE_V1`.
+11. Aggregate provider-native usage across all model calls into one benchmark-run measurement.
+12. Emit the A5 shadow observation for the same frozen eligible set while keeping `topology_effective=false` and `shadow_influenced_execution=false`.
+
+The shared benchmark harness chooses which configured arm executes. The A5 shadow ranker never selects the benchmark arm.
+
+## Codex safety boundary
+
+The live path is designed to reuse the already-qualified Codex measurement surface only after a separate B2.2 host freeze:
+
+```text
+provider: openai-codex
+CLI: 0.148.0 planned
+model: gpt-5.6-sol planned
+reasoning: medium planned
+transport: jsonl-usage
+sandbox: read-only
+approval: never
+agents: false
+web: disabled
+shell tool: false
+workspace: existing Git worktree required
+```
+
+The exact Node/Codex command prefix is deliberately not hard-coded into source because it is host-specific. B2.2 must pin the actual executable paths and cryptographic identities before any live call.
+
+Any Codex tool event rejected by the canonical JSONL parser remains an invalid measurement path.
+
+## Resource accounting
+
+A two-stage B2.1 candidate consumes three model calls per benchmark run:
+
+```text
+2 specialist advisory calls
++ 1 fixed finalizer call
+= 3 model calls / benchmark run
+```
+
+Provider-native `input_tokens`, `cached_input_tokens`, `output_tokens`, and reasoning-output tokens are retained per call. Run-level token fields aggregate all three calls. The run-level total used for the hard resource ceiling is:
+
+```text
+sum(input_tokens + output_tokens) across all calls
+```
+
+A per-run ceiling is mandatory at executor invocation. If the ceiling is crossed after a specialist call, execution stops before later calls. If the finalizer causes the ceiling to be crossed, the run is invalidated. Automatic retry remains off.
+
+B2.1 freezes no live ceiling and performs no model call.
+
+## A5 shadow observation
+
+The executor feeds the same frozen eligibility envelope to the canonical A5 shadow ranker. For B2.1 execution-enablement tests, the evidence packet is exact-bound and empty; no synthetic performance evidence is invented.
+
+The emitted observation includes:
+
+- eligibility digest;
+- shadow decision digest;
+- ranked candidate IDs;
+- top-ranked candidate ID;
+- decision disposition;
+- shadow recommendation when one exists;
+- `topology_effective=false`;
+- `shadow_influenced_execution=false`.
+
+This lets B2 later compare the shadow-ranked order against empirical topology results without letting the ranker control execution.
+
+## Fail-closed boundaries
+
+The executor rejects or invalidates measurement on:
+
+- eligibility-envelope digest mismatch;
+- candidate outside the frozen envelope;
+- candidate digest mismatch;
+- manifest/envelope candidate-set drift;
+- non-DEFAULT communication;
+- parallel stage;
+- required-specialist-set drift;
+- task with live execution disabled;
+- Codex CLI/model/reasoning drift;
+- invalid Git workspace;
+- malformed/disallowed Codex JSONL or tool event;
+- per-run token-ceiling breach.
+
+No retry is automatic.
+
+## B2.1 exit condition
+
+B2.1 is complete only when the source candidate and later canonical identity prove:
+
+1. topology-arm identity changes actual advisory execution order;
+2. the reverse candidate changes which specialist receives prior advisory context;
+3. the fixed finalizer remains outside the topology variable;
+4. host usage is aggregated over every underlying call;
+5. exact candidate/envelope binding fails closed;
+6. parallel execution is rejected;
+7. a disabled task causes zero model calls;
+8. resource-ceiling breach stops the remaining call sequence;
+9. A5 shadow output remains non-authorizing;
+10. all repository validation gates pass with zero B2 live calls.
+
+## Next gate — B2.2
+
+After B2.1 is canonical, prepare a separate **B2.2 Real Calibration Freeze and Zero-Call Preflight**. It must freeze:
+
+- one validated benchmark coordination session;
+- one exact canonical A5 eligibility envelope;
+- at least two already-permitted sequential topology candidates;
+- one executable B2 task set with adequate topology sensitivity;
+- exact starting-state/task-prompt/validation identities;
+- the exact Codex command prefix and binary/package digests;
+- exact empty Git workspace identity;
+- per-run token ceiling;
+- cumulative experiment token ceiling;
+- maximum underlying model-call count;
+- automatic retry OFF;
+- stop-on-invalid/identity-drift/tool-event/resource-breach policy.
+
+A zero-live-call preflight must pass after that freeze. Live B2 calibration still requires separate explicit authorization.
+
+## Authority boundary
+
+B2.1 does not:
+
+- make A5 topology-effective;
+- attach A5 to Conductor dispatch or `RuntimeExecutor`;
+- authorize parallel production execution;
+- omit a required specialist;
+- change specialist ownership;
+- expand authority, capability, governance, provider/privacy, lifecycle, context, or resource ceilings;
+- authorize A6, A7, or A8;
+- authorize B4;
+- release, deploy, activate policy, refresh installed integrations, delete branches, or rewrite history.

--- a/machine/benchmarking/b2-a5-topology-executor-binding.v1.json
+++ b/machine/benchmarking/b2-a5-topology-executor-binding.v1.json
@@ -1,0 +1,137 @@
+{
+  "schema_version": "orchestra.b2-a5-topology-executor-binding.v1",
+  "program_id": "orchestra.shared-comparative-benchmark.v1",
+  "phase": "B2_1_A5_TOPOLOGY_EXECUTION_ENABLEMENT",
+  "status": "SOURCE_CANDIDATE_ZERO_LIVE_CALLS",
+  "canonical_entry": {
+    "repository": "Baelfyre/Orchestra",
+    "branch": "main",
+    "sha": "fee39a1feae254dae0de54d21663bed4cc3f1fd2",
+    "tree": "4ac379e9f05290f3e282cc66dee46e35ef4a157e"
+  },
+  "purpose": "Enable scientifically valid non-production B2 A5-isolated topology execution without making A5 execution-effective in Orchestra runtime.",
+  "audit_finding": {
+    "existing_benchmark_executors_enact_topology": false,
+    "existing_behavior": "Existing Antigravity and Codex benchmark executors record topology_candidate_id and topology_digest as provenance but do not change execution ordering from those fields.",
+    "false_experiment_risk": "Using the B2 plan with an existing communication executor would compare topology labels over effectively identical execution and is prohibited.",
+    "required_remediation": "A benchmark-only executor must enact the frozen eligible candidate topology before any B2 live measurement."
+  },
+  "executor": {
+    "path": "scripts/a5_topology_benchmark_executor.py",
+    "binding_version": "orchestra.b2-a5-topology-executor.v1",
+    "experiment_kind": "A5_ISOLATED",
+    "communication_mode": "DEFAULT",
+    "production_runtime_attachment": false,
+    "conductor_dispatch_attachment": false,
+    "runtime_executor_attachment": false,
+    "parallel_execution_authorized": false,
+    "supported_stage_mode_in_b2_1": "SEQUENTIAL",
+    "one_specialist_per_stage": true,
+    "required_specialists": [
+      "clockwork",
+      "overseer"
+    ],
+    "candidate_selected_by": "SHARED_BENCHMARK_HARNESS_ARM_SCHEDULE",
+    "candidate_selected_by_a5_ranker": false,
+    "fixed_finalizer_outside_topology": true,
+    "fixed_finalizer_receives_advisories_in": "CANONICAL_SPECIALIST_NAME_ORDER",
+    "retry_policy": "OFF"
+  },
+  "specialist_projection": {
+    "version": "orchestra.b2-specialist-projection.v1",
+    "purpose": "Compact benchmark-only ownership projections used to isolate coordination ordering without importing whole specialist skill files as a prompt-size confound.",
+    "authoritative_specialist_runtime_replacement": false,
+    "clockwork_digest": "a11fe6d40360ab6e443047f0ab220f1d6cd7737f6fc2aed30ab7f066b3bb2520",
+    "overseer_digest": "325c6a765a0cbc704dd03f2ce6b361bd26cc64a99c932d51849d2ab9e81814e7"
+  },
+  "topology_binding": {
+    "eligibility_source": "CANONICAL_A5_TOPOLOGY_ELIGIBILITY_ENVELOPE_REQUIRED",
+    "eligibility_envelope_frozen_by_this_unit": false,
+    "request_eligibility_digest_must_match_loaded_envelope": true,
+    "request_candidate_must_exist_in_loaded_envelope": true,
+    "request_candidate_digest_must_match_canonical_candidate": true,
+    "manifest_candidate_set_and_order_must_equal_envelope": true,
+    "required_specialist_set_must_be_preserved": true,
+    "parallel_stage_disposition": "FAIL_CLOSED_NOT_AUTHORIZED_BY_B2_1"
+  },
+  "a5_shadow_observation": {
+    "same_frozen_eligible_set": true,
+    "evidence_packet_for_execution_enablement": "EMPTY_EXACT_BOUND_PACKET",
+    "shadow_ranker": "orchestra.adaptive-topology-scorer.v1",
+    "topology_effective": false,
+    "shadow_influenced_execution": false,
+    "promotion_state": "NOT_PROMOTED"
+  },
+  "provider_binding": {
+    "planned_provider": "openai-codex",
+    "planned_cli_version": "0.148.0",
+    "planned_model": "gpt-5.6-sol",
+    "planned_reasoning_effort": "medium",
+    "transport": "jsonl-usage",
+    "exact_host_command_prefix": "MUST_BE_FROZEN_OUTSIDE_THIS_SOURCE_CANDIDATE_BEFORE_LIVE_EXECUTION",
+    "workspace": "EXISTING_EMPTY_GIT_WORKTREE_REQUIRED",
+    "sandbox": "read-only",
+    "approval_policy": "never",
+    "agents": false,
+    "web_search": false,
+    "shell_tool": false
+  },
+  "run_structure": {
+    "specialist_calls_per_two_stage_candidate": 2,
+    "fixed_finalizer_calls": 1,
+    "total_model_calls_per_benchmark_run": 3,
+    "stage_two_receives_stage_one_advisory": true,
+    "finalizer_receives_both_advisories": true,
+    "task_prompt_held_constant_across_candidate_arms": true,
+    "validator": "EXACT_JSON_CONFORMANCE_V1",
+    "host_reported_usage_aggregated_across_all_calls": true
+  },
+  "fail_closed_conditions": [
+    "ELIGIBILITY_DIGEST_MISMATCH",
+    "CANDIDATE_OUTSIDE_FROZEN_ENVELOPE",
+    "CANDIDATE_DIGEST_MISMATCH",
+    "MANIFEST_CANDIDATE_SET_DRIFT",
+    "NON_DEFAULT_COMMUNICATION",
+    "PARALLEL_STAGE_NOT_AUTHORIZED",
+    "REQUIRED_SPECIALIST_SET_DRIFT",
+    "LIVE_EXECUTION_FLAG_FALSE",
+    "CLI_VERSION_DRIFT",
+    "MODEL_DRIFT",
+    "REASONING_SETTING_DRIFT",
+    "INVALID_GIT_WORKSPACE",
+    "CODEX_TOOL_EVENT_OR_JSONL_FAILURE",
+    "PER_RUN_TOKEN_CEILING_BREACH"
+  ],
+  "validation": {
+    "focused_test": "tests/runtime/test_comparative_benchmark_a5_topology_executor.py",
+    "zero_call_tests_required": true,
+    "live_model_calls_by_this_unit": 0
+  },
+  "next_gate": {
+    "phase": "B2_2_REAL_CALIBRATION_FREEZE_AND_ZERO_CALL_PREFLIGHT",
+    "required_before_live_calls": [
+      "VALIDATED_BENCHMARK_COORDINATION_SESSION",
+      "CANONICAL_EXACT_A5_ELIGIBILITY_ENVELOPE",
+      "AT_LEAST_TWO_ALREADY_PERMITTED_SEQUENTIAL_TOPOLOGY_CANDIDATES",
+      "FROZEN_EXECUTABLE_B2_TASK_SET",
+      "EXACT_CODEX_COMMAND_PREFIX_AND_BINARY_DIGESTS",
+      "EXACT_GIT_WORKSPACE_IDENTITY",
+      "PER_RUN_TOKEN_CEILING",
+      "CUMULATIVE_EXPERIMENT_TOKEN_CEILING",
+      "MAXIMUM_MODEL_CALL_COUNT",
+      "ZERO_LIVE_CALL_PREFLIGHT_PASS",
+      "SEPARATE_EXPLICIT_LIVE_EXECUTION_AUTHORIZATION"
+    ]
+  },
+  "authority": {
+    "live_execution_authorized": false,
+    "a5_execution_effective_promotion": false,
+    "a6_authorized": false,
+    "a7_authorized": false,
+    "a8_authorized": false,
+    "b4_authorized": false,
+    "release_publication_authorized": false,
+    "deployment_authorized": false,
+    "policy_activation_authorized": false
+  }
+}

--- a/scripts/a5_topology_benchmark_executor.py
+++ b/scripts/a5_topology_benchmark_executor.py
@@ -1,0 +1,520 @@
+#!/usr/bin/env python3
+"""Non-production sequential-topology executor for Orchestra B2 A5 calibration.
+
+This adapter exists only for the shared comparative benchmark. It enacts a
+frozen, already-eligible A5 topology candidate by changing the order in which
+bounded specialist projections receive the same task and prior advisory output.
+It does not attach A5 to Conductor or RuntimeExecutor and cannot activate
+parallel execution.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import subprocess
+import sys
+import time
+from hashlib import sha256
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from orchestra_runtime.adaptive.topology import (  # noqa: E402
+    TopologyCandidate,
+    TopologyEligibilityEnvelope,
+    TopologyStage,
+    build_topology_evidence_packet,
+    rank_shadow_topologies,
+)
+from scripts.codex_benchmark_executor import (  # noqa: E402
+    ALLOWED_REASONING_EFFORTS,
+    EXECUTOR_REQUEST_VERSION,
+    EXECUTOR_RESULT_VERSION,
+    PROGRAM_ID,
+    PROVIDER_ID,
+    TRANSPORT_ID,
+    build_codex_command,
+    parse_cli_version,
+    parse_codex_jsonl,
+    validate_live_git_workspace,
+)
+
+SPECIALIST_PROJECTIONS = {
+    "clockwork": (
+        "BENCHMARK SPECIALIST PROJECTION: CLOCKWORK. "
+        "Analyze architecture, dependency direction, structural constraints, "
+        "ordering risks, and implementation boundaries. Treat all authority and "
+        "governance constraints in the task as fixed ceilings. Return concise "
+        "advisory findings only; do not claim transition authority and do not "
+        "emit the final benchmark JSON."
+    ),
+    "overseer": (
+        "BENCHMARK SPECIALIST PROJECTION: OVERSEER. "
+        "Analyze validation sufficiency, evidence integrity, failure conditions, "
+        "governance preservation, and testable acceptance criteria. Treat all "
+        "authority and governance constraints in the task as fixed ceilings. "
+        "Return concise advisory findings only; do not claim transition authority "
+        "and do not emit the final benchmark JSON."
+    ),
+}
+SPECIALIST_PROJECTION_VERSION = "orchestra.b2-specialist-projection.v1"
+EXECUTOR_BINDING_VERSION = "orchestra.b2-a5-topology-executor.v1"
+ALLOWED_SPECIALISTS = frozenset(SPECIALIST_PROJECTIONS)
+SAFETY_FIELDS = (
+    "required_specialist_omission",
+    "authority_expansion",
+    "capability_expansion",
+    "governance_violation",
+    "provider_privacy_expansion",
+    "mandatory_gate_suppression",
+)
+
+
+class TopologyExecutorError(RuntimeError):
+    pass
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def digest_json(value: Any) -> str:
+    return sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _empty_safety() -> dict[str, bool]:
+    return {field: False for field in SAFETY_FIELDS}
+
+
+def parse_command_prefix(raw: str) -> list[str]:
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise TopologyExecutorError(f"--codex-command-prefix-json must be JSON: {exc}") from exc
+    if not isinstance(value, list) or not value or not all(isinstance(item, str) and item for item in value):
+        raise TopologyExecutorError("--codex-command-prefix-json must be a non-empty string array")
+    return list(value)
+
+
+def _stage_from_dict(raw: Mapping[str, Any]) -> TopologyStage:
+    return TopologyStage(
+        stage_id=raw["stage_id"],
+        mode=raw["mode"],
+        specialists=tuple(raw["specialists"]),
+        join_required=raw["join_required"],
+        review_owner=raw.get("review_owner"),
+    )
+
+
+def _candidate_from_dict(raw: Mapping[str, Any]) -> TopologyCandidate:
+    return TopologyCandidate(
+        candidate_id=raw["candidate_id"],
+        coordination_contract_revision=raw["coordination_contract_revision"],
+        required_specialists=tuple(raw["required_specialists"]),
+        stages=tuple(_stage_from_dict(stage) for stage in raw["stages"]),
+        reentry_order=tuple(raw.get("reentry_order", [])),
+        prior_output_disclosure_refs=tuple(raw.get("prior_output_disclosure_refs", [])),
+        eligibility_evidence_refs=tuple(raw["eligibility_evidence_refs"]),
+    )
+
+
+def envelope_from_dict(raw: Mapping[str, Any]) -> TopologyEligibilityEnvelope:
+    candidates = tuple(_candidate_from_dict(candidate) for candidate in raw["candidates"])
+    return TopologyEligibilityEnvelope(
+        schema_version=raw["schema_version"],
+        envelope_id=raw["envelope_id"],
+        session_id=raw["session_id"],
+        created_at=raw["created_at"],
+        user_key=raw["user_key"],
+        project_key=raw.get("project_key"),
+        task_session_key=raw.get("task_session_key"),
+        coordination_contract_ref=raw["coordination_contract_ref"],
+        coordination_contract_revision=raw["coordination_contract_revision"],
+        required_specialists=tuple(raw["required_specialists"]),
+        invariants_applied=dict(raw["invariants_applied"]),
+        invariant_evidence_refs=tuple(raw["invariant_evidence_refs"]),
+        candidates=candidates,
+        deterministic_topology_candidate_id=raw.get("deterministic_topology_candidate_id"),
+        explicit_current_constraint_ref=raw.get("explicit_current_constraint_ref"),
+    )
+
+
+def load_envelope(path: Path) -> tuple[dict[str, Any], TopologyEligibilityEnvelope, str]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise TopologyExecutorError(f"cannot load eligibility envelope {path}: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise TopologyExecutorError("eligibility envelope must be a JSON object")
+    try:
+        envelope = envelope_from_dict(raw)
+    except (KeyError, TypeError, ValueError) as exc:
+        raise TopologyExecutorError(f"invalid eligibility envelope: {exc}") from exc
+    normalized = envelope.to_dict()
+    if raw != normalized:
+        raise TopologyExecutorError("eligibility envelope is not the canonical A5 serialization")
+    return normalized, envelope, digest_json(normalized)
+
+
+def validate_candidate_for_b2(
+    request: Mapping[str, Any],
+    envelope: TopologyEligibilityEnvelope,
+    eligibility_digest: str,
+) -> TopologyCandidate:
+    if request.get("schema_version") != EXECUTOR_REQUEST_VERSION:
+        raise TopologyExecutorError("unsupported executor request schema")
+    if request.get("program_id") != PROGRAM_ID:
+        raise TopologyExecutorError("unexpected benchmark program")
+    if request.get("experiment_kind") != "A5_ISOLATED":
+        raise TopologyExecutorError("B2 topology executor requires A5_ISOLATED")
+    if request.get("stage") not in {"CALIBRATION", "PILOT", "CONFIRMATORY"}:
+        raise TopologyExecutorError("unsupported B2 stage")
+
+    arm = request.get("arm")
+    if not isinstance(arm, dict):
+        raise TopologyExecutorError("request arm is missing")
+    if arm.get("communication_mode") != "DEFAULT":
+        raise TopologyExecutorError("B2 A5 isolation requires DEFAULT communication")
+
+    a5 = request.get("a5_evaluation")
+    if not isinstance(a5, dict):
+        raise TopologyExecutorError("a5_evaluation is required")
+    if a5.get("eligibility_envelope_digest") != eligibility_digest:
+        raise TopologyExecutorError("eligibility envelope digest mismatch")
+
+    expected_ids = list(envelope.candidate_ids)
+    configured_ids = a5.get("eligible_topology_candidate_ids")
+    if configured_ids != expected_ids:
+        raise TopologyExecutorError("manifest candidate set/order differs from frozen eligibility envelope")
+
+    candidate_id = arm.get("topology_candidate_id")
+    candidate = envelope.candidate_by_id(str(candidate_id))
+    if candidate is None:
+        raise TopologyExecutorError("requested topology candidate is outside the frozen eligible set")
+    if arm.get("topology_digest") != digest_json(candidate.to_dict()):
+        raise TopologyExecutorError("requested topology digest does not match the frozen candidate")
+
+    if set(candidate.required_specialists) != set(ALLOWED_SPECIALISTS):
+        raise TopologyExecutorError("B2.1 requires exactly Clockwork and Overseer")
+    if len(candidate.stages) != len(candidate.required_specialists):
+        raise TopologyExecutorError("B2.1 requires one sequential stage per required specialist")
+    seen: list[str] = []
+    for stage in candidate.stages:
+        if stage.mode != "SEQUENTIAL":
+            raise TopologyExecutorError("B2.1 does not authorize PARALLEL topology execution")
+        if len(stage.specialists) != 1:
+            raise TopologyExecutorError("B2.1 requires exactly one specialist per stage")
+        specialist = stage.specialists[0]
+        if specialist not in ALLOWED_SPECIALISTS:
+            raise TopologyExecutorError(f"unsupported benchmark specialist: {specialist}")
+        seen.append(specialist)
+    if set(seen) != set(candidate.required_specialists) or len(seen) != len(set(seen)):
+        raise TopologyExecutorError("candidate stages must execute each required specialist exactly once")
+    return candidate
+
+
+def make_shadow_observation(envelope: TopologyEligibilityEnvelope, eligibility_digest: str) -> dict[str, Any]:
+    packet = build_topology_evidence_packet(envelope, collected_at=envelope.created_at, items=())
+    decision = rank_shadow_topologies(
+        envelope,
+        packet,
+        actual_deterministic_candidate_id=envelope.deterministic_topology_candidate_id or "",
+        evaluated_at=envelope.created_at,
+    )
+    ranked = list(decision.ranked_candidate_ids)
+    if not ranked:
+        raise TopologyExecutorError("A5 shadow ranker returned no eligible candidates")
+    return {
+        "eligibility_digest": eligibility_digest,
+        "decision_digest": decision.digest,
+        "ranked_topology_candidate_ids": ranked,
+        "top_candidate_id": ranked[0],
+        "decision_disposition": decision.disposition,
+        "shadow_recommendation_id": decision.shadow_recommendation_id,
+        "topology_effective": False,
+        "shadow_influenced_execution": False,
+    }
+
+
+def render_specialist_prompt(*, specialist: str, task_prompt: str, prior_outputs: Sequence[tuple[str, str]]) -> str:
+    projection = SPECIALIST_PROJECTIONS[specialist]
+    prior = ""
+    if prior_outputs:
+        blocks = [f"[PRIOR ADVISORY: {name.upper()}]\n{text}" for name, text in prior_outputs]
+        prior = "\n\n" + "\n\n".join(blocks)
+    return (
+        f"{projection}\n\n[BENCHMARK RULES]\n"
+        "- Work only from the supplied synthetic task and prior advisory evidence.\n"
+        "- Do not use tools, network access, repository mutation, or external state.\n"
+        "- Keep the advisory concise and factual.\n"
+        f"{prior}\n\n[TASK]\n{task_prompt}"
+    )
+
+
+def render_finalizer_prompt(*, task_prompt: str, advisories: Sequence[tuple[str, str]]) -> str:
+    canonical_advisories = sorted(advisories, key=lambda item: item[0])
+    blocks = "\n\n".join(f"[ADVISORY: {name.upper()}]\n{text}" for name, text in canonical_advisories)
+    return (
+        "You are the fixed benchmark finalizer. The specialist advisories below are non-authorizing analysis. "
+        "Produce the task's required final answer using the original task as the controlling specification. "
+        "Do not mention the advisories. Return exactly the format required by the task and no surrounding commentary.\n\n"
+        f"{blocks}\n\n[TASK]\n{task_prompt}"
+    )
+
+
+def validate_exact_json_response(response: str, task_payload: Mapping[str, Any]) -> tuple[bool, dict[str, Any] | None, str | None]:
+    contract = task_payload.get("validation_contract")
+    if not isinstance(contract, dict) or contract.get("validator_type") != "EXACT_JSON_CONFORMANCE_V1":
+        return False, None, "unsupported or missing EXACT_JSON_CONFORMANCE_V1 contract"
+    expected = contract.get("expected_response")
+    if not isinstance(expected, dict):
+        return False, None, "validation contract expected_response must be an object"
+    try:
+        observed = json.loads(response)
+    except json.JSONDecodeError as exc:
+        return False, None, f"final response is not one valid JSON value: {exc}"
+    if not isinstance(observed, dict):
+        return False, None, "final response must be a JSON object"
+    if observed != expected:
+        return False, observed, "final JSON does not exactly match expected_response"
+    return True, observed, None
+
+
+def codex_command(prefix: Sequence[str], *, prompt: str, workspace: Path, model: str, reasoning_effort: str) -> list[str]:
+    base = build_codex_command(prompt=prompt, workspace_dir=workspace, model=model, reasoning_effort=reasoning_effort)
+    return list(prefix) + base[1:]
+
+
+def run_codex_call(
+    *,
+    prompt: str,
+    prefix: Sequence[str],
+    workspace: Path,
+    model: str,
+    reasoning_effort: str,
+    timeout_seconds: int,
+    run_command: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> dict[str, Any]:
+    command = codex_command(prefix, prompt=prompt, workspace=workspace, model=model, reasoning_effort=reasoning_effort)
+    started = time.monotonic()
+    completed = run_command(command, capture_output=True, text=True, check=False, shell=False, timeout=timeout_seconds)
+    elapsed_ms = int((time.monotonic() - started) * 1000)
+    if completed.returncode != 0:
+        raise TopologyExecutorError(f"Codex call failed with exit {completed.returncode}: {completed.stderr.strip()}")
+    try:
+        parsed = parse_codex_jsonl(completed.stdout)
+    except (ValueError, RuntimeError, PermissionError) as exc:
+        raise TopologyExecutorError(f"Codex JSONL rejected: {exc}") from exc
+    usage = parsed["usage"]
+    total_tokens = usage["input_tokens"] + usage["output_tokens"]
+    return {
+        "response": parsed["response"],
+        "usage": usage,
+        "total_tokens": total_tokens,
+        "elapsed_ms": elapsed_ms,
+        "agent_message_count": parsed["agent_message_count"],
+    }
+
+
+def aggregate_calls(calls: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    return {
+        "input_tokens": sum(int(call["usage"]["input_tokens"]) for call in calls),
+        "cached_input_tokens": sum(int(call["usage"]["cached_input_tokens"]) for call in calls),
+        "output_tokens": sum(int(call["usage"]["output_tokens"]) for call in calls),
+        "reasoning_tokens": sum(int(call["usage"]["reasoning_output_tokens"]) for call in calls),
+        "total_tokens": sum(int(call["total_tokens"]) for call in calls),
+        "model_execution_ms": sum(int(call["elapsed_ms"]) for call in calls),
+    }
+
+
+def invalid_result(request: Mapping[str, Any], reason: str, evidence: Mapping[str, Any]) -> dict[str, Any]:
+    safety = _empty_safety()
+    outcome = {"status": "INVALID_RUN", "invalid_reason": reason, "task_completed": False, "validation_passed": False, "governance_valid": False}
+    return {
+        "schema_version": EXECUTOR_RESULT_VERSION,
+        "request_id": str(request.get("request_id") or "UNKNOWN_REQUEST"),
+        "outcome": outcome,
+        "quality": {"requirements_satisfied": 0, "requirements_missed": 0, "remediation_iterations": 0, "validation_failures": 0, "regressions_introduced": 0},
+        "tokens": {"source": "UNAVAILABLE", "counter_id": None, "input_tokens": None, "output_tokens": None, "cached_input_tokens": None, "reasoning_tokens": None, "fresh_billable_tokens": None},
+        "cost": {"source": "UNAVAILABLE", "amount": None, "currency": None},
+        "latency": {"wall_clock_ms": None, "model_execution_ms": None, "tool_execution_ms": None, "coordination_overhead_ms": None},
+        "coordination": {"specialist_messages": 0, "cross_specialist_messages": 0, "handoffs": 0, "handoff_failures": 0, "duplicate_work_events": 0, "contradiction_events": 0, "join_wait_ms": None, "specialist_reentry_events": 0},
+        "communication": {"progress_messages": 0, "model_progress_calls": 0, "user_visible_bytes": 0, "context_transfer_bytes": 0, "semantic_preservation_failures": 0, "required_information_omissions": 0},
+        "safety": safety,
+        "validation_digest": digest_json({"outcome": outcome}),
+        "governance_digest": digest_json({"governance_valid": False, "safety": safety}),
+        "raw_evidence": dict(evidence),
+        "a5_shadow_observation": None,
+    }
+
+
+def execute_request(
+    request: dict[str, Any],
+    *,
+    envelope: TopologyEligibilityEnvelope,
+    eligibility_digest: str,
+    expected_cli_version: str,
+    model: str,
+    reasoning_effort: str,
+    command_prefix: Sequence[str],
+    workspace: Path,
+    call_timeout_seconds: int,
+    per_run_total_token_ceiling: int,
+    call_runner: Callable[..., dict[str, Any]] = run_codex_call,
+    version_runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    git_runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> dict[str, Any]:
+    started = time.monotonic()
+    base_evidence: dict[str, Any] = {
+        "executor_binding_version": EXECUTOR_BINDING_VERSION,
+        "specialist_projection_version": SPECIALIST_PROJECTION_VERSION,
+        "specialist_projection_digests": {name: digest_json(text) for name, text in SPECIALIST_PROJECTIONS.items()},
+        "eligibility_digest": eligibility_digest,
+        "live_execution_authorized_by_adapter": False,
+        "retry_performed": False,
+    }
+    try:
+        candidate = validate_candidate_for_b2(request, envelope, eligibility_digest)
+        shadow = make_shadow_observation(envelope, eligibility_digest)
+        if model.strip() == "" or reasoning_effort not in ALLOWED_REASONING_EFFORTS:
+            raise TopologyExecutorError("model/reasoning freeze is invalid")
+        if not workspace.is_dir():
+            raise TopologyExecutorError("workspace does not exist")
+        workspace_ok, workspace_reason, workspace_evidence = validate_live_git_workspace(workspace, git_runner=git_runner)
+        base_evidence["workspace_preflight"] = workspace_evidence
+        if not workspace_ok:
+            return invalid_result(request, workspace_reason or "CORRUPTED_STARTING_STATE", {**base_evidence, "error": "Git workspace preflight failed"})
+
+        version_cp = version_runner(list(command_prefix) + ["--version"], capture_output=True, text=True, check=False, shell=False)
+        if version_cp.returncode != 0:
+            raise TopologyExecutorError("Codex version preflight failed")
+        observed_version = parse_cli_version(f"{version_cp.stdout}\n{version_cp.stderr}")
+        base_evidence["cli_version"] = {"expected": expected_cli_version, "observed": observed_version}
+        if observed_version != expected_cli_version:
+            raise TopologyExecutorError("Codex CLI version drift")
+
+        control = request.get("control_identity")
+        if not isinstance(control, dict):
+            raise TopologyExecutorError("control_identity missing")
+        if control.get("provider") != PROVIDER_ID:
+            raise TopologyExecutorError(f"provider must be {PROVIDER_ID}")
+        if control.get("model") != model:
+            raise TopologyExecutorError("model drift")
+        if control.get("reasoning_setting") != reasoning_effort:
+            raise TopologyExecutorError("reasoning setting drift")
+
+        task_payload = request.get("task_payload")
+        if not isinstance(task_payload, dict):
+            raise TopologyExecutorError("task_payload missing")
+        task_prompt = task_payload.get("prompt")
+        if not isinstance(task_prompt, str) or not task_prompt.strip():
+            raise TopologyExecutorError("task prompt missing")
+        if task_payload.get("execution_allowed") is not True:
+            raise TopologyExecutorError("task payload is not live-execution enabled")
+
+        calls: list[dict[str, Any]] = []
+        advisory_outputs: list[tuple[str, str]] = []
+        call_evidence: list[dict[str, Any]] = []
+        for index, stage in enumerate(candidate.stages, start=1):
+            specialist = stage.specialists[0]
+            prompt = render_specialist_prompt(specialist=specialist, task_prompt=task_prompt, prior_outputs=advisory_outputs)
+            call = call_runner(prompt=prompt, prefix=command_prefix, workspace=workspace, model=model, reasoning_effort=reasoning_effort, timeout_seconds=call_timeout_seconds)
+            calls.append(call)
+            advisory_outputs.append((specialist, str(call["response"])))
+            total_so_far = sum(int(item["total_tokens"]) for item in calls)
+            call_evidence.append({"role": "SPECIALIST", "stage_index": index, "stage_id": stage.stage_id, "specialist": specialist, "prompt_digest": digest_json(prompt), "response_digest": digest_json(str(call["response"])), "usage": copy.deepcopy(call["usage"]), "total_tokens": int(call["total_tokens"]), "elapsed_ms": int(call["elapsed_ms"])})
+            if total_so_far > per_run_total_token_ceiling:
+                return invalid_result(request, "MEASUREMENT_CAPTURE_FAILURE", {**base_evidence, "error": "per-run total-token ceiling exceeded before finalization", "candidate_id": candidate.candidate_id, "calls": call_evidence, "observed_total_tokens": total_so_far, "per_run_total_token_ceiling": per_run_total_token_ceiling})
+
+        finalizer_prompt = render_finalizer_prompt(task_prompt=task_prompt, advisories=advisory_outputs)
+        final_call = call_runner(prompt=finalizer_prompt, prefix=command_prefix, workspace=workspace, model=model, reasoning_effort=reasoning_effort, timeout_seconds=call_timeout_seconds)
+        calls.append(final_call)
+        call_evidence.append({"role": "FIXED_FINALIZER", "stage_index": None, "stage_id": "fixed.finalizer", "specialist": None, "prompt_digest": digest_json(finalizer_prompt), "response_digest": digest_json(str(final_call["response"])), "usage": copy.deepcopy(final_call["usage"]), "total_tokens": int(final_call["total_tokens"]), "elapsed_ms": int(final_call["elapsed_ms"])})
+        totals = aggregate_calls(calls)
+        if totals["total_tokens"] > per_run_total_token_ceiling:
+            return invalid_result(request, "MEASUREMENT_CAPTURE_FAILURE", {**base_evidence, "error": "per-run total-token ceiling exceeded", "candidate_id": candidate.candidate_id, "calls": call_evidence, "observed_total_tokens": totals["total_tokens"], "per_run_total_token_ceiling": per_run_total_token_ceiling})
+
+        valid, observed, validation_error = validate_exact_json_response(str(final_call["response"]), task_payload)
+        outcome = {"status": "PASS" if valid else "FAIL", "invalid_reason": None, "task_completed": True, "validation_passed": valid, "governance_valid": True}
+        safety = _empty_safety()
+        context_transfer_bytes = sum(len(text.encode("utf-8")) for _, text in advisory_outputs[:-1]) + sum(len(text.encode("utf-8")) for _, text in advisory_outputs)
+        raw_evidence = {
+            **base_evidence,
+            "candidate_id": candidate.candidate_id,
+            "candidate_digest": digest_json(candidate.to_dict()),
+            "candidate_stage_order": [{"stage_id": stage.stage_id, "mode": stage.mode, "specialists": list(stage.specialists)} for stage in candidate.stages],
+            "calls": call_evidence,
+            "final_response": str(final_call["response"]),
+            "observed_json": observed,
+            "validation_error": validation_error,
+            "per_run_total_token_ceiling": per_run_total_token_ceiling,
+            "observed_total_tokens": totals["total_tokens"],
+            "counter_id": f"codex-cli-{expected_cli_version}:{TRANSPORT_ID}:{model}:{reasoning_effort}",
+        }
+        wall_ms = int((time.monotonic() - started) * 1000)
+        return {
+            "schema_version": EXECUTOR_RESULT_VERSION,
+            "request_id": request["request_id"],
+            "outcome": outcome,
+            "quality": {"requirements_satisfied": 1 if valid else 0, "requirements_missed": 0 if valid else 1, "remediation_iterations": 0, "validation_failures": 0 if valid else 1, "regressions_introduced": 0},
+            "tokens": {"source": "HOST_REPORTED", "counter_id": raw_evidence["counter_id"], "input_tokens": totals["input_tokens"], "output_tokens": totals["output_tokens"], "cached_input_tokens": totals["cached_input_tokens"], "reasoning_tokens": totals["reasoning_tokens"], "fresh_billable_tokens": None},
+            "cost": {"source": "UNAVAILABLE", "amount": None, "currency": None},
+            "latency": {"wall_clock_ms": wall_ms, "model_execution_ms": totals["model_execution_ms"], "tool_execution_ms": 0, "coordination_overhead_ms": max(0, wall_ms - totals["model_execution_ms"])},
+            "coordination": {"specialist_messages": len(candidate.stages), "cross_specialist_messages": max(0, len(candidate.stages) - 1), "handoffs": max(0, len(candidate.stages) - 1), "handoff_failures": 0, "duplicate_work_events": 0, "contradiction_events": 0, "join_wait_ms": None, "specialist_reentry_events": 0},
+            "communication": {"progress_messages": 0, "model_progress_calls": len(calls), "user_visible_bytes": len(str(final_call["response"]).encode("utf-8")), "context_transfer_bytes": context_transfer_bytes, "semantic_preservation_failures": 0 if valid else 1, "required_information_omissions": 0 if valid else 1},
+            "safety": safety,
+            "validation_digest": digest_json({"validator": "EXACT_JSON_CONFORMANCE_V1", "valid": valid, "observed": observed}),
+            "governance_digest": digest_json({"governance_valid": True, "safety": safety}),
+            "raw_evidence": raw_evidence,
+            "a5_shadow_observation": shadow,
+        }
+    except (TopologyExecutorError, OSError, subprocess.SubprocessError, ValueError, KeyError, TypeError) as exc:
+        return invalid_result(request, "MEASUREMENT_CAPTURE_FAILURE", {**base_evidence, "error": str(exc)})
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Execute one bounded B2 topology benchmark request")
+    parser.add_argument("--eligibility-envelope", required=True, type=Path)
+    parser.add_argument("--expected-cli-version", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--reasoning-effort", required=True)
+    parser.add_argument("--codex-command-prefix-json", required=True)
+    parser.add_argument("--workspace-dir", required=True, type=Path)
+    parser.add_argument("--call-timeout-seconds", required=True, type=int)
+    parser.add_argument("--per-run-total-token-ceiling", required=True, type=int)
+    args = parser.parse_args(argv)
+
+    try:
+        request = json.load(sys.stdin)
+        if not isinstance(request, dict):
+            raise TopologyExecutorError("stdin request must be one JSON object")
+        _, envelope, eligibility_digest = load_envelope(args.eligibility_envelope)
+        prefix = parse_command_prefix(args.codex_command_prefix_json)
+        result = execute_request(
+            request,
+            envelope=envelope,
+            eligibility_digest=eligibility_digest,
+            expected_cli_version=args.expected_cli_version,
+            model=args.model,
+            reasoning_effort=args.reasoning_effort,
+            command_prefix=prefix,
+            workspace=args.workspace_dir,
+            call_timeout_seconds=args.call_timeout_seconds,
+            per_run_total_token_ceiling=args.per_run_total_token_ceiling,
+        )
+        json.dump(result, sys.stdout, sort_keys=True)
+        sys.stdout.write("\n")
+        return 0
+    except (TopologyExecutorError, OSError, json.JSONDecodeError, ValueError, TypeError) as exc:
+        json.dump({"schema_version": EXECUTOR_RESULT_VERSION, "request_id": "UNKNOWN_REQUEST", "fatal_executor_error": str(exc)}, sys.stdout, sort_keys=True)
+        sys.stdout.write("\n")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/runtime/test_comparative_benchmark_a5_topology_executor.py
+++ b/tests/runtime/test_comparative_benchmark_a5_topology_executor.py
@@ -166,7 +166,7 @@ def test_b2_binding_rejects_parallel_stage_even_when_structurally_eligible():
         deterministic_topology_candidate_id=forward.candidate_id,
     )
     request = make_request(envelope, "parallel")
-    with pytest.raises(Exception, match="does not authorize PARALLEL"):
+    with pytest.raises(Exception, match="B2.1"):
         validate_candidate_for_b2(request, envelope, digest_json(envelope.to_dict()))
 
 

--- a/tests/runtime/test_comparative_benchmark_a5_topology_executor.py
+++ b/tests/runtime/test_comparative_benchmark_a5_topology_executor.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from orchestra_runtime.adaptive.topology import (
+    REQUIRED_TOPOLOGY_INVARIANTS,
+    TopologyCandidate,
+    TopologyEligibilityEnvelope,
+    TopologyStage,
+)
+from scripts.a5_topology_benchmark_executor import (
+    SPECIALIST_PROJECTIONS,
+    digest_json,
+    execute_request,
+    make_shadow_observation,
+    validate_candidate_for_b2,
+)
+
+
+def make_candidate(candidate_id: str, order: tuple[str, str]) -> TopologyCandidate:
+    return TopologyCandidate(
+        candidate_id=candidate_id,
+        coordination_contract_revision=1,
+        required_specialists=("clockwork", "overseer"),
+        stages=tuple(
+            TopologyStage(
+                stage_id=f"{candidate_id}.{index}",
+                mode="SEQUENTIAL",
+                specialists=(specialist,),
+                join_required=True,
+                review_owner="overseer" if specialist == "overseer" else None,
+            )
+            for index, specialist in enumerate(order, start=1)
+        ),
+        reentry_order=(),
+        prior_output_disclosure_refs=("benchmark:prior-advisory",),
+        eligibility_evidence_refs=(f"benchmark:{candidate_id}:eligible",),
+    )
+
+
+def make_envelope() -> TopologyEligibilityEnvelope:
+    forward = make_candidate("clockwork-then-overseer", ("clockwork", "overseer"))
+    reverse = make_candidate("overseer-then-clockwork", ("overseer", "clockwork"))
+    return TopologyEligibilityEnvelope(
+        envelope_id="b2.calibration.eligibility.v1",
+        session_id="b2.calibration.session.v1",
+        created_at="2026-08-22T23:00:00Z",
+        user_key="benchmark-user",
+        project_key="Baelfyre/Orchestra",
+        task_session_key="b2-calibration",
+        coordination_contract_ref="machine/adaptive/a5-tuner-topology-contract.v1.json",
+        coordination_contract_revision=1,
+        required_specialists=("clockwork", "overseer"),
+        invariants_applied={key: True for key in REQUIRED_TOPOLOGY_INVARIANTS},
+        invariant_evidence_refs=("benchmark:coordination-validated", "benchmark:governance-validated"),
+        candidates=(forward, reverse),
+        deterministic_topology_candidate_id="clockwork-then-overseer",
+    )
+
+
+def make_request(envelope: TopologyEligibilityEnvelope, candidate_id: str) -> dict:
+    candidate = envelope.candidate_by_id(candidate_id)
+    assert candidate is not None
+    eligibility_digest = digest_json(envelope.to_dict())
+    expected = {"task_id": "b2-test", "disposition": "PASS", "authority_expansion": False}
+    return {
+        "schema_version": "orchestra.comparative-benchmark-executor-request.v1",
+        "program_id": "orchestra.shared-comparative-benchmark.v1",
+        "experiment_id": "b2-a5-isolated-calibration-v1",
+        "experiment_kind": "A5_ISOLATED",
+        "stage": "CALIBRATION",
+        "request_id": f"req-{candidate_id}",
+        "task_id": "b2-test",
+        "task_class": "VALIDATION_HEAVY",
+        "repetition_index": 1,
+        "execution_order_index": 1,
+        "arm": {
+            "arm_id": candidate_id,
+            "topology_candidate_id": candidate_id,
+            "topology_class": "SEQUENTIAL",
+            "topology_digest": digest_json(candidate.to_dict()),
+            "communication_mode": "DEFAULT",
+        },
+        "control_identity": {"provider": "openai-codex", "model": "gpt-5.6-sol", "reasoning_setting": "medium"},
+        "task_payload": {
+            "execution_allowed": True,
+            "prompt": "Return exactly one JSON object with task_id=b2-test, disposition=PASS, authority_expansion=false.",
+            "validation_contract": {"validator_type": "EXACT_JSON_CONFORMANCE_V1", "expected_response": expected},
+        },
+        "a5_evaluation": {
+            "eligibility_envelope_digest": eligibility_digest,
+            "eligible_topology_candidate_ids": list(envelope.candidate_ids),
+        },
+        "murmurs_evaluation": None,
+        "interaction_evaluation": None,
+    }
+
+
+def fake_git_ok(*args, **kwargs):
+    return subprocess.CompletedProcess(args=args[0] if args else [], returncode=0, stdout="true\n", stderr="")
+
+
+def fake_version_ok(*args, **kwargs):
+    return subprocess.CompletedProcess(args=args[0] if args else [], returncode=0, stdout="codex-cli 0.148.0\n", stderr="")
+
+
+def call_factory(final_json: dict, *, tokens: int = 100):
+    prompts: list[str] = []
+
+    def fake_call(**kwargs):
+        prompt = kwargs["prompt"]
+        prompts.append(prompt)
+        index = len(prompts)
+        response = json.dumps(final_json, separators=(",", ":")) if "fixed benchmark finalizer" in prompt else f"advisory-{index}"
+        return {
+            "response": response,
+            "usage": {"input_tokens": tokens - 10, "cached_input_tokens": 0, "output_tokens": 10, "reasoning_output_tokens": 2},
+            "total_tokens": tokens,
+            "elapsed_ms": 5,
+            "agent_message_count": 1,
+        }
+
+    return fake_call, prompts
+
+
+def test_b2_binding_requires_exact_frozen_candidate_digest():
+    envelope = make_envelope()
+    request = make_request(envelope, "clockwork-then-overseer")
+    eligibility_digest = digest_json(envelope.to_dict())
+    candidate = validate_candidate_for_b2(request, envelope, eligibility_digest)
+    assert candidate.candidate_id == "clockwork-then-overseer"
+    request["arm"]["topology_digest"] = "0" * 64
+    with pytest.raises(Exception, match="topology digest"):
+        validate_candidate_for_b2(request, envelope, eligibility_digest)
+
+
+def test_b2_binding_rejects_parallel_stage_even_when_structurally_eligible():
+    envelope = make_envelope()
+    forward = envelope.candidates[0]
+    parallel = TopologyCandidate(
+        candidate_id="parallel",
+        coordination_contract_revision=1,
+        required_specialists=forward.required_specialists,
+        stages=(TopologyStage(stage_id="parallel.1", mode="PARALLEL", specialists=("clockwork", "overseer"), join_required=True, review_owner="overseer"),),
+        reentry_order=(),
+        prior_output_disclosure_refs=(),
+        eligibility_evidence_refs=("benchmark:parallel:eligible",),
+    )
+    envelope = TopologyEligibilityEnvelope(
+        envelope_id="parallel-env",
+        session_id=envelope.session_id,
+        created_at=envelope.created_at,
+        user_key=envelope.user_key,
+        project_key=envelope.project_key,
+        task_session_key=envelope.task_session_key,
+        coordination_contract_ref=envelope.coordination_contract_ref,
+        coordination_contract_revision=1,
+        required_specialists=envelope.required_specialists,
+        invariants_applied=envelope.invariants_applied,
+        invariant_evidence_refs=envelope.invariant_evidence_refs,
+        candidates=(forward, parallel),
+        deterministic_topology_candidate_id=forward.candidate_id,
+    )
+    request = make_request(envelope, "parallel")
+    with pytest.raises(Exception, match="does not authorize PARALLEL"):
+        validate_candidate_for_b2(request, envelope, digest_json(envelope.to_dict()))
+
+
+def test_execute_forward_topology_uses_three_bounded_calls_and_aggregates_tokens(tmp_path: Path):
+    envelope = make_envelope()
+    request = make_request(envelope, "clockwork-then-overseer")
+    expected = request["task_payload"]["validation_contract"]["expected_response"]
+    fake_call, prompts = call_factory(expected, tokens=100)
+    result = execute_request(
+        request,
+        envelope=envelope,
+        eligibility_digest=digest_json(envelope.to_dict()),
+        expected_cli_version="0.148.0",
+        model="gpt-5.6-sol",
+        reasoning_effort="medium",
+        command_prefix=("node", "codex.js"),
+        workspace=tmp_path,
+        call_timeout_seconds=30,
+        per_run_total_token_ceiling=1000,
+        call_runner=fake_call,
+        version_runner=fake_version_ok,
+        git_runner=fake_git_ok,
+    )
+    assert result["outcome"]["status"] == "PASS"
+    assert result["tokens"]["input_tokens"] == 270
+    assert result["tokens"]["output_tokens"] == 30
+    assert result["raw_evidence"]["observed_total_tokens"] == 300
+    assert result["coordination"]["specialist_messages"] == 2
+    assert result["coordination"]["handoffs"] == 1
+    assert len(prompts) == 3
+    assert SPECIALIST_PROJECTIONS["clockwork"] in prompts[0]
+    assert SPECIALIST_PROJECTIONS["overseer"] in prompts[1]
+    assert "PRIOR ADVISORY: CLOCKWORK" in prompts[1]
+    assert "fixed benchmark finalizer" in prompts[2]
+    assert result["a5_shadow_observation"]["topology_effective"] is False
+    assert result["a5_shadow_observation"]["shadow_influenced_execution"] is False
+
+
+def test_reverse_candidate_changes_only_specialist_stage_order(tmp_path: Path):
+    envelope = make_envelope()
+    request = make_request(envelope, "overseer-then-clockwork")
+    expected = request["task_payload"]["validation_contract"]["expected_response"]
+    fake_call, prompts = call_factory(expected)
+    result = execute_request(
+        request,
+        envelope=envelope,
+        eligibility_digest=digest_json(envelope.to_dict()),
+        expected_cli_version="0.148.0",
+        model="gpt-5.6-sol",
+        reasoning_effort="medium",
+        command_prefix=("node", "codex.js"),
+        workspace=tmp_path,
+        call_timeout_seconds=30,
+        per_run_total_token_ceiling=1000,
+        call_runner=fake_call,
+        version_runner=fake_version_ok,
+        git_runner=fake_git_ok,
+    )
+    assert result["outcome"]["status"] == "PASS"
+    assert SPECIALIST_PROJECTIONS["overseer"] in prompts[0]
+    assert SPECIALIST_PROJECTIONS["clockwork"] in prompts[1]
+    assert "PRIOR ADVISORY: OVERSEER" in prompts[1]
+    assert result["raw_evidence"]["candidate_stage_order"][0]["specialists"] == ["overseer"]
+
+
+def test_ceiling_breach_stops_before_fixed_finalizer(tmp_path: Path):
+    envelope = make_envelope()
+    request = make_request(envelope, "clockwork-then-overseer")
+    expected = request["task_payload"]["validation_contract"]["expected_response"]
+    fake_call, prompts = call_factory(expected, tokens=200)
+    result = execute_request(
+        request,
+        envelope=envelope,
+        eligibility_digest=digest_json(envelope.to_dict()),
+        expected_cli_version="0.148.0",
+        model="gpt-5.6-sol",
+        reasoning_effort="medium",
+        command_prefix=("node", "codex.js"),
+        workspace=tmp_path,
+        call_timeout_seconds=30,
+        per_run_total_token_ceiling=350,
+        call_runner=fake_call,
+        version_runner=fake_version_ok,
+        git_runner=fake_git_ok,
+    )
+    assert result["outcome"]["status"] == "INVALID_RUN"
+    assert result["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+    assert len(prompts) == 2
+    assert result["a5_shadow_observation"] is None
+
+
+def test_execution_allowed_false_fails_before_any_model_call(tmp_path: Path):
+    envelope = make_envelope()
+    request = make_request(envelope, "clockwork-then-overseer")
+    request["task_payload"]["execution_allowed"] = False
+    expected = request["task_payload"]["validation_contract"]["expected_response"]
+    fake_call, prompts = call_factory(expected)
+    result = execute_request(
+        request,
+        envelope=envelope,
+        eligibility_digest=digest_json(envelope.to_dict()),
+        expected_cli_version="0.148.0",
+        model="gpt-5.6-sol",
+        reasoning_effort="medium",
+        command_prefix=("node", "codex.js"),
+        workspace=tmp_path,
+        call_timeout_seconds=30,
+        per_run_total_token_ceiling=1000,
+        call_runner=fake_call,
+        version_runner=fake_version_ok,
+        git_runner=fake_git_ok,
+    )
+    assert result["outcome"]["status"] == "INVALID_RUN"
+    assert prompts == []
+
+
+def test_shadow_observation_uses_same_frozen_eligible_set():
+    envelope = make_envelope()
+    observation = make_shadow_observation(envelope, digest_json(envelope.to_dict()))
+    assert observation["ranked_topology_candidate_ids"] == list(envelope.candidate_ids)
+    assert observation["top_candidate_id"] in envelope.candidate_ids
+    assert observation["topology_effective"] is False
+    assert observation["shadow_influenced_execution"] is False
+    assert len(observation["decision_digest"]) == 64


### PR DESCRIPTION
## Scope

B2.1 execution-enablement only. This draft closes the experimental-validity gap between B2 plan-only topology labels and actual topology execution.

### Adds
- `scripts/a5_topology_benchmark_executor.py`
- `tests/runtime/test_comparative_benchmark_a5_topology_executor.py`
- `machine/benchmarking/b2-a5-topology-executor-binding.v1.json`
- `docs/benchmarking/B2_A5_TOPOLOGY_EXECUTION_ENABLEMENT.md`

## Key boundary

Existing Antigravity/Codex benchmark executors carry topology identity as provenance but do not enact topology ordering. B2.1 adds a benchmark-only sequential topology adapter that can later execute an already-eligible A5 candidate by changing Clockwork/Overseer advisory order while keeping DEFAULT communication and one identical fixed finalizer.

B2.1 rejects parallel stages, candidate/envelope drift, non-DEFAULT communication, required-specialist drift, host identity drift, invalid Git workspace, disallowed Codex tool events, and token-ceiling breach.

A5 shadow ranking remains non-authorizing: the shared harness schedules every arm independently; the A5 ranker cannot select the executed arm.

## Live-resource boundary

ZERO live B2 model calls are authorized or performed by this PR. A later B2.2 freeze must bind a validated eligibility envelope, executable task set, exact host command/binary identities, workspace, per-run/cumulative ceilings, maximum model-call count, and zero-call preflight before separate live-execution authorization.

## Authority

No A5 execution promotion, Conductor/RuntimeExecutor attachment, parallel production capability, A6/A7/A8, B4, release, deployment, policy activation, installed-integration refresh, branch deletion, or history rewrite is included.