### PR TITLE
UIX-4: add component and asset preservation contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## Post-v1.6.0 UIX-3 Theme, Layout, and Effect Profile Registry - Candidate
+## Post-v1.6.0 UIX-4 Component and Asset Preservation - Candidate
+
+- Adds the library-neutral UIX-4 component and asset preservation contract with exact reuse precedence, variant/state coverage, semantic token preservation, provenance, substitution, and intentional-deviation rules.
+- Adds deterministic valid/invalid fixtures and runtime validation for incomplete coverage, unapproved substitutions, known-asset provenance, and non-authorizing authority boundaries.
+- Keeps implementation, dependency, external-tool, Figma, release, deployment, and policy activation outside this bounded candidate.
+
+## Post-v1.6.0 UIX-3 Theme, Layout, and Effect Profile Registry - Canonical
 
 - Adds the library-neutral UIX-3 profile registry, separating foundations, layouts, complete themes or systems, and optional effects.
 - Adds deterministic composition rules for required foundation/layout selections, mutually exclusive full systems, single optional effects, accessibility invariants, and project-native precedence.

--- a/README.json
+++ b/README.json
@@ -54,7 +54,7 @@
       "authority_note": "UIX-2 preserves evidence and reports unresolved design inputs; it does not grant implementation authority, authorize dependency adoption, make external tools authoritative, or authorize Figma mutation."
     },
     "governed_ui_design_profile_registry_uix3": {
-      "status": "IMPLEMENTED_PENDING_CANONICAL_VALIDATION",
+      "status": "IMPLEMENTED_CANONICAL",
       "purpose": "Library-neutral UIX-3 registry separating foundations, layouts, complete themes or systems, and optional effects with deterministic composition and accessibility invariants.",
       "machine_sources": ["machine/schemas/ui-profile-registry.schema.json", "machine/ui/ui-profile-registry.v1.json"],
       "human_sources": ["docs/project/UIX_3_THEME_LAYOUT_EFFECT_PROFILE_REGISTRY.md"],
@@ -63,6 +63,17 @@
       "code_connect_required": false,
       "runtime_integration": false,
       "authority_note": "UIX-3 profile metadata constrains composition evidence only; profile names do not authorize arbitrary CSS, implementation, dependency adoption, external tools, validation bypass, or Figma mutation."
+    },
+    "governed_ui_component_asset_preservation_uix4": {
+      "status": "IMPLEMENTED_PENDING_CANONICAL_VALIDATION",
+      "purpose": "Evidence-bound UIX-4 component mapping, variant and interaction-state coverage, semantic token preservation, asset provenance, substitution, and intentional-deviation contract.",
+      "machine_sources": ["machine/schemas/component-asset-preservation.schema.json", "machine/ui/component-asset-preservation-contract.v1.json"],
+      "human_sources": ["docs/project/UIX_4_COMPONENT_ASSET_PRESERVATION.md"],
+      "validation_surface": "tests/runtime/test_component_asset_preservation.py",
+      "figma_required": false,
+      "code_connect_required": false,
+      "runtime_integration": false,
+      "authority_note": "UIX-4 preserves component and asset evidence; it does not grant implementation authority, authorize silent substitutions, add dependencies, make external tools authoritative, or authorize Figma mutation."
     },
     "host_update_planning": {"status": "INCLUDED_IN_V1_6_CANDIDATE", "machine_sources": ["machine/hosts/update-contract.v1.json"], "human_sources": ["docs/setup/HOST_UPDATES.md"]},
     "adapter_sdk_and_prap_certification": {
@@ -597,6 +608,8 @@
     "readme_machine_index_schema": "machine/schemas/readme-machine-index.schema.json",
     "ui_profile_registry_schema": "machine/schemas/ui-profile-registry.schema.json",
     "ui_profile_registry": "machine/ui/ui-profile-registry.v1.json",
+    "component_asset_preservation_schema": "machine/schemas/component-asset-preservation.schema.json",
+    "component_asset_preservation_contract": "machine/ui/component-asset-preservation-contract.v1.json",
     "comparative_benchmark_codex_c2_portability_r1": "machine/benchmarking/codex-c2-portability-r1-preexecution.v1.json",
     "comparative_benchmark_codex_c2_portability_r1_live_authorization": "machine/benchmarking/codex-c2-portability-r1-live-execution-authorization.v1.json"
   },

