### PR TITLE
Fix B2.5 Codex JSONL UTF-8 decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Post-v1.6.0 Comparative Benchmark B2.5 UTF-8 Recovery - Candidate
+
+- Makes Codex JSONL subprocess decoding explicitly UTF-8 with strict decode errors, removing the Windows locale codec from the evidence boundary.
+- Adds zero-live-call Unicode and malformed-byte regression coverage while preserving exact usage objects and advisory hashes.
+- Retains the stopped 13-run, 42-call session as historical invalidated evidence and refreshes only shared-executor implementation identities, including B2.4 compatibility, for one fresh B2.5 replacement session.
+
 ## Post-v1.6.0 Comparative Benchmark B2.5 Driver Import Remediation - Candidate
 
 - Adds the missing standard-library `argparse` import required by the prepared B2.5 driver entrypoint.

--- a/README.json
+++ b/README.json
@@ -282,8 +282,8 @@
       "next_gate": "B2_5_HELD_OUT_TASK_SET_FREEZE_AND_ZERO_CALL_PREFLIGHT"
     },
     "comparative_measurement_b2_5": {
-      "status": "B2_5_CONFIRMATORY_PREPARATION_FROZEN_NOT_LIVE_EXECUTED",
-      "purpose": "Freeze a new held-out confirmatory task set, deterministic paired execution plan, exact host/workspace boundary, zero-call preflight, and fail-closed live driver.",
+      "status": "B2_5_UTF8_RECOVERY_FROZEN_NOT_LIVE_AUTHORIZED",
+      "purpose": "Preserve the held-out confirmatory design while binding Codex JSONL decoding explicitly to strict UTF-8 after the historical Windows locale-decoding stop.",
       "program_id": "orchestra.shared-comparative-benchmark.v1",
       "experiment_id": "b2-confirmatory-measurement-v1",
       "tasks": ["b2-confirm-single-domain-state-transition", "b2-confirm-multi-domain-order-entitlement", "b2-confirm-architecture-plugin-boundary", "b2-confirm-debugging-event-duplication", "b2-confirm-security-capability-scope", "b2-confirm-validation-partial-write", "b2-confirm-doc-implementation-contract", "b2-confirm-dependency-version-skew", "b2-confirm-parallel-artifact-join", "b2-confirm-high-coordination-contract-rollout"],
@@ -291,7 +291,8 @@
       "preregistration_digest": "a77b563acf95189a96647641426244903cf950b760946c5d38a06b37c0292e1f",
       "manifest_digest": "8207f16cb2a9fa93b414c0651c16f183cab27c3c859604bbd62197e1198e9041",
       "plan_digest": "5e8eacb7ef042b8a9e9c90c9d6406075533df8afcdbf62b1f9a01d57ffa8c2d9",
-      "freeze_digest": "e13a3b4d8f62822db3ae9edce8256c2ca94d344577b125d04a779032253e95af",
+      "freeze_digest": "66fc567ab448f87f824ba113c7646b1d7a7b59f1e1b7daf98cece8b5e86f3c11",
+      "executor_sha256": "d33104cc684c28e175038ca7eba18adcde78a9d063bb73a2d31bca77d72912ce",
       "driver_sha256": "77c4821ff638e90ceadbc80964b520d25b0c23abb874d5e494fca91a77c19f5e",
       "planned_runs": 40,
       "codex_calls_per_run": 3,
@@ -302,10 +303,15 @@
       "machine_sources": ["machine/benchmarking/b2-5-held-out-task-set.v1.json", "machine/benchmarking/b2-5-confirmatory-preregistration.v1.json", "machine/benchmarking/b2-5-confirmatory-manifest.v1.json", "machine/benchmarking/b2-5-confirmatory-plan.v1.json", "machine/benchmarking/b2-5-confirmatory-freeze.v1.json"],
       "human_sources": ["docs/benchmarking/B2_CONFIRMATORY_MEASUREMENT_DESIGN.md", "docs/benchmarking/B2_CONFIRMATORY_EVIDENCE_INSTRUMENTATION.md", "docs/benchmarking/B2_5_CONFIRMATORY_PREPARATION.md"],
       "live_execution_authorized": false,
-      "live_model_calls_consumed": 0,
+      "live_model_calls_consumed": 42,
+      "historical_stopped_session_accepted_runs": 13,
+      "historical_stopped_session_attempted_slots": 14,
+      "historical_stopped_session_primary_inference_eligible": false,
+      "replacement_session_authorized_after_canonicalization": true,
+      "maximum_additional_underlying_model_calls": 120,
       "benefit_claim_allowed": false,
       "a5_execution_promotion": "NOT_AUTHORIZED",
-      "next_gate": "B2_5_EXACT_HEAD_VALIDATION_SIGNED_CANONICALIZATION_THEN_SEPARATELY_AUTHORIZED_EXECUTION"
+      "next_gate": "B2_5_UTF8_RECOVERY_EXACT_HEAD_VALIDATION_SIGNED_CANONICALIZATION_THEN_ONE_REPLACEMENT_SESSION"
     },
     "comparative_measurement_b3_1": {
       "status": "CALIBRATION_COMPLETED_AND_VALIDATED",

--- a/docs/benchmarking/B2_5_CONFIRMATORY_PREPARATION.md
+++ b/docs/benchmarking/B2_5_CONFIRMATORY_PREPARATION.md
@@ -41,10 +41,16 @@ Machine records:
 
 `scripts/b2_5_confirmatory_driver.py` requires an exact live authorization bound to the freeze, task-set, manifest, plan, and preparation Git identities. It uses the corrected executor flags `--codex-command-prefix-json` and `--workspace-dir`, preserves the complete B2.3.1 evidence contract and session artifacts, and stops before the next slot after any invalid run, validator failure, identity drift, repository mutation, evidence mismatch, counter-provenance failure, or resource overflow. The driver is not run during preparation.
 
+## UTF-8 recovery boundary
+
+The first empirical B2.5 session stopped fail-closed at slot 14 after 13 accepted runs and 42 actual model calls. Windows decoded Codex JSONL with the locale-dependent `cp1252` codec and rejected a byte before evidence parsing. That stopped session remains historical invalidated-session evidence and is excluded from primary confirmatory inference.
+
+The corrected executor requests `encoding="utf-8"` and `errors="strict"` for Codex subprocess output. Invalid UTF-8 remains a measurement-capture failure; replacement characters and ignored decode errors are prohibited. The task set, prompts, expected responses, validators, manifest, plan, randomization seed, topology arms, resource limits, and preregistered analysis are unchanged. Because the executor identity changed, the freeze binds its new source SHA-256 before one full fresh replacement session may begin from slot 1.
+
 ## Authority state
 
 The preparation freeze records `live_execution_authorized=false`, `benefit_claim_allowed=false`, and `a5_promotion_evidence_allowed=false`. B2.5 live execution is a separately gated action after exact-head validation, signed materialization, canonicalization, and independent canonical verification. A5 effective promotion, production attachment, B4, release, deployment, policy activation, integration refresh, destructive cleanup, force push, and history rewrite remain unauthorized.
 
 ## Next gate
 
-Complete exact-head validation and signed canonicalization of this preparation package. Only then may the separately authorized B2.5 execution session be created and run once against the frozen 40-slot plan.
+Complete exact-head validation and signed canonicalization of the UTF-8 recovery package. Only then may the authorized child B2.5 replacement session be created and run once from slot 1 against the unchanged frozen 40-slot plan.

--- a/machine/benchmarking/b2-5-confirmatory-freeze.v1.json
+++ b/machine/benchmarking/b2-5-confirmatory-freeze.v1.json
@@ -116,7 +116,7 @@
     "preflight": "scripts/b2_5_confirmatory_preflight.py",
     "driver": "scripts/b2_5_confirmatory_driver.py",
     "sha256": {
-      "scripts/a5_topology_benchmark_executor.py": "dc3eff98b9477e0776d55a6e3312e5e66205e2ee31c13874652dcb0c557e3f9a",
+      "scripts/a5_topology_benchmark_executor.py": "d33104cc684c28e175038ca7eba18adcde78a9d063bb73a2d31bca77d72912ce",
       "scripts/b2_confirmatory_evidence.py": "7828fec435094bbd415ad8ba635ea0f43df9dd4798425aec6ca535b603edbb01",
       "scripts/b2_5_confirmatory_preflight.py": "0b98a6f3280f964ff337b1d1b8e16b81f4a2038da1a08880d473fc272bab06cf",
       "scripts/b2_5_confirmatory_driver.py": "77c4821ff638e90ceadbc80964b520d25b0c23abb874d5e494fca91a77c19f5e"

--- a/machine/benchmarking/b2-instrumentation-pilot-freeze.v1.json
+++ b/machine/benchmarking/b2-instrumentation-pilot-freeze.v1.json
@@ -102,7 +102,7 @@
     "preflight": "scripts/b2_instrumentation_pilot_preflight.py",
     "driver": "scripts/b2_instrumentation_pilot_driver.py",
     "sha256": {
-      "scripts/a5_topology_benchmark_executor.py": "dc3eff98b9477e0776d55a6e3312e5e66205e2ee31c13874652dcb0c557e3f9a",
+      "scripts/a5_topology_benchmark_executor.py": "d33104cc684c28e175038ca7eba18adcde78a9d063bb73a2d31bca77d72912ce",
       "scripts/b2_confirmatory_evidence.py": "7828fec435094bbd415ad8ba635ea0f43df9dd4798425aec6ca535b603edbb01",
       "scripts/b2_instrumentation_pilot_preflight.py": "51a0f9e3f67742cc2ca96aec90502476519576a572896015761bfce5cc5e8a70",
       "scripts/b2_instrumentation_pilot_driver.py": "0c08ed5920687e3d32aa7c614e521887ac305ab348b09a6538b3ff4dfb196424"

--- a/scripts/a5_topology_benchmark_executor.py
+++ b/scripts/a5_topology_benchmark_executor.py
@@ -312,7 +312,16 @@ def run_codex_call(
 ) -> dict[str, Any]:
     command = codex_command(prefix, prompt=prompt, workspace=workspace, model=model, reasoning_effort=reasoning_effort)
     started = time.monotonic()
-    completed = run_command(command, capture_output=True, text=True, check=False, shell=False, timeout=timeout_seconds)
+    completed = run_command(
+        command,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="strict",
+        check=False,
+        shell=False,
+        timeout=timeout_seconds,
+    )
     elapsed_ms = int((time.monotonic() - started) * 1000)
     if completed.returncode != 0:
         raise TopologyExecutorError(f"Codex call failed with exit {completed.returncode}: {completed.stderr.strip()}")

--- a/tests/runtime/test_comparative_benchmark_a5_topology_executor.py
+++ b/tests/runtime/test_comparative_benchmark_a5_topology_executor.py
@@ -408,19 +408,22 @@ def test_executor_rejects_invalid_cached_counter_before_next_call(tmp_path: Path
     assert result["raw_evidence"]["rejected_turn_completed_usage"]["cached_input_tokens"] == 11
 
 
-def test_run_codex_call_preserves_exact_turn_completed_usage_with_zero_live_call(tmp_path: Path):
+@pytest.mark.parametrize("response", ["advisory", "advisory-雪"])
+def test_run_codex_call_preserves_exact_turn_completed_usage_with_zero_live_call(tmp_path: Path, response: str):
     usage = {"input_tokens": 21, "cached_input_tokens": 3, "output_tokens": 4, "reasoning_output_tokens": 2, "provider_extension": 9}
     raw = "\n".join(
         [
             json.dumps({"type": "thread.started", "thread_id": "t"}),
-            json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "advisory"}}),
+            json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": response}}, ensure_ascii=False),
             json.dumps({"type": "turn.completed", "usage": usage}),
         ]
     )
     observed_commands: list[list[str]] = []
+    observed_kwargs: list[dict] = []
 
     def fake_process(command, **kwargs):
         observed_commands.append(command)
+        observed_kwargs.append(kwargs)
         return subprocess.CompletedProcess(command, 0, stdout=raw, stderr="")
 
     call = run_codex_call(
@@ -433,9 +436,27 @@ def test_run_codex_call_preserves_exact_turn_completed_usage_with_zero_live_call
         run_command=fake_process,
     )
     assert len(observed_commands) == 1
+    assert observed_kwargs == [{"capture_output": True, "text": True, "encoding": "utf-8", "errors": "strict", "check": False, "shell": False, "timeout": 30}]
     assert call["turn_completed_usage"] == usage
     assert call["usage"] == {key: usage[key] for key in ("input_tokens", "cached_input_tokens", "output_tokens", "reasoning_output_tokens")}
-    assert call["response"] == "advisory"
+    assert call["response"] == response
+    assert build_response_evidence(call["response"])["response_utf8_sha256"] == sha256(response.encode("utf-8")).hexdigest()
+
+
+def test_run_codex_call_fails_closed_on_invalid_utf8_without_live_call(tmp_path: Path):
+    def fake_process(_command, **kwargs):
+        assert kwargs["encoding"] == "utf-8"
+        assert kwargs["errors"] == "strict"
+        raise UnicodeDecodeError("utf-8", b"\x80", 0, 1, "invalid start byte")
+
+    def fake_call(**kwargs):
+        return run_codex_call(**kwargs, run_command=fake_process)
+
+    envelope = make_envelope()
+    result = execute_with_fixtures(make_request(envelope, "clockwork-then-overseer"), envelope, tmp_path, fake_call)
+    assert result["outcome"]["status"] == "INVALID_RUN"
+    assert result["outcome"]["invalid_reason"] == "MEASUREMENT_CAPTURE_FAILURE"
+    assert "invalid start byte" in result["raw_evidence"]["error"]
 
 
 def test_fixture_integration_uses_only_injected_fake_runners(tmp_path: Path):


### PR DESCRIPTION
## Summary
- decode Codex JSONL explicitly as strict UTF-8
- add zero-live-call ASCII, Unicode, usage/hash, and malformed-byte regression coverage
- refresh only shared executor-bound freeze identities and record the stopped B2.5 session as historical evidence

## Validation
- 53 focused B2 tests passed
- B2.5 exact-host zero-call preflight passed with live_model_calls=0
- B2.4 zero-call compatibility preflight passed
- strict governance, structure, and manifest validation passed

## Boundaries
- task set, manifest, plan, seed, prompts, validators, thresholds, topology arms, retry policy, and resource limits are unchanged
- no live model calls were made during remediation