### PR TITLE
docs(profile): add public-safe PIO contract

### DIFF
--- a/profile-pio.json
+++ b/profile-pio.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": "1.0",
+  "project": "Orchestra",
+  "featured": true,
+  "summary": "Portable governance and orchestration runtime for structured AI-assisted software development.",
+  "status": "v1.7.0 published; post-release work on main",
+  "next": "Post-v1.7 maintenance and bounded runtime evolution",
+  "url": "https://github.com/Baelfyre/Orchestra"
+}

--- a/profile-pio.json
+++ b/profile-pio.json
@@ -3,7 +3,7 @@
   "project": "Orchestra",
   "featured": true,
   "summary": "Portable governance and orchestration runtime for structured AI-assisted software development.",
-  "status": "v1.7.0 published; post-release work on main",
-  "next": "Post-v1.7 maintenance and bounded runtime evolution",
+  "status": "Latest release: v1.7.0",
+  "next": "Next release: not announced",
   "url": "https://github.com/Baelfyre/Orchestra"
 }


### PR DESCRIPTION
## Scope

Add root `profile-pio.json` as a bounded public-profile presentation contract for the `Baelfyre/Baelfyre` GitHub profile.

The file is presentation metadata only and does not alter or override `PROJECT_STATE.md`, `PROJECT_CONTEXT.md`, `README.json`, release records, machine-readable governance state, validation evidence, specialist/runtime state, Padayon continuity, or canonical repository state.

## Release-only exposure

The PIO deliberately exposes only release-facing lifecycle state:

- `status` identifies the latest published public release;
- `next` identifies the next publicly announced release, or states that none is announced;
- internal post-release maintenance, implementation campaigns, experiment state, host/runtime progress, promotion state, and other unpublished lifecycle detail are excluded.

The stable presentation fields remain limited to schema version, project name, Featured Project visibility, concise summary, release-facing status/next, and canonical public repository URL.

It must not expose commit/tree identities, branch names, workflow/run IDs, authority envelopes, specialist execution details, private prompts, internal machine paths, security-sensitive state, unpublished implementation detail, or local environment information.

## Fresh canonical derivation

The preceding model-selection correction is now canonical and post-merge verified. Fresh canonical sources still establish `v1.7.0` as `PUBLISHED_VERIFIED` and `Target Release: NONE_DECLARED`.

Therefore the public projection remains, without content churn:

```text
status = Latest release: v1.7.0
next = Next release: not announced
```

Post-release work on `main` is intentionally not projected into the PIO.

## Reconciliation

This branch was reconciled forward onto the fresh verified canonical `main` without force push or history rewrite. The `profile-pio.json` blob is preserved byte-for-byte from the reviewed release-only draft. Validation from the prior base is stale and is not reused as merge permission.

## Validation

The exact reconciled PIO head must pass Orchestra's native pull-request validation and governance workflows, including Governance Check, Required Analysis Compatibility, validate/runtime evidence, cross-platform validation, documentation impact checks, machine-readable contract checks where applicable, and pre-merge exact-head verification. Missing, pending, stale, skipped, cancelled, or failed evidence is not permission.

## Maintenance rule

Release-facing PIO state is reviewed when a canonical public release is published/changed or when a next release is publicly announced/changed. Stable identity fields (`summary`, `featured`, `url`) are reviewed only when those public presentation values materially change. Internal maintenance or implementation progress alone must not trigger PIO churn.

## Merge gate

Human merge authorization has been provided in the current thread. Merge remains conditional on fresh exact-head validation, signed materialization, a fresh signed canonical PR, zero unresolved review threads, and expected-head protection. No release/publication, deployment, policy activation, installed-integration refresh, destructive cleanup, branch deletion, force push, or history rewrite is authorized by this PIO transition.