--- a/docs/project/UIX_4_COMPONENT_ASSET_PRESERVATION.md
+++ b/docs/project/UIX_4_COMPONENT_ASSET_PRESERVATION.md
@@ -1,0 +1,46 @@
+# UIX-4 Component and Asset Preservation Contracts
+
+Status: `UIX_4_COMPONENT_ASSET_PRESERVATION_IMPLEMENTED_PENDING_CANONICAL_VALIDATION`
+
+Recorded: 2026-08-24
+
+Entry baseline: `d27fbd6b89b297646c7e30ffb8bac193bbdc0cf4`
+
+## Purpose
+
+UIX-4 defines the evidence-bound contract used to preserve project-native component mappings, interaction-state and variant coverage, semantic tokens, and font/icon/image/illustration/logo provenance before implementation. It makes substitution and intentional deviation visible instead of allowing a visually plausible approximation to become an undocumented source of truth.
+
+## Canonical machine surface
+
+- Schema: `machine/schemas/component-asset-preservation.schema.json`
+- Contract: `machine/ui/component-asset-preservation-contract.v1.json`
+- Invalid substitution fixture: `tests/fixtures/ui/uix4-invalid-unapproved-substitution.json`
+- Invalid coverage fixture: `tests/fixtures/ui/uix4-invalid-incomplete-state-coverage.json`
+- Deterministic validation: `tests/runtime/test_component_asset_preservation.py`
+
+Schema version: `orchestra.component-asset-preservation.v1`
+
+## Preservation precedence
+
+1. Exact supplied project asset or component.
+2. Verified existing project-native equivalent.
+3. Approved semantic mapping.
+4. Explicitly approved adaptation.
+5. Reviewed new implementation.
+6. `UNRESOLVED` rather than a fabricated replacement.
+
+Components must record variants, interaction states, semantic tokens, mapping target, and coverage disposition. Incomplete coverage blocks implementation readiness. An intentional adaptation requires both a reason and an approval reference.
+
+## Asset provenance and substitution
+
+Every font, icon, image, illustration, and logo record requires source identity, provenance status, license or source status, an evidence reference, and a substitution policy. Known assets cannot be approximated without explicit approval and provenance. Invented SVG or logo paths, novelty fonts, and silent known-asset substitutions remain prohibited.
+
+## Authority boundary
+
+This contract is evidence. It does not grant implementation, CSS, validation, dependency-adoption, external-tool, or Figma-mutation authority. Governor review remains applicable when asset, license, IP, or dependency adoption is proposed.
+
+## Ownership and exit
+
+Cloak owns preservation semantics and static fidelity requirements. Clockwork owns later component boundaries. Ponytail owns only authorized project-native implementation. Overseer owns rendered and accessibility evidence. Conductor and Arbiter retain routing and transition ownership.
+
+UIX-4 exits only after exact-tree validation, fresh protected-main checks, signed materialization, canonical promotion, and independent tree/signature readback.

--- a/docs/project/UI_DESIGN_FIDELITY_SYSTEM_PLAN.md
+++ b/docs/project/UI_DESIGN_FIDELITY_SYSTEM_PLAN.md
@@ -1,10 +1,10 @@
 # Governed UI Design Fidelity System Plan
 
-Status: `UIX_3_ACTIVE_PROFILE_REGISTRY`
+Status: `UIX_4_ACTIVE_COMPONENT_ASSET_PRESERVATION`
 
 Recorded: 2026-08-24
 
-Activation baseline: `8e4f3bb5e878131e8c038ea195311c92ca08cfde`
+Activation baseline: `d27fbd6b89b297646c7e30ffb8bac193bbdc0cf4`
 
 Historical design source: closed-unmerged PR #471 (`docs: plan governed UI design fidelity system`)
 
@@ -32,7 +32,7 @@ That sequencing gate is now resolved:
 
 Unchecked entries in `docs/project/ROADMAP.md` under Deferred and Future Work are backlog candidates, not automatic prerequisites. They do not block UIX unless an item becomes an explicit dependency or the maintainer changes priority.
 
-UIX-0 is complete, UIX-1 is canonical at `c331634dc63fbebb86ca07274c06262d5b52a50d`, UIX-2 is canonical at `8e4f3bb5e878131e8c038ea195311c92ca08cfde`, and UIX-3 is the active bounded unit on the current source branch. This current-state reconciliation supersedes the earlier UIX-0-only sequencing statement; historical UIX-0 and UIX-1 phase documents retain their phase-era status wording. The plan does not itself authorize dependency installation, Figma mutation, external authentication, release, deployment, marketplace publication, policy activation, or another protected action.
+UIX-0 is complete, UIX-1 is canonical at `c331634dc63fbebb86ca07274c06262d5b52a50d`, UIX-2 is canonical at `8e4f3bb5e878131e8c038ea195311c92ca08cfde`, UIX-3 is canonical at `d27fbd6b89b297646c7e30ffb8bac193bbdc0cf4`, and UIX-4 is the active bounded unit on the current source branch. This current-state reconciliation supersedes the earlier UIX-0-only sequencing statement; historical UIX-0 and UIX-1 phase documents retain their phase-era status wording. The plan does not itself authorize dependency installation, Figma mutation, external authentication, release, deployment, marketplace publication, policy activation, or another protected action.
 
 ## Existing ownership
 
@@ -282,4 +282,4 @@ The UIX campaign does not:
 
 ## Current bounded next action
 
-Complete UIX-3 through fresh exact-head validation and signed canonicalization of the theme, layout, and effect profile registry. Stop before UIX-4 until UIX-3 has an independent canonical readback.
+Complete UIX-4 through fresh exact-head validation and signed canonicalization of the component and asset preservation contract. Stop before UIX-5 until UIX-4 has an independent canonical readback.

