### PR TITLE
UIX-6: define optional UI adapter boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
-## Post-v1.6.0 UIX-5 Specialist Integration - Candidate
+## Post-v1.6.0 UIX-6 Optional UI Adapter Boundaries - Candidate
+
+- Adds the library-neutral UIX-6 host and optional UI evidence capability audit for Figma, Code Connect, Storybook, Playwright, axe, and project-native design-token surfaces.
+- Records explicit evidence limitations and preserves Codex/Antigravity supported maturity versus scaffold-only host classifications.
+- Records `NO_ADOPTION`: no dependency, runtime adapter, installed-integration refresh, external call, Figma mutation, release, deployment, or policy activation.
+
+## Post-v1.6.0 UIX-5 Specialist Integration - Canonical
 
 - Adds the library-neutral UIX-5 specialist integration flow for governed UI evidence consumption through the existing Conductor, Cloak, Clockwork, Governor, Ponytail, Overseer, and Arbiter workflow.
 - Adds explicit handoff, ownership, conditional adoption review, evidence, and non-authority contracts with deterministic negative fixtures.
-- Keeps Caveman presentation-only, Butler inactive, external tools optional, and runtime, dependency, Figma, release, deployment, and policy changes outside this bounded candidate.
+- Canonicalized through signed materialization and independent readback at `7d9c020` with Caveman presentation-only, Butler inactive, external tools optional, and no runtime, dependency, Figma, release, deployment, or policy change.
 
 ## Post-v1.6.0 UIX-4 Component and Asset Preservation - Canonical
 

--- a/README.json
+++ b/README.json
@@ -76,7 +76,7 @@
       "authority_note": "UIX-4 preserves component and asset evidence; it does not grant implementation authority, authorize silent substitutions, add dependencies, make external tools authoritative, or authorize Figma mutation."
     },
     "governed_ui_specialist_integration_uix5": {
-      "status": "IMPLEMENTED_PENDING_CANONICAL_VALIDATION",
+      "status": "IMPLEMENTED_CANONICAL",
       "purpose": "Library-neutral UIX-5 flow for consuming governed UI evidence through the existing Conductor, Cloak, Clockwork, Governor, Ponytail, Overseer, and Arbiter workflow with explicit non-overlapping ownership.",
       "machine_sources": ["machine/schemas/specialist-integration-flow.schema.json", "machine/ui/specialist-integration-flow.v1.json"],
       "human_sources": ["docs/project/UIX_5_SPECIALIST_INTEGRATION.md"],
@@ -85,6 +85,18 @@
       "code_connect_required": false,
       "runtime_integration": false,
       "authority_note": "UIX-5 sequences existing specialists and binds evidence to handoffs; it does not create a specialist, expand authority, make UI or rendered evidence approval, activate adoption, or authorize Figma mutation."
+    },
+    "governed_ui_optional_adapter_boundaries_uix6": {
+      "status": "IMPLEMENTED_NO_ADOPTION_PENDING_CANONICAL_VALIDATION",
+      "purpose": "Library-neutral UIX-6 audit and boundary contract for optional Figma, Code Connect, Storybook, Playwright, axe, and project-native design-token evidence capabilities.",
+      "machine_sources": ["machine/schemas/optional-adapter-boundaries.schema.json", "machine/ui/optional-adapter-boundaries.v1.json"],
+      "human_sources": ["docs/project/UIX_6_OPTIONAL_ADAPTER_BOUNDARIES.md"],
+      "validation_surface": "tests/runtime/test_optional_adapter_boundaries.py",
+      "figma_required": false,
+      "code_connect_required": false,
+      "runtime_integration": false,
+      "adoption_disposition": "NO_ADOPTION",
+      "authority_note": "UIX-6 records optional capability boundaries and explicit evidence limitations; it does not adopt dependencies, refresh installed integrations, create a Figma client, make external tools authoritative, or authorize Figma mutation."
     },
     "host_update_planning": {"status": "INCLUDED_IN_V1_6_CANDIDATE", "machine_sources": ["machine/hosts/update-contract.v1.json"], "human_sources": ["docs/setup/HOST_UPDATES.md"]},
     "adapter_sdk_and_prap_certification": {
@@ -623,6 +635,8 @@
     "component_asset_preservation_contract": "machine/ui/component-asset-preservation-contract.v1.json",
     "specialist_integration_flow_schema": "machine/schemas/specialist-integration-flow.schema.json",
     "specialist_integration_flow": "machine/ui/specialist-integration-flow.v1.json",
+    "optional_adapter_boundaries_schema": "machine/schemas/optional-adapter-boundaries.schema.json",
+    "optional_adapter_boundaries": "machine/ui/optional-adapter-boundaries.v1.json",
     "comparative_benchmark_codex_c2_portability_r1": "machine/benchmarking/codex-c2-portability-r1-preexecution.v1.json",
     "comparative_benchmark_codex_c2_portability_r1_live_authorization": "machine/benchmarking/codex-c2-portability-r1-live-execution-authorization.v1.json"
   },

