### PR TITLE
fix(mcp): make 2026 discovery Codex-compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This root changelog is release-oriented. Detailed pre-v1.7 development chronology remains preserved byte-for-byte in [the historical changelog archive](docs/history/CHANGELOG_PRE_V1_7.md), Git history, merged pull requests, decision records, and validation evidence.
 
+## Post-v1.7 Codex MCP 2026 discovery compatibility
+
+- Corrected the MCP `2026-07-28` `server/discover` result shape by adding `ttlMs: 0` and `cacheScope: "private"`, matching the modern Codex discovery contract while preventing reusable discovery caching or stale capability assumptions.
+- Added a focused Codex discovery compatibility regression test and synchronized the detailed MCP transport documentation plus `README.json` machine parity.
+- Codex hosts still require the `mcp_2026_07_28` feature and `CODEX_MCP_PROTOCOL_VERSION=2026-07-28` stdio-server marker; this repository change does not itself establish a successful installed-host connection.
+- The fix preserves required MCP `_meta` validation and the modern stateless lifecycle. It does not add the retired `initialize` lifecycle, expand tool or runtime authority, publish a release, deploy, activate policy, refresh installed integrations, or authorize protected operations.
+
 ## Post-v1.7 O7.7 trusted Registry joint conformance
 
 - Added an executable cross-repository O7.7 conformance gate against immutable `registry-v0.4.0`, exact release source `488c979b37dd84d8645fd8e6c288d297375c4e5b`, release-manifest SHA-256 `040d6576cf10e9f7e3a9a051792869541c1d33b7af3c665fad8eecb939c7baaa`, and bundle SHA-256 `e0457a75837d169d7bb8a7da14d8f4141d35a691952ff8f8978ef793e3cf92d3`.

--- a/README.json
+++ b/README.json
@@ -182,13 +182,13 @@
     "developer_portal": {"status": "PUBLISHED_V1_6_STABLE", "machine_sources": ["machine/developer-portal/catalog.v1.json"], "human_sources": ["docs/developer/README.md"]},
     "mcp_stdio_transport": {
       "status": "PUBLISHED_V1_6_STABLE",
-      "purpose": "Expose a bounded Orchestra tool surface to MCP-compatible clients while preserving existing PRAP, governance, runtime, and authority boundaries.",
+      "purpose": "Expose a bounded Orchestra tool surface to MCP-compatible clients, including Codex MCP 2026 discovery with non-cacheable private cache hints, while preserving existing PRAP, governance, runtime, and authority boundaries.",
       "protocol_revision": "2026-07-28",
       "transport": "stdio",
       "quickstart_command": "python scripts/mcp_server.py --adapter codex",
       "surface": ["server/discover", "tools/list", "tools/call"],
       "human_sources": ["docs/developer/MCP_STDIO_TRANSPORT.md"],
-      "authority_note": "MCP is transport, not authority."
+      "authority_note": "MCP is transport, not authority. Discovery uses ttlMs=0 and cacheScope=private so capability discovery is not reusable cached authority."
     },
     "murmurs_presentation": {"status": "IMPLEMENTED_OPT_IN_RESEARCH_NOT_PROMOTED", "machine_sources": ["machine/presentation/murmurs-policy.v1.json", "machine/presentation/murmurs-vocabulary.v1.json"], "human_sources": ["docs/project/MURMURS_COMMUNICATION_BUDGET.md"], "token_savings_claim": "CONFIRMATORY_BENEFIT_NOT_ESTABLISHED"},
     "hybrid_context_representation": {"status": "PUBLISHED_V1_6_STABLE", "human_sources": ["docs/HYBRID_CONTEXT_FORMATS.md"], "json_authority": "CANONICAL_FOR_STRUCTURED_MACHINE_STATE", "toon_authority": "DERIVED_VALIDATED_NON_AUTHORITATIVE"},

--- a/docs/developer/MCP_STDIO_TRANSPORT.md
+++ b/docs/developer/MCP_STDIO_TRANSPORT.md
@@ -49,7 +49,7 @@ For persistent Codex use, the feature can be enabled in the user's Codex configu
 
 MCP `2026-07-28` uses a stateless request model. Orchestra does not implement the retired `initialize` / `initialized` handshake or MCP protocol sessions in this transport. Requests must declare `io.modelcontextprotocol/protocolVersion` in `_meta`; unsupported versions fail with the MCP unsupported-protocol-version error.
 