--- a/machine/schemas/component-asset-preservation.schema.json
+++ b/machine/schemas/component-asset-preservation.schema.json
@@ -1,0 +1,338 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.orchestra.dev/machine/component-asset-preservation/1.0.0",
+  "title": "Orchestra Component and Asset Preservation Contract",
+  "description": "Evidence-bound UIX-4 component reuse, coverage, provenance, substitution, and deviation rules.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schema_version",
+    "contract_id",
+    "role",
+    "consumes",
+    "precedence",
+    "component_contract",
+    "asset_contract",
+    "components",
+    "assets",
+    "deviation_rules",
+    "authority"
+  ],
+  "properties": {
+    "$schema": {"const": "../schemas/component-asset-preservation.schema.json"},
+    "schema_version": {"const": "orchestra.component-asset-preservation.v1"},
+    "contract_id": {"const": "uix4-component-asset-preservation"},
+    "role": {"const": "CLOAK_COMPONENT_ASSET_PRESERVATION"},
+    "consumes": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ui_design_contract_schema",
+        "source_preservation_report_schema",
+        "profile_registry_schema"
+      ],
+      "properties": {
+        "ui_design_contract_schema": {"const": "machine/schemas/ui-design-contract.schema.json"},
+        "source_preservation_report_schema": {
+          "const": "machine/schemas/design-source-preservation-report.schema.json"
+        },
+        "profile_registry_schema": {"const": "machine/schemas/ui-profile-registry.schema.json"}
+      }
+    },
+    "precedence": {
+      "type": "array",
+      "prefixItems": [
+        {"const": "EXACT_SUPPLIED_PROJECT_ASSET_OR_COMPONENT"},
+        {"const": "VERIFIED_EXISTING_PROJECT_NATIVE_EQUIVALENT"},
+        {"const": "APPROVED_SEMANTIC_MAPPING"},
+        {"const": "EXPLICITLY_APPROVED_ADAPTATION"},
+        {"const": "REVIEWED_NEW_IMPLEMENTATION"},
+        {"const": "UNRESOLVED_NO_FABRICATED_REPLACEMENT"}
+      ],
+      "items": false,
+      "minItems": 6,
+      "maxItems": 6
+    },
+    "component_contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "required_variant_coverage",
+        "required_interaction_state_coverage",
+        "semantic_token_preservation",
+        "mapping_kinds",
+        "incomplete_coverage_disposition",
+        "unresolved_mapping_disposition"
+      ],
+      "properties": {
+        "required_variant_coverage": {"const": true},
+        "required_interaction_state_coverage": {"const": true},
+        "semantic_token_preservation": {"const": true},
+        "mapping_kinds": {
+          "type": "array",
+          "prefixItems": [
+            {"const": "EXACT"},
+            {"const": "VERIFIED_PROJECT_NATIVE"},
+            {"const": "APPROVED_SEMANTIC_MAPPING"},
+            {"const": "APPROVED_ADAPTATION"},
+            {"const": "REVIEWED_NEW"},
+            {"const": "UNRESOLVED"}
+          ],
+          "items": false,
+          "minItems": 6,
+          "maxItems": 6
+        },
+        "incomplete_coverage_disposition": {"const": "BLOCKED_INCOMPLETE_COVERAGE"},
+        "unresolved_mapping_disposition": {"const": "UNRESOLVED_NO_FABRICATION"}
+      }
+    },
+    "asset_contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "asset_types",
+        "provenance_requirement",
+        "substitution_policies",
+        "known_asset_without_evidence",
+        "known_asset_approximation"
+      ],
+      "properties": {
+        "asset_types": {
+          "type": "array",
+          "prefixItems": [
+            {"const": "FONT"},
+            {"const": "ICON"},
+            {"const": "IMAGE"},
+            {"const": "ILLUSTRATION"},
+            {"const": "LOGO"}
+          ],
+          "items": false,
+          "minItems": 5,
+          "maxItems": 5
+        },
+        "provenance_requirement": {"const": "SOURCE_IDENTITY_AND_PROVENANCE_STATUS_REQUIRED"},
+        "substitution_policies": {
+          "type": "array",
+          "prefixItems": [
+            {"const": "EXACT_REQUIRED"},
+            {"const": "PROJECT_MATCH_ALLOWED"},
+            {"const": "APPROVAL_REQUIRED"},
+            {"const": "NO_SUBSTITUTION"}
+          ],
+          "items": false,
+          "minItems": 4,
+          "maxItems": 4
+        },
+        "known_asset_without_evidence": {"const": "REJECT"},
+        "known_asset_approximation": {"const": "REJECT_WITHOUT_EXPLICIT_APPROVAL_AND_PROVENANCE"}
+      }
+    },
+    "components": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/component"}
+    },
+    "assets": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/asset"}
+    },
+    "deviation_rules": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "intentional_adaptation_requires_reason_and_approval",
+        "substitution_requires_approval_when_not_exact",
+        "invented_svg_or_logo_allowed",
+        "novel_font_adoption_allowed",
+        "silent_known_asset_substitution_allowed",
+        "unresolved_is_implementation_ready"
+      ],
+      "properties": {
+        "intentional_adaptation_requires_reason_and_approval": {"const": true},
+        "substitution_requires_approval_when_not_exact": {"const": true},
+        "invented_svg_or_logo_allowed": {"const": false},
+        "novel_font_adoption_allowed": {"const": false},
+        "silent_known_asset_substitution_allowed": {"const": false},
+        "unresolved_is_implementation_ready": {"const": false}
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "contract_grants_implementation_authority",
+        "external_tools_grant_authority",
+        "validation_grants_authority",
+        "dependency_adoption_authorized",
+        "figma_mutation_authorized"
+      ],
+      "properties": {
+        "contract_grants_implementation_authority": {"const": false},
+        "external_tools_grant_authority": {"const": false},
+        "validation_grants_authority": {"const": false},
+        "dependency_adoption_authorized": {"const": false},
+        "figma_mutation_authorized": {"const": false}
+      }
+    }
+  },
+  "$defs": {
+    "component": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "component_id",
+        "source_ref",
+        "mapping_kind",
+        "target",
+        "variants",
+        "states",
+        "semantic_tokens",
+        "coverage_status",
+        "implementation_disposition"
+      ],
+      "properties": {
+        "component_id": {"type": "string", "minLength": 1},
+        "source_ref": {"type": "string", "minLength": 1},
+        "mapping_kind": {
+          "enum": [
+            "EXACT",
+            "VERIFIED_PROJECT_NATIVE",
+            "APPROVED_SEMANTIC_MAPPING",
+            "APPROVED_ADAPTATION",
+            "REVIEWED_NEW",
+            "UNRESOLVED"
+          ]
+        },
+        "target": {"type": ["string", "null"]},
+        "variants": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "states": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "semantic_tokens": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "coverage_status": {"enum": ["COMPLETE", "INCOMPLETE", "UNRESOLVED"]},
+        "implementation_disposition": {
+          "enum": [
+            "READY_FOR_IMPLEMENTATION",
+            "BLOCKED_INCOMPLETE_COVERAGE",
+            "UNRESOLVED_NO_FABRICATION"
+          ]
+        },
+        "reason": {"type": "string", "minLength": 1},
+        "approval_ref": {"type": "string", "minLength": 1},
+        "review_ref": {"type": "string", "minLength": 1},
+        "unresolved_reason": {"type": "string", "minLength": 1}
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "mapping_kind": {
+                "enum": [
+                  "EXACT",
+                  "VERIFIED_PROJECT_NATIVE",
+                  "APPROVED_SEMANTIC_MAPPING",
+                  "APPROVED_ADAPTATION",
+                  "REVIEWED_NEW"
+                ]
+              }
+            },
+            "required": ["mapping_kind"]
+          },
+          "then": {
+            "properties": {"target": {"type": "string", "minLength": 1}},
+            "required": ["target"]
+          }
+        },
+        {
+          "if": {"properties": {"mapping_kind": {"const": "APPROVED_ADAPTATION"}}, "required": ["mapping_kind"]},
+          "then": {"required": ["reason", "approval_ref"]}
+        },
+        {
+          "if": {"properties": {"mapping_kind": {"const": "REVIEWED_NEW"}}, "required": ["mapping_kind"]},
+          "then": {"required": ["review_ref"]}
+        },
+        {
+          "if": {"properties": {"mapping_kind": {"const": "UNRESOLVED"}}, "required": ["mapping_kind"]},
+          "then": {
+            "properties": {"target": {"type": "null"}},
+            "required": ["unresolved_reason"]
+          }
+        },
+        {
+          "if": {"properties": {"coverage_status": {"const": "COMPLETE"}}, "required": ["coverage_status"]},
+          "then": {"properties": {"implementation_disposition": {"const": "READY_FOR_IMPLEMENTATION"}}}
+        },
+        {
+          "if": {"properties": {"coverage_status": {"const": "INCOMPLETE"}}, "required": ["coverage_status"]},
+          "then": {"properties": {"implementation_disposition": {"const": "BLOCKED_INCOMPLETE_COVERAGE"}}}
+        },
+        {
+          "if": {"properties": {"coverage_status": {"const": "UNRESOLVED"}}, "required": ["coverage_status"]},
+          "then": {"properties": {"implementation_disposition": {"const": "UNRESOLVED_NO_FABRICATION"}}}
+        }
+      ]
+    },
+    "asset": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "asset_id",
+        "asset_type",
+        "semantic_role",
+        "source_identity",
+        "provenance_status",
+        "license_or_source_status",
+        "substitution_policy",
+        "evidence_ref"
+      ],
+      "properties": {
+        "asset_id": {"type": "string", "minLength": 1},
+        "asset_type": {"enum": ["FONT", "ICON", "IMAGE", "ILLUSTRATION", "LOGO"]},
+        "semantic_role": {"type": "string", "minLength": 1},
+        "source_identity": {"type": "string", "minLength": 1},
+        "provenance_status": {"enum": ["CONFIRMED", "REVIEW_REQUIRED", "UNRESOLVED"]},
+        "license_or_source_status": {
+          "enum": ["CONFIRMED", "REVIEW_REQUIRED", "NOT_APPLICABLE", "UNRESOLVED"]
+        },
+        "substitution_policy": {
+          "enum": ["EXACT_REQUIRED", "PROJECT_MATCH_ALLOWED", "APPROVAL_REQUIRED", "NO_SUBSTITUTION"]
+        },
+        "evidence_ref": {"type": "string", "minLength": 1},
+        "match_basis": {"type": "string", "minLength": 1},
+        "reason": {"type": "string", "minLength": 1},
+        "approval_ref": {"type": "string", "minLength": 1}
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {"substitution_policy": {"const": "PROJECT_MATCH_ALLOWED"}},
+            "required": ["substitution_policy"]
+          },
+          "then": {"required": ["match_basis"]}
+        },
+        {
+          "if": {
+            "properties": {"substitution_policy": {"const": "APPROVAL_REQUIRED"}},
+            "required": ["substitution_policy"]
+          },
+          "then": {"required": ["reason", "approval_ref"]}
+        }
+      ]
+    }
+  }
+}