--- a/docs/project/UIX_5_SPECIALIST_INTEGRATION.md
+++ b/docs/project/UIX_5_SPECIALIST_INTEGRATION.md
@@ -1,6 +1,6 @@
 # UIX-5 Specialist Integration Flow
 
-Status: `UIX_5_SPECIALIST_INTEGRATION_IMPLEMENTED_PENDING_CANONICAL_VALIDATION`
+Status: `UIX_5_SPECIALIST_INTEGRATION_IMPLEMENTED_CANONICAL`
 
 Recorded: 2026-08-24
 
@@ -51,4 +51,4 @@ Caveman remains presentation-only. Butler is not a registered or active owner. U
 
 This is a contract-only integration surface. It does not add runtime integration, frontend dependencies, external-tool authority, Figma mutation, asset or dependency adoption authority, release authority, or policy activation. Missing or contradictory upstream evidence remains unresolved and must stop or reroute through the existing Conductor, Overseer, Governor, or Arbiter boundaries.
 
-UIX-5 exits only after the exact flow, ownership boundaries, negative fixtures, and repository validation are proven, followed by fresh protected-main checks, signed materialization, canonical promotion, and independent readback.
+UIX-5 exited after the exact flow, ownership boundaries, negative fixtures, repository validation, fresh protected-main checks, signed materialization, canonical promotion, and independent readback at `7d9c020`.

--- a/docs/project/UIX_6_OPTIONAL_ADAPTER_BOUNDARIES.md
+++ b/docs/project/UIX_6_OPTIONAL_ADAPTER_BOUNDARIES.md
@@ -1,0 +1,35 @@
+# UIX-6 Optional UI Adapter Boundaries
+
+Status: `UIX_6_OPTIONAL_ADAPTER_BOUNDARIES_IMPLEMENTED_NO_ADOPTION_PENDING_CANONICAL_VALIDATION`
+
+Recorded: 2026-08-24
+
+Entry baseline: `7d9c020a5fbd70b7270d86e24f8922928bc5613b`
+
+## Purpose
+
+UIX-6 audits the current host and adapter surfaces before considering optional UI evidence integrations. It prefers project-native evidence and keeps Figma, Code Connect, Storybook, Playwright, axe, and token tooling optional.
+
+## Audit result
+
+The repository currently provides library-neutral UIX contracts and read-only host/adapter certification surfaces. Codex and Antigravity are `SUPPORTED` hosts; Claude Code, Cursor, Windsurf, VS Code/VSCodium, JetBrains, Zed, and Neovim remain `SCAFFOLD_ONLY`. No external UI target, provider call, installed-integration refresh, or UI-tool dependency adoption was used for this audit.
+
+The project-native design-token evidence boundary is available through the UIX-1 through UIX-4 contracts. The five external-tool candidate capabilities are unavailable optional evidence sources. Their absence is reported as an explicit evidence limitation, not silently filled with guessed data.
+
+## Canonical machine surface
+
+- Schema: `machine/schemas/optional-adapter-boundaries.schema.json`
+- Capability audit: `machine/ui/optional-adapter-boundaries.v1.json`
+- Invalid dependency fixture: `tests/fixtures/ui/uix6-invalid-dependency-adoption.json`
+- Invalid authority fixture: `tests/fixtures/ui/uix6-invalid-authority-source.json`
+- Deterministic validation: `tests/runtime/test_optional_adapter_boundaries.py`
+- Host maturity source: `machine/hosts/update-contract.v1.json`
+- Adapter compatibility source: `docs/setup/ADAPTER_SDK_PRAP.md`
+
+Schema version: `orchestra.ui-optional-adapter-boundaries.v1`
+
+## Terminal disposition
+
+`NO_ADOPTION` is the canonical UIX-6 outcome. Implementing optional external-tool adapters would require separate dependency, host, license, security, and supply-chain authority. This phase therefore adds only the capability and adapter boundary contract; it does not install a dependency, create a home-grown Figma client, mutate Figma, refresh an installed integration, add runtime behavior, or make an external service authoritative.
+
+Any later adapter proposal must pass the separate dependency and host authorization gate, preserve project-native fallback behavior, and expose evidence only. Host maturity and PRAP compatibility remain separate facts.

--- a/docs/project/UI_DESIGN_FIDELITY_SYSTEM_PLAN.md
+++ b/docs/project/UI_DESIGN_FIDELITY_SYSTEM_PLAN.md
@@ -1,10 +1,10 @@
 # Governed UI Design Fidelity System Plan
 
-Status: `UIX_5_ACTIVE_SPECIALIST_INTEGRATION`
+Status: `UIX_6_ACTIVE_OPTIONAL_ADAPTER_BOUNDARIES`
 
 Recorded: 2026-08-24
 
-Activation baseline: `3a7f18bd49c7aa16cfc4568fd42f9b06c37cb847`
+Activation baseline: `7d9c020a5fbd70b7270d86e24f8922928bc5613b`
 
 Historical design source: closed-unmerged PR #471 (`docs: plan governed UI design fidelity system`)
 
