### PR TITLE
feat: add UIX-3 profile registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
-## Post-v1.6.0 UIX-2 Design-Source Preservation - Candidate
+## Post-v1.6.0 UIX-3 Theme, Layout, and Effect Profile Registry - Candidate
+
+- Adds the library-neutral UIX-3 profile registry, separating foundations, layouts, complete themes or systems, and optional effects.
+- Adds deterministic composition rules for required foundation/layout selections, mutually exclusive full systems, single optional effects, accessibility invariants, and project-native precedence.
+- Keeps profile metadata non-authorizing: no arbitrary CSS values, frontend dependency, external tool, Figma mutation, runtime integration, release, deployment, or policy activation is introduced.
+
+## Post-v1.6.0 UIX-2 Design-Source Preservation - Canonical
 
 - Adds the library-neutral UIX-2 design-source preservation workflow, schemas, deterministic fixtures, runtime validation, and pre-implementation handoff contract.
-- Adds `README.json` machine-discovery parity for UIX-2, records UIX-1 as canonical at entry `main` commit `c331634dc63fbebb86ca07274c06262d5b52a50d`, and reconciles the current UIX plan to the active PR #538 source head `8222342a746e7e20418572e562ba53cc1092a6c7`.
-- Keeps historical UIX phase wording, external design tools, dependency adoption, Figma mutation, release, deployment, and policy activation outside this bounded candidate.
+- Adds `README.json` machine-discovery parity for UIX-2 and records its canonical main readback at `8e4f3bb5e878131e8c038ea195311c92ca08cfde`.
+- Keeps historical UIX phase wording, external design tools, dependency adoption, Figma mutation, release, deployment, and policy activation outside this bounded phase.
 
 ## Post-v1.6.0 UIX-1 UI Design Contract - Candidate
 

--- a/README.json
+++ b/README.json
@@ -43,7 +43,7 @@
       "authority_note": "The UI Design Contract is evidence, not implementation authority. Figma, Code Connect, Storybook, Playwright, component libraries, and token tools remain optional capabilities; contract or validation evidence cannot grant or expand authority."
     },
     "governed_ui_design_source_preservation_uix2": {
-      "status": "IMPLEMENTED_PENDING_CANONICAL_VALIDATION",
+      "status": "IMPLEMENTED_CANONICAL",
       "purpose": "Library-neutral design-source intake and preservation workflow for source identity, evidence inventory, project-native component and token mapping, asset provenance, unresolved evidence, and pre-implementation handoff.",
       "machine_sources": ["machine/schemas/design-source-preservation-report.schema.json", "machine/schemas/design-source-preservation-workflow.schema.json", "machine/ui/design-source-preservation-workflow.v1.json"],
       "human_sources": ["docs/project/UIX_2_DESIGN_SOURCE_PRESERVATION.md"],
@@ -52,6 +52,17 @@
       "code_connect_required": false,
       "runtime_integration": false,
       "authority_note": "UIX-2 preserves evidence and reports unresolved design inputs; it does not grant implementation authority, authorize dependency adoption, make external tools authoritative, or authorize Figma mutation."
+    },
+    "governed_ui_design_profile_registry_uix3": {
+      "status": "IMPLEMENTED_PENDING_CANONICAL_VALIDATION",
+      "purpose": "Library-neutral UIX-3 registry separating foundations, layouts, complete themes or systems, and optional effects with deterministic composition and accessibility invariants.",
+      "machine_sources": ["machine/schemas/ui-profile-registry.schema.json", "machine/ui/ui-profile-registry.v1.json"],
+      "human_sources": ["docs/project/UIX_3_THEME_LAYOUT_EFFECT_PROFILE_REGISTRY.md"],
+      "validation_surface": "tests/runtime/test_ui_profile_registry.py",
+      "figma_required": false,
+      "code_connect_required": false,
+      "runtime_integration": false,
+      "authority_note": "UIX-3 profile metadata constrains composition evidence only; profile names do not authorize arbitrary CSS, implementation, dependency adoption, external tools, validation bypass, or Figma mutation."
     },
     "host_update_planning": {"status": "INCLUDED_IN_V1_6_CANDIDATE", "machine_sources": ["machine/hosts/update-contract.v1.json"], "human_sources": ["docs/setup/HOST_UPDATES.md"]},
     "adapter_sdk_and_prap_certification": {
@@ -584,6 +595,8 @@
     "prap_certification_evidence_schema": "machine/schemas/prap-certification-evidence.schema.json",
     "developer_portal_catalog_schema": "machine/schemas/developer-portal-catalog.schema.json",
     "readme_machine_index_schema": "machine/schemas/readme-machine-index.schema.json",
+    "ui_profile_registry_schema": "machine/schemas/ui-profile-registry.schema.json",
+    "ui_profile_registry": "machine/ui/ui-profile-registry.v1.json",
     "comparative_benchmark_codex_c2_portability_r1": "machine/benchmarking/codex-c2-portability-r1-preexecution.v1.json",
     "comparative_benchmark_codex_c2_portability_r1_live_authorization": "machine/benchmarking/codex-c2-portability-r1-live-execution-authorization.v1.json"
   },

