### PR TITLE
feat(o7): canonicalize trusted Registry joint conformance

### DIFF
--- a/.github/workflows/registry-o7-joint-conformance.yml
+++ b/.github/workflows/registry-o7-joint-conformance.yml
@@ -1,0 +1,133 @@
+name: Registry O7 Joint Conformance
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/registry-o7-joint-conformance.yml"
+      - "scripts/validate_registry_o7_joint_conformance.py"
+      - "orchestra_runtime/registry_o7.py"
+      - "orchestra_runtime/registry_adaptive.py"
+      - "docs/architecture/contracts/registry-o7-runtime-state.v1.json"
+      - "tests/runtime/test_registry_o7_joint_conformance_contract.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/registry-o7-joint-conformance.yml"
+      - "scripts/validate_registry_o7_joint_conformance.py"
+      - "orchestra_runtime/registry_o7.py"
+      - "orchestra_runtime/registry_adaptive.py"
+      - "docs/architecture/contracts/registry-o7-runtime-state.v1.json"
+      - "tests/runtime/test_registry_o7_joint_conformance_contract.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  joint-conformance:
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY_REPOSITORY: Baelfyre/Orchestra-Compliance-Registry
+      REGISTRY_CODE_COMMIT: 4926a3b5f48122dd45f3c8e83a12b8d071dd5387
+      REGISTRY_CODE_TREE: 01be27bde90f6faa59ab74d60ba13af480c11b1d
+      REGISTRY_RELEASE_TAG: registry-v0.4.0
+      REGISTRY_RELEASE_SOURCE: 488c979b37dd84d8645fd8e6c288d297375c4e5b
+      REGISTRY_RELEASE_MANIFEST_SHA256: 040d6576cf10e9f7e3a9a051792869541c1d33b7af3c665fad8eecb939c7baaa
+      REGISTRY_BUNDLE_SHA256: e0457a75837d169d7bb8a7da14d8f4141d35a691952ff8f8978ef793e3cf92d3
+
+    steps:
+      - name: Checkout Orchestra
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Checkout exact Registry integration code
+        uses: actions/checkout@v4
+        with:
+          repository: Baelfyre/Orchestra-Compliance-Registry
+          ref: 4926a3b5f48122dd45f3c8e83a12b8d071dd5387
+          path: _registry
+          fetch-depth: 1
+
+      - name: Verify Registry integration code identity
+        shell: bash
+        run: |
+          test "$(git -C _registry rev-parse HEAD)" = "$REGISTRY_CODE_COMMIT"
+          test "$(git -C _registry rev-parse HEAD^{tree})" = "$REGISTRY_CODE_TREE"
+
+      - name: Install Registry MCP transport dependency
+        run: python -m pip install -r _registry/requirements-mcp.txt
+
+      - name: Verify immutable release and download exact assets
+        shell: bash
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import urllib.request
+          from pathlib import Path
+
+          repo = os.environ["REGISTRY_REPOSITORY"]
+          tag = os.environ["REGISTRY_RELEASE_TAG"]
+          source = os.environ["REGISTRY_RELEASE_SOURCE"]
+          manifest_sha = os.environ["REGISTRY_RELEASE_MANIFEST_SHA256"]
+          bundle_sha = os.environ["REGISTRY_BUNDLE_SHA256"]
+          headers = {"User-Agent": "Orchestra-O7-Joint-Conformance"}
+
+          def get_json(url: str):
+              request = urllib.request.Request(url, headers=headers)
+              with urllib.request.urlopen(request, timeout=30) as response:
+                  return json.load(response)
+
+          release = get_json(f"https://api.github.com/repos/{repo}/releases/tags/{tag}")
+          if release.get("tag_name") != tag:
+              raise SystemExit("Registry release tag mismatch")
+          if release.get("draft") is not False or release.get("prerelease") is not False or release.get("immutable") is not True:
+              raise SystemExit("Registry v0.4.0 is not published immutable non-prerelease")
+          ref = get_json(f"https://api.github.com/repos/{repo}/git/ref/tags/{tag}")
+          if ref.get("object", {}).get("sha") != source:
+              raise SystemExit("Registry v0.4.0 tag source drift")
+
+          required = {
+              "orchestra-compliance-registry.zip",
+              "orchestra-compliance-registry.zip.sha256",
+              "release-manifest.json",
+              "release-manifest.sha256",
+          }
+          assets = {item.get("name"): item for item in release.get("assets", [])}
+          if set(assets) != required:
+              raise SystemExit(f"Registry v0.4.0 asset set mismatch: {sorted(assets)}")
+          if assets["release-manifest.json"].get("digest") != f"sha256:{manifest_sha}":
+              raise SystemExit("Registry release-manifest asset digest drift")
+          if assets["orchestra-compliance-registry.zip"].get("digest") != f"sha256:{bundle_sha}":
+              raise SystemExit("Registry bundle asset digest drift")
+
+          target = Path("artifacts/registry-v0.4.0")
+          target.mkdir(parents=True, exist_ok=True)
+          for name in sorted(required):
+              request = urllib.request.Request(assets[name]["browser_download_url"], headers=headers)
+              with urllib.request.urlopen(request, timeout=60) as response:
+                  (target / name).write_bytes(response.read())
+          PY
+
+      - name: Validate O7.7 joint conformance
+        run: |
+          python scripts/validate_registry_o7_joint_conformance.py \
+            --registry-root _registry \
+            --release-assets artifacts/registry-v0.4.0 \
+            --output artifacts/o7-7-joint-conformance.json
+
+      - name: Run O7.7 contract tests
+        run: python -m unittest tests.runtime.test_registry_o7_joint_conformance_contract -v
+
+      - name: Preserve O7.7 joint conformance evidence
+        uses: actions/upload-artifact@v7
+        with:
+          name: registry-o7-joint-conformance-${{ github.sha }}
+          path: artifacts/o7-7-joint-conformance.json
+          if-no-files-found: error
+          retention-days: 90

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This root changelog is release-oriented. Detailed pre-v1.7 development chronology remains preserved byte-for-byte in [the historical changelog archive](docs/history/CHANGELOG_PRE_V1_7.md), Git history, merged pull requests, decision records, and validation evidence.
 