@@ -32,7 +32,7 @@ That sequencing gate is now resolved:
 
 Unchecked entries in `docs/project/ROADMAP.md` under Deferred and Future Work are backlog candidates, not automatic prerequisites. They do not block UIX unless an item becomes an explicit dependency or the maintainer changes priority.
 
-UIX-0 is complete, UIX-1 is canonical at `c331634dc63fbebb86ca07274c06262d5b52a50d`, UIX-2 is canonical at `8e4f3bb5e878131e8c038ea195311c92ca08cfde`, UIX-3 is canonical at `d27fbd6b89b297646c7e30ffb8bac193bbdc0cf4`, UIX-4 is canonical at `3a7f18bd49c7aa16cfc4568fd42f9b06c37cb847`, and UIX-5 is the active bounded unit on the current source branch. This current-state reconciliation supersedes the earlier UIX-0-only sequencing statement; historical UIX-0 and UIX-1 phase documents retain their phase-era status wording. The plan does not itself authorize dependency installation, Figma mutation, external authentication, release, deployment, marketplace publication, policy activation, or another protected action.
+UIX-0 is complete, UIX-1 is canonical at `c331634dc63fbebb86ca07274c06262d5b52a50d`, UIX-2 is canonical at `8e4f3bb5e878131e8c038ea195311c92ca08cfde`, UIX-3 is canonical at `d27fbd6b89b297646c7e30ffb8bac193bbdc0cf4`, UIX-4 is canonical at `3a7f18bd49c7aa16cfc4568fd42f9b06c37cb847`, UIX-5 is canonical at `7d9c020a5fbd70b7270d86e24f8922928bc5613b`, and UIX-6 is the active bounded unit on the current source branch. This current-state reconciliation supersedes the earlier UIX-0-only sequencing statement; historical UIX-0 and UIX-1 phase documents retain their phase-era status wording. The plan does not itself authorize dependency installation, Figma mutation, external authentication, release, deployment, marketplace publication, policy activation, or another protected action.
 
 ## Existing ownership
 
@@ -282,4 +282,4 @@ The UIX campaign does not:
 
 ## Current bounded next action
 
-Complete UIX-5 through fresh exact-head validation and signed canonicalization of the specialist integration flow. Stop before UIX-6 until UIX-5 has an independent canonical readback.
+Complete UIX-6 through fresh exact-head validation and signed canonicalization of the optional adapter boundary contract, with explicit `NO_ADOPTION`. Stop before UIX-7 until UIX-6 has an independent canonical readback.