--- a/machine/ui/component-asset-preservation-contract.v1.json
+++ b/machine/ui/component-asset-preservation-contract.v1.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "../schemas/component-asset-preservation.schema.json",
+  "schema_version": "orchestra.component-asset-preservation.v1",
+  "contract_id": "uix4-component-asset-preservation",
+  "role": "CLOAK_COMPONENT_ASSET_PRESERVATION",
+  "consumes": {
+    "ui_design_contract_schema": "machine/schemas/ui-design-contract.schema.json",
+    "source_preservation_report_schema": "machine/schemas/design-source-preservation-report.schema.json",
+    "profile_registry_schema": "machine/schemas/ui-profile-registry.schema.json"
+  },
+  "precedence": [
+    "EXACT_SUPPLIED_PROJECT_ASSET_OR_COMPONENT",
+    "VERIFIED_EXISTING_PROJECT_NATIVE_EQUIVALENT",
+    "APPROVED_SEMANTIC_MAPPING",
+    "EXPLICITLY_APPROVED_ADAPTATION",
+    "REVIEWED_NEW_IMPLEMENTATION",
+    "UNRESOLVED_NO_FABRICATED_REPLACEMENT"
+  ],
+  "component_contract": {
+    "required_variant_coverage": true,
+    "required_interaction_state_coverage": true,
+    "semantic_token_preservation": true,
+    "mapping_kinds": [
+      "EXACT",
+      "VERIFIED_PROJECT_NATIVE",
+      "APPROVED_SEMANTIC_MAPPING",
+      "APPROVED_ADAPTATION",
+      "REVIEWED_NEW",
+      "UNRESOLVED"
+    ],
+    "incomplete_coverage_disposition": "BLOCKED_INCOMPLETE_COVERAGE",
+    "unresolved_mapping_disposition": "UNRESOLVED_NO_FABRICATION"
+  },
+  "asset_contract": {
+    "asset_types": ["FONT", "ICON", "IMAGE", "ILLUSTRATION", "LOGO"],
+    "provenance_requirement": "SOURCE_IDENTITY_AND_PROVENANCE_STATUS_REQUIRED",
+    "substitution_policies": [
+      "EXACT_REQUIRED",
+      "PROJECT_MATCH_ALLOWED",
+      "APPROVAL_REQUIRED",
+      "NO_SUBSTITUTION"
+    ],
+    "known_asset_without_evidence": "REJECT",
+    "known_asset_approximation": "REJECT_WITHOUT_EXPLICIT_APPROVAL_AND_PROVENANCE"
+  },
+  "components": [
+    {
+      "component_id": "checkout_button",
+      "source_ref": "uix2:evidence:component:checkout_button",
+      "mapping_kind": "VERIFIED_PROJECT_NATIVE",
+      "target": "project:components/Button",
+      "variants": ["default", "icon_only"],
+      "states": ["default", "hover", "focus_visible", "disabled", "error"],
+      "semantic_tokens": ["color.action.primary", "space.control.inline", "radius.control"],
+      "coverage_status": "COMPLETE",
+      "implementation_disposition": "READY_FOR_IMPLEMENTATION"
+    }
+  ],
+  "assets": [
+    {
+      "asset_id": "brand_font",
+      "asset_type": "FONT",
+      "semantic_role": "primary interface typography",
+      "source_identity": "project:fonts/inter",
+      "provenance_status": "CONFIRMED",
+      "license_or_source_status": "CONFIRMED",
+      "substitution_policy": "PROJECT_MATCH_ALLOWED",
+      "evidence_ref": "uix2:evidence:asset:brand_font",
+      "match_basis": "verified project-native font role"
+    },
+    {
+      "asset_id": "checkout_icon",
+      "asset_type": "ICON",
+      "semantic_role": "checkout confirmation action",
+      "source_identity": "project:icons/check",
+      "provenance_status": "CONFIRMED",
+      "license_or_source_status": "NOT_APPLICABLE",
+      "substitution_policy": "PROJECT_MATCH_ALLOWED",
+      "evidence_ref": "uix2:evidence:asset:checkout_icon",
+      "match_basis": "verified project-native icon component"
+    },
+    {
+      "asset_id": "checkout_hero",
+      "asset_type": "IMAGE",
+      "semantic_role": "checkout product context",
+      "source_identity": "project:images/checkout-hero",
+      "provenance_status": "CONFIRMED",
+      "license_or_source_status": "CONFIRMED",
+      "substitution_policy": "EXACT_REQUIRED",
+      "evidence_ref": "uix2:evidence:asset:checkout_hero"
+    },
+    {
+      "asset_id": "empty_state_illustration",
+      "asset_type": "ILLUSTRATION",
+      "semantic_role": "empty checkout state",
+      "source_identity": "project:illustrations/empty-checkout",
+      "provenance_status": "CONFIRMED",
+      "license_or_source_status": "CONFIRMED",
+      "substitution_policy": "EXACT_REQUIRED",
+      "evidence_ref": "uix2:evidence:asset:empty_state_illustration"
+    },
+    {
+      "asset_id": "brand_logo",
+      "asset_type": "LOGO",
+      "semantic_role": "brand identity",
+      "source_identity": "project:logos/primary",
+      "provenance_status": "CONFIRMED",
+      "license_or_source_status": "CONFIRMED",
+      "substitution_policy": "NO_SUBSTITUTION",
+      "evidence_ref": "uix2:evidence:asset:brand_logo"
+    }
+  ],
+  "deviation_rules": {
+    "intentional_adaptation_requires_reason_and_approval": true,
+    "substitution_requires_approval_when_not_exact": true,
+    "invented_svg_or_logo_allowed": false,
+    "novel_font_adoption_allowed": false,
+    "silent_known_asset_substitution_allowed": false,
+    "unresolved_is_implementation_ready": false
+  },
+  "authority": {
+    "contract_grants_implementation_authority": false,
+    "external_tools_grant_authority": false,
+    "validation_grants_authority": false,
+    "dependency_adoption_authorized": false,
+    "figma_mutation_authorized": false
+  }
+}