+## Post-v1.7 O7.7 trusted Registry joint conformance
+
+- Added an executable cross-repository O7.7 conformance gate against immutable `registry-v0.4.0`, exact release source `488c979b37dd84d8645fd8e6c288d297375c4e5b`, release-manifest SHA-256 `040d6576cf10e9f7e3a9a051792869541c1d33b7af3c665fad8eecb939c7baaa`, and bundle SHA-256 `e0457a75837d169d7bb8a7da14d8f4141d35a691952ff8f8978ef793e3cf92d3`.
+- Bound joint conformance to the validated post-release Registry runtime at commit `4926a3b5f48122dd45f3c8e83a12b8d071dd5387`, tree `01be27bde90f6faa59ab74d60ba13af480c11b1d`, including trusted direct-JSON identity verification without changing the immutable v0.4.0 release.
+- Verified the same privacy `EVIDENCE` query through trusted direct JSON, verified indexed gateway, and read-only MCP transport with semantic parity across records, source IDs, obligation IDs, query digest, freshness evidence, and normalized `ComplianceQueryReceipt` identity.
+- Preserved Registry canonical JSON as authority, retained O1-O6 fallback and fail-closed semantic/integrity behavior, and prohibited authority expansion and model-authored integrity repair.
+- The R7.9 benchmark did not establish token-efficiency benefit, so no token-efficiency claim is introduced. O7.7 conformance evidence does not itself authorize an Orchestra release, deployment, policy activation, installed-integration refresh, or any other protected action.
+
 ## Post-v1.7 O7.1-O7.6 Registry R7 direct consumption runtime
 
 - Integrated Orchestra O7.1 through O7.6 against the canonical Registry R7.1-R7.6 stable direct surface at commit `155c21ab54f704d876ae4a0c2d995f5591f13930`, tree `ea99fce806a455c4c1e2c912277c44d3595f54d8`, without reimplementing Registry-owned query semantics in Orchestra.

--- a/README.json
+++ b/README.json
@@ -580,14 +580,15 @@
       "authority_note": "Registry capability, freshness, delta, and routing evidence cannot expand Orchestra authority, publish Registry state, bypass Conductor routing, or replace Governor/Steward/Arbiter evidence controls."
     },
     "registry_query_optimization_o7": {
-      "status": "O7_1_O7_6_IMPLEMENTED_PENDING_CANONICALIZATION",
+      "status": "O7_1_O7_7_IMPLEMENTED_JOINT_CONFORMANCE_PASS_PENDING_CANONICALIZATION",
       "purpose": "Consume the Registry R7 typed/indexed/projection query gateway using the smallest sufficient context while preserving O1-O6 semantics, exact Registry identities, existing compliance receipts, and fail-closed behavior.",
       "runtime_surface": "orchestra_runtime/registry_o7.py",
       "machine_sources": ["docs/architecture/contracts/registry-o7-runtime-state.v1.json"],
       "human_sources": ["docs/architecture/REGISTRY_QUERY_OPTIMIZATION_O7.md"],
-      "validation_surfaces": ["tests/runtime/test_registry_o7.py", "tests/runtime/test_registry_o7_runtime_state.py"],
+      "validation_surfaces": ["tests/runtime/test_registry_o7.py", "tests/runtime/test_registry_o7_runtime_state.py", "tests/runtime/test_registry_o7_joint_conformance_contract.py"],
       "registry_r7_1_r7_6_canonical": {"repository": "Baelfyre/Orchestra-Compliance-Registry", "sha": "155c21ab54f704d876ae4a0c2d995f5591f13930", "tree": "ea99fce806a455c4c1e2c912277c44d3595f54d8", "surface_status": "IMPLEMENTED_STABLE_DIRECT_SURFACE_R7_1_R7_6"},
-      "implementation_order": "O7_1_O7_6_IMPLEMENTED_AFTER_STABLE_REGISTRY_R7_SURFACE",
+      "registry_r7_trusted_release": {"repository": "Baelfyre/Orchestra-Compliance-Registry", "release_tag": "registry-v0.4.0", "release_source_sha": "488c979b37dd84d8645fd8e6c288d297375c4e5b", "release_manifest_sha256": "040d6576cf10e9f7e3a9a051792869541c1d33b7af3c665fad8eecb939c7baaa", "bundle_sha256": "e0457a75837d169d7bb8a7da14d8f4141d35a691952ff8f8978ef793e3cf92d3", "post_release_runtime_sha": "4926a3b5f48122dd45f3c8e83a12b8d071dd5387", "post_release_runtime_tree": "01be27bde90f6faa59ab74d60ba13af480c11b1d", "publication_state": "PUBLISHED_IMMUTABLE_VERIFIED"},
+      "implementation_order": "O7_1_O7_6_CANONICAL_THEN_O7_7_VERIFIED_AGAINST_TRUSTED_REGISTRY_V0_4_0",
       "required_compatibility_floor": {"cap.query.v1": "1.0.0"},
       "planned_optional_capabilities": ["cap.query.projection.v1", "cap.query.relationships.v1", "cap.query.indexed-read.v1", "cap.query.budget.v1", "cap.transport.mcp.v1"],
       "preferred_transport_order": ["DIRECT_LOCAL_INDEXED_GATEWAY", "DIRECT_LOCAL_JSON_QUERY", "OPTIONAL_MCP_TRANSPORT"],
@@ -597,7 +598,7 @@
       "frozen_invariants": ["O1_CAPABILITY_NEGOTIATION", "O2_COMPATIBILITY_FAIL_CLOSED", "O3_QUERY_SEMANTICS", "O4_QUERY_SCOPED_FRESHNESS", "O5_RELEASE_DELTA", "O6_DOMAIN_ROUTING", "CONDUCTOR_EXCLUSIVE_ROUTING", "GOVERNOR_APPLICABILITY", "STEWARD_TRACEABILITY", "ARBITER_SET_EQUALITY"],
       "planned_release_target": "v1.8.0_AFTER_REGISTRY_R7_TRUSTED_RELEASE_AND_JOINT_CONFORMANCE",
       "token_efficiency_claim": "NOT_CLAIMED_UNTIL_MEASURED",
-      "authority_note": "O7 is a planned read-path optimization only. MCP remains transport, the Registry index remains derived, query/projection choice cannot change compliance meaning, and no O7 path may expand authority or bypass existing evidence gates."
+      "authority_note": "O7.1-O7.6 are canonical read-path optimizations and O7.7 joint conformance has passed against immutable Registry v0.4.0. MCP remains transport, the Registry index remains derived, query/projection choice cannot change compliance meaning, and O7 evidence grants no merge, release, deployment, policy, or other protected-action authority."
     },
     "comparative_measurement_codex_c2_portability_r1": {
       "status": "C2R1_EXECUTION_COMPLETE_RECONCILED_CANONICAL",
@@ -912,7 +913,7 @@
     "codex_baseline_readiness": "SUPERSEDED_BY_C1_C2R1_COMPLETED_RECONCILIATIONS",
     "codex_c1_cross_provider_reconciliation": "C1_COMPLETE_RECONCILED_CALIBRATION_ONLY",
     "registry_adaptive_consumption_o1_o6": "CANONICAL_IMPLEMENTED_VALIDATED_AND_REGISTRY_RECONCILED",
-    "registry_query_optimization_o7": "O7_1_O7_6_IMPLEMENTED_PENDING_CANONICALIZATION_O7_7_BLOCKED",
+    "registry_query_optimization_o7": "O7_1_O7_7_IMPLEMENTED_JOINT_CONFORMANCE_PASS_PENDING_CANONICALIZATION",
     "murmurs_live_host_token_measurement": "B3_TERMINAL_EVIDENCE_RECONCILED_BENEFIT_NOT_ESTABLISHED",
     "codex_c2_portability_r1": "C2R1_EXECUTION_COMPLETE_RECONCILED_CANONICAL"
   },