--- a/machine/schemas/optional-adapter-boundaries.schema.json
+++ b/machine/schemas/optional-adapter-boundaries.schema.json
@@ -1,0 +1,142 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Baelfyre/Orchestra/blob/main/machine/schemas/optional-adapter-boundaries.schema.json",
+  "title": "Orchestra UIX-6 Optional Adapter Boundaries",
+  "description": "Closed capability audit and explicit no-adoption disposition for optional UI evidence adapters.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schema_version",
+    "role",
+    "entry_baseline",
+    "host_maturity",
+    "capabilities",
+    "audit",
+    "adapter_policy",
+    "terminal_disposition",
+    "authority"
+  ],
+  "properties": {
+    "$schema": {"const": "../schemas/optional-adapter-boundaries.schema.json"},
+    "schema_version": {"const": "orchestra.ui-optional-adapter-boundaries.v1"},
+    "role": {"const": "UIX_6_OPTIONAL_ADAPTER_BOUNDARIES"},
+    "entry_baseline": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+    "host_maturity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source", "supported_hosts", "scaffold_only_hosts"],
+      "properties": {
+        "source": {"const": "machine/hosts/update-contract.v1.json"},
+        "supported_hosts": {"const": ["codex", "antigravity"]},
+        "scaffold_only_hosts": {"const": ["claude-code", "cursor", "windsurf", "vscode", "jetbrains", "zed", "neovim"]}
+      }
+    },
+    "capabilities": {
+      "type": "array",
+      "minItems": 6,
+      "maxItems": 6,
+      "prefixItems": [
+        {"allOf": [{"$ref": "#/$defs/capability"}, {"properties": {"id": {"const": "FIGMA_STRUCTURED_CONTEXT"}, "status": {"const": "UNAVAILABLE_OPTIONAL"}}}]},
+        {"allOf": [{"$ref": "#/$defs/capability"}, {"properties": {"id": {"const": "FIGMA_CODE_CONNECT_TEMPLATE_EVIDENCE"}, "status": {"const": "UNAVAILABLE_OPTIONAL"}}}]},
+        {"allOf": [{"$ref": "#/$defs/capability"}, {"properties": {"id": {"const": "STORYBOOK_COMPONENT_STATE_EVIDENCE"}, "status": {"const": "UNAVAILABLE_OPTIONAL"}}}]},
+        {"allOf": [{"$ref": "#/$defs/capability"}, {"properties": {"id": {"const": "PLAYWRIGHT_RENDERED_BROWSER_EVIDENCE"}, "status": {"const": "UNAVAILABLE_OPTIONAL"}}}]},
+        {"allOf": [{"$ref": "#/$defs/capability"}, {"properties": {"id": {"const": "AXE_ACCESSIBILITY_EVIDENCE"}, "status": {"const": "UNAVAILABLE_OPTIONAL"}}}]},
+        {"allOf": [{"$ref": "#/$defs/capability"}, {"properties": {"id": {"const": "PROJECT_NATIVE_DESIGN_TOKEN_EVIDENCE"}, "status": {"const": "AVAILABLE_CONTRACT_ONLY"}}}]}
+      ],
+      "items": false
+    },
+    "audit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repository_evidence_only",
+        "project_target",
+        "external_calls_performed",
+        "dependency_changes",
+        "installed_integration_refresh",
+        "figma_mutations"
+      ],
+      "properties": {
+        "repository_evidence_only": {"const": true},
+        "project_target": {"const": "ORCHESTRA_REPOSITORY_ONLY_NO_EXTERNAL_TARGET"},
+        "external_calls_performed": {"const": false},
+        "dependency_changes": {"const": false},
+        "installed_integration_refresh": {"const": false},
+        "figma_mutations": {"const": false}
+      }
+    },
+    "adapter_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "project_native_first",
+        "external_service_authority",
+        "dependency_adoption_authorized",
+        "installed_integration_refresh_authorized",
+        "homegrown_figma_client_allowed",
+        "missing_capability_behavior",
+        "runtime_integration"
+      ],
+      "properties": {
+        "project_native_first": {"const": true},
+        "external_service_authority": {"const": false},
+        "dependency_adoption_authorized": {"const": false},
+        "installed_integration_refresh_authorized": {"const": false},
+        "homegrown_figma_client_allowed": {"const": false},
+        "missing_capability_behavior": {"const": "EXPLICIT_EVIDENCE_LIMITATION"},
+        "runtime_integration": {"const": false}
+      }
+    },
+    "terminal_disposition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "reason", "new_dependencies", "new_runtime_adapters", "next_gate"],
+      "properties": {
+        "status": {"const": "NO_ADOPTION"},
+        "reason": {"type": "string", "minLength": 1},
+        "new_dependencies": {"const": []},
+        "new_runtime_adapters": {"const": []},
+        "next_gate": {"const": "SEPARATE_DEPENDENCY_AND_HOST_AUTHORIZATION"}
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "adapter_contract_grants_authority",
+        "capability_detection_grants_authority",
+        "external_tool_grants_authority",
+        "dependency_adoption_authorized",
+        "installed_refresh_authorized",
+        "figma_mutation_authorized",
+        "release_authorized"
+      ],
+      "properties": {
+        "adapter_contract_grants_authority": {"const": false},
+        "capability_detection_grants_authority": {"const": false},
+        "external_tool_grants_authority": {"const": false},
+        "dependency_adoption_authorized": {"const": false},
+        "installed_refresh_authorized": {"const": false},
+        "figma_mutation_authorized": {"const": false},
+        "release_authorized": {"const": false}
+      }
+    }
+  },
+  "$defs": {
+    "capability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "status", "evidence_refs", "reader_boundary", "authority_class", "adoption_disposition", "missing_capability_behavior"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "status": {"enum": ["AVAILABLE_CONTRACT_ONLY", "UNAVAILABLE_OPTIONAL"]},
+        "evidence_refs": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "reader_boundary": {"enum": ["PROJECT_NATIVE_EVIDENCE_ONLY", "OPTIONAL_READ_ONLY_EXTERNAL_EVIDENCE"]},
+        "authority_class": {"const": "EVIDENCE_ONLY"},
+        "adoption_disposition": {"const": "NO_ADOPTION"},
+        "missing_capability_behavior": {"const": "EXPLICIT_EVIDENCE_LIMITATION"}
+      }
+    }
+  }
+}