--- a/tests/fixtures/ui/uix4-invalid-incomplete-state-coverage.json
+++ b/tests/fixtures/ui/uix4-invalid-incomplete-state-coverage.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "../schemas/component-asset-preservation.schema.json",
+  "schema_version": "orchestra.component-asset-preservation.v1",
+  "contract_id": "uix4-invalid-incomplete-state-coverage",
+  "role": "CLOAK_COMPONENT_ASSET_PRESERVATION",
+  "consumes": {
+    "ui_design_contract_schema": "machine/schemas/ui-design-contract.schema.json",
+    "source_preservation_report_schema": "machine/schemas/design-source-preservation-report.schema.json",
+    "profile_registry_schema": "machine/schemas/ui-profile-registry.schema.json"
+  },
+  "precedence": [
+    "EXACT_SUPPLIED_PROJECT_ASSET_OR_COMPONENT",
+    "VERIFIED_EXISTING_PROJECT_NATIVE_EQUIVALENT",
+    "APPROVED_SEMANTIC_MAPPING",
+    "EXPLICITLY_APPROVED_ADAPTATION",
+    "REVIEWED_NEW_IMPLEMENTATION",
+    "UNRESOLVED_NO_FABRICATED_REPLACEMENT"
+  ],
+  "component_contract": {
+    "required_variant_coverage": true,
+    "required_interaction_state_coverage": true,
+    "semantic_token_preservation": true,
+    "mapping_kinds": ["EXACT", "VERIFIED_PROJECT_NATIVE", "APPROVED_SEMANTIC_MAPPING", "APPROVED_ADAPTATION", "REVIEWED_NEW", "UNRESOLVED"],
+    "incomplete_coverage_disposition": "BLOCKED_INCOMPLETE_COVERAGE",
+    "unresolved_mapping_disposition": "UNRESOLVED_NO_FABRICATION"
+  },
+  "asset_contract": {
+    "asset_types": ["FONT", "ICON", "IMAGE", "ILLUSTRATION", "LOGO"],
+    "provenance_requirement": "SOURCE_IDENTITY_AND_PROVENANCE_STATUS_REQUIRED",
+    "substitution_policies": ["EXACT_REQUIRED", "PROJECT_MATCH_ALLOWED", "APPROVAL_REQUIRED", "NO_SUBSTITUTION"],
+    "known_asset_without_evidence": "REJECT",
+    "known_asset_approximation": "REJECT_WITHOUT_EXPLICIT_APPROVAL_AND_PROVENANCE"
+  },
+  "components": [
+    {
+      "component_id": "incomplete_component",
+      "source_ref": "uix2:evidence:component:incomplete_component",
+      "mapping_kind": "EXACT",
+      "target": "project:components/Incomplete",
+      "variants": ["default"],
+      "states": ["default"],
+      "semantic_tokens": ["color.surface"],
+      "coverage_status": "INCOMPLETE",
+      "implementation_disposition": "READY_FOR_IMPLEMENTATION"
+    }
+  ],
+  "assets": [
+    {
+      "asset_id": "known_image",
+      "asset_type": "IMAGE",
+      "semantic_role": "known image",
+      "source_identity": "project:images/known",
+      "provenance_status": "CONFIRMED",
+      "license_or_source_status": "CONFIRMED",
+      "substitution_policy": "EXACT_REQUIRED",
+      "evidence_ref": "uix2:evidence:asset:known_image"
+    }
+  ],
+  "deviation_rules": {
+    "intentional_adaptation_requires_reason_and_approval": true,
+    "substitution_requires_approval_when_not_exact": true,
+    "invented_svg_or_logo_allowed": false,
+    "novel_font_adoption_allowed": false,
+    "silent_known_asset_substitution_allowed": false,
+    "unresolved_is_implementation_ready": false
+  },
+  "authority": {
+    "contract_grants_implementation_authority": false,
+    "external_tools_grant_authority": false,
+    "validation_grants_authority": false,
+    "dependency_adoption_authorized": false,
+    "figma_mutation_authorized": false
+  }
+}

