### PR TITLE
feat(o7): rematerialize R7 direct consumption runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This root changelog is release-oriented. Detailed pre-v1.7 development chronology remains preserved byte-for-byte in [the historical changelog archive](docs/history/CHANGELOG_PRE_V1_7.md), Git history, merged pull requests, decision records, and validation evidence.
 
+## Post-v1.7 O7.1-O7.6 Registry R7 direct consumption runtime
+
+- Integrated Orchestra O7.1 through O7.6 against the canonical Registry R7.1-R7.6 stable direct surface at commit `155c21ab54f704d876ae4a0c2d995f5591f13930`, tree `ea99fce806a455c4c1e2c912277c44d3595f54d8`, without reimplementing Registry-owned query semantics in Orchestra.
+- Added optional R7 capability negotiation, deterministic indexed/direct-JSON/O1-O6 fallback selection, `MINIMAL`/`SUMMARY`/`EVIDENCE`/`FULL` projection-aware consumption, and normalization into the existing `ComplianceQueryReceipt` evidence model.
+- Added fail-closed semantic and result-digest integrity checks, deterministic index rejection/fallback behavior, context-budget capability gating, exact source/obligation identity preservation, and machine-readable runtime state bound to the verified Registry dependency.
+- Preserved the existing O1-O6 compatibility path when optional R7 capabilities are absent; required `cap.query.v1` incompatibility remains fail closed and transport/projection choices do not expand authority.
+- R7.7 MCP, Registry `v0.4.0` trusted immutable publication, trusted-release integration, measured R7.9 efficiency benchmarking, O7.7 joint conformance, release, deployment, and policy authority remain outside this runtime increment and are not claimed by it.
+
 ## Post-v1.7 O7.0 Registry consumer contract freeze
 
 - Froze Orchestra O7.0 consumer expectations against the signed Registry R7 architecture at commit `c1910806ed3ea9147af96b1c49a9f72aef75e0f6`, tree `0c37d7bf47fc20b49b26fea156c8e180db57b4a3`, and R7 document blob `9f24a10f455a77509ec5246e6981ca2672624ca1` while retaining Registry R7 status `APPROVED_PLANNED_NOT_IMPLEMENTED`.

--- a/docs/architecture/contracts/registry-o7-runtime-state.v1.json
+++ b/docs/architecture/contracts/registry-o7-runtime-state.v1.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": "orchestra.registry-o7-runtime-state.v1",
+  "authority": "DESCRIPTIVE_NON_AUTHORIZING",
+  "orchestra_baseline": {
+    "repository": "Baelfyre/Orchestra",
+    "base_commit_sha": "92b7871aef8444d84f6859586b9cb801393fd386",
+    "base_tree_sha": "037ab47a6003e78b8df868848978be219a896d6e",
+    "o7_0": "MERGED_VERIFIED"
+  },
+  "registry_dependency": {
+    "repository": "Baelfyre/Orchestra-Compliance-Registry",
+    "canonical_commit_sha": "155c21ab54f704d876ae4a0c2d995f5591f13930",
+    "canonical_tree_sha": "ea99fce806a455c4c1e2c912277c44d3595f54d8",
+    "signature": "VERIFIED",
+    "canonical_validation": "PASS",
+    "surface_status": "IMPLEMENTED_STABLE_DIRECT_SURFACE_R7_1_R7_6",
+    "entry_condition": "IMPLEMENTED_STABLE_REGISTRY_R7_SURFACE_REQUIRED",
+    "entry_condition_satisfied": true
+  },
+  "implementation": {
+    "status": "O7_1_O7_6_IMPLEMENTED_PENDING_CANONICALIZATION",
+    "phases": {
+      "O7.1": "IMPLEMENTED",
+      "O7.2": "IMPLEMENTED",
+      "O7.3": "IMPLEMENTED",
+      "O7.4": "IMPLEMENTED",
+      "O7.5": "IMPLEMENTED",
+      "O7.6": "IMPLEMENTED",
+      "O7.7": "BLOCKED_PENDING_R7_7_AND_TRUSTED_RELEASE_INTEGRATION"
+    },
+    "runtime_module": "orchestra_runtime/registry_o7.py",
+    "test_module": "tests/runtime/test_registry_o7.py"
+  },
+  "transport": {
+    "preference": [
+      "DIRECT_LOCAL_INDEXED_GATEWAY",
+      "DIRECT_LOCAL_JSON_QUERY",
+      "OPTIONAL_MCP_TRANSPORT"
+    ],
+    "registry_gateway_semantics_are_reimplemented_in_orchestra": false,
+    "registry_gateway_is_injected_consumer_boundary": true,
+    "legacy_o1_o6_fallback_preserved": true,
+    "mcp_currently_available": false
+  },
+  "compatibility": {
+    "required_capability": "cap.query.v1>=1.0.0",
+    "r7_optional_capabilities": [
+      "cap.query.projection.v1>=1.0.0",
+      "cap.query.relationships.v1>=1.0.0",
+      "cap.query.indexed-read.v1>=1.0.0",
+      "cap.query.budget.v1>=1.0.0",
+      "cap.transport.mcp.v1>=1.0.0"
+    ],
+    "optional_absence_disposition": "USE_CURRENT_O1_O6_PATH",
+    "required_incompatibility_disposition": "FAIL_CLOSED"
+  },
+  "integrity": {
+    "index_mismatch_disposition": "REJECT_INDEX_THEN_DIRECT_JSON_OR_LEGACY_FALLBACK",
+    "semantic_query_mismatch_disposition": "FAIL_CLOSED",
+    "result_digest_mismatch_disposition": "FAIL_CLOSED",
+    "model_authored_integrity_repair_allowed": false
+  },
+  "release_boundary": {
+    "trusted_registry_v0_4_0_published": false,
+    "r7_7_mcp_implemented": false,
+    "joint_r7_o7_conformance_complete": false,
+    "orchestra_release_integration_authorized_by_this_state": false
+  },
+  "authority_expansion": false
+}

