### PR TITLE
fix(governance): reconcile required merge-check profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This root changelog is release-oriented. Detailed pre-v1.7 development chronolog
 
 - Added the UIX-9B V2 deterministic live-proof evaluator, frozen calibration cases, isolated UI fixture, machine contracts, zero-call adjudication path, and human authorization envelope.
 - Corrected the UIX-9A and UIX-9B preparation runners to bind the frozen canonical SHA to `origin/main`, allowing a validated preparation candidate to run ahead on its isolated branch without changing frozen proof identities.
+- Reconciled the autonomous merge-readiness contract with the maintainer-approved required-check profile: one `native-ubuntu-latest` context and `Compatibility CodeQL (python)` as the required analysis context; duplicate Ubuntu contexts and retired `Analyze (actions)` / `Analyze (python)` required contexts are now modeled as policy drift.
 
 ## v1.7.0 - Adaptive Intelligence, Portable Memory & Design Fidelity
 

--- a/docs/governance/AUTONOMOUS_MERGE_READINESS_PROTOCOL.md
+++ b/docs/governance/AUTONOMOUS_MERGE_READINESS_PROTOCOL.md
@@ -54,9 +54,23 @@ Require branches to be up to date before merging: ON
 Block force pushes: ON
 ```
 
+The exact required status contexts are:
+
+```text
+governance-check
+validate
+runtime-tests
+native-windows-latest
+native-ubuntu-latest
+native-macos-latest
+Compatibility CodeQL (python)
+```
+
+Each required status context must appear exactly once. Duplicate required contexts or reintroduction of retired required contexts are policy drift and block ordinary autonomous merge readiness until reconciled.
+
 The bypass list is intentionally retained as repository-operational capability. It is non-authorizing for governed autonomous progression unless a separate explicit bypass authority is granted. Ordinary autonomous merge execution records `bypass_used=false`.
 
-A live ruleset that is stricter than this profile may constrain progression further. A live ruleset that materially weakens this profile is policy drift and blocks autonomous merge until reviewed.
+A live ruleset that is stricter than this profile may constrain progression further. A live ruleset that materially weakens or contradicts this profile is policy drift and blocks autonomous merge until reviewed.
 
 ## Required Evidence Snapshot
 
@@ -65,7 +79,7 @@ A pre-merge snapshot must bind all evidence to one exact current PR head SHA and
 - canonical base health;
 - current PR head SHA;
 - whether that head was re-read immediately before merge;
-- the live `Protect main` profile;
+- the live `Protect main` profile, including the exact required status-context inventory;
 - selected merge method;
 - whether bypass was used;
 - changelog freshness when significant paths changed;
@@ -87,10 +101,11 @@ The canonical exact required-check inventory is:
 | Cross-platform Validation | `native-windows-latest` |
 | Cross-platform Validation | `native-ubuntu-latest` |
 | Cross-platform Validation | `native-macos-latest` |
-| CodeQL | `Analyze (actions)` |
-| CodeQL | `Analyze (python)` |
+| Required Analysis Compatibility | `Compatibility CodeQL (python)` |
 
-Repository rules may become stricter and require additional checks. Additional required checks must also pass; this table is a minimum exact profile for the current Orchestra ruleset, not a bypass list.
+Supporting jobs may still execute inside a workflow, but they are not merge-required evidence unless their contexts are present in the exact current `Protect main` required-status profile. In particular, `Analyze (actions)` and `Analyze (python)` are not part of the current required merge profile.
+
+Repository rules may become stricter and require additional checks. Additional required checks must also pass; this table is the maintainer-approved exact profile for the current Orchestra ruleset and must be reconciled whenever the live ruleset changes.
 
 ## Fail-Closed Interpretation
 
@@ -109,6 +124,8 @@ UNRESOLVED_BLOCKER = BLOCK
 UNRESOLVED_REVIEW_THREAD = BLOCK
 REQUIRED_CHANGELOG_MISSING = BLOCK
 RULESET_PROFILE_DRIFT = BLOCK
+DUPLICATE_REQUIRED_STATUS_CONTEXT = BLOCK
+RETIRED_REQUIRED_STATUS_CONTEXT = BLOCK
 MERGE_METHOD_NOT_SQUASH = BLOCK
 MERGEABLE_UNKNOWN = WAIT_FOR_EVIDENCE
 MERGEABLE_STATE_UNKNOWN = WAIT_FOR_EVIDENCE
@@ -133,19 +150,20 @@ Before merge:
 
 1. Read the PR and capture the current head SHA.
 2. Read the live ruleset and verify the effective policy remains compatible with the canonical profile.
-3. Require `Squash` as the selected merge method.
-4. Require ordinary governed execution to use no bypass.
-5. Fetch fresh required workflow/job state for that exact head.
-6. Require every required job to exist.
-7. Require every required job status to be `completed`.
-8. Require every required job conclusion to be `success`.
-9. Require every job's evidence head SHA to equal the current PR head SHA.
-10. Require zero unresolved review threads.
-11. Re-read the current PR REST state immediately before merge, including both `mergeable` and raw `mergeable_state`.
-12. If the head changed, discard prior evidence and return `STALE_EVIDENCE`.
-13. If `mergeable` is not yet known or `mergeable_state` is missing/`unknown`, return `WAIT_FOR_EVIDENCE`.
-14. Require `mergeable == true` and `mergeable_state == clean`; otherwise return `BLOCK`.
-15. Use `expected_head_sha` or the platform's equivalent compare-and-swap guard when issuing the merge.
+3. Require the exact required status contexts to match the current approved inventory, with every context appearing once and no retired required context present.
+4. Require `Squash` as the selected merge method.
+5. Require ordinary governed execution to use no bypass.
+6. Fetch fresh required workflow/job state for that exact head.
+7. Require every required job to exist.
+8. Require every required job status to be `completed`.
+9. Require every required job conclusion to be `success`.
+10. Require every job's evidence head SHA to equal the current PR head SHA.
+11. Require zero unresolved review threads.
+12. Re-read the current PR REST state immediately before merge, including both `mergeable` and raw `mergeable_state`.
+13. If the head changed, discard prior evidence and return `STALE_EVIDENCE`.
+14. If `mergeable` is not yet known or `mergeable_state` is missing/`unknown`, return `WAIT_FOR_EVIDENCE`.
+15. Require `mergeable == true` and `mergeable_state == clean`; otherwise return `BLOCK`.
+16. Use `expected_head_sha` or the platform's equivalent compare-and-swap guard when issuing the merge.
 
 Any remediation commit invalidates all earlier check evidence. The complete required matrix must be collected again for the new head.
 
@@ -270,4 +288,4 @@ The executable contract is:
 - `tests/behavior/autonomous-merge-readiness-fixtures.json`
 - `tests/runtime/test_autonomous_merge_readiness_contract.py`
 
-The fixtures intentionally cover missing check data, pending jobs, failed governance/runtime/cross-platform/CodeQL checks, stale heads, red baseline progression, changelog omission, boolean mergeability misuse, missing and unknown mergeable state, blocked/behind/dirty/unstable mergeable states, ruleset drift, unauthorized bypass use, non-Squash merge selection, unresolved review threads, pre-merge gate preservation, tree mismatch, parent drift, unsigned canonical commits, and unverified post-merge state.
+The v4 fixtures intentionally cover missing check data, pending jobs, failed governance/runtime/cross-platform/required-analysis checks, stale heads, red baseline progression, changelog omission, boolean mergeability misuse, missing and unknown mergeable state, blocked/behind/dirty/unstable mergeable states, ruleset drift, duplicate required status contexts, retired required contexts, unauthorized bypass use, non-Squash merge selection, unresolved review threads, pre-merge gate preservation, tree mismatch, parent drift, unsigned canonical commits, and unverified post-merge state.

--- a/scripts/validate_autonomous_merge_readiness_contract.py
+++ b/scripts/validate_autonomous_merge_readiness_contract.py
@@ -71,7 +71,19 @@ def ruleset_matches(snapshot):
     ruleset = snapshot.get("ruleset")
     if not isinstance(ruleset, dict):
         return False
-    return all(ruleset.get(key) == value for key, value in EXPECTED_RULESET.items())
+
+    for key, value in EXPECTED_RULESET.items():
+        if key == "required_status_contexts":
+            continue
+        if ruleset.get(key) != value:
+            return False
+
+    contexts = ruleset.get("required_status_contexts")
+    if not isinstance(contexts, list):
+        return False
+    if len(contexts) != len(set(contexts)):
+        return False
+    return set(contexts) == set(REQUIRED_STATUS_CONTEXTS)
 
 
 def evaluate_mergeability(snapshot):

--- a/scripts/validate_autonomous_merge_readiness_contract.py
+++ b/scripts/validate_autonomous_merge_readiness_contract.py
@@ -4,7 +4,7 @@ import re
 import sys
 from pathlib import Path
 
-SCHEMA_VERSION = "orchestra-autonomous-merge-readiness-v3"
+SCHEMA_VERSION = "orchestra-autonomous-merge-readiness-v4"
 
 REQUIRED_CHECKS = (
     ("Governance Check", "governance-check"),
@@ -13,8 +13,17 @@ REQUIRED_CHECKS = (
     ("Cross-platform Validation", "native-windows-latest"),
     ("Cross-platform Validation", "native-ubuntu-latest"),
     ("Cross-platform Validation", "native-macos-latest"),
-    ("CodeQL", "Analyze (actions)"),
-    ("CodeQL", "Analyze (python)"),
+    ("Required Analysis Compatibility", "Compatibility CodeQL (python)"),
+)
+
+REQUIRED_STATUS_CONTEXTS = (
+    "governance-check",
+    "validate",
+    "runtime-tests",
+    "native-windows-latest",
+    "native-ubuntu-latest",
+    "native-macos-latest",
+    "Compatibility CodeQL (python)",
 )
 
 EXPECTED_RULESET = {
@@ -32,6 +41,7 @@ EXPECTED_RULESET = {
     "require_branches_up_to_date": True,
     "block_force_pushes": True,
     "restrict_deletions": True,
+    "required_status_contexts": list(REQUIRED_STATUS_CONTEXTS),
 }
 
 CHECK_STATUSES = {"queued", "in_progress", "completed"}
@@ -321,6 +331,8 @@ def validate(root):
         "BYPASS_CAPABILITY != GOVERNANCE_AUTHORIZATION",
         "NO_CHECK_DATA = WAIT_FOR_EVIDENCE",
         "MERGEABLE_STATE_BLOCKED = BLOCK",
+        "DUPLICATE_REQUIRED_STATUS_CONTEXT = BLOCK",
+        "Compatibility CodeQL (python)",
         "mergeable_state == clean",
         "Squash",
         "expected_head_sha",

--- a/tests/behavior/autonomous-merge-readiness-fixtures.json
+++ b/tests/behavior/autonomous-merge-readiness-fixtures.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "orchestra-autonomous-merge-readiness-v3",
+  "schema_version": "orchestra-autonomous-merge-readiness-v4",
   "required_checks": [
     {"workflow": "Governance Check", "job": "governance-check"},
     {"workflow": "validate", "job": "validate"},
@@ -7,8 +7,7 @@
     {"workflow": "Cross-platform Validation", "job": "native-windows-latest"},
     {"workflow": "Cross-platform Validation", "job": "native-ubuntu-latest"},
     {"workflow": "Cross-platform Validation", "job": "native-macos-latest"},
-    {"workflow": "CodeQL", "job": "Analyze (actions)"},
-    {"workflow": "CodeQL", "job": "Analyze (python)"}
+    {"workflow": "Required Analysis Compatibility", "job": "Compatibility CodeQL (python)"}
   ],
   "expected_ruleset": {
     "required_approvals": 0,
@@ -24,7 +23,16 @@
     "require_status_checks": true,
     "require_branches_up_to_date": true,
     "block_force_pushes": true,
-    "restrict_deletions": true
+    "restrict_deletions": true,
+    "required_status_contexts": [
+      "governance-check",
+      "validate",
+      "runtime-tests",
+      "native-windows-latest",
+      "native-ubuntu-latest",
+      "native-macos-latest",
+      "Compatibility CodeQL (python)"
+    ]
   },
   "base_snapshot": {
     "base_health": "GREEN",
@@ -52,7 +60,16 @@
       "require_status_checks": true,
       "require_branches_up_to_date": true,
       "block_force_pushes": true,
-      "restrict_deletions": true
+      "restrict_deletions": true,
+      "required_status_contexts": [
+        "governance-check",
+        "validate",
+        "runtime-tests",
+        "native-windows-latest",
+        "native-ubuntu-latest",
+        "native-macos-latest",
+        "Compatibility CodeQL (python)"
+      ]
     },
     "checks": [
       {"workflow": "Governance Check", "job": "governance-check", "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "completed", "conclusion": "success"},
@@ -61,20 +78,19 @@
       {"workflow": "Cross-platform Validation", "job": "native-windows-latest", "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "completed", "conclusion": "success"},
       {"workflow": "Cross-platform Validation", "job": "native-ubuntu-latest", "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "completed", "conclusion": "success"},
       {"workflow": "Cross-platform Validation", "job": "native-macos-latest", "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "completed", "conclusion": "success"},
-      {"workflow": "CodeQL", "job": "Analyze (actions)", "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "completed", "conclusion": "success"},
-      {"workflow": "CodeQL", "job": "Analyze (python)", "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "completed", "conclusion": "success"}
+      {"workflow": "Required Analysis Compatibility", "job": "Compatibility CodeQL (python)", "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "completed", "conclusion": "success"}
     ]
   },
   "pre_merge_cases": [
     {"id": "fully-green", "expected_disposition": "READY_FOR_MERGE"},
     {"id": "no-check-data", "overrides": {"checks": null}, "expected_disposition": "WAIT_FOR_EVIDENCE"},
     {"id": "missing-runtime", "remove_check": "validate/runtime-tests", "expected_disposition": "WAIT_FOR_EVIDENCE"},
-    {"id": "missing-codeql-actions", "remove_check": "CodeQL/Analyze (actions)", "expected_disposition": "WAIT_FOR_EVIDENCE"},
+    {"id": "missing-codeql-compatibility", "remove_check": "Required Analysis Compatibility/Compatibility CodeQL (python)", "expected_disposition": "WAIT_FOR_EVIDENCE"},
     {"id": "queued-windows", "check_overrides": {"Cross-platform Validation/native-windows-latest": {"status": "queued", "conclusion": null}}, "expected_disposition": "WAIT_FOR_EVIDENCE"},
     {"id": "in-progress-macos", "check_overrides": {"Cross-platform Validation/native-macos-latest": {"status": "in_progress", "conclusion": null}}, "expected_disposition": "WAIT_FOR_EVIDENCE"},
     {"id": "governance-failed", "check_overrides": {"Governance Check/governance-check": {"conclusion": "failure"}}, "expected_disposition": "BLOCK"},
     {"id": "runtime-failed", "check_overrides": {"validate/runtime-tests": {"conclusion": "failure"}}, "expected_disposition": "BLOCK"},
-    {"id": "codeql-python-failed", "check_overrides": {"CodeQL/Analyze (python)": {"conclusion": "failure"}}, "expected_disposition": "BLOCK"},
+    {"id": "compatibility-codeql-failed", "check_overrides": {"Required Analysis Compatibility/Compatibility CodeQL (python)": {"conclusion": "failure"}}, "expected_disposition": "BLOCK"},
     {"id": "cross-platform-failed", "check_overrides": {"Cross-platform Validation/native-ubuntu-latest": {"conclusion": "failure"}}, "expected_disposition": "BLOCK"},
     {"id": "required-skipped", "check_overrides": {"validate/validate": {"conclusion": "skipped"}}, "expected_disposition": "BLOCK"},
     {"id": "required-cancelled", "check_overrides": {"validate/runtime-tests": {"conclusion": "cancelled"}}, "expected_disposition": "BLOCK"},
@@ -96,6 +112,8 @@
     {"id": "unresolved-thread", "overrides": {"unresolved_review_threads": 1}, "expected_disposition": "BLOCK"},
     {"id": "approval-requirement-drift", "ruleset_overrides": {"required_approvals": 1}, "expected_disposition": "BLOCK"},
     {"id": "merge-method-drift", "ruleset_overrides": {"allowed_merge_methods": ["rebase"]}, "expected_disposition": "BLOCK"},
+    {"id": "duplicate-ubuntu-required-context", "ruleset_overrides": {"required_status_contexts": ["governance-check", "validate", "runtime-tests", "native-windows-latest", "native-ubuntu-latest", "native-ubuntu-latest", "native-macos-latest", "Compatibility CodeQL (python)"]}, "expected_disposition": "BLOCK"},
+    {"id": "retired-codeql-required-contexts", "ruleset_overrides": {"required_status_contexts": ["governance-check", "validate", "runtime-tests", "native-windows-latest", "native-ubuntu-latest", "native-macos-latest", "Analyze (actions)", "Analyze (python)"]}, "expected_disposition": "BLOCK"},
     {"id": "selected-rebase", "overrides": {"selected_merge_method": "rebase"}, "expected_disposition": "BLOCK"},
     {"id": "signature-rule-disabled", "ruleset_overrides": {"require_signed_commits": false}, "expected_disposition": "BLOCK"},
     {"id": "bypass-used", "overrides": {"bypass_used": true}, "expected_disposition": "BLOCK"}

--- a/tests/behavior/autonomous-merge-readiness-fixtures.json
+++ b/tests/behavior/autonomous-merge-readiness-fixtures.json
@@ -83,6 +83,7 @@
   },
   "pre_merge_cases": [
     {"id": "fully-green", "expected_disposition": "READY_FOR_MERGE"},
+    {"id": "reordered-required-contexts", "ruleset_overrides": {"required_status_contexts": ["native-macos-latest", "governance-check", "Compatibility CodeQL (python)", "native-ubuntu-latest", "validate", "native-windows-latest", "runtime-tests"]}, "expected_disposition": "READY_FOR_MERGE"},
     {"id": "no-check-data", "overrides": {"checks": null}, "expected_disposition": "WAIT_FOR_EVIDENCE"},
     {"id": "missing-runtime", "remove_check": "validate/runtime-tests", "expected_disposition": "WAIT_FOR_EVIDENCE"},
     {"id": "missing-codeql-compatibility", "remove_check": "Required Analysis Compatibility/Compatibility CodeQL (python)", "expected_disposition": "WAIT_FOR_EVIDENCE"},

--- a/tests/runtime/test_autonomous_merge_readiness_contract.py
+++ b/tests/runtime/test_autonomous_merge_readiness_contract.py
@@ -44,6 +44,12 @@ def test_fully_green_exact_head_is_ready():
     assert validator.evaluate_pre_merge(snapshot) == case["expected_disposition"]
 
 
+def test_required_status_context_order_is_not_policy_drift():
+    case, snapshot = pre_case("reordered-required-contexts")
+    assert validator.evaluate_pre_merge(snapshot) == "READY_FOR_MERGE"
+    assert case["expected_disposition"] == "READY_FOR_MERGE"
+
+
 def test_missing_and_pending_evidence_waits():
     for case_id in (
         "no-check-data",

--- a/tests/runtime/test_autonomous_merge_readiness_contract.py
+++ b/tests/runtime/test_autonomous_merge_readiness_contract.py
@@ -48,7 +48,7 @@ def test_missing_and_pending_evidence_waits():
     for case_id in (
         "no-check-data",
         "missing-runtime",
-        "missing-codeql-actions",
+        "missing-codeql-compatibility",
         "queued-windows",
         "in-progress-macos",
         "head-not-reconfirmed",
@@ -66,7 +66,7 @@ def test_any_required_check_failure_blocks():
     for case_id in (
         "governance-failed",
         "runtime-failed",
-        "codeql-python-failed",
+        "compatibility-codeql-failed",
         "cross-platform-failed",
         "required-skipped",
         "required-cancelled",
@@ -127,11 +127,22 @@ def test_ruleset_and_merge_method_drift_block():
     for case_id in (
         "approval-requirement-drift",
         "merge-method-drift",
+        "duplicate-ubuntu-required-context",
+        "retired-codeql-required-contexts",
         "selected-rebase",
         "signature-rule-disabled",
     ):
         _, snapshot = pre_case(case_id)
         assert validator.evaluate_pre_merge(snapshot) == "BLOCK"
+
+
+def test_required_status_context_profile_is_exact_and_unique():
+    contexts = fixture_data()["expected_ruleset"]["required_status_contexts"]
+    assert len(contexts) == len(set(contexts))
+    assert contexts.count("native-ubuntu-latest") == 1
+    assert "Compatibility CodeQL (python)" in contexts
+    assert "Analyze (actions)" not in contexts
+    assert "Analyze (python)" not in contexts
 
 
 def test_bypass_capability_is_not_governance_authority():


### PR DESCRIPTION
## Campaign 0 scope

Reconcile Orchestra's repository-side autonomous merge-readiness policy with the maintainer-approved current `Protect main` required-check profile.

### Required profile

- `governance-check`
- `validate`
- `runtime-tests`
- `native-windows-latest`
- `native-ubuntu-latest` exactly once
- `native-macos-latest`
- `Compatibility CodeQL (python)`

`Analyze (actions)` and `Analyze (python)` are no longer required merge contexts. They may still execute as supporting workflow jobs.

### Changes

- bump autonomous merge-readiness fixture contract to v4;
- replace the retired required CodeQL pair with `Required Analysis Compatibility / Compatibility CodeQL (python)`;
- bind the expected ruleset snapshot to the exact unique required-status-context inventory;
- treat context ordering as non-semantic while rejecting duplicates, missing entries, extras, or retired required contexts;
- add fail-closed cases for duplicate `native-ubuntu-latest` and retired CodeQL required contexts plus a positive reordered-context case;
- update focused runtime tests and governance documentation;
- add a changelog record.

### Boundary

No Prime Directive or Development Lifecycle V2 implementation is included here. No autonomy-profile change, merge, release, deployment, policy activation, destructive action, branch deletion, force push, history rewrite, or live ruleset mutation was performed.

### Known external reconciliation item

The live GitHub ruleset still contains a duplicate `native-ubuntu-latest` required-status entry. The repository contract intentionally classifies that as policy drift. The ruleset setting must be reconciled separately before Campaign 0 can be considered fully closed.

Source baseline: `7e08a1d4aa09cbdf7632f5a86461fb3cd3e50fe9`
Current source head: `838179da05bb638ffde165f628813a3b850901fa`