### PR TITLE
Materialize signed B2.5 driver remediation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Post-v1.6.0 Comparative Benchmark B2.5 Driver Import Remediation - Candidate
+
+- Adds the missing standard-library `argparse` import required by the prepared B2.5 driver entrypoint.
+- The first authorized continuation stopped before executor invocation; no B2.5 live model call or accepted run was consumed.
+
 ## Post-v1.6.0 Comparative Benchmark B2.5 Confirmatory Preparation - Candidate
 
 - Freezes ten new held-out synthetic tasks, one per B0 stratum, with exact task decisions, validation gates, and no authority expansion.

--- a/README.json
+++ b/README.json
@@ -291,6 +291,8 @@
       "preregistration_digest": "a77b563acf95189a96647641426244903cf950b760946c5d38a06b37c0292e1f",
       "manifest_digest": "8207f16cb2a9fa93b414c0651c16f183cab27c3c859604bbd62197e1198e9041",
       "plan_digest": "5e8eacb7ef042b8a9e9c90c9d6406075533df8afcdbf62b1f9a01d57ffa8c2d9",
+      "freeze_digest": "e13a3b4d8f62822db3ae9edce8256c2ca94d344577b125d04a779032253e95af",
+      "driver_sha256": "77c4821ff638e90ceadbc80964b520d25b0c23abb874d5e494fca91a77c19f5e",
       "planned_runs": 40,
       "codex_calls_per_run": 3,
       "maximum_underlying_model_calls": 120,

--- a/machine/benchmarking/b2-5-confirmatory-freeze.v1.json
+++ b/machine/benchmarking/b2-5-confirmatory-freeze.v1.json
@@ -119,7 +119,7 @@
       "scripts/a5_topology_benchmark_executor.py": "dc3eff98b9477e0776d55a6e3312e5e66205e2ee31c13874652dcb0c557e3f9a",
       "scripts/b2_confirmatory_evidence.py": "7828fec435094bbd415ad8ba635ea0f43df9dd4798425aec6ca535b603edbb01",
       "scripts/b2_5_confirmatory_preflight.py": "0b98a6f3280f964ff337b1d1b8e16b81f4a2038da1a08880d473fc272bab06cf",
-      "scripts/b2_5_confirmatory_driver.py": "1bfa0314fb3226e47b1d495d46f5ebf0ba0cbacac29fe43cc63556b16731f9dd"
+      "scripts/b2_5_confirmatory_driver.py": "77c4821ff638e90ceadbc80964b520d25b0c23abb874d5e494fca91a77c19f5e"
     }
   },
   "evidence_contract": {

--- a/scripts/b2_5_confirmatory_driver.py
+++ b/scripts/b2_5_confirmatory_driver.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import subprocess
 import sys


### PR DESCRIPTION
Materialize the exact validated B2.5 driver import remediation onto canonical B2.5 preparation for signed verification. Source PR #511 passed all required exact-head checks and is closed unmerged. No live model calls are performed by this materialization.