--- a/docs/project/UIX_3_THEME_LAYOUT_EFFECT_PROFILE_REGISTRY.md
+++ b/docs/project/UIX_3_THEME_LAYOUT_EFFECT_PROFILE_REGISTRY.md
@@ -1,0 +1,58 @@
+# UIX-3 Theme, Layout, and Effect Profile Registry
+
+Status: `UIX_3_PROFILE_REGISTRY_IMPLEMENTED_PENDING_CANONICAL_VALIDATION`
+
+Recorded: 2026-08-24
+
+Entry baseline: `8e4f3bb5e878131e8c038ea195311c92ca08cfde`
+
+## Purpose
+
+UIX-3 defines a versioned, library-neutral registry for composing a foundation, layout, complete theme/design system, and optional visual effect. The registry prevents models from treating every visual idea as a peer theme or mixing unrelated systems without a deterministic rejection rule.
+
+The registry is metadata and evidence. It does not prescribe CSS values, select a frontend stack, authorize implementation, authorize dependency adoption, make an external tool authoritative, or authorize Figma mutation.
+
+## Canonical machine surface
+
+- Schema: `machine/schemas/ui-profile-registry.schema.json`
+- Registry: `machine/ui/ui-profile-registry.v1.json`
+- Valid composition fixture: `tests/fixtures/ui/uix3-valid-profile-composition.json`
+- Invalid composition fixture: `tests/fixtures/ui/uix3-invalid-full-system-mix.json`
+- Deterministic validation: `tests/runtime/test_ui_profile_registry.py`
+
+Schema version: `orchestra.ui-profile-registry.v1`
+
+## Taxonomy
+
+The initial registry deliberately keeps categories distinct:
+
+- Foundation: `minimalist`
+- Layout: `bento_grid`
+- Full theme or system: `dark_cyberpunk`, `neo_brutalism`, `material_3`, `retro_web_90s`
+- Optional effect: `glassmorphism`, `neumorphism`, `claymorphism`, `aurora`
+
+`bento_grid` is a layout profile, not a theme. `material_3` is a complete system and is not a casual mix-in with another complete system.
+
+## Composition rules
+
+- Exactly one foundation and one layout are required.
+- At most one full theme or system may be selected.
+- At most one optional effect may be selected in v1.
+- Unknown profiles, category mismatches, duplicate selections, and incompatibilities reject the composition.
+- Optional effects must not weaken interaction-critical contrast or focus.
+- Existing project design systems take precedence over generated profile defaults.
+- Profile names do not authorize arbitrary CSS values.
+
+## Accessibility invariants
+
+Semantic structure and names, keyboard and focus behavior, interaction-critical contrast, target size and error states, reduced-motion behavior, and forced-colors behavior remain active for every profile composition. These are requirements for later implementation and rendered evidence, not claims that a registry entry has passed accessibility validation.
+
+## Authority boundary
+
+The registry grants no implementation, CSS, validation, dependency-adoption, external-tool, or Figma-mutation authority. Figma, Code Connect, Storybook, Playwright, axe, and frontend component libraries remain optional capabilities outside this phase.
+
+## Ownership and exit
+
+Cloak owns the profile semantics and accessibility invariants. Clockwork owns any later host-neutral composition boundary. Ponytail owns only authorized project-native implementation. Overseer owns rendered/accessibility evidence. Conductor and Arbiter retain routing and transition ownership.
+
+UIX-3 exits only after the exact source tree passes focused and repository validation, fresh protected-main checks, signed materialization, canonical promotion, and independent tree/signature readback.

--- a/docs/project/UI_DESIGN_FIDELITY_SYSTEM_PLAN.md
+++ b/docs/project/UI_DESIGN_FIDELITY_SYSTEM_PLAN.md
@@ -1,10 +1,10 @@
 # Governed UI Design Fidelity System Plan
 
-Status: `UIX_2_ACTIVE_SOURCE_PRESERVATION`
+Status: `UIX_3_ACTIVE_PROFILE_REGISTRY`
 
 Recorded: 2026-08-24
 
-Activation baseline: `c331634dc63fbebb86ca07274c06262d5b52a50d`
+Activation baseline: `8e4f3bb5e878131e8c038ea195311c92ca08cfde`
 
 Historical design source: closed-unmerged PR #471 (`docs: plan governed UI design fidelity system`)
 