--- a/docs/architecture/contracts/registry-o7-runtime-state.v1.json
+++ b/docs/architecture/contracts/registry-o7-runtime-state.v1.json
@@ -3,33 +3,50 @@
   "authority": "DESCRIPTIVE_NON_AUTHORIZING",
   "orchestra_baseline": {
     "repository": "Baelfyre/Orchestra",
-    "base_commit_sha": "92b7871aef8444d84f6859586b9cb801393fd386",
-    "base_tree_sha": "037ab47a6003e78b8df868848978be219a896d6e",
-    "o7_0": "MERGED_VERIFIED"
+    "base_commit_sha": "6428a02b9b4a89a467c3fe7443e9478dbef79989",
+    "base_tree_sha": "dce106063f23dde35c60e15b384530c6188393aa",
+    "o7_0": "MERGED_VERIFIED",
+    "o7_1_o7_6": "CANONICAL_MERGED_VERIFIED"
   },
   "registry_dependency": {
     "repository": "Baelfyre/Orchestra-Compliance-Registry",
-    "canonical_commit_sha": "155c21ab54f704d876ae4a0c2d995f5591f13930",
-    "canonical_tree_sha": "ea99fce806a455c4c1e2c912277c44d3595f54d8",
+    "canonical_commit_sha": "4926a3b5f48122dd45f3c8e83a12b8d071dd5387",
+    "canonical_tree_sha": "01be27bde90f6faa59ab74d60ba13af480c11b1d",
     "signature": "VERIFIED",
     "canonical_validation": "PASS",
-    "surface_status": "IMPLEMENTED_STABLE_DIRECT_SURFACE_R7_1_R7_6",
-    "entry_condition": "IMPLEMENTED_STABLE_REGISTRY_R7_SURFACE_REQUIRED",
+    "surface_status": "R7_1_R7_9_IMPLEMENTED_WITH_TRUSTED_DIRECT_JSON_IDENTITY_REMEDIATION",
+    "entry_condition": "TRUSTED_REGISTRY_V0_4_0_AND_POST_RELEASE_R7_RUNTIME_REQUIRED",
     "entry_condition_satisfied": true
   },