--- a/tests/fixtures/ui/uix4-invalid-unapproved-substitution.json
+++ b/tests/fixtures/ui/uix4-invalid-unapproved-substitution.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "../schemas/component-asset-preservation.schema.json",
+  "schema_version": "orchestra.component-asset-preservation.v1",
+  "contract_id": "uix4-invalid-unapproved-substitution",
+  "role": "CLOAK_COMPONENT_ASSET_PRESERVATION",
+  "consumes": {
+    "ui_design_contract_schema": "machine/schemas/ui-design-contract.schema.json",
+    "source_preservation_report_schema": "machine/schemas/design-source-preservation-report.schema.json",
+    "profile_registry_schema": "machine/schemas/ui-profile-registry.schema.json"
+  },
+  "precedence": [
+    "EXACT_SUPPLIED_PROJECT_ASSET_OR_COMPONENT",
+    "VERIFIED_EXISTING_PROJECT_NATIVE_EQUIVALENT",
+    "APPROVED_SEMANTIC_MAPPING",
+    "EXPLICITLY_APPROVED_ADAPTATION",
+    "REVIEWED_NEW_IMPLEMENTATION",
+    "UNRESOLVED_NO_FABRICATED_REPLACEMENT"
+  ],
+  "component_contract": {
+    "required_variant_coverage": true,
+    "required_interaction_state_coverage": true,
+    "semantic_token_preservation": true,
+    "mapping_kinds": ["EXACT", "VERIFIED_PROJECT_NATIVE", "APPROVED_SEMANTIC_MAPPING", "APPROVED_ADAPTATION", "REVIEWED_NEW", "UNRESOLVED"],
+    "incomplete_coverage_disposition": "BLOCKED_INCOMPLETE_COVERAGE",
+    "unresolved_mapping_disposition": "UNRESOLVED_NO_FABRICATION"
+  },
+  "asset_contract": {
+    "asset_types": ["FONT", "ICON", "IMAGE", "ILLUSTRATION", "LOGO"],
+    "provenance_requirement": "SOURCE_IDENTITY_AND_PROVENANCE_STATUS_REQUIRED",
+    "substitution_policies": ["EXACT_REQUIRED", "PROJECT_MATCH_ALLOWED", "APPROVAL_REQUIRED", "NO_SUBSTITUTION"],
+    "known_asset_without_evidence": "REJECT",
+    "known_asset_approximation": "REJECT_WITHOUT_EXPLICIT_APPROVAL_AND_PROVENANCE"
+  },
+  "components": [
+    {
+      "component_id": "known_component",
+      "source_ref": "uix2:evidence:component:known_component",
+      "mapping_kind": "EXACT",
+      "target": "project:components/Known",
+      "variants": ["default"],
+      "states": ["default", "focus_visible"],
+      "semantic_tokens": ["color.surface"],
+      "coverage_status": "COMPLETE",
+      "implementation_disposition": "READY_FOR_IMPLEMENTATION"
+    }
+  ],
+  "assets": [
+    {
+      "asset_id": "known_logo",
+      "asset_type": "LOGO",
+      "semantic_role": "brand identity",
+      "source_identity": "project:logos/primary",
+      "provenance_status": "CONFIRMED",
+      "license_or_source_status": "CONFIRMED",
+      "substitution_policy": "APPROVAL_REQUIRED",
+      "evidence_ref": "uix2:evidence:asset:known_logo"
+    }
+  ],
+  "deviation_rules": {
+    "intentional_adaptation_requires_reason_and_approval": true,
+    "substitution_requires_approval_when_not_exact": true,
+    "invented_svg_or_logo_allowed": false,
+    "novel_font_adoption_allowed": false,
+    "silent_known_asset_substitution_allowed": false,
+    "unresolved_is_implementation_ready": false
+  },
+  "authority": {
+    "contract_grants_implementation_authority": false,
+    "external_tools_grant_authority": false,
+    "validation_grants_authority": false,
+    "dependency_adoption_authorized": false,
+    "figma_mutation_authorized": false
+  }
+}