--- a/machine/ui/optional-adapter-boundaries.v1.json
+++ b/machine/ui/optional-adapter-boundaries.v1.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "../schemas/optional-adapter-boundaries.schema.json",
+  "schema_version": "orchestra.ui-optional-adapter-boundaries.v1",
+  "role": "UIX_6_OPTIONAL_ADAPTER_BOUNDARIES",
+  "entry_baseline": "7d9c020a5fbd70b7270d86e24f8922928bc5613b",
+  "host_maturity": {
+    "source": "machine/hosts/update-contract.v1.json",
+    "supported_hosts": ["codex", "antigravity"],
+    "scaffold_only_hosts": ["claude-code", "cursor", "windsurf", "vscode", "jetbrains", "zed", "neovim"]
+  },
+  "capabilities": [
+    {"id": "FIGMA_STRUCTURED_CONTEXT", "status": "UNAVAILABLE_OPTIONAL", "evidence_refs": ["docs/project/UIX_1_UI_DESIGN_CONTRACT.md", "docs/project/UIX_2_DESIGN_SOURCE_PRESERVATION.md"], "reader_boundary": "OPTIONAL_READ_ONLY_EXTERNAL_EVIDENCE", "authority_class": "EVIDENCE_ONLY", "adoption_disposition": "NO_ADOPTION", "missing_capability_behavior": "EXPLICIT_EVIDENCE_LIMITATION"},
+    {"id": "FIGMA_CODE_CONNECT_TEMPLATE_EVIDENCE", "status": "UNAVAILABLE_OPTIONAL", "evidence_refs": ["docs/project/UIX_1_UI_DESIGN_CONTRACT.md", "docs/setup/ADAPTER_SDK_PRAP.md"], "reader_boundary": "OPTIONAL_READ_ONLY_EXTERNAL_EVIDENCE", "authority_class": "EVIDENCE_ONLY", "adoption_disposition": "NO_ADOPTION", "missing_capability_behavior": "EXPLICIT_EVIDENCE_LIMITATION"},
+    {"id": "STORYBOOK_COMPONENT_STATE_EVIDENCE", "status": "UNAVAILABLE_OPTIONAL", "evidence_refs": ["docs/project/UIX_2_DESIGN_SOURCE_PRESERVATION.md", "docs/setup/ADAPTER_SDK_PRAP.md"], "reader_boundary": "OPTIONAL_READ_ONLY_EXTERNAL_EVIDENCE", "authority_class": "EVIDENCE_ONLY", "adoption_disposition": "NO_ADOPTION", "missing_capability_behavior": "EXPLICIT_EVIDENCE_LIMITATION"},
+    {"id": "PLAYWRIGHT_RENDERED_BROWSER_EVIDENCE", "status": "UNAVAILABLE_OPTIONAL", "evidence_refs": ["docs/project/UIX_1_UI_DESIGN_CONTRACT.md", "docs/setup/VALIDATION.md"], "reader_boundary": "OPTIONAL_READ_ONLY_EXTERNAL_EVIDENCE", "authority_class": "EVIDENCE_ONLY", "adoption_disposition": "NO_ADOPTION", "missing_capability_behavior": "EXPLICIT_EVIDENCE_LIMITATION"},
+    {"id": "AXE_ACCESSIBILITY_EVIDENCE", "status": "UNAVAILABLE_OPTIONAL", "evidence_refs": ["docs/project/UIX_1_UI_DESIGN_CONTRACT.md", "docs/setup/VALIDATION.md"], "reader_boundary": "OPTIONAL_READ_ONLY_EXTERNAL_EVIDENCE", "authority_class": "EVIDENCE_ONLY", "adoption_disposition": "NO_ADOPTION", "missing_capability_behavior": "EXPLICIT_EVIDENCE_LIMITATION"},
+    {"id": "PROJECT_NATIVE_DESIGN_TOKEN_EVIDENCE", "status": "AVAILABLE_CONTRACT_ONLY", "evidence_refs": ["machine/schemas/ui-design-contract.schema.json", "machine/schemas/design-source-preservation-workflow.schema.json", "machine/schemas/component-asset-preservation.schema.json"], "reader_boundary": "PROJECT_NATIVE_EVIDENCE_ONLY", "authority_class": "EVIDENCE_ONLY", "adoption_disposition": "NO_ADOPTION", "missing_capability_behavior": "EXPLICIT_EVIDENCE_LIMITATION"}
+  ],
+  "audit": {
+    "repository_evidence_only": true,
+    "project_target": "ORCHESTRA_REPOSITORY_ONLY_NO_EXTERNAL_TARGET",
+    "external_calls_performed": false,
+    "dependency_changes": false,
+    "installed_integration_refresh": false,
+    "figma_mutations": false
+  },
+  "adapter_policy": {
+    "project_native_first": true,
+    "external_service_authority": false,
+    "dependency_adoption_authorized": false,
+    "installed_integration_refresh_authorized": false,
+    "homegrown_figma_client_allowed": false,
+    "missing_capability_behavior": "EXPLICIT_EVIDENCE_LIMITATION",
+    "runtime_integration": false
+  },
+  "terminal_disposition": {
+    "status": "NO_ADOPTION",
+    "reason": "Existing library-neutral UIX contracts and read-only host/adapter certification surfaces define the useful boundary. Implementing optional external-tool adapters would require separate dependency or host authority that is not granted by this campaign.",
+    "new_dependencies": [],
+    "new_runtime_adapters": [],
+    "next_gate": "SEPARATE_DEPENDENCY_AND_HOST_AUTHORIZATION"
+  },
+  "authority": {
+    "adapter_contract_grants_authority": false,
+    "capability_detection_grants_authority": false,
+    "external_tool_grants_authority": false,
+    "dependency_adoption_authorized": false,
+    "installed_refresh_authorized": false,
+    "figma_mutation_authorized": false,
+    "release_authorized": false
+  }
+}