-`server/discover` advertises only the protocol revision and tools capability implemented by this bounded server. `tools/list` returns a deterministic projection of commands that are both exposed by the selected existing adapter and present in the current trusted runtime policy. Tool definitions accept one field only, `prompt`, with `additionalProperties: false`.
+`server/discover` advertises only the protocol revision and tools capability implemented by this bounded server. Its discovery result includes `ttlMs: 0` and `cacheScope: "private"`, satisfying the MCP 2026 discovery result contract while preventing reusable discovery caching or stale capability assumptions. These cache hints are transport metadata only and do not grant runtime authority. `tools/list` returns a deterministic projection of commands that are both exposed by the selected existing adapter and present in the current trusted runtime policy. Tool definitions accept one field only, `prompt`, with `additionalProperties: false`.
 
 ## Authority boundary
 
@@ -78,6 +78,7 @@ Unknown tools and malformed tool arguments are protocol-level errors. Existing O
 The focused runtime tests cover:
 
 - current protocol discovery;
+- Codex-compatible discovery cache-hint shape;
 - deterministic tool ordering and runtime-policy projection;
 - exact-command routing independent of prompt triggers;
 - a fresh trusted runtime per tool call;

--- a/orchestra_runtime/mcp_transport.py
+++ b/orchestra_runtime/mcp_transport.py
@@ -195,6 +195,8 @@ class McpToolTransport:
                 "Orchestra exposes existing governed runtime commands as MCP tools. "
                 "MCP metadata and tool arguments do not grant runtime authority or governance approval."
             ),
+            "ttlMs": 0,
+            "cacheScope": "private",
             "_meta": self._response_meta(),
         }
 

--- a/tests/runtime/test_mcp_codex_discovery_compat.py
+++ b/tests/runtime/test_mcp_codex_discovery_compat.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from orchestra_runtime.mcp_transport import (
+    MCP_PROTOCOL_VERSION,
+    MCP_PROTOCOL_VERSION_META_KEY,
+    build_mcp_stdio_transport,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_codex_2026_discovery_result_includes_required_cache_hints() -> None:
+    transport = build_mcp_stdio_transport(ROOT, backing_adapter="codex")
+    response = transport.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "server/discover",
+            "params": {
+                "_meta": {
+                    MCP_PROTOCOL_VERSION_META_KEY: MCP_PROTOCOL_VERSION,
+                    "io.modelcontextprotocol/clientInfo": {
+                        "name": "codex-compat-test",
+                        "version": "0.150.1",
+                    },
+                    "io.modelcontextprotocol/clientCapabilities": {},
+                }
+            },
+        }
+    )
+
+    result = response["result"]
+    assert result["resultType"] == "complete"
+    assert result["supportedVersions"] == [MCP_PROTOCOL_VERSION]
+    assert result["capabilities"] == {"tools": {}}
+    assert result["ttlMs"] == 0
+    assert result["cacheScope"] == "private"
+    assert result["_meta"]["io.modelcontextprotocol/serverInfo"]["name"] == "orchestra"


### PR DESCRIPTION
## Problem
With Codex 0.150.1 correctly configured for MCP `2026-07-28`, Orchestra reaches `server/discover` but Codex rejects the response as a generic `CallToolResult` instead of a discovery result (`expect initialized result`).

Codex's own 2026 discovery fixture includes the required cache hints `ttlMs` and `cacheScope`. Orchestra's discovery result omitted both.

## Bounded fix
- add `ttlMs: 0` to `server/discover`
- add `cacheScope: "private"` to `server/discover`
- add a focused Codex discovery compatibility regression test
- document the non-cacheable/private discovery contract
- synchronize `README.json` and focused CHANGELOG parity required by governance

`ttlMs: 0` + private scope deliberately prevents reusable discovery caching and stale capability assumptions.

## Validated source identity
- canonical base: `9dc3db1af2a3d02a2aa6df0da09f1be2e69671a1`
- reviewed unsigned source head: `029421d1ede8c7264c0883ab7c298019e5b4ffc4`
- reviewed source tree: `bc639f9e0a8be7ed4c6491b0c7793c74c75b04d4`
- source gates: Governance PASS; validate PASS; Required Analysis Compatibility PASS; Cross-platform PASS; Cosmic Ray PASS; GitHub Advanced Security CodeQL PASS
- signed materialized commit: `a2ce6865df33f9c14a50a19bb52e137858e8ee4a`
- signed materialized tree: `bc639f9e0a8be7ed4c6491b0c7793c74c75b04d4` (exact reviewed-tree identity)

This source PR is intentionally not the canonical merge vehicle after signed materialization.

## Authority boundary
No tool surface, runtime binding, governance rule, authority, deployment, release, installed-integration refresh, policy/ruleset setting, or legacy handshake is added or weakened. Missing/invalid 2026 `_meta` remains fail closed.