--- a/tests/runtime/test_component_asset_preservation.py
+++ b/tests/runtime/test_component_asset_preservation.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = ROOT / "machine" / "schemas" / "component-asset-preservation.schema.json"
+CONTRACT_PATH = ROOT / "machine" / "ui" / "component-asset-preservation-contract.v1.json"
+INVALID_FIXTURES = (
+    ROOT / "tests" / "fixtures" / "ui" / "uix4-invalid-unapproved-substitution.json",
+    ROOT / "tests" / "fixtures" / "ui" / "uix4-invalid-incomplete-state-coverage.json",
+)
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _validator() -> jsonschema.Draft202012Validator:
+    schema = _load(SCHEMA_PATH)
+    jsonschema.Draft202012Validator.check_schema(schema)
+    return jsonschema.Draft202012Validator(schema)
+
+
+def test_uix4_schema_and_contract_are_valid() -> None:
+    contract = _load(CONTRACT_PATH)
+    _validator().validate(contract)
+
+    assert contract["schema_version"] == "orchestra.component-asset-preservation.v1"
+    assert len(contract["components"]) == 1
+    assert {asset["asset_type"] for asset in contract["assets"]} == {
+        "FONT",
+        "ICON",
+        "IMAGE",
+        "ILLUSTRATION",
+        "LOGO",
+    }
+
+
+@pytest.mark.parametrize("fixture_path", INVALID_FIXTURES)
+def test_uix4_invalid_fixtures_are_rejected(fixture_path: Path) -> None:
+    with pytest.raises(jsonschema.ValidationError):
+        _validator().validate(_load(fixture_path))
+
+
+def test_uix4_precedence_and_component_coverage_are_fail_closed() -> None:
+    contract = _load(CONTRACT_PATH)
+    assert contract["precedence"] == [
+        "EXACT_SUPPLIED_PROJECT_ASSET_OR_COMPONENT",
+        "VERIFIED_EXISTING_PROJECT_NATIVE_EQUIVALENT",
+        "APPROVED_SEMANTIC_MAPPING",
+        "EXPLICITLY_APPROVED_ADAPTATION",
+        "REVIEWED_NEW_IMPLEMENTATION",
+        "UNRESOLVED_NO_FABRICATED_REPLACEMENT",
+    ]
+
+    component = contract["components"][0]
+    assert component["variants"]
+    assert {"focus_visible", "disabled", "error"} <= set(component["states"])
+    assert component["semantic_tokens"]
+    assert component["coverage_status"] == "COMPLETE"
+    assert component["implementation_disposition"] == "READY_FOR_IMPLEMENTATION"
+
+    incomplete = copy.deepcopy(contract)
+    incomplete["components"][0]["coverage_status"] = "INCOMPLETE"
+    with pytest.raises(jsonschema.ValidationError):
+        _validator().validate(incomplete)
+
+
+def test_uix4_adaptations_and_substitutions_require_traceable_approval() -> None:
+    contract = _load(CONTRACT_PATH)
+    component = copy.deepcopy(contract["components"][0])
+    component["mapping_kind"] = "APPROVED_ADAPTATION"
+    component.pop("approval_ref", None)
+    component.pop("reason", None)
+    candidate = copy.deepcopy(contract)
+    candidate["components"] = [component]
+
+    with pytest.raises(jsonschema.ValidationError):
+        _validator().validate(candidate)
+
+    component["reason"] = "Approved semantic adaptation preserves the project component boundary."
+    component["approval_ref"] = "human-approval:uix4-component-adaptation"
+    _validator().validate(candidate)
+
+    asset = copy.deepcopy(contract["assets"][-1])
+    asset["substitution_policy"] = "APPROVAL_REQUIRED"
+    asset["reason"] = "A replacement is required because the supplied asset is unavailable."
+    candidate["assets"] = [asset]
+    with pytest.raises(jsonschema.ValidationError):
+        _validator().validate(candidate)
+
+    asset["approval_ref"] = "human-approval:uix4-asset-substitution"
+    _validator().validate(candidate)
+
+
+def test_uix4_known_assets_preserve_provenance_and_never_grant_authority() -> None:
+    contract = _load(CONTRACT_PATH)
+    for asset in contract["assets"]:
+        assert asset["source_identity"]
+        assert asset["evidence_ref"]
+        assert asset["provenance_status"] in {"CONFIRMED", "REVIEW_REQUIRED", "UNRESOLVED"}
+
+    assert contract["asset_contract"]["known_asset_without_evidence"] == "REJECT"
+    assert contract["deviation_rules"]["invented_svg_or_logo_allowed"] is False
+    assert contract["deviation_rules"]["silent_known_asset_substitution_allowed"] is False
+    assert all(value is False for value in contract["authority"].values())
+
+    invalid = copy.deepcopy(contract)
+    invalid["assets"][0]["arbitrary_css_value"] = "#fff"
+    with pytest.raises(jsonschema.ValidationError):
+        _validator().validate(invalid)


### PR DESCRIPTION
## Scope
- add the canonical UIX-4 component and asset preservation schema and contract
- capture project-native component state coverage, semantic token references, asset provenance, and bounded substitution rules
- add positive and negative contract tests and update canonical UIX capability indexes

## Evidence
- focused UIX1-UIX4 tests: 28 passed
- README behavior and impact gates passed
- structure, manifest, strict governance, compileall, and full behavior validation passed
- source commit is signed; no runtime behavior, dependency, Figma, release, or policy changes

## Governance
- this source PR is validation-only and will be closed unmerged after checks
- source branch is retained for audit; materialization and canonical promotion require separate exact-head PRs