--- a/orchestra_runtime/registry_o7.py
+++ b/orchestra_runtime/registry_o7.py
@@ -1,0 +1,429 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+import re
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
+from .compliance_protocol import ComplianceQueryReceipt
+from . import registry_adaptive
+
+O7_RUNTIME_SCHEMA = "orchestra.registry-o7-runtime.v1"
+R7_RESPONSE_SCHEMA = "orchestra.compliance-registry.r7-query-response.v1"
+R7_RECEIPT_SCHEMA = "orchestra.compliance-registry.r7-query-receipt.v1"
+CANONICAL_REPOSITORY = registry_adaptive.CANONICAL_REPOSITORY
+
+R7_OPTIONAL_CAPABILITIES: dict[str, str] = {
+    "cap.query.projection.v1": "1.0.0",
+    "cap.query.relationships.v1": "1.0.0",
+    "cap.query.indexed-read.v1": "1.0.0",
+    "cap.query.budget.v1": "1.0.0",
+    "cap.transport.mcp.v1": "1.0.0",
+}
+R7_DIRECT_BASE_CAPABILITIES = {
+    "cap.query.projection.v1",
+    "cap.query.relationships.v1",
+}
+ALLOWED_PROJECTIONS = ("MINIMAL", "SUMMARY", "EVIDENCE", "FULL")
+DIRECT_INDEXED = "DIRECT_LOCAL_INDEXED_GATEWAY"
+DIRECT_JSON = "DIRECT_LOCAL_JSON_QUERY"
+OPTIONAL_MCP = "OPTIONAL_MCP_TRANSPORT"
+LEGACY_O1_O6 = "USE_CURRENT_O1_O6_PATH"
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+WORKFLOW_DEFAULT_PROJECTION: dict[str, str] = {
+    "conductor_discovery": "MINIMAL",
+    "governor_applicability_review": "SUMMARY",
+    "steward_requirements_traceability": "EVIDENCE",
+    "explicit_audit_escalation": "FULL",
+}
+
+
+class O7RegistryError(ValueError):
+    """Base fail-closed O7 consumer error."""
+
+
+class O7SemanticMismatch(O7RegistryError):
+    """Registry response does not match the exact consumer request."""
+
+
+class O7IndexIntegrityError(O7RegistryError):
+    """Verified-index identity or digest validation failed."""
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def stable_digest(value: Any) -> str:
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def _text(value: object, field_name: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise O7RegistryError(f"{field_name} must be non-empty")
+    return text
+
+
+def _sha(value: object, field_name: str) -> str:
+    text = _text(value, field_name).lower()
+    if SHA256_RE.fullmatch(text) is None:
+        raise O7RegistryError(f"{field_name} must be a lowercase SHA-256 digest")
+    return text
+
+
+def _values(values: Iterable[object] | None, field_name: str) -> tuple[str, ...]:
+    if values is None:
+        return ()
+    normalized = tuple(sorted({_text(value, field_name) for value in values}))
+    return normalized
+
+
+@dataclass(frozen=True, slots=True)
+class O7QueryRequest:
+    workflow_stage: str
+    jurisdictions: tuple[str, ...] = ()
+    providers: tuple[str, ...] = ()
+    domains: tuple[str, ...] = ()
+    source_id: str | None = None
+    obligation_id: str | None = None
+    projection: str | None = None
+    maximum_context_bytes: int | None = None
+    limit: int = 50
+    cursor: str | None = None
+    representation: str = "AUTO"
+    explicit_mcp: bool = False
+
+    def __post_init__(self) -> None:
+        stage = _text(self.workflow_stage, "workflow_stage")
+        if stage not in WORKFLOW_DEFAULT_PROJECTION:
+            raise O7RegistryError(f"unsupported O7 workflow stage: {stage}")
+        object.__setattr__(self, "workflow_stage", stage)
+        object.__setattr__(self, "jurisdictions", _values(self.jurisdictions, "jurisdiction"))
+        object.__setattr__(self, "providers", _values(self.providers, "provider"))
+        object.__setattr__(self, "domains", _values(self.domains, "domain"))
+        if self.source_id is not None:
+            object.__setattr__(self, "source_id", _text(self.source_id, "source_id"))
+        if self.obligation_id is not None:
+            object.__setattr__(self, "obligation_id", _text(self.obligation_id, "obligation_id"))
+        if self.projection is not None:
+            projection = _text(self.projection, "projection").upper()
+            if projection not in ALLOWED_PROJECTIONS:
+                raise O7RegistryError(f"unsupported O7 projection: {projection}")
+            object.__setattr__(self, "projection", projection)
+        if isinstance(self.limit, bool) or not isinstance(self.limit, int) or not 1 <= self.limit <= 1000:
+            raise O7RegistryError("limit must be an integer between 1 and 1000")
+        if self.maximum_context_bytes is not None:
+            if isinstance(self.maximum_context_bytes, bool) or not isinstance(self.maximum_context_bytes, int) or self.maximum_context_bytes <= 0:
+                raise O7RegistryError("maximum_context_bytes must be a positive integer")
+        representation = _text(self.representation, "representation").upper()
+        if representation not in {"AUTO", "JSON", "TOON"}:
+            raise O7RegistryError("representation must be AUTO, JSON, or TOON")
+        object.__setattr__(self, "representation", representation)
+        if not isinstance(self.explicit_mcp, bool):
+            raise O7RegistryError("explicit_mcp must be bool")
+
+    @property
+    def effective_projection(self) -> str:
+        return self.projection or WORKFLOW_DEFAULT_PROJECTION[self.workflow_stage]
+
+    @property
+    def r7_single_filter_compatible(self) -> bool:
+        return all(len(values) <= 1 for values in (self.jurisdictions, self.providers, self.domains))
+
+    def receipt_filters(self) -> dict[str, str]:
+        return {
+            "jurisdictions": ",".join(self.jurisdictions),
+            "providers": ",".join(self.providers),
+            "domains": ",".join(self.domains),
+            "source_id": self.source_id or "",
+            "obligation_id": self.obligation_id or "",
+        }
+
+    def gateway_request(self) -> dict[str, Any]:
+        if not self.r7_single_filter_compatible:
+            raise O7RegistryError("R7 direct gateway currently accepts at most one jurisdiction/provider/domain filter")
+        return {
+            "record_type": "obligations",
+            "filters": {
+                "domain": self.domains[0] if self.domains else None,
+                "jurisdiction": self.jurisdictions[0] if self.jurisdictions else None,
+                "provider": self.providers[0] if self.providers else None,
+                "source_id": self.source_id,
+                "obligation_id": self.obligation_id,
+            },
+            "projection": self.effective_projection,
+            "fields": [],
+            "include_freshness": True,
+            "limit": self.limit,
+            "cursor": self.cursor,
+            "maximum_context_bytes": self.maximum_context_bytes,
+            "representation": self.representation,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class O7TransportPlan:
+    disposition: str
+    transport: str
+    projection: str
+    reason: str
+    authority_expansion: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": O7_RUNTIME_SCHEMA,
+            "disposition": self.disposition,
+            "transport": self.transport,
+            "projection": self.projection,
+            "reason": self.reason,
+            "authority_expansion": self.authority_expansion,
+        }
+
+
+GatewayCall = Callable[[str, Mapping[str, Any]], Mapping[str, Any]]
+LegacyCall = Callable[[O7QueryRequest], Mapping[str, Any]]
+
+
+def negotiate_o7_capabilities(surface: Mapping[str, Any]) -> dict[str, Any]:
+    optional = {**registry_adaptive.OPTIONAL_CAPABILITIES, **R7_OPTIONAL_CAPABILITIES}
+    return registry_adaptive.negotiate_capabilities(
+        surface,
+        required=registry_adaptive.REQUIRED_CAPABILITIES,
+        optional=optional,
+    )
+
+
+def _matched_optional(negotiation: Mapping[str, Any]) -> set[str]:
+    values = negotiation.get("matched_optional_capability_ids", [])
+    if not isinstance(values, Sequence) or isinstance(values, (str, bytes)):
+        raise O7RegistryError("capability negotiation matched_optional_capability_ids must be an array")
+    return {_text(value, "matched optional capability") for value in values}
+
+
+def select_o7_transport(
+    request: O7QueryRequest,
+    negotiation: Mapping[str, Any],
+    *,
+    available_transports: Iterable[str],
+) -> O7TransportPlan:
+    if negotiation.get("disposition") != "COMPATIBLE":
+        raise O7RegistryError("required Registry capability incompatibility: FAIL_CLOSED")
+    matched = _matched_optional(negotiation)
+    available = set(_values(available_transports, "available transport"))
+    projection = request.effective_projection
+
+    if not request.r7_single_filter_compatible:
+        return O7TransportPlan(LEGACY_O1_O6, LEGACY_O1_O6, projection, "R7_SINGLE_FILTER_CONTRACT_NOT_SUFFICIENT")
+    if not R7_DIRECT_BASE_CAPABILITIES <= matched:
+        return O7TransportPlan(LEGACY_O1_O6, LEGACY_O1_O6, projection, "R7_DIRECT_BASE_CAPABILITY_ABSENT")
+    if request.maximum_context_bytes is not None and "cap.query.budget.v1" not in matched:
+        return O7TransportPlan(LEGACY_O1_O6, LEGACY_O1_O6, projection, "R7_BUDGET_CAPABILITY_ABSENT")
+    if request.explicit_mcp:
+        if OPTIONAL_MCP in available and "cap.transport.mcp.v1" in matched:
+            return O7TransportPlan("R7_OPTIMIZED", OPTIONAL_MCP, projection, "EXPLICIT_MCP_SELECTED")
+        if DIRECT_JSON in available:
+            return O7TransportPlan("R7_OPTIMIZED", DIRECT_JSON, projection, "MCP_UNAVAILABLE_DIRECT_FALLBACK")
+        return O7TransportPlan(LEGACY_O1_O6, LEGACY_O1_O6, projection, "MCP_AND_R7_DIRECT_UNAVAILABLE")
+    if DIRECT_INDEXED in available and "cap.query.indexed-read.v1" in matched:
+        return O7TransportPlan("R7_OPTIMIZED", DIRECT_INDEXED, projection, "VERIFIED_INDEXED_GATEWAY_AVAILABLE")
+    if DIRECT_JSON in available:
+        return O7TransportPlan("R7_OPTIMIZED", DIRECT_JSON, projection, "DIRECT_JSON_FALLBACK")
+    return O7TransportPlan(LEGACY_O1_O6, LEGACY_O1_O6, projection, "R7_TRANSPORT_UNAVAILABLE")
+
+
+def _verify_registry_identity(registry_identity: Mapping[str, Any], receipt: Mapping[str, Any]) -> None:
+    if receipt.get("canonical_repository") != CANONICAL_REPOSITORY:
+        raise O7SemanticMismatch("R7 canonical repository mismatch")
+    if registry_identity.get("canonical_repository") != CANONICAL_REPOSITORY:
+        raise O7SemanticMismatch("active Registry canonical repository mismatch")
+    pairs = (
+        ("registry_version", "registry_version"),
+        ("release_sequence", "release_sequence"),
+        ("release_tag", "release_tag"),
+        ("manifest_sha256", "release_manifest_sha256"),
+    )
+    for active_key, receipt_key in pairs:
+        if registry_identity.get(active_key) != receipt.get(receipt_key):
+            raise O7SemanticMismatch(f"R7 receipt identity mismatch for {receipt_key}")
+
+
+def _verify_request_echo(request: O7QueryRequest, response: Mapping[str, Any]) -> None:
+    query = response.get("query")
+    if not isinstance(query, Mapping):
+        raise O7SemanticMismatch("R7 response is missing query echo")
+    expected = request.gateway_request()
+    for key in ("record_type", "projection", "include_freshness", "limit", "cursor", "maximum_context_bytes"):
+        if query.get(key) != expected[key]:
+            raise O7SemanticMismatch(f"R7 semantic query mismatch for {key}")
+    filters = query.get("filters")
+    if not isinstance(filters, Mapping) or dict(filters) != expected["filters"]:
+        raise O7SemanticMismatch("R7 semantic query mismatch for filters")
+
+
+def normalize_r7_query(
+    request: O7QueryRequest,
+    response: Mapping[str, Any],
+    *,
+    registry_identity: Mapping[str, Any],
+    negotiation: Mapping[str, Any],
+    transport: str,
+) -> dict[str, Any]:
+    if response.get("schema_version") != R7_RESPONSE_SCHEMA:
+        raise O7SemanticMismatch("unsupported R7 query response schema")
+    if response.get("authority") != "DERIVED_NON_AUTHORITATIVE":
+        raise O7SemanticMismatch("R7 response attempted authority expansion")
+    if response.get("projection") != request.effective_projection:
+        raise O7SemanticMismatch("R7 response projection mismatch")
+    backend = response.get("backend")
+    if transport in {DIRECT_INDEXED, DIRECT_JSON} and backend != transport:
+        raise O7SemanticMismatch("R7 response backend mismatch")
+    _verify_request_echo(request, response)
+
+    receipt = response.get("receipt")
+    if not isinstance(receipt, Mapping) or receipt.get("schema_version") != R7_RECEIPT_SCHEMA:
+        raise O7SemanticMismatch("R7 response is missing a supported receipt")
+    if receipt.get("authority") != "NONE_EVIDENCE_ONLY" or receipt.get("authority_expansion") is not False:
+        raise O7SemanticMismatch("R7 receipt attempted authority expansion")
+    if receipt.get("model_authored_integrity_repair") is not False:
+        raise O7SemanticMismatch("model-authored R7 integrity repair is prohibited")
+    if receipt.get("external_reverification_required_before_trust_or_mutation") is not True:
+        raise O7SemanticMismatch("R7 receipt removed external reverification boundary")
+    if receipt.get("promotion_from_receipt_forbidden") is not True:
+        raise O7SemanticMismatch("R7 receipt attempted promotion authority")
+    if receipt.get("publication_trust") != "TRUSTED_RELEASE_IDENTITY_VERIFIED":
+        raise O7SemanticMismatch("O7 optimized consumption requires trusted Registry release identity")
+    if receipt.get("registry_authority_realm") != "TRUSTED_RELEASE_READ_MODEL":
+        raise O7SemanticMismatch("O7 optimized consumption requires trusted release read model")
+    _verify_registry_identity(registry_identity, receipt)
+
+    query_digest = _sha(receipt.get("query_semantic_sha256"), "R7 query digest")
+    result_digest = _sha(receipt.get("result_semantic_sha256"), "R7 result digest")
+    records = response.get("records")
+    if not isinstance(records, list) or not all(isinstance(item, Mapping) for item in records):
+        raise O7SemanticMismatch("R7 response records must be an array of objects")
+    if stable_digest(records) != result_digest:
+        raise O7SemanticMismatch("R7 result semantic digest mismatch")
+
+    source_ids = _values(receipt.get("exact_source_ids", []), "R7 exact source ID")
+    obligation_ids = _values(receipt.get("exact_obligation_ids", []), "R7 exact obligation ID")
+    record_obligation_ids = _values((item.get("obligation_id") for item in records), "R7 record obligation ID")
+    if obligation_ids != record_obligation_ids:
+        raise O7SemanticMismatch("R7 exact obligation identity differs from returned records")
+    if response.get("count") != len(records):
+        raise O7SemanticMismatch("R7 response count mismatch")
+
+    freshness = receipt.get("freshness_evidence")
+    if not isinstance(freshness, list) or not all(isinstance(item, Mapping) for item in freshness):
+        raise O7SemanticMismatch("R7 freshness evidence must be an array of objects")
+    freshness_ids = _values((item.get("source_id") for item in freshness), "R7 freshness source ID")
+    if freshness_ids != source_ids:
+        raise O7SemanticMismatch("R7 freshness evidence does not cover the exact source set")
+
+    capability_evidence = receipt.get("capability_negotiation_evidence")
+    if not isinstance(capability_evidence, list) or not all(isinstance(item, Mapping) for item in capability_evidence):
+        raise O7SemanticMismatch("R7 capability evidence must be an array of objects")
+    domain_evidence = receipt.get("domain_routing_evidence")
+    if not isinstance(domain_evidence, Mapping):
+        raise O7SemanticMismatch("R7 domain-routing evidence must be an object")
+
+    compliance_receipt = ComplianceQueryReceipt(
+        canonical_repository=CANONICAL_REPOSITORY,
+        registry_version=_text(receipt.get("registry_version"), "registry_version"),
+        release_sequence=receipt.get("release_sequence"),
+        release_tag=_text(receipt.get("release_tag"), "release_tag"),
+        manifest_sha256=_sha(receipt.get("release_manifest_sha256"), "release manifest digest"),
+        filters=tuple(sorted((key, value) for key, value in request.receipt_filters().items() if value)),
+        source_ids=source_ids,
+        obligation_ids=obligation_ids,
+    )
+    routing_domains = request.domains or _values(domain_evidence.get("returned_domains", []), "returned domain")
+    routing = registry_adaptive.resolve_specialists(routing_domains)
+    normalized = {
+        "schema_version": O7_RUNTIME_SCHEMA,
+        "mode": "R7_OPTIMIZED",
+        "transport": transport,
+        "projection": request.effective_projection,
+        "registry_identity": dict(registry_identity),
+        "query_digest": query_digest,
+        "source_ids": list(source_ids),
+        "obligation_ids": list(obligation_ids),
+        "freshness_evidence": [dict(item) for item in freshness],
+        "capability_negotiation": dict(negotiation),
+        "registry_capability_evidence": [dict(item) for item in capability_evidence],
+        "domain_routing_evidence": dict(domain_evidence),
+        "routing": routing,
+        "compliance_query_receipt": compliance_receipt.to_dict(),
+        "compliance_query_receipt_digest": compliance_receipt.digest,
+        "records": [dict(item) for item in records],
+        "next_cursor": response.get("next_cursor"),
+        "encoded_bytes": response.get("encoded_bytes"),
+        "authority_expansion": False,
+        "model_authored_integrity_repair": False,
+    }
+    normalized["digest"] = stable_digest(normalized)
+    return normalized
+
+
+def execute_o7_query(
+    request: O7QueryRequest,
+    *,
+    capability_surface: Mapping[str, Any],
+    registry_identity: Mapping[str, Any],
+    available_transports: Iterable[str],
+    r7_gateway: GatewayCall | None,
+    legacy_query: LegacyCall,
+) -> dict[str, Any]:
+    negotiation = negotiate_o7_capabilities(capability_surface)
+    plan = select_o7_transport(request, negotiation, available_transports=available_transports)
+    if plan.disposition == LEGACY_O1_O6:
+        legacy = dict(legacy_query(request))
+        return {
+            "schema_version": O7_RUNTIME_SCHEMA,
+            "mode": LEGACY_O1_O6,
+            "transport_plan": plan.to_dict(),
+            "capability_negotiation": negotiation,
+            "legacy_result": legacy,
+            "authority_expansion": False,
+        }
+    if r7_gateway is None:
+        legacy = dict(legacy_query(request))
+        return {
+            "schema_version": O7_RUNTIME_SCHEMA,
+            "mode": LEGACY_O1_O6,
+            "transport_plan": O7TransportPlan(LEGACY_O1_O6, LEGACY_O1_O6, plan.projection, "R7_GATEWAY_NOT_BOUND").to_dict(),
+            "capability_negotiation": negotiation,
+            "legacy_result": legacy,
+            "authority_expansion": False,
+        }
+
+    gateway_request = request.gateway_request()
+    transport = plan.transport
+    try:
+        response = r7_gateway(transport, gateway_request)
+    except O7IndexIntegrityError:
+        available = set(available_transports)
+        if transport == DIRECT_INDEXED and DIRECT_JSON in available:
+            transport = DIRECT_JSON
+            response = r7_gateway(transport, gateway_request)
+        else:
+            legacy = dict(legacy_query(request))
+            return {
+                "schema_version": O7_RUNTIME_SCHEMA,
+                "mode": LEGACY_O1_O6,
+                "transport_plan": O7TransportPlan(LEGACY_O1_O6, LEGACY_O1_O6, plan.projection, "INDEX_INTEGRITY_REJECTED_FALLBACK").to_dict(),
+                "capability_negotiation": negotiation,
+                "legacy_result": legacy,
+                "authority_expansion": False,
+            }
+    normalized = normalize_r7_query(
+        request,
+        response,
+        registry_identity=registry_identity,
+        negotiation=negotiation,
+        transport=transport,
+    )
+    normalized["transport_plan"] = O7TransportPlan("R7_OPTIMIZED", transport, plan.projection, "NORMALIZED_R7_RESULT").to_dict()
+    return normalized

--- a/tests/runtime/test_registry_o7.py
+++ b/tests/runtime/test_registry_o7.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from orchestra_runtime import registry_adaptive
+from orchestra_runtime import registry_o7 as o7
+
+
+REGISTRY_IDENTITY = {
+    "canonical_repository": o7.CANONICAL_REPOSITORY,
+    "registry_version": "0.4.0-test",
+    "release_sequence": 4,
+    "release_tag": "registry-v0.4.0-test",
+    "manifest_sha256": "a" * 64,
+}
+
+
+def capability_surface(*, include_index: bool = True, include_budget: bool = True) -> dict:
+    capabilities = [
+        {
+            "capability_id": "cap.query.v1",
+            "contract_version": "1.0.0",
+            "status": "SUPPORTED",
+            "required_records": ["sources", "obligations"],
+            "optional": False,
+            "fallback": "NONE",
+        }
+    ]
+    for capability_id in (
+        "cap.query.projection.v1",
+        "cap.query.relationships.v1",
+        "cap.query.indexed-read.v1",
+        "cap.query.budget.v1",
+    ):
+        if capability_id == "cap.query.indexed-read.v1" and not include_index:
+            continue
+        if capability_id == "cap.query.budget.v1" and not include_budget:
+            continue
+        capabilities.append(
+            {
+                "capability_id": capability_id,
+                "contract_version": "1.0.0",
+                "status": "SUPPORTED",
+                "required_records": ["sources", "obligations"],
+                "optional": True,
+                "fallback": "DIRECT_LOCAL_JSON_QUERY",
+            }
+        )
+    return {
+        "schema_version": registry_adaptive.CAPABILITY_MANIFEST_SCHEMA,
+        "canonical_repository": o7.CANONICAL_REPOSITORY,
+        "authority": "DESCRIPTIVE_NON_AUTHORIZING",
+        "capabilities": capabilities,
+        "authority_boundaries": {
+            "legal_interpretation": False,
+            "project_applicability": False,
+            "orchestra_execution": False,
+            "automatic_merge": False,
+            "trusted_release_publication": False,
+        },
+    }
+
+
+def request(**overrides) -> o7.O7QueryRequest:
+    values = {
+        "workflow_stage": "steward_requirements_traceability",
+        "jurisdictions": ("PH",),
+        "domains": ("privacy",),
+    }
+    values.update(overrides)
+    return o7.O7QueryRequest(**values)
+
+
+def response_for(req: o7.O7QueryRequest, *, backend: str = o7.DIRECT_JSON) -> dict:
+    records = [
+        {
+            "obligation_id": "PH-O",
+            "title": "Privacy obligation",
+            "summary": "Evidence-bound requirement.",
+            "source_ids": ["PH-A"],
+            "jurisdiction_ids": ["PH"],
+            "provider_ids": [],
+            "domains": ["privacy"],
+            "source_locator": {"kind": "section", "value": "1"},
+            "required_evidence": ["evidence"],
+            "interpretation_state": "SOURCE_TEXT_REVIEWED",
+            "_source_freshness": [
+                {
+                    "source_id": "PH-A",
+                    "source_status": {"source_id": "PH-A", "status": "VERIFIED_CURRENT"},
+                    "review_schedule": {"source_id": "PH-A", "next_review_due": "2027-01-01"},
+                }
+            ],
+        }
+    ]
+    query = req.gateway_request()
+    receipt = {
+        "schema_version": o7.R7_RECEIPT_SCHEMA,
+        "authority": "NONE_EVIDENCE_ONLY",
+        "canonical_repository": o7.CANONICAL_REPOSITORY,
+        "registry_authority_realm": "TRUSTED_RELEASE_READ_MODEL",
+        "publication_trust": "TRUSTED_RELEASE_IDENTITY_VERIFIED",
+        "registry_version": REGISTRY_IDENTITY["registry_version"],
+        "release_sequence": REGISTRY_IDENTITY["release_sequence"],
+        "release_tag": REGISTRY_IDENTITY["release_tag"],
+        "release_manifest_sha256": REGISTRY_IDENTITY["manifest_sha256"],
+        "registry_manifest_sha256": "b" * 64,
+        "registry_semantic_sha256": "c" * 64,
+        "relationship_semantic_sha256": "d" * 64,
+        "backend": backend,
+        "projection": req.effective_projection,
+        "representation": "JSON",
+        "query_semantic_sha256": "e" * 64,
+        "result_semantic_sha256": o7.stable_digest(records),
+        "exact_source_ids": ["PH-A"],
+        "exact_obligation_ids": ["PH-O"],
+        "freshness_evidence": [
+            {
+                "source_id": "PH-A",
+                "source_status": {"source_id": "PH-A", "status": "VERIFIED_CURRENT"},
+                "review_schedule": {"source_id": "PH-A", "next_review_due": "2027-01-01"},
+            }
+        ],
+        "capability_negotiation_evidence": [
+            {"capability_id": "cap.query.v1", "contract_version": "1.0.0", "status": "SUPPORTED"},
+            {"capability_id": "cap.query.projection.v1", "contract_version": "1.0.0", "status": "SUPPORTED"},
+        ],
+        "domain_routing_evidence": {"requested_domain": "privacy", "returned_domains": ["privacy"]},
+        "next_cursor": None,
+        "integrity_disposition": "VERIFIED_INDEX" if backend == o7.DIRECT_INDEXED else "DIRECT_CANONICAL_JSON",
+        "authority_expansion": False,
+        "model_authored_integrity_repair": False,
+        "external_reverification_required_before_trust_or_mutation": True,
+        "promotion_from_receipt_forbidden": True,
+    }
+    return {
+        "schema_version": o7.R7_RESPONSE_SCHEMA,
+        "authority": "DERIVED_NON_AUTHORITATIVE",
+        "backend": backend,
+        "projection": req.effective_projection,
+        "query": query,
+        "total_filtered": 1,
+        "count": 1,
+        "next_cursor": None,
+        "records": records,
+        "receipt": receipt,
+        "encoded_bytes": 1000,
+    }
+
+
+def test_o7_1_negotiation_recognizes_r7_capabilities_as_optional() -> None:
+    negotiation = o7.negotiate_o7_capabilities(capability_surface())
+    assert negotiation["disposition"] == "COMPATIBLE"
+    assert "cap.query.projection.v1" in negotiation["matched_optional_capability_ids"]
+    assert "cap.query.relationships.v1" in negotiation["matched_optional_capability_ids"]
+    assert "cap.query.indexed-read.v1" in negotiation["matched_optional_capability_ids"]
+    assert "cap.transport.mcp.v1" in negotiation["missing_optional_capability_ids"]
+
+
+def test_o7_1_optional_r7_absence_uses_current_o1_o6_path() -> None:
+    surface = capability_surface()
+    surface["capabilities"] = [surface["capabilities"][0]]
+    negotiation = o7.negotiate_o7_capabilities(surface)
+    plan = o7.select_o7_transport(request(), negotiation, available_transports=(o7.DIRECT_JSON,))
+    assert plan.disposition == o7.LEGACY_O1_O6
+    assert plan.authority_expansion is False
+
+
+def test_o7_2_prefers_verified_indexed_gateway_when_advertised_and_bound() -> None:
+    negotiation = o7.negotiate_o7_capabilities(capability_surface())
+    plan = o7.select_o7_transport(
+        request(), negotiation, available_transports=(o7.DIRECT_JSON, o7.DIRECT_INDEXED)
+    )
+    assert plan.transport == o7.DIRECT_INDEXED
+
+
+def test_o7_2_falls_back_to_direct_json_when_index_capability_absent() -> None:
+    negotiation = o7.negotiate_o7_capabilities(capability_surface(include_index=False))
+    plan = o7.select_o7_transport(
+        request(), negotiation, available_transports=(o7.DIRECT_JSON, o7.DIRECT_INDEXED)
+    )
+    assert plan.transport == o7.DIRECT_JSON
+
+
+def test_o7_3_workflow_projection_defaults_are_bounded() -> None:
+    assert o7.O7QueryRequest(workflow_stage="conductor_discovery").effective_projection == "MINIMAL"
+    assert o7.O7QueryRequest(workflow_stage="governor_applicability_review").effective_projection == "SUMMARY"
+    assert o7.O7QueryRequest(workflow_stage="steward_requirements_traceability").effective_projection == "EVIDENCE"
+    assert o7.O7QueryRequest(workflow_stage="explicit_audit_escalation").effective_projection == "FULL"
+
+
+def test_o7_4_normalizes_r7_result_into_existing_compliance_receipt_identity() -> None:
+    req = request()
+    negotiation = o7.negotiate_o7_capabilities(capability_surface())
+    normalized = o7.normalize_r7_query(
+        req,
+        response_for(req),
+        registry_identity=REGISTRY_IDENTITY,
+        negotiation=negotiation,
+        transport=o7.DIRECT_JSON,
+    )
+    receipt = normalized["compliance_query_receipt"]
+    assert receipt["source_ids"] == ["PH-A"]
+    assert receipt["obligation_ids"] == ["PH-O"]
+    assert receipt["manifest_sha256"] == REGISTRY_IDENTITY["manifest_sha256"]
+    assert normalized["query_digest"] == "e" * 64
+    assert normalized["freshness_evidence"][0]["source_id"] == "PH-A"
+    assert normalized["capability_negotiation"]["disposition"] == "COMPATIBLE"
+    assert normalized["domain_routing_evidence"]["returned_domains"] == ["privacy"]
+    assert normalized["routing"]["specialist_ids"] == ["the-governor"]
+    assert normalized["authority_expansion"] is False
+
+
+def test_o7_5_semantic_request_mismatch_fails_closed_without_legacy_repair() -> None:
+    req = request()
+    bad = response_for(req)
+    bad["query"]["filters"]["domain"] = "security"
+    negotiation = o7.negotiate_o7_capabilities(capability_surface())
+    with pytest.raises(o7.O7SemanticMismatch):
+        o7.normalize_r7_query(
+            req,
+            bad,
+            registry_identity=REGISTRY_IDENTITY,
+            negotiation=negotiation,
+            transport=o7.DIRECT_JSON,
+        )
+
+
+def test_o7_5_result_digest_mismatch_fails_closed() -> None:
+    req = request()
+    bad = response_for(req)
+    bad["records"][0]["title"] = "tampered"
+    negotiation = o7.negotiate_o7_capabilities(capability_surface())
+    with pytest.raises(o7.O7SemanticMismatch, match="semantic digest"):
+        o7.normalize_r7_query(
+            req,
+            bad,
+            registry_identity=REGISTRY_IDENTITY,
+            negotiation=negotiation,
+            transport=o7.DIRECT_JSON,
+        )
+
+
+def test_o7_5_index_integrity_failure_falls_back_to_direct_json() -> None:
+    req = request()
+    calls: list[str] = []
+
+    def gateway(transport: str, _query: dict) -> dict:
+        calls.append(transport)
+        if transport == o7.DIRECT_INDEXED:
+            raise o7.O7IndexIntegrityError("digest mismatch")
+        return response_for(req, backend=o7.DIRECT_JSON)
+
+    def legacy(_request: o7.O7QueryRequest) -> dict:
+        raise AssertionError("legacy path should not be used when direct JSON fallback is available")
+
+    result = o7.execute_o7_query(
+        req,
+        capability_surface=capability_surface(),
+        registry_identity=REGISTRY_IDENTITY,
+        available_transports=(o7.DIRECT_INDEXED, o7.DIRECT_JSON),
+        r7_gateway=gateway,
+        legacy_query=legacy,
+    )
+    assert calls == [o7.DIRECT_INDEXED, o7.DIRECT_JSON]
+    assert result["transport"] == o7.DIRECT_JSON
+
+
+def test_o7_6_budget_request_uses_legacy_when_registry_budget_capability_absent() -> None:
+    req = request(maximum_context_bytes=4096)
+    negotiation = o7.negotiate_o7_capabilities(capability_surface(include_budget=False))
+    plan = o7.select_o7_transport(req, negotiation, available_transports=(o7.DIRECT_JSON,))
+    assert plan.disposition == o7.LEGACY_O1_O6
+    assert plan.reason == "R7_BUDGET_CAPABILITY_ABSENT"
+
+
+def test_o7_multi_value_filter_preserves_o1_o6_semantics_via_fallback() -> None:
+    req = request(jurisdictions=("PH", "SG"))
+    negotiation = o7.negotiate_o7_capabilities(capability_surface())
+    plan = o7.select_o7_transport(req, negotiation, available_transports=(o7.DIRECT_JSON,))
+    assert plan.disposition == o7.LEGACY_O1_O6
+    assert plan.reason == "R7_SINGLE_FILTER_CONTRACT_NOT_SUFFICIENT"
+
+
+def test_o7_required_capability_incompatibility_fails_closed() -> None:
+    surface = capability_surface()
+    surface["capabilities"] = [
+        item for item in surface["capabilities"] if item["capability_id"] != "cap.query.v1"
+    ]
+    negotiation = o7.negotiate_o7_capabilities(surface)
+    with pytest.raises(o7.O7RegistryError, match="FAIL_CLOSED"):
+        o7.select_o7_transport(request(), negotiation, available_transports=(o7.DIRECT_JSON,))
+
+
+def test_o7_model_authored_integrity_repair_is_rejected() -> None:
+    req = request()
+    bad = copy.deepcopy(response_for(req))
+    bad["receipt"]["model_authored_integrity_repair"] = True
+    negotiation = o7.negotiate_o7_capabilities(capability_surface())
+    with pytest.raises(o7.O7SemanticMismatch, match="prohibited"):
+        o7.normalize_r7_query(
+            req,
+            bad,
+            registry_identity=REGISTRY_IDENTITY,
+            negotiation=negotiation,
+            transport=o7.DIRECT_JSON,
+        )

--- a/tests/runtime/test_registry_o7_runtime_state.py
+++ b/tests/runtime/test_registry_o7_runtime_state.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+STATE = ROOT / "docs" / "architecture" / "contracts" / "registry-o7-runtime-state.v1.json"
+
+
+def test_o7_runtime_state_is_bound_to_verified_registry_r7_direct_surface() -> None:
+    state = json.loads(STATE.read_text(encoding="utf-8"))
+    assert state["schema_version"] == "orchestra.registry-o7-runtime-state.v1"
+    assert state["authority"] == "DESCRIPTIVE_NON_AUTHORIZING"
+    registry = state["registry_dependency"]
+    assert registry["canonical_commit_sha"] == "155c21ab54f704d876ae4a0c2d995f5591f13930"
+    assert registry["canonical_tree_sha"] == "ea99fce806a455c4c1e2c912277c44d3595f54d8"
+    assert registry["signature"] == "VERIFIED"
+    assert registry["canonical_validation"] == "PASS"
+    assert registry["entry_condition_satisfied"] is True
+
+
+def test_o7_runtime_state_preserves_future_release_and_mcp_gates() -> None:
+    state = json.loads(STATE.read_text(encoding="utf-8"))
+    phases = state["implementation"]["phases"]
+    assert all(phases[f"O7.{index}"] == "IMPLEMENTED" for index in range(1, 7))
+    assert phases["O7.7"] == "BLOCKED_PENDING_R7_7_AND_TRUSTED_RELEASE_INTEGRATION"
+    assert state["transport"]["registry_gateway_semantics_are_reimplemented_in_orchestra"] is False
+    assert state["transport"]["mcp_currently_available"] is False
+    assert state["release_boundary"]["trusted_registry_v0_4_0_published"] is False
+    assert state["release_boundary"]["joint_r7_o7_conformance_complete"] is False
+    assert state["authority_expansion"] is False


### PR DESCRIPTION
## Scope

Fresh signed materialization transport after the protected-main changelog-freshness failure on superseded PR #601.

### Exact remediated source
- canonical base: `92b7871aef8444d84f6859586b9cb801393fd386`
- source head: `e09e624f8501b4c17e335a1fbcb8b495d2abddb2`
- source tree: `f7de8fdb24889586bf62fe1759efb7148f7f0427`
- Registry dependency: `Baelfyre/Orchestra-Compliance-Registry@155c21ab54f704d876ae4a0c2d995f5591f13930`

### Remediation
Adds the focused root `CHANGELOG.md` entry required by strict repository governance for the significant O7 runtime and runtime-test changes. Runtime semantics remain the bounded O7.1-O7.6 implementation previously reviewed.

### Boundaries
No R7.7 MCP, trusted Registry v0.4.0 publication, R7.8 trusted-release integration, R7.9 benchmark, O7.7 joint conformance, release, deployment, or policy activation is claimed.

This PR targets an isolated `materialize/**` branch solely for signed materialization. Canonical promotion requires a new signed head and fresh protected-main validation.