--- a/tests/fixtures/ui/uix6-invalid-authority-source.json
+++ b/tests/fixtures/ui/uix6-invalid-authority-source.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../schemas/optional-adapter-boundaries.schema.json",
+  "schema_version": "orchestra.ui-optional-adapter-boundaries.v1",
+  "role": "UIX_6_OPTIONAL_ADAPTER_BOUNDARIES",
+  "entry_baseline": "7d9c020a5fbd70b7270d86e24f8922928bc5613b",
+  "host_maturity": {"source": "machine/hosts/update-contract.v1.json", "supported_hosts": ["codex", "antigravity"], "scaffold_only_hosts": ["claude-code", "cursor", "windsurf", "vscode", "jetbrains", "zed", "neovim"]},
+  "capabilities": [
+    {"id": "FIGMA_STRUCTURED_CONTEXT", "status": "UNAVAILABLE_OPTIONAL", "evidence_refs": ["docs/project/UIX_1_UI_DESIGN_CONTRACT.md"], "reader_boundary": "OPTIONAL_READ_ONLY_EXTERNAL_EVIDENCE", "authority_class": "EVIDENCE_ONLY", "adoption_disposition": "NO_ADOPTION", "missing_capability_behavior": "EXPLICIT_EVIDENCE_LIMITATION"},
+    {"id": "FIGMA_CODE_CONNECT_TEMPLATE_EVIDENCE", "status": "UNAVAILABLE_OPTIONAL", "evidence_refs": ["docs/project/UIX_1_UI_DESIGN_CONTRACT.md"], "reader_boundary": "OPTIONAL_READ_ONLY_EXTERNAL_EVIDENCE", "authority_class": "EVIDENCE_ONLY", "adoption_disposition": "NO_ADOPTION", "missing_capability_behavior": "EXPLICIT_EVIDENCE_LIMITATION"},
+    {"id": "STORYBOOK_COMPONENT_STATE_EVIDENCE", "status": "UNAVAILABLE_OPTIONAL", "evidence_refs": ["docs/project/UIX_2_DESIGN_SOURCE_PRESERVATION.md"], "reader_boundary": "OPTIONAL_READ_ONLY_EXTERNAL_EVIDENCE", "authority_class": "EVIDENCE_ONLY", "adoption_disposition": "NO_ADOPTION", "missing_capability_behavior": "EXPLICIT_EVIDENCE_LIMITATION"},
+    {"id": "PLAYWRIGHT_RENDERED_BROWSER_EVIDENCE", "status": "UNAVAILABLE_OPTIONAL", "evidence_refs": ["docs/setup/VALIDATION.md"], "reader_boundary": "OPTIONAL_READ_ONLY_EXTERNAL_EVIDENCE", "authority_class": "EVIDENCE_ONLY", "adoption_disposition": "NO_ADOPTION", "missing_capability_behavior": "EXPLICIT_EVIDENCE_LIMITATION"},
+    {"id": "AXE_ACCESSIBILITY_EVIDENCE", "status": "UNAVAILABLE_OPTIONAL", "evidence_refs": ["docs/setup/VALIDATION.md"], "reader_boundary": "OPTIONAL_READ_ONLY_EXTERNAL_EVIDENCE", "authority_class": "EVIDENCE_ONLY", "adoption_disposition": "NO_ADOPTION", "missing_capability_behavior": "EXPLICIT_EVIDENCE_LIMITATION"},
+    {"id": "PROJECT_NATIVE_DESIGN_TOKEN_EVIDENCE", "status": "AVAILABLE_CONTRACT_ONLY", "evidence_refs": ["machine/schemas/ui-design-contract.schema.json"], "reader_boundary": "PROJECT_NATIVE_EVIDENCE_ONLY", "authority_class": "EVIDENCE_ONLY", "adoption_disposition": "NO_ADOPTION", "missing_capability_behavior": "EXPLICIT_EVIDENCE_LIMITATION"}
+  ],
+  "audit": {"repository_evidence_only": true, "project_target": "ORCHESTRA_REPOSITORY_ONLY_NO_EXTERNAL_TARGET", "external_calls_performed": false, "dependency_changes": false, "installed_integration_refresh": false, "figma_mutations": false},
+  "adapter_policy": {"project_native_first": true, "external_service_authority": false, "dependency_adoption_authorized": false, "installed_integration_refresh_authorized": false, "homegrown_figma_client_allowed": false, "missing_capability_behavior": "EXPLICIT_EVIDENCE_LIMITATION", "runtime_integration": false},
+  "terminal_disposition": {"status": "NO_ADOPTION", "reason": "Invalid fixture: external capability was made authoritative.", "new_dependencies": [], "new_runtime_adapters": [], "next_gate": "SEPARATE_DEPENDENCY_AND_HOST_AUTHORIZATION"},
+  "authority": {"adapter_contract_grants_authority": false, "capability_detection_grants_authority": true, "external_tool_grants_authority": false, "dependency_adoption_authorized": false, "installed_refresh_authorized": false, "figma_mutation_authorized": false, "release_authorized": false}
+}