@@ -32,7 +32,7 @@ That sequencing gate is now resolved:
 
 Unchecked entries in `docs/project/ROADMAP.md` under Deferred and Future Work are backlog candidates, not automatic prerequisites. They do not block UIX unless an item becomes an explicit dependency or the maintainer changes priority.
 
-UIX-0 is complete, UIX-1 is canonical at `c331634dc63fbebb86ca07274c06262d5b52a50d`, and UIX-2 is the active bounded unit through PR #538 at source head `8222342a746e7e20418572e562ba53cc1092a6c7`. This current-state reconciliation supersedes the earlier UIX-0-only sequencing statement; historical UIX-0 and UIX-1 phase documents retain their phase-era status wording. The plan does not itself authorize dependency installation, Figma mutation, external authentication, release, deployment, marketplace publication, policy activation, or another protected action.
+UIX-0 is complete, UIX-1 is canonical at `c331634dc63fbebb86ca07274c06262d5b52a50d`, UIX-2 is canonical at `8e4f3bb5e878131e8c038ea195311c92ca08cfde`, and UIX-3 is the active bounded unit on the current source branch. This current-state reconciliation supersedes the earlier UIX-0-only sequencing statement; historical UIX-0 and UIX-1 phase documents retain their phase-era status wording. The plan does not itself authorize dependency installation, Figma mutation, external authentication, release, deployment, marketplace publication, policy activation, or another protected action.
 
 ## Existing ownership
 
@@ -282,4 +282,4 @@ The UIX campaign does not:
 
 ## Current bounded next action
 
-Complete UIX-2 through fresh exact-head validation and signed canonicalization of the design-source preservation contract. Stop before UIX-3 until UIX-2 has an independent canonical readback.
+Complete UIX-3 through fresh exact-head validation and signed canonicalization of the theme, layout, and effect profile registry. Stop before UIX-4 until UIX-3 has an independent canonical readback.