+  "trusted_release": {
+    "release_tag": "registry-v0.4.0",
+    "registry_version": "0.4.0",
+    "release_sequence": 4,
+    "source_commit_sha": "488c979b37dd84d8645fd8e6c288d297375c4e5b",
+    "source_tree_sha": "0d3bbf34ec7ab7e4833fba225aba96b829de1cec",
+    "release_manifest_sha256": "040d6576cf10e9f7e3a9a051792869541c1d33b7af3c665fad8eecb939c7baaa",
+    "bundle_sha256": "e0457a75837d169d7bb8a7da14d8f4141d35a691952ff8f8978ef793e3cf92d3",
+    "release_id": 378292109,
+    "draft": false,
+    "prerelease": false,
+    "immutable": true,
+    "publication_state": "PUBLISHED_IMMUTABLE_VERIFIED"
+  },
   "implementation": {
-    "status": "O7_1_O7_6_IMPLEMENTED_PENDING_CANONICALIZATION",
+    "status": "O7_1_O7_7_IMPLEMENTED_JOINT_CONFORMANCE_PASS_PENDING_CANONICALIZATION",
     "phases": {
-      "O7.1": "IMPLEMENTED",
-      "O7.2": "IMPLEMENTED",
-      "O7.3": "IMPLEMENTED",
-      "O7.4": "IMPLEMENTED",
-      "O7.5": "IMPLEMENTED",
-      "O7.6": "IMPLEMENTED",
-      "O7.7": "BLOCKED_PENDING_R7_7_AND_TRUSTED_RELEASE_INTEGRATION"
+      "O7.1": "CANONICAL_MERGED_VERIFIED",
+      "O7.2": "CANONICAL_MERGED_VERIFIED",
+      "O7.3": "CANONICAL_MERGED_VERIFIED",
+      "O7.4": "CANONICAL_MERGED_VERIFIED",
+      "O7.5": "CANONICAL_MERGED_VERIFIED",
+      "O7.6": "CANONICAL_MERGED_VERIFIED",
+      "O7.7": "JOINT_CONFORMANCE_PASS_PENDING_SIGNED_MATERIALIZATION_AND_CANONICALIZATION"
     },
     "runtime_module": "orchestra_runtime/registry_o7.py",
-    "test_module": "tests/runtime/test_registry_o7.py"
+    "joint_conformance_validator": "scripts/validate_registry_o7_joint_conformance.py",
+    "runtime_test_module": "tests/runtime/test_registry_o7.py",
+    "joint_contract_test_module": "tests/runtime/test_registry_o7_joint_conformance_contract.py"
   },
   "transport": {
     "preference": [
@@ -40,7 +57,10 @@
     "registry_gateway_semantics_are_reimplemented_in_orchestra": false,
     "registry_gateway_is_injected_consumer_boundary": true,
     "legacy_o1_o6_fallback_preserved": true,
-    "mcp_currently_available": false
+    "trusted_direct_json_available": true,
+    "trusted_indexed_available": true,
+    "mcp_currently_available": true,
+    "mcp_read_only": true
   },
   "compatibility": {
     "required_capability": "cap.query.v1>=1.0.0",
@@ -58,12 +78,42 @@
     "index_mismatch_disposition": "REJECT_INDEX_THEN_DIRECT_JSON_OR_LEGACY_FALLBACK",
     "semantic_query_mismatch_disposition": "FAIL_CLOSED",
     "result_digest_mismatch_disposition": "FAIL_CLOSED",
+    "trusted_direct_json_identity_required": true,
+    "trusted_release_manifest_digest_required": true,
     "model_authored_integrity_repair_allowed": false
   },
+  "joint_conformance": {
+    "workflow": ".github/workflows/registry-o7-joint-conformance.yml",
+    "required_transports": [
+      "DIRECT_LOCAL_JSON_QUERY",
+      "DIRECT_LOCAL_INDEXED_GATEWAY",
+      "OPTIONAL_MCP_TRANSPORT"
+    ],
+    "same_release_identity_required": true,
+    "semantic_parity_required": true,
+    "exact_source_and_obligation_identity_required": true,
+    "freshness_parity_required": true,
+    "normalized_compliance_query_receipt_required": true,
+    "authority_expansion_allowed": false,
+    "canonicalization_requires_gate_pass": true,
+    "latest_evidence_status": "PASS",
+    "latest_evidence_workflow_run_id": 33153052348,
+    "latest_evidence_source_head": "226918a47bbfc7616ab0d92d3423c721b6c0cf2c"
+  },
+  "benchmark_boundary": {
+    "r7_9_complete": true,
+    "projected_byte_benefit_established": false,
+    "token_efficiency_established": false,
+    "token_efficiency_claim_allowed": false,
+    "reason": "HOST_REPORTED_INPUT_TOKENS_UNAVAILABLE_AND_MEASURED_PROJECTED_BYTE_BENEFIT_NOT_ESTABLISHED"
+  },
   "release_boundary": {
-    "trusted_registry_v0_4_0_published": false,
-    "r7_7_mcp_implemented": false,
-    "joint_r7_o7_conformance_complete": false,
+    "trusted_registry_v0_4_0_published": true,
+    "trusted_registry_v0_4_0_immutable_verified": true,
+    "r7_7_mcp_implemented": true,
+    "r7_8_trusted_release_integration_implemented": true,
+    "r7_9_benchmark_complete": true,
+    "joint_r7_o7_conformance_complete": true,
     "orchestra_release_integration_authorized_by_this_state": false
   },
   "authority_expansion": false

--- a/scripts/validate_registry_o7_joint_conformance.py
+++ b/scripts/validate_registry_o7_joint_conformance.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Validate Orchestra O7.7 against the immutable Registry v0.4.0 release.
+
+The Registry owns R7 query/index/MCP semantics. This validator binds the Registry
+implementation at the integration boundary, verifies the immutable trusted release,
+and requires direct JSON, indexed, and MCP consumption to normalize through the
+existing Orchestra O7 runtime without authority expansion.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Mapping
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from orchestra_runtime import registry_adaptive, registry_o7
+
+ORCHESTRA_BASE_COMMIT = "6428a02b9b4a89a467c3fe7443e9478dbef79989"
+REGISTRY_CODE_COMMIT = "4926a3b5f48122dd45f3c8e83a12b8d071dd5387"
+REGISTRY_CODE_TREE = "01be27bde90f6faa59ab74d60ba13af480c11b1d"
+TRUSTED_RELEASE_TAG = "registry-v0.4.0"
+TRUSTED_RELEASE_SOURCE_COMMIT = "488c979b37dd84d8645fd8e6c288d297375c4e5b"
+TRUSTED_RELEASE_MANIFEST_SHA256 = "040d6576cf10e9f7e3a9a051792869541c1d33b7af3c665fad8eecb939c7baaa"
+TRUSTED_RELEASE_BUNDLE_SHA256 = "e0457a75837d169d7bb8a7da14d8f4141d35a691952ff8f8978ef793e3cf92d3"
+
+
+class JointConformanceError(RuntimeError):
+    pass
+
+
+def _registry_modules(registry_root: Path):
+    registry_root = registry_root.resolve()
+    if str(registry_root) not in sys.path:
+        sys.path.insert(0, str(registry_root))
+    from scripts import r7_mcp_server, r7_query_gateway, r7_trusted_release  # type: ignore
+
+    return r7_mcp_server, r7_query_gateway, r7_trusted_release
+
+
+def _query_spec(module: Any, request: Mapping[str, Any]):
+    filters = request.get("filters")
+    if not isinstance(filters, Mapping):
+        raise JointConformanceError("O7 gateway request filters must be an object")
+    fields = request.get("fields", [])
+    if not isinstance(fields, list):
+        raise JointConformanceError("O7 gateway request fields must be an array")
+    return module.QuerySpec(
+        record_type=request["record_type"],
+        domain=filters.get("domain"),
+        jurisdiction=filters.get("jurisdiction"),
+        provider=filters.get("provider"),
+        source_id=filters.get("source_id"),
+        obligation_id=filters.get("obligation_id"),
+        projection=request["projection"],
+        fields=tuple(fields),
+        include_freshness=request["include_freshness"],
+        limit=request["limit"],
+        cursor=request["cursor"],
+        maximum_context_bytes=request["maximum_context_bytes"],
+        representation=request["representation"],
+    )
+
+
+def _mcp_arguments(request: Mapping[str, Any]) -> dict[str, Any]:
+    filters = request["filters"]
+    return {
+        "record_type": request["record_type"],
+        "domain": filters.get("domain"),
+        "jurisdiction": filters.get("jurisdiction"),
+        "provider": filters.get("provider"),
+        "source_id": filters.get("source_id"),
+        "obligation_id": filters.get("obligation_id"),
+        "projection": request["projection"],
+        "fields": request["fields"],
+        "include_freshness": request["include_freshness"],
+        "limit": request["limit"],
+        "cursor": request["cursor"],
+        "maximum_context_bytes": request["maximum_context_bytes"],
+        "representation": request["representation"],
+    }
+
+
+def _assert_same_semantics(label: str, left: Mapping[str, Any], right: Mapping[str, Any]) -> None:
+    for key in ("records", "source_ids", "obligation_ids", "query_digest", "freshness_evidence"):
+        if left.get(key) != right.get(key):
+            raise JointConformanceError(f"{label} semantic mismatch for {key}")
+    if left.get("authority_expansion") is not False or right.get("authority_expansion") is not False:
+        raise JointConformanceError(f"{label} attempted authority expansion")
+    if left.get("model_authored_integrity_repair") is not False or right.get("model_authored_integrity_repair") is not False:
+        raise JointConformanceError(f"{label} permitted model-authored integrity repair")
+
+
+def run_conformance(registry_root: Path, release_assets: Path) -> dict[str, Any]:
+    r7_mcp_server, r7_query_gateway, r7_trusted_release = _registry_modules(registry_root)
+    release_assets = release_assets.resolve()
+    verified = r7_trusted_release.verify_release_assets(release_assets)
+    if verified.registry_version != "0.4.0" or verified.release_sequence != 4 or verified.release_tag != TRUSTED_RELEASE_TAG:
+        raise JointConformanceError("trusted Registry v0.4.0 identity mismatch")
+    if verified.release_manifest_sha256 != TRUSTED_RELEASE_MANIFEST_SHA256:
+        raise JointConformanceError("trusted Registry release-manifest digest mismatch")
+    if verified.bundle_sha256 != TRUSTED_RELEASE_BUNDLE_SHA256:
+        raise JointConformanceError("trusted Registry bundle digest mismatch")
+
+    with tempfile.TemporaryDirectory(prefix="orchestra-o7-joint-") as name:
+        temp = Path(name)
+        installed = temp / "registry-v0.4.0"
+        verified, installed_root = r7_trusted_release.install_release(release_assets, installed)
+        index_path = temp / "registry-r7.sqlite"
+        cache = r7_trusted_release.build_verified_index(
+            installed_root,
+            index_path,
+            TRUSTED_RELEASE_MANIFEST_SHA256,
+        )
+        if cache.get("authority_expansion") is not False or cache.get("canonical_json_remains_authority") is not True:
+            raise JointConformanceError("Registry cache evidence changed authority semantics")
+
+        direct_gateway = r7_query_gateway.RegistryQueryGateway(
+            installed_root,
+            release_identity=verified.identity,
+            contract_root=registry_root,
+        )
+        indexed_gateway = r7_query_gateway.RegistryQueryGateway(
+            installed_root,
+            index_path=index_path,
+            release_identity=verified.identity,
+            contract_root=registry_root,
+        )
+        mcp_adapter = r7_mcp_server.RegistryMcpAdapter(indexed_gateway)
+        status = mcp_adapter.registry_status()
+        if status.get("authority_expansion") is not False or status.get("registry_mutation") is not False:
+            raise JointConformanceError("Registry MCP status violated read-only boundary")
+        if status.get("mcp_capability") != "cap.transport.mcp.v1":
+            raise JointConformanceError("Registry MCP capability mismatch")
+
+        capability_surface = registry_adaptive.load_capability_surface(installed_root, verified.registry_version)
+        registry_identity = {
+            "canonical_repository": registry_o7.CANONICAL_REPOSITORY,
+            "registry_version": verified.registry_version,
+            "release_sequence": verified.release_sequence,
+            "release_tag": verified.release_tag,
+            "manifest_sha256": verified.release_manifest_sha256,
+        }
+        request = registry_o7.O7QueryRequest(
+            workflow_stage="steward_requirements_traceability",
+            domains=("privacy",),
+            projection="EVIDENCE",
+            limit=100,
+            representation="JSON",
+        )
+
+        def legacy_query(_: registry_o7.O7QueryRequest) -> Mapping[str, Any]:
+            raise JointConformanceError("O7.7 conformance unexpectedly entered legacy O1-O6 fallback")
+
+        def gateway_call(transport: str, payload: Mapping[str, Any]) -> Mapping[str, Any]:
+            if transport == registry_o7.DIRECT_JSON:
+                return direct_gateway.query(_query_spec(r7_query_gateway, payload))
+            if transport == registry_o7.DIRECT_INDEXED:
+                return indexed_gateway.query(_query_spec(r7_query_gateway, payload))
+            if transport == registry_o7.OPTIONAL_MCP:
+                return mcp_adapter.registry_query(**_mcp_arguments(payload))
+            raise JointConformanceError(f"unexpected O7 transport: {transport}")
+
+        direct = registry_o7.execute_o7_query(
+            request,
+            capability_surface=capability_surface,
+            registry_identity=registry_identity,
+            available_transports=(registry_o7.DIRECT_JSON,),
+            r7_gateway=gateway_call,
+            legacy_query=legacy_query,
+        )
+        indexed = registry_o7.execute_o7_query(
+            request,
+            capability_surface=capability_surface,
+            registry_identity=registry_identity,
+            available_transports=(registry_o7.DIRECT_INDEXED, registry_o7.DIRECT_JSON),
+            r7_gateway=gateway_call,
+            legacy_query=legacy_query,
+        )
+        mcp_request = registry_o7.O7QueryRequest(
+            workflow_stage=request.workflow_stage,
+            domains=request.domains,
+            projection=request.projection,
+            limit=request.limit,
+            representation=request.representation,
+            explicit_mcp=True,
+        )
+        mcp = registry_o7.execute_o7_query(
+            mcp_request,
+            capability_surface=capability_surface,
+            registry_identity=registry_identity,
+            available_transports=(registry_o7.DIRECT_INDEXED, registry_o7.DIRECT_JSON, registry_o7.OPTIONAL_MCP),
+            r7_gateway=gateway_call,
+            legacy_query=legacy_query,
+        )
+
+        expected_transports = {
+            "direct": (direct, registry_o7.DIRECT_JSON),
+            "indexed": (indexed, registry_o7.DIRECT_INDEXED),
+            "mcp": (mcp, registry_o7.OPTIONAL_MCP),
+        }
+        for label, (result, transport) in expected_transports.items():
+            if result.get("mode") != "R7_OPTIMIZED" or result.get("transport") != transport:
+                raise JointConformanceError(f"{label} did not use expected R7 optimized transport")
+            receipt = result.get("compliance_query_receipt")
+            if not isinstance(receipt, Mapping):
+                raise JointConformanceError(f"{label} missing normalized ComplianceQueryReceipt")
+            if receipt.get("registry_version") != "0.4.0" or receipt.get("release_sequence") != 4:
+                raise JointConformanceError(f"{label} normalized receipt Registry identity mismatch")
+            if receipt.get("release_tag") != TRUSTED_RELEASE_TAG or receipt.get("manifest_sha256") != TRUSTED_RELEASE_MANIFEST_SHA256:
+                raise JointConformanceError(f"{label} normalized receipt release identity mismatch")
+
+        _assert_same_semantics("direct/indexed", direct, indexed)
+        _assert_same_semantics("indexed/MCP", indexed, mcp)
+        if not direct.get("records"):
+            raise JointConformanceError("O7.7 privacy conformance query returned no records")
+
+        evidence = {
+            "schema_version": "orchestra.registry-o7-joint-conformance.v1",
+            "authority": "EVIDENCE_ONLY_NON_AUTHORIZING",
+            "status": "PASS",
+            "orchestra": {
+                "repository": "Baelfyre/Orchestra",
+                "base_commit": ORCHESTRA_BASE_COMMIT,
+            },
+            "registry_code": {
+                "repository": "Baelfyre/Orchestra-Compliance-Registry",
+                "commit": REGISTRY_CODE_COMMIT,
+                "tree": REGISTRY_CODE_TREE,
+            },
+            "trusted_release": {
+                "tag": TRUSTED_RELEASE_TAG,
+                "source_commit": TRUSTED_RELEASE_SOURCE_COMMIT,
+                "registry_version": verified.registry_version,
+                "release_sequence": verified.release_sequence,
+                "release_manifest_sha256": verified.release_manifest_sha256,
+                "bundle_sha256": verified.bundle_sha256,
+                "immutable_release_required": True,
+            },
+            "transports": {
+                "direct_json": "PASS",
+                "indexed": "PASS",
+                "mcp_read_only": "PASS",
+                "semantic_parity": "PASS",
+            },
+            "normalized_record_count": len(direct["records"]),
+            "source_ids": direct["source_ids"],
+            "obligation_ids": direct["obligation_ids"],
+            "query_digest": direct["query_digest"],
+            "authority_expansion": False,
+            "model_authored_integrity_repair": False,
+            "canonical_registry_json_remains_authority": True,
+        }
+        return evidence
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate Registry R7 and Orchestra O7.7 joint conformance")
+    parser.add_argument("--registry-root", type=Path, required=True)
+    parser.add_argument("--release-assets", type=Path, required=True)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        evidence = run_conformance(args.registry_root, args.release_assets)
+        encoded = json.dumps(evidence, indent=2, sort_keys=True) + "\n"
+        if args.output is not None:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(encoded, encoding="utf-8")
+        print(encoded, end="")
+        return 0
+    except Exception as exc:
+        print(f"ORCHESTRA_O7_7_JOINT_CONFORMANCE_FAIL={exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/runtime/test_registry_o7_joint_conformance_contract.py
+++ b/tests/runtime/test_registry_o7_joint_conformance_contract.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+STATE = ROOT / "docs" / "architecture" / "contracts" / "registry-o7-runtime-state.v1.json"
+WORKFLOW = ROOT / ".github" / "workflows" / "registry-o7-joint-conformance.yml"
+VALIDATOR = ROOT / "scripts" / "validate_registry_o7_joint_conformance.py"
+
+
+class RegistryO7JointConformanceContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.state = json.loads(STATE.read_text(encoding="utf-8"))
+
+    def test_trusted_release_identity_is_frozen(self) -> None:
+        release = self.state["trusted_release"]
+        self.assertEqual("registry-v0.4.0", release["release_tag"])
+        self.assertEqual("0.4.0", release["registry_version"])
+        self.assertEqual(4, release["release_sequence"])
+        self.assertEqual("488c979b37dd84d8645fd8e6c288d297375c4e5b", release["source_commit_sha"])
+        self.assertEqual("040d6576cf10e9f7e3a9a051792869541c1d33b7af3c665fad8eecb939c7baaa", release["release_manifest_sha256"])
+        self.assertEqual("e0457a75837d169d7bb8a7da14d8f4141d35a691952ff8f8978ef793e3cf92d3", release["bundle_sha256"])
+        self.assertTrue(release["immutable"])
+        self.assertFalse(release["draft"])
+        self.assertFalse(release["prerelease"])
+
+    def test_registry_post_release_runtime_is_frozen(self) -> None:
+        dependency = self.state["registry_dependency"]
+        self.assertEqual("4926a3b5f48122dd45f3c8e83a12b8d071dd5387", dependency["canonical_commit_sha"])
+        self.assertEqual("01be27bde90f6faa59ab74d60ba13af480c11b1d", dependency["canonical_tree_sha"])
+        self.assertEqual("VERIFIED", dependency["signature"])
+        self.assertEqual("PASS", dependency["canonical_validation"])
+
+    def test_three_transport_gate_is_fail_closed_and_non_authorizing(self) -> None:
+        conformance = self.state["joint_conformance"]
+        self.assertEqual(
+            ["DIRECT_LOCAL_JSON_QUERY", "DIRECT_LOCAL_INDEXED_GATEWAY", "OPTIONAL_MCP_TRANSPORT"],
+            conformance["required_transports"],
+        )
+        self.assertTrue(conformance["same_release_identity_required"])
+        self.assertTrue(conformance["semantic_parity_required"])
+        self.assertTrue(conformance["exact_source_and_obligation_identity_required"])
+        self.assertTrue(conformance["freshness_parity_required"])
+        self.assertTrue(conformance["normalized_compliance_query_receipt_required"])
+        self.assertFalse(conformance["authority_expansion_allowed"])
+        self.assertTrue(conformance["canonicalization_requires_gate_pass"])
+        self.assertFalse(self.state["authority_expansion"])
+        self.assertFalse(self.state["release_boundary"]["orchestra_release_integration_authorized_by_this_state"])
+
+    def test_mcp_is_optional_read_only_transport(self) -> None:
+        self.assertIn("cap.transport.mcp.v1>=1.0.0", self.state["compatibility"]["r7_optional_capabilities"])
+        self.assertTrue(self.state["transport"]["mcp_currently_available"])
+        self.assertTrue(self.state["transport"]["mcp_read_only"])
+        self.assertFalse(self.state["transport"]["registry_gateway_semantics_are_reimplemented_in_orchestra"])
+
+    def test_benchmark_does_not_overclaim_efficiency(self) -> None:
+        boundary = self.state["benchmark_boundary"]
+        self.assertTrue(boundary["r7_9_complete"])
+        self.assertFalse(boundary["projected_byte_benefit_established"])
+        self.assertFalse(boundary["token_efficiency_established"])
+        self.assertFalse(boundary["token_efficiency_claim_allowed"])
+
+    def test_workflow_and_validator_bind_exact_cross_repo_identities(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        validator = VALIDATOR.read_text(encoding="utf-8")
+        for token in (
+            "4926a3b5f48122dd45f3c8e83a12b8d071dd5387",
+            "01be27bde90f6faa59ab74d60ba13af480c11b1d",
+            "registry-v0.4.0",
+            "488c979b37dd84d8645fd8e6c288d297375c4e5b",
+            "040d6576cf10e9f7e3a9a051792869541c1d33b7af3c665fad8eecb939c7baaa",
+            "e0457a75837d169d7bb8a7da14d8f4141d35a691952ff8f8978ef793e3cf92d3",
+        ):
+            self.assertIn(token, workflow)
+            self.assertIn(token, validator)
+        self.assertIn("RegistryMcpAdapter", validator)
+        self.assertIn("DIRECT_JSON", validator)
+        self.assertIn("DIRECT_INDEXED", validator)
+        self.assertIn("OPTIONAL_MCP", validator)
+        self.assertIn("canonical_registry_json_remains_authority", validator)
+        self.assertIn('workflow_stage="steward_requirements_traceability"', validator)
+
+    def test_completed_state_cannot_precede_trusted_release(self) -> None:
+        complete = self.state["release_boundary"]["joint_r7_o7_conformance_complete"]
+        self.assertIsInstance(complete, bool)
+        if complete:
+            self.assertTrue(self.state["release_boundary"]["trusted_registry_v0_4_0_published"])
+            self.assertTrue(self.state["release_boundary"]["trusted_registry_v0_4_0_immutable_verified"])
+            self.assertTrue(self.state["release_boundary"]["r7_7_mcp_implemented"])
+            self.assertTrue(self.state["release_boundary"]["r7_8_trusted_release_integration_implemented"])
+            self.assertTrue(self.state["release_boundary"]["r7_9_benchmark_complete"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runtime/test_registry_o7_runtime_state.py
+++ b/tests/runtime/test_registry_o7_runtime_state.py
@@ -7,25 +7,35 @@ ROOT = Path(__file__).resolve().parents[2]
 STATE = ROOT / "docs" / "architecture" / "contracts" / "registry-o7-runtime-state.v1.json"
 
 
-def test_o7_runtime_state_is_bound_to_verified_registry_r7_direct_surface() -> None:
+def test_o7_runtime_state_is_bound_to_verified_registry_r7_trusted_surface() -> None:
     state = json.loads(STATE.read_text(encoding="utf-8"))
     assert state["schema_version"] == "orchestra.registry-o7-runtime-state.v1"
     assert state["authority"] == "DESCRIPTIVE_NON_AUTHORIZING"
     registry = state["registry_dependency"]
-    assert registry["canonical_commit_sha"] == "155c21ab54f704d876ae4a0c2d995f5591f13930"
-    assert registry["canonical_tree_sha"] == "ea99fce806a455c4c1e2c912277c44d3595f54d8"
+    assert registry["canonical_commit_sha"] == "4926a3b5f48122dd45f3c8e83a12b8d071dd5387"
+    assert registry["canonical_tree_sha"] == "01be27bde90f6faa59ab74d60ba13af480c11b1d"
     assert registry["signature"] == "VERIFIED"
     assert registry["canonical_validation"] == "PASS"
     assert registry["entry_condition_satisfied"] is True
+    release = state["trusted_release"]
+    assert release["release_tag"] == "registry-v0.4.0"
+    assert release["registry_version"] == "0.4.0"
+    assert release["release_sequence"] == 4
+    assert release["publication_state"] == "PUBLISHED_IMMUTABLE_VERIFIED"
+    assert release["immutable"] is True
 
 
-def test_o7_runtime_state_preserves_future_release_and_mcp_gates() -> None:
+def test_o7_runtime_state_records_verified_joint_conformance_without_authority_expansion() -> None:
     state = json.loads(STATE.read_text(encoding="utf-8"))
     phases = state["implementation"]["phases"]
-    assert all(phases[f"O7.{index}"] == "IMPLEMENTED" for index in range(1, 7))
-    assert phases["O7.7"] == "BLOCKED_PENDING_R7_7_AND_TRUSTED_RELEASE_INTEGRATION"
+    assert all(phases[f"O7.{index}"] == "CANONICAL_MERGED_VERIFIED" for index in range(1, 7))
+    assert phases["O7.7"] == "JOINT_CONFORMANCE_PASS_PENDING_SIGNED_MATERIALIZATION_AND_CANONICALIZATION"
     assert state["transport"]["registry_gateway_semantics_are_reimplemented_in_orchestra"] is False
-    assert state["transport"]["mcp_currently_available"] is False
-    assert state["release_boundary"]["trusted_registry_v0_4_0_published"] is False
-    assert state["release_boundary"]["joint_r7_o7_conformance_complete"] is False
+    assert state["transport"]["mcp_currently_available"] is True
+    assert state["transport"]["mcp_read_only"] is True
+    assert state["release_boundary"]["trusted_registry_v0_4_0_published"] is True
+    assert state["release_boundary"]["trusted_registry_v0_4_0_immutable_verified"] is True
+    assert state["release_boundary"]["joint_r7_o7_conformance_complete"] is True
+    assert state["release_boundary"]["orchestra_release_integration_authorized_by_this_state"] is False
+    assert state["joint_conformance"]["latest_evidence_status"] == "PASS"
     assert state["authority_expansion"] is False


### PR DESCRIPTION
## Canonical O7.7 promotion

Promote the exact GitHub-signed O7.7 materialization after verified cross-repository conformance against immutable Registry `registry-v0.4.0`.

### Exact Orchestra identities
- canonical base: `6428a02b9b4a89a467c3fe7443e9478dbef79989`
- signed materialized head: `ff45a97e7b388f712904b35ec6012e16dc8d1271`
- materialized tree: `f6422410a1c440fe51c5e5aeca718ca3d4402928`
- reviewed unsigned source tree: `f6422410a1c440fe51c5e5aeca718ca3d4402928`
- signature: GitHub VERIFIED
- materialized parent: exact canonical base

### Trusted Registry dependency
- release: `registry-v0.4.0`
- release source: `488c979b37dd84d8645fd8e6c288d297375c4e5b`
- release manifest SHA-256: `040d6576cf10e9f7e3a9a051792869541c1d33b7af3c665fad8eecb939c7baaa`
- bundle SHA-256: `e0457a75837d169d7bb8a7da14d8f4141d35a691952ff8f8978ef793e3cf92d3`
- post-release Registry runtime: `4926a3b5f48122dd45f3c8e83a12b8d071dd5387`, tree `01be27bde90f6faa59ab74d60ba13af480c11b1d`

### O7.7 evidence
The executable joint-conformance gate validates trusted direct JSON, verified indexed gateway, and read-only MCP transport against the same immutable release. Records, source IDs, obligation IDs, query digest, freshness evidence, trusted release identity, and normalized `ComplianceQueryReceipt` semantics must match. Registry canonical JSON remains authority. Authority expansion and model-authored integrity repair remain forbidden.

### Validation boundary
This canonical PR must rerun the full protected-main exact-head matrix. Materialization evidence is not reused as canonical readiness. Merge is permitted only if every required/applicable check is terminal green, the PR is mergeable/clean with zero unresolved review threads, `main` has not drifted, and the expected signed head remains exact.

O7.7 conformance does not itself authorize an Orchestra product release, deployment, policy activation, installed-integration refresh, bypass, destructive cleanup, or other protected action.