--- a/tests/fixtures/ui/uix6-invalid-dependency-adoption.json
+++ b/tests/fixtures/ui/uix6-invalid-dependency-adoption.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../schemas/optional-adapter-boundaries.schema.json",
+  "schema_version": "orchestra.ui-optional-adapter-boundaries.v1",
+  "role": "UIX_6_OPTIONAL_ADAPTER_BOUNDARIES",
+  "entry_baseline": "7d9c020a5fbd70b7270d86e24f8922928bc5613b",
+  "host_maturity": {"source": "machine/hosts/update-contract.v1.json", "supported_hosts": ["codex", "antigravity"], "scaffold_only_hosts": ["claude-code", "cursor", "windsurf", "vscode", "jetbrains", "zed", "neovim"]},
+  "capabilities": [
+    {"id": "FIGMA_STRUCTURED_CONTEXT", "status": "UNAVAILABLE_OPTIONAL", "evidence_refs": ["docs/project/UIX_1_UI_DESIGN_CONTRACT.md"], "reader_boundary": "OPTIONAL_READ_ONLY_EXTERNAL_EVIDENCE", "authority_class": "EVIDENCE_ONLY", "adoption_disposition": "NO_ADOPTION", "missing_capability_behavior": "EXPLICIT_EVIDENCE_LIMITATION"},
+    {"id": "FIGMA_CODE_CONNECT_TEMPLATE_EVIDENCE", "status": "UNAVAILABLE_OPTIONAL", "evidence_refs": ["docs/project/UIX_1_UI_DESIGN_CONTRACT.md"], "reader_boundary": "OPTIONAL_READ_ONLY_EXTERNAL_EVIDENCE", "authority_class": "EVIDENCE_ONLY", "adoption_disposition": "NO_ADOPTION", "missing_capability_behavior": "EXPLICIT_EVIDENCE_LIMITATION"},
+    {"id": "STORYBOOK_COMPONENT_STATE_EVIDENCE", "status": "UNAVAILABLE_OPTIONAL", "evidence_refs": ["docs/project/UIX_2_DESIGN_SOURCE_PRESERVATION.md"], "reader_boundary": "OPTIONAL_READ_ONLY_EXTERNAL_EVIDENCE", "authority_class": "EVIDENCE_ONLY", "adoption_disposition": "NO_ADOPTION", "missing_capability_behavior": "EXPLICIT_EVIDENCE_LIMITATION"},
+    {"id": "PLAYWRIGHT_RENDERED_BROWSER_EVIDENCE", "status": "UNAVAILABLE_OPTIONAL", "evidence_refs": ["docs/setup/VALIDATION.md"], "reader_boundary": "OPTIONAL_READ_ONLY_EXTERNAL_EVIDENCE", "authority_class": "EVIDENCE_ONLY", "adoption_disposition": "NO_ADOPTION", "missing_capability_behavior": "EXPLICIT_EVIDENCE_LIMITATION"},
+    {"id": "AXE_ACCESSIBILITY_EVIDENCE", "status": "UNAVAILABLE_OPTIONAL", "evidence_refs": ["docs/setup/VALIDATION.md"], "reader_boundary": "OPTIONAL_READ_ONLY_EXTERNAL_EVIDENCE", "authority_class": "EVIDENCE_ONLY", "adoption_disposition": "NO_ADOPTION", "missing_capability_behavior": "EXPLICIT_EVIDENCE_LIMITATION"},
+    {"id": "PROJECT_NATIVE_DESIGN_TOKEN_EVIDENCE", "status": "AVAILABLE_CONTRACT_ONLY", "evidence_refs": ["machine/schemas/ui-design-contract.schema.json"], "reader_boundary": "PROJECT_NATIVE_EVIDENCE_ONLY", "authority_class": "EVIDENCE_ONLY", "adoption_disposition": "NO_ADOPTION", "missing_capability_behavior": "EXPLICIT_EVIDENCE_LIMITATION"}
+  ],
+  "audit": {"repository_evidence_only": true, "project_target": "ORCHESTRA_REPOSITORY_ONLY_NO_EXTERNAL_TARGET", "external_calls_performed": false, "dependency_changes": true, "installed_integration_refresh": false, "figma_mutations": false},
+  "adapter_policy": {"project_native_first": true, "external_service_authority": false, "dependency_adoption_authorized": false, "installed_integration_refresh_authorized": false, "homegrown_figma_client_allowed": false, "missing_capability_behavior": "EXPLICIT_EVIDENCE_LIMITATION", "runtime_integration": false},
+  "terminal_disposition": {"status": "NO_ADOPTION", "reason": "Invalid fixture: dependency adoption was recorded in the audit.", "new_dependencies": ["example-ui-adapter"], "new_runtime_adapters": [], "next_gate": "SEPARATE_DEPENDENCY_AND_HOST_AUTHORIZATION"},
+  "authority": {"adapter_contract_grants_authority": false, "capability_detection_grants_authority": false, "external_tool_grants_authority": false, "dependency_adoption_authorized": false, "installed_refresh_authorized": false, "figma_mutation_authorized": false, "release_authorized": false}
+}