--- a/machine/schemas/ui-profile-registry.schema.json
+++ b/machine/schemas/ui-profile-registry.schema.json
@@ -1,0 +1,246 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.orchestra.dev/machine/ui-profile-registry/1.0.0",
+  "title": "Orchestra UI Theme, Layout, and Effect Profile Registry",
+  "description": "Library-neutral UIX-3 profile taxonomy and deterministic composition constraints.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schema_version",
+    "registry_id",
+    "role",
+    "taxonomy",
+    "profiles",
+    "composition_rules",
+    "accessibility_invariants",
+    "authority"
+  ],
+  "properties": {
+    "$schema": {"const": "../schemas/ui-profile-registry.schema.json"},
+    "schema_version": {"const": "orchestra.ui-profile-registry.v1"},
+    "registry_id": {"const": "uix3-theme-layout-effect-profiles"},
+    "role": {"const": "UIX_3_PROFILE_REGISTRY"},
+    "taxonomy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["foundation", "layout", "full_theme_or_system", "optional_effect"],
+      "properties": {
+        "foundation": {
+          "type": "array",
+          "prefixItems": [{"const": "minimalist"}],
+          "items": false,
+          "minItems": 1,
+          "maxItems": 1
+        },
+        "layout": {
+          "type": "array",
+          "prefixItems": [{"const": "bento_grid"}],
+          "items": false,
+          "minItems": 1,
+          "maxItems": 1
+        },
+        "full_theme_or_system": {
+          "type": "array",
+          "prefixItems": [
+            {"const": "dark_cyberpunk"},
+            {"const": "neo_brutalism"},
+            {"const": "material_3"},
+            {"const": "retro_web_90s"}
+          ],
+          "items": false,
+          "minItems": 4,
+          "maxItems": 4
+        },
+        "optional_effect": {
+          "type": "array",
+          "prefixItems": [
+            {"const": "glassmorphism"},
+            {"const": "neumorphism"},
+            {"const": "claymorphism"},
+            {"const": "aurora"}
+          ],
+          "items": false,
+          "minItems": 4,
+          "maxItems": 4
+        }
+      }
+    },
+    "profiles": {
+      "type": "array",
+      "minItems": 10,
+      "maxItems": 10,
+      "items": {"$ref": "#/$defs/profile"}
+    },
+    "composition_rules": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "required_categories",
+        "optional_categories",
+        "maximum_selections_by_category",
+        "full_system_mix_policy",
+        "incompatibility_rules",
+        "layout_classification",
+        "effect_safety",
+        "profile_name_authority",
+        "project_precedence",
+        "unknown_profile_disposition"
+      ],
+      "properties": {
+        "required_categories": {
+          "type": "array",
+          "prefixItems": [{"const": "foundation"}, {"const": "layout"}],
+          "items": false,
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "optional_categories": {
+          "type": "array",
+          "prefixItems": [
+            {"const": "full_theme_or_system"},
+            {"const": "optional_effect"}
+          ],
+          "items": false,
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "maximum_selections_by_category": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["foundation", "layout", "full_theme_or_system", "optional_effect"],
+          "properties": {
+            "foundation": {"const": 1},
+            "layout": {"const": 1},
+            "full_theme_or_system": {"const": 1},
+            "optional_effect": {"const": 1}
+          }
+        },
+        "full_system_mix_policy": {"const": "MUTUALLY_EXCLUSIVE"},
+        "incompatibility_rules": {
+          "type": "array",
+          "minItems": 2,
+          "items": {"$ref": "#/$defs/incompatibilityRule"}
+        },
+        "layout_classification": {"const": "BENTO_GRID_IS_LAYOUT_NOT_THEME"},
+        "effect_safety": {
+          "const": "OPTIONAL_EFFECTS_MUST_NOT_WEAKEN_INTERACTION_CRITICAL_CONTRAST_OR_FOCUS"
+        },
+        "profile_name_authority": {
+          "const": "PROFILE_IDENTIFIERS_DO_NOT_AUTHORIZE_ARBITRARY_CSS_VALUES"
+        },
+        "project_precedence": {
+          "const": "EXISTING_PROJECT_DESIGN_SYSTEM_OVERRIDES_PROFILE_DEFAULTS"
+        },
+        "unknown_profile_disposition": {"const": "REJECT_COMPOSITION"}
+      }
+    },
+    "accessibility_invariants": {
+      "type": "array",
+      "minItems": 6,
+      "items": {"$ref": "#/$defs/accessibilityInvariant"}
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "registry_grants_implementation_authority",
+        "profile_grants_css_authority",
+        "external_tools_grant_authority",
+        "validation_grants_authority",
+        "dependency_adoption_authorized",
+        "figma_mutation_authorized"
+      ],
+      "properties": {
+        "registry_grants_implementation_authority": {"const": false},
+        "profile_grants_css_authority": {"const": false},
+        "external_tools_grant_authority": {"const": false},
+        "validation_grants_authority": {"const": false},
+        "dependency_adoption_authorized": {"const": false},
+        "figma_mutation_authorized": {"const": false}
+      }
+    }
+  },
+  "$defs": {
+    "profile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "profile_id",
+        "category",
+        "display_name",
+        "purpose",
+        "composition_role",
+        "accessibility_behavior",
+        "value_authority"
+      ],
+      "properties": {
+        "profile_id": {"type": "string", "pattern": "^[a-z0-9_]+$"},
+        "category": {
+          "enum": ["foundation", "layout", "full_theme_or_system", "optional_effect"]
+        },
+        "display_name": {"type": "string", "minLength": 1},
+        "purpose": {"type": "string", "minLength": 1},
+        "composition_role": {
+          "enum": [
+            "REQUIRED_FOUNDATION",
+            "REQUIRED_LAYOUT",
+            "OPTIONAL_FULL_THEME_OR_SYSTEM",
+            "OPTIONAL_EFFECT"
+          ]
+        },
+        "accessibility_behavior": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["contrast", "reduced_motion", "forced_colors"],
+          "properties": {
+            "contrast": {
+              "enum": ["INHERIT_GLOBAL_INVARIANT", "RESTRICT_INTERACTION_CRITICAL_SURFACES"]
+            },
+            "reduced_motion": {"const": "INHERIT_GLOBAL_INVARIANT"},
+            "forced_colors": {"const": "INHERIT_GLOBAL_INVARIANT"}
+          }
+        },
+        "value_authority": {
+          "const": "METADATA_ONLY_NO_ARBITRARY_CSS_AUTHORITY"
+        }
+      }
+    },
+    "incompatibilityRule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["rule_id", "kind", "profile_ids", "disposition", "reason"],
+      "properties": {
+        "rule_id": {"type": "string", "minLength": 1},
+        "kind": {"enum": ["CATEGORY_MUTUALLY_EXCLUSIVE", "CATEGORY_MAXIMUM"]},
+        "profile_ids": {
+          "type": "array",
+          "minItems": 2,
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "disposition": {"const": "REJECT_COMPOSITION"},
+        "reason": {"type": "string", "minLength": 1}
+      }
+    },
+    "accessibilityInvariant": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["invariant_id", "requirement", "applies_to"],
+      "properties": {
+        "invariant_id": {
+          "enum": [
+            "SEMANTIC_STRUCTURE_AND_NAMES",
+            "KEYBOARD_AND_FOCUS",
+            "INTERACTION_CRITICAL_CONTRAST",
+            "TARGET_SIZE_AND_ERROR_STATES",
+            "REDUCED_MOTION",
+            "FORCED_COLORS"
+          ]
+        },
+        "requirement": {"type": "string", "minLength": 1},
+        "applies_to": {"const": "ALL_PROFILE_COMPOSITIONS"}
+      }
+    }
+  }
+}