--- a/tests/runtime/test_optional_adapter_boundaries.py
+++ b/tests/runtime/test_optional_adapter_boundaries.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = ROOT / "machine" / "schemas" / "optional-adapter-boundaries.schema.json"
+CONTRACT_PATH = ROOT / "machine" / "ui" / "optional-adapter-boundaries.v1.json"
+HOST_CONTRACT_PATH = ROOT / "machine" / "hosts" / "update-contract.v1.json"
+INVALID_FIXTURES = (
+    ROOT / "tests" / "fixtures" / "ui" / "uix6-invalid-dependency-adoption.json",
+    ROOT / "tests" / "fixtures" / "ui" / "uix6-invalid-authority-source.json",
+)
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _validator() -> jsonschema.Draft202012Validator:
+    schema = _load(SCHEMA_PATH)
+    jsonschema.Draft202012Validator.check_schema(schema)
+    return jsonschema.Draft202012Validator(schema)
+
+
+def test_uix6_contract_is_valid_and_matches_host_maturity() -> None:
+    contract = _load(CONTRACT_PATH)
+    _validator().validate(contract)
+
+    assert contract["schema_version"] == "orchestra.ui-optional-adapter-boundaries.v1"
+    hosts = {entry["host_id"]: entry["maturity"] for entry in _load(HOST_CONTRACT_PATH)["hosts"]}
+    assert [host for host, maturity in hosts.items() if maturity == "SUPPORTED"] == contract["host_maturity"]["supported_hosts"]
+    assert [host for host, maturity in hosts.items() if maturity == "SCAFFOLD_ONLY"] == contract["host_maturity"]["scaffold_only_hosts"]
+
+
+@pytest.mark.parametrize("fixture_path", INVALID_FIXTURES)
+def test_uix6_invalid_adoption_and_authority_fixtures_are_rejected(fixture_path: Path) -> None:
+    with pytest.raises(jsonschema.ValidationError):
+        _validator().validate(_load(fixture_path))
+
+
+def test_uix6_capability_audit_is_explicit_and_project_native_first() -> None:
+    contract = _load(CONTRACT_PATH)
+    capabilities = contract["capabilities"]
+    assert [entry["id"] for entry in capabilities] == [
+        "FIGMA_STRUCTURED_CONTEXT",
+        "FIGMA_CODE_CONNECT_TEMPLATE_EVIDENCE",
+        "STORYBOOK_COMPONENT_STATE_EVIDENCE",
+        "PLAYWRIGHT_RENDERED_BROWSER_EVIDENCE",
+        "AXE_ACCESSIBILITY_EVIDENCE",
+        "PROJECT_NATIVE_DESIGN_TOKEN_EVIDENCE",
+    ]
+    assert capabilities[-1]["status"] == "AVAILABLE_CONTRACT_ONLY"
+    assert all(entry["adoption_disposition"] == "NO_ADOPTION" for entry in capabilities)
+    assert all((ROOT / ref).is_file() for entry in capabilities for ref in entry["evidence_refs"])
+    assert contract["adapter_policy"]["project_native_first"] is True
+    assert contract["adapter_policy"]["missing_capability_behavior"] == "EXPLICIT_EVIDENCE_LIMITATION"
+
+
+def test_uix6_no_adoption_is_fail_closed_and_non_authorizing() -> None:
+    contract = _load(CONTRACT_PATH)
+    assert contract["terminal_disposition"]["status"] == "NO_ADOPTION"
+    assert contract["terminal_disposition"]["new_dependencies"] == []
+    assert contract["terminal_disposition"]["new_runtime_adapters"] == []
+    assert contract["audit"]["external_calls_performed"] is False
+    assert contract["audit"]["dependency_changes"] is False
+    assert contract["audit"]["installed_integration_refresh"] is False
+    assert contract["audit"]["figma_mutations"] is False
+    assert all(value is False for value in contract["authority"].values())


### PR DESCRIPTION
## Scope
- add the canonical UIX-6 optional adapter-boundaries audit and machine contract
- record current host maturity and project-native evidence surfaces before considering external UI adapters
- preserve optional Figma, Code Connect, Storybook, Playwright, axe, and token capability boundaries with explicit evidence limitations
- record `NO_ADOPTION` and advance the UIX fidelity plan to the UIX-6 bounded unit

## Evidence
- focused UIX1-UIX6 tests: 38 passed
- README machine-index and impact gates passed
- structure, manifest, strict governance, compileall, diff checks, and full behavior validation passed
- source commit is signed; no dependency, runtime, external call, installed refresh, Figma, release, or policy change

## Governance
- this source PR is validation-only and will be closed unmerged after fresh checks
- source branch is retained for audit; materialization and canonical promotion require separate exact-head PRs