--- a/machine/ui/ui-profile-registry.v1.json
+++ b/machine/ui/ui-profile-registry.v1.json
@@ -1,0 +1,216 @@
+{
+  "$schema": "../schemas/ui-profile-registry.schema.json",
+  "schema_version": "orchestra.ui-profile-registry.v1",
+  "registry_id": "uix3-theme-layout-effect-profiles",
+  "role": "UIX_3_PROFILE_REGISTRY",
+  "taxonomy": {
+    "foundation": ["minimalist"],
+    "layout": ["bento_grid"],
+    "full_theme_or_system": ["dark_cyberpunk", "neo_brutalism", "material_3", "retro_web_90s"],
+    "optional_effect": ["glassmorphism", "neumorphism", "claymorphism", "aurora"]
+  },
+  "profiles": [
+    {
+      "profile_id": "minimalist",
+      "category": "foundation",
+      "display_name": "Minimalist",
+      "purpose": "Reduce visual noise and prioritize semantic structure without prescribing implementation values.",
+      "composition_role": "REQUIRED_FOUNDATION",
+      "accessibility_behavior": {
+        "contrast": "INHERIT_GLOBAL_INVARIANT",
+        "reduced_motion": "INHERIT_GLOBAL_INVARIANT",
+        "forced_colors": "INHERIT_GLOBAL_INVARIANT"
+      },
+      "value_authority": "METADATA_ONLY_NO_ARBITRARY_CSS_AUTHORITY"
+    },
+    {
+      "profile_id": "bento_grid",
+      "category": "layout",
+      "display_name": "Bento Grid",
+      "purpose": "Arrange responsive content regions with explicit containment and order; this profile is a layout, not a theme.",
+      "composition_role": "REQUIRED_LAYOUT",
+      "accessibility_behavior": {
+        "contrast": "INHERIT_GLOBAL_INVARIANT",
+        "reduced_motion": "INHERIT_GLOBAL_INVARIANT",
+        "forced_colors": "INHERIT_GLOBAL_INVARIANT"
+      },
+      "value_authority": "METADATA_ONLY_NO_ARBITRARY_CSS_AUTHORITY"
+    },
+    {
+      "profile_id": "dark_cyberpunk",
+      "category": "full_theme_or_system",
+      "display_name": "Dark Cyberpunk",
+      "purpose": "A complete dark visual system with expressive technology-oriented emphasis.",
+      "composition_role": "OPTIONAL_FULL_THEME_OR_SYSTEM",
+      "accessibility_behavior": {
+        "contrast": "INHERIT_GLOBAL_INVARIANT",
+        "reduced_motion": "INHERIT_GLOBAL_INVARIANT",
+        "forced_colors": "INHERIT_GLOBAL_INVARIANT"
+      },
+      "value_authority": "METADATA_ONLY_NO_ARBITRARY_CSS_AUTHORITY"
+    },
+    {
+      "profile_id": "neo_brutalism",
+      "category": "full_theme_or_system",
+      "display_name": "Neo Brutalism",
+      "purpose": "A complete high-contrast visual system with direct hierarchy and deliberate visual weight.",
+      "composition_role": "OPTIONAL_FULL_THEME_OR_SYSTEM",
+      "accessibility_behavior": {
+        "contrast": "INHERIT_GLOBAL_INVARIANT",
+        "reduced_motion": "INHERIT_GLOBAL_INVARIANT",
+        "forced_colors": "INHERIT_GLOBAL_INVARIANT"
+      },
+      "value_authority": "METADATA_ONLY_NO_ARBITRARY_CSS_AUTHORITY"
+    },
+    {
+      "profile_id": "material_3",
+      "category": "full_theme_or_system",
+      "display_name": "Material 3",
+      "purpose": "A complete system profile whose components, state model, and tokens remain a coherent unit.",
+      "composition_role": "OPTIONAL_FULL_THEME_OR_SYSTEM",
+      "accessibility_behavior": {
+        "contrast": "INHERIT_GLOBAL_INVARIANT",
+        "reduced_motion": "INHERIT_GLOBAL_INVARIANT",
+        "forced_colors": "INHERIT_GLOBAL_INVARIANT"
+      },
+      "value_authority": "METADATA_ONLY_NO_ARBITRARY_CSS_AUTHORITY"
+    },
+    {
+      "profile_id": "retro_web_90s",
+      "category": "full_theme_or_system",
+      "display_name": "Retro Web 90s",
+      "purpose": "A complete nostalgic web visual system with explicit preservation of modern interaction requirements.",
+      "composition_role": "OPTIONAL_FULL_THEME_OR_SYSTEM",
+      "accessibility_behavior": {
+        "contrast": "INHERIT_GLOBAL_INVARIANT",
+        "reduced_motion": "INHERIT_GLOBAL_INVARIANT",
+        "forced_colors": "INHERIT_GLOBAL_INVARIANT"
+      },
+      "value_authority": "METADATA_ONLY_NO_ARBITRARY_CSS_AUTHORITY"
+    },
+    {
+      "profile_id": "glassmorphism",
+      "category": "optional_effect",
+      "display_name": "Glassmorphism",
+      "purpose": "An optional translucent surface treatment that may be used only where interaction-critical contrast and focus remain intact.",
+      "composition_role": "OPTIONAL_EFFECT",
+      "accessibility_behavior": {
+        "contrast": "RESTRICT_INTERACTION_CRITICAL_SURFACES",
+        "reduced_motion": "INHERIT_GLOBAL_INVARIANT",
+        "forced_colors": "INHERIT_GLOBAL_INVARIANT"
+      },
+      "value_authority": "METADATA_ONLY_NO_ARBITRARY_CSS_AUTHORITY"
+    },
+    {
+      "profile_id": "neumorphism",
+      "category": "optional_effect",
+      "display_name": "Neumorphism",
+      "purpose": "An optional soft-surface treatment that must not obscure boundaries, focus, or interaction-critical contrast.",
+      "composition_role": "OPTIONAL_EFFECT",
+      "accessibility_behavior": {
+        "contrast": "RESTRICT_INTERACTION_CRITICAL_SURFACES",
+        "reduced_motion": "INHERIT_GLOBAL_INVARIANT",
+        "forced_colors": "INHERIT_GLOBAL_INVARIANT"
+      },
+      "value_authority": "METADATA_ONLY_NO_ARBITRARY_CSS_AUTHORITY"
+    },
+    {
+      "profile_id": "claymorphism",
+      "category": "optional_effect",
+      "display_name": "Claymorphism",
+      "purpose": "An optional dimensional surface treatment that must preserve semantic boundaries and usable focus states.",
+      "composition_role": "OPTIONAL_EFFECT",
+      "accessibility_behavior": {
+        "contrast": "RESTRICT_INTERACTION_CRITICAL_SURFACES",
+        "reduced_motion": "INHERIT_GLOBAL_INVARIANT",
+        "forced_colors": "INHERIT_GLOBAL_INVARIANT"
+      },
+      "value_authority": "METADATA_ONLY_NO_ARBITRARY_CSS_AUTHORITY"
+    },
+    {
+      "profile_id": "aurora",
+      "category": "optional_effect",
+      "display_name": "Aurora",
+      "purpose": "An optional atmospheric light effect that must yield to interaction-critical contrast, focus, and reduced-motion requirements.",
+      "composition_role": "OPTIONAL_EFFECT",
+      "accessibility_behavior": {
+        "contrast": "RESTRICT_INTERACTION_CRITICAL_SURFACES",
+        "reduced_motion": "INHERIT_GLOBAL_INVARIANT",
+        "forced_colors": "INHERIT_GLOBAL_INVARIANT"
+      },
+      "value_authority": "METADATA_ONLY_NO_ARBITRARY_CSS_AUTHORITY"
+    }
+  ],
+  "composition_rules": {
+    "required_categories": ["foundation", "layout"],
+    "optional_categories": ["full_theme_or_system", "optional_effect"],
+    "maximum_selections_by_category": {
+      "foundation": 1,
+      "layout": 1,
+      "full_theme_or_system": 1,
+      "optional_effect": 1
+    },
+    "full_system_mix_policy": "MUTUALLY_EXCLUSIVE",
+    "incompatibility_rules": [
+      {
+        "rule_id": "full-system-mutual-exclusion",
+        "kind": "CATEGORY_MUTUALLY_EXCLUSIVE",
+        "profile_ids": ["dark_cyberpunk", "neo_brutalism", "material_3", "retro_web_90s"],
+        "disposition": "REJECT_COMPOSITION",
+        "reason": "Complete systems must remain coherent rather than being mixed as unrelated peer themes."
+      },
+      {
+        "rule_id": "optional-effect-single-selection",
+        "kind": "CATEGORY_MAXIMUM",
+        "profile_ids": ["glassmorphism", "neumorphism", "claymorphism", "aurora"],
+        "disposition": "REJECT_COMPOSITION",
+        "reason": "UIX-3 permits at most one optional effect so surface treatments cannot stack without explicit later evidence."
+      }
+    ],
+    "layout_classification": "BENTO_GRID_IS_LAYOUT_NOT_THEME",
+    "effect_safety": "OPTIONAL_EFFECTS_MUST_NOT_WEAKEN_INTERACTION_CRITICAL_CONTRAST_OR_FOCUS",
+    "profile_name_authority": "PROFILE_IDENTIFIERS_DO_NOT_AUTHORIZE_ARBITRARY_CSS_VALUES",
+    "project_precedence": "EXISTING_PROJECT_DESIGN_SYSTEM_OVERRIDES_PROFILE_DEFAULTS",
+    "unknown_profile_disposition": "REJECT_COMPOSITION"
+  },
+  "accessibility_invariants": [
+    {
+      "invariant_id": "SEMANTIC_STRUCTURE_AND_NAMES",
+      "requirement": "Semantic structure and accessible names remain required for every profile composition.",
+      "applies_to": "ALL_PROFILE_COMPOSITIONS"
+    },
+    {
+      "invariant_id": "KEYBOARD_AND_FOCUS",
+      "requirement": "Keyboard operation and visible usable focus remain required for every profile composition.",
+      "applies_to": "ALL_PROFILE_COMPOSITIONS"
+    },
+    {
+      "invariant_id": "INTERACTION_CRITICAL_CONTRAST",
+      "requirement": "Interaction-critical controls cannot lose required contrast or focus visibility because of a profile or effect.",
+      "applies_to": "ALL_PROFILE_COMPOSITIONS"
+    },
+    {
+      "invariant_id": "TARGET_SIZE_AND_ERROR_STATES",
+      "requirement": "Target-size and error-state requirements remain active regardless of visual profile.",
+      "applies_to": "ALL_PROFILE_COMPOSITIONS"
+    },
+    {
+      "invariant_id": "REDUCED_MOTION",
+      "requirement": "Reduced-motion preferences remain invariant and must be honored by any implementation or effect.",
+      "applies_to": "ALL_PROFILE_COMPOSITIONS"
+    },
+    {
+      "invariant_id": "FORCED_COLORS",
+      "requirement": "Forced-colors behavior remains usable and cannot be disabled by a selected profile.",
+      "applies_to": "ALL_PROFILE_COMPOSITIONS"
+    }
+  ],
+  "authority": {
+    "registry_grants_implementation_authority": false,
+    "profile_grants_css_authority": false,
+    "external_tools_grant_authority": false,
+    "validation_grants_authority": false,
+    "dependency_adoption_authorized": false,
+    "figma_mutation_authorized": false
+  }
+}

--- a/tests/fixtures/ui/uix3-invalid-full-system-mix.json
+++ b/tests/fixtures/ui/uix3-invalid-full-system-mix.json
@@ -1,0 +1,9 @@
+{
+  "registry": "machine/ui/ui-profile-registry.v1.json",
+  "selection": {
+    "foundation": ["minimalist"],
+    "layout": ["bento_grid"],
+    "full_theme_or_system": ["material_3", "dark_cyberpunk"],
+    "optional_effect": []
+  }
+}

--- a/tests/fixtures/ui/uix3-valid-profile-composition.json
+++ b/tests/fixtures/ui/uix3-valid-profile-composition.json
@@ -1,0 +1,9 @@
+{
+  "registry": "machine/ui/ui-profile-registry.v1.json",
+  "selection": {
+    "foundation": ["minimalist"],
+    "layout": ["bento_grid"],
+    "full_theme_or_system": ["material_3"],
+    "optional_effect": ["aurora"]
+  }
+}

--- a/tests/runtime/test_ui_profile_registry.py
+++ b/tests/runtime/test_ui_profile_registry.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = ROOT / "machine" / "schemas" / "ui-profile-registry.schema.json"
+REGISTRY_PATH = ROOT / "machine" / "ui" / "ui-profile-registry.v1.json"
+VALID_COMPOSITION = ROOT / "tests" / "fixtures" / "ui" / "uix3-valid-profile-composition.json"
+INVALID_COMPOSITION = ROOT / "tests" / "fixtures" / "ui" / "uix3-invalid-full-system-mix.json"
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _validator() -> jsonschema.Draft202012Validator:
+    schema = _load(SCHEMA_PATH)
+    jsonschema.Draft202012Validator.check_schema(schema)
+    return jsonschema.Draft202012Validator(schema)
+
+
+def _composition_errors(selection: dict, registry: dict) -> list[str]:
+    rules = registry["composition_rules"]
+    profiles = {profile["profile_id"]: profile for profile in registry["profiles"]}
+    errors: list[str] = []
+
+    for category in rules["required_categories"]:
+        if len(selection.get(category, [])) != 1:
+            errors.append(f"{category} must have exactly one selection")
+
+    for category in rules["required_categories"] + rules["optional_categories"]:
+        selected = selection.get(category, [])
+        if not isinstance(selected, list):
+            errors.append(f"{category} selection must be a list")
+            continue
+        maximum = rules["maximum_selections_by_category"][category]
+        if len(selected) > maximum:
+            errors.append(f"{category} exceeds its maximum selection count")
+        for profile_id in selected:
+            profile = profiles.get(profile_id)
+            if profile is None:
+                errors.append(f"unknown profile: {profile_id}")
+            elif profile["category"] != category:
+                errors.append(f"{profile_id} is not a {category} profile")
+
+    selected_ids = [profile_id for values in selection.values() for profile_id in values]
+    if len(selected_ids) != len(set(selected_ids)):
+        errors.append("a profile cannot be selected more than once")
+
+    for rule in rules["incompatibility_rules"]:
+        selected_count = len(set(selected_ids).intersection(rule["profile_ids"]))
+        if rule["kind"] == "CATEGORY_MUTUALLY_EXCLUSIVE" and selected_count > 1:
+            errors.append(rule["rule_id"])
+        if rule["kind"] == "CATEGORY_MAXIMUM" and selected_count > 1:
+            errors.append(rule["rule_id"])
+
+    return errors
+
+
+def test_uix3_schema_and_registry_are_valid() -> None:
+    registry = _load(REGISTRY_PATH)
+    _validator().validate(registry)
+
+    assert registry["schema_version"] == "orchestra.ui-profile-registry.v1"
+    assert len(registry["profiles"]) == 10
+    assert {profile["profile_id"] for profile in registry["profiles"]} == {
+        "minimalist",
+        "bento_grid",
+        "dark_cyberpunk",
+        "neo_brutalism",
+        "material_3",
+        "retro_web_90s",
+        "glassmorphism",
+        "neumorphism",
+        "claymorphism",
+        "aurora",
+    }
+
+
+def test_uix3_taxonomy_separates_foundation_layout_system_and_effect() -> None:
+    registry = _load(REGISTRY_PATH)
+    profiles = {profile["profile_id"]: profile for profile in registry["profiles"]}
+
+    assert profiles["minimalist"]["category"] == "foundation"
+    assert profiles["bento_grid"]["category"] == "layout"
+    assert profiles["material_3"]["category"] == "full_theme_or_system"
+    assert profiles["glassmorphism"]["category"] == "optional_effect"
+    assert registry["composition_rules"]["layout_classification"] == "BENTO_GRID_IS_LAYOUT_NOT_THEME"
+    assert registry["composition_rules"]["full_system_mix_policy"] == "MUTUALLY_EXCLUSIVE"
+
+
+def test_uix3_valid_and_invalid_compositions_are_deterministic() -> None:
+    registry = _load(REGISTRY_PATH)
+    valid = _load(VALID_COMPOSITION)
+    invalid = _load(INVALID_COMPOSITION)
+
+    assert _composition_errors(valid["selection"], registry) == []
+    assert "full-system-mutual-exclusion" in _composition_errors(invalid["selection"], registry)
+
+
+def test_uix3_accessibility_invariants_are_theme_neutral() -> None:
+    registry = _load(REGISTRY_PATH)
+    invariant_ids = {item["invariant_id"] for item in registry["accessibility_invariants"]}
+    assert {"REDUCED_MOTION", "FORCED_COLORS", "INTERACTION_CRITICAL_CONTRAST"} <= invariant_ids
+
+    for profile in registry["profiles"]:
+        behavior = profile["accessibility_behavior"]
+        assert behavior["reduced_motion"] == "INHERIT_GLOBAL_INVARIANT"
+        assert behavior["forced_colors"] == "INHERIT_GLOBAL_INVARIANT"
+    for profile_id in registry["taxonomy"]["optional_effect"]:
+        assert profiles_by_id(registry)[profile_id]["accessibility_behavior"]["contrast"] == (
+            "RESTRICT_INTERACTION_CRITICAL_SURFACES"
+        )
+
+
+def profiles_by_id(registry: dict) -> dict:
+    return {profile["profile_id"]: profile for profile in registry["profiles"]}
+
+
+def test_uix3_profile_names_do_not_grant_css_or_implementation_authority() -> None:
+    registry = _load(REGISTRY_PATH)
+    assert registry["composition_rules"]["profile_name_authority"] == (
+        "PROFILE_IDENTIFIERS_DO_NOT_AUTHORIZE_ARBITRARY_CSS_VALUES"
+    )
+    assert registry["composition_rules"]["project_precedence"] == (
+        "EXISTING_PROJECT_DESIGN_SYSTEM_OVERRIDES_PROFILE_DEFAULTS"
+    )
+    assert all(value is False for value in registry["authority"].values())
+
+    invalid = json.loads(json.dumps(registry))
+    invalid["profiles"][0]["css_values"] = {"color": "#fff"}
+    with pytest.raises(jsonschema.ValidationError):
+        _validator().validate(invalid)


### PR DESCRIPTION
Governed UIX-3 source phase. Adds a library-neutral theme/layout/effect registry, deterministic composition and accessibility invariants, fixtures/tests, and README/plan parity. Profile metadata is non-authorizing: no CSS values, frontend dependency, external tool, Figma mutation, runtime integration, release, deployment, or policy activation.