### PR TITLE
fix(runtime): require explicit Codex model selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This root changelog is release-oriented. Detailed pre-v1.7 development chronology remains preserved byte-for-byte in [the historical changelog archive](docs/history/CHANGELOG_PRE_V1_7.md), Git history, merged pull requests, decision records, and validation evidence.
 
+## Post-v1.7 Codex user-selected model configuration candidate
+
+- Added a pre-E7 trusted configuration boundary that requires an explicit non-empty Codex model identifier instead of treating the Sol model used by E5/E6 verification as a permanent runtime default.
+- Added focused runtime tests proving the selected model and optional reasoning effort are carried into the existing bounded read-only and mutation-assessment configurations without widening approval, sandbox, network, write-scope, specialist, or command controls.
+- Preserved the historical E5/E6 `gpt-5.6-sol` proof identity unchanged for reproducibility. Historical tested-model identity is evidence only and does not define Orchestra's runtime default.
+- This candidate does not decide E7 promotion, enable default runtime mutation, claim MCP mutation E2E, merge canonically, publish a release, deploy, activate policy, refresh integrations, or authorize destructive operations.
+
 ## Post-v1.7 Codex host bridge E5 candidate
 
 - Added an internal, experimental Codex App Server bridge candidate behind the existing `ISpecialistExecutionEngine` boundary for the bounded E5 `review-docs` to Scribe proof. The default runtime and default MCP builders remain route-only.

--- a/docs/project/SPECIALIST_RUNTIME_HOST_MODEL_SELECTION.md
+++ b/docs/project/SPECIALIST_RUNTIME_HOST_MODEL_SELECTION.md
@@ -1,0 +1,58 @@
+# Specialist Runtime Host Model Selection
+
+**Status:** PRE-E7 REVIEW CANDIDATE
+**Scope:** Codex host model selection only
+**Authority:** No E7 promotion, merge, release, deployment, policy activation, or default-runtime mutation authority is created by this document.
+
+## Purpose
+
+The E5 and E6 live proofs were intentionally executed with `gpt-5.6-sol` as a frozen evidence identity. That tested model must not become Orchestra's permanent runtime model.
+
+The supported model-selection rule for any later promoted Codex host-execution surface is:
+
+```text
+MODEL_HARDCODED_IN_PROMOTED_SURFACE = FALSE
+MODEL_SELECTION_SOURCE = USER_CONFIG
+MODEL_SELECTION_FROM_PROMPT = DENIED
+MODEL_SELECTION_FROM_TASK_TEXT = DENIED
+MODEL_SELECTION_FROM_MCP_META = DENIED
+MODEL_SELECTION != EXECUTION_AUTHORITY
+```
+
+## Configuration contract
+
+`internal/codex_user_model_selection.py` introduces an explicit `CodexUserModelSelection` configuration object.
+
+- The caller supplies a non-empty model identifier.
+- Optional reasoning effort is supplied through the same trusted configuration boundary.
+- The selected model is bound into the existing Codex read-only or mutation-assessment configuration.
+- Approval policy, sandbox mode, network policy, write scope, specialist scope, and command scope are not widened by model selection.
+- Task input, specialist guidance, and MCP metadata do not select or override the model.
+
+The configuration builders intentionally have no GPT model default. A future UI or adapter may populate this value from a host-provided model catalog, but the repository does not maintain a permanent static model list.
+
+## Historical evidence boundary
+
+The existing E5/E6 proof implementations retain their `gpt-5.6-sol` pin because those files describe and reproduce the exact historical verification environment.
+
+```text
+E5_TESTED_MODEL = gpt-5.6-sol
+E6_TESTED_MODEL = gpt-5.6-sol
+HISTORICAL_TEST_MODEL != ORCHESTRA_RUNTIME_DEFAULT
+```
+
+Changing the historical proof identity would weaken reproducibility and would incorrectly rewrite already-collected evidence.
+
+## Review boundary
+
+This correction is intentionally staged before the E7 human promotion decision.
+
+```text
+MODEL_SELECTION_CORRECTION = REVIEW_CANDIDATE
+E7_PROMOTION = NOT_DECIDED_BY_THIS_CHANGE
+DEFAULT_ROUTE_ONLY_BEHAVIOR = PRESERVED
+DEFAULT_RUNTIME_MUTATION = NOT_ENABLED
+MCP_MUTATION_E2E = NOT_CLAIMED
+```
+
+If accepted, E7 can evaluate the optional host-execution capability with the additional condition that model choice remains explicit user/host configuration rather than a model hard-coded by Orchestra.

--- a/internal/codex_user_model_selection.py
+++ b/internal/codex_user_model_selection.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from internal.codex_app_server_bridge import CodexAppServerConfig
+from internal.codex_app_server_mutation_assessment import CodexMutationAssessmentConfig
+
+
+MODEL_SELECTION_SOURCE = "USER_CONFIG"
+
+
+@dataclass(frozen=True, slots=True)
+class CodexUserModelSelection:
+    """Trusted user/host configuration for Codex model selection.
+
+    This object is intentionally separate from task input, MCP metadata, and
+    specialist guidance. Model choice is configuration, not execution authority.
+    """
+
+    model: str
+    reasoning_effort: str | None = None
+
+    def __post_init__(self) -> None:
+        model = self.model.strip()
+        if not model:
+            raise ValueError("Codex model selection must be explicit and non-empty")
+        if any(character in model for character in ("\r", "\n", "\x00")):
+            raise ValueError("Codex model selection contains an unsafe control character")
+        object.__setattr__(self, "model", model)
+
+        if self.reasoning_effort is not None:
+            effort = self.reasoning_effort.strip()
+            if not effort:
+                raise ValueError("reasoning_effort must be non-empty when supplied")
+            if any(character in effort for character in ("\r", "\n", "\x00")):
+                raise ValueError("reasoning_effort contains an unsafe control character")
+            object.__setattr__(self, "reasoning_effort", effort)
+
+    @property
+    def evidence_identity(self) -> str:
+        return f"codex-model:{self.model}"
+
+
+def build_read_only_config(
+    selection: CodexUserModelSelection,
+    *,
+    turn_timeout_seconds: int = 180,
+    require_clean_worktree: bool = True,
+    allowed_specialists: tuple[str, ...] = ("scribe",),
+    allowed_commands: tuple[str, ...] = ("review-docs",),
+) -> CodexAppServerConfig:
+    """Bind an explicit user-selected model to the bounded read-only bridge."""
+
+    return CodexAppServerConfig(
+        model=selection.model,
+        reasoning_effort=selection.reasoning_effort,
+        turn_timeout_seconds=turn_timeout_seconds,
+        require_clean_worktree=require_clean_worktree,
+        approval_policy="never",
+        sandbox_mode="read-only",
+        network_access=False,
+        allowed_specialists=allowed_specialists,
+        allowed_commands=allowed_commands,
+    )
+
+
+def build_mutation_assessment_config(
+    selection: CodexUserModelSelection,
+    *,
+    turn_timeout_seconds: int = 240,
+    writable_root: str = "mutation",
+    allowed_relative_paths: tuple[str, ...] = ("mutation/target.md",),
+    allowed_specialists: tuple[str, ...] = ("ponytail",),
+    allowed_commands: tuple[str, ...] = ("ponytail",),
+) -> CodexMutationAssessmentConfig:
+    """Bind an explicit user-selected model to the bounded E6-style assessment."""
+
+    return CodexMutationAssessmentConfig(
+        model=selection.model,
+        reasoning_effort=selection.reasoning_effort,
+        turn_timeout_seconds=turn_timeout_seconds,
+        approval_policy="never",
+        sandbox_mode="workspace-write",
+        network_access=False,
+        writable_root=writable_root,
+        allowed_relative_paths=allowed_relative_paths,
+        allowed_specialists=allowed_specialists,
+        allowed_commands=allowed_commands,
+    )

--- a/tests/runtime/test_codex_user_model_selection.py
+++ b/tests/runtime/test_codex_user_model_selection.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import pytest
+
+from internal.codex_user_model_selection import (
+    MODEL_SELECTION_SOURCE,
+    CodexUserModelSelection,
+    build_mutation_assessment_config,
+    build_read_only_config,
+)
+
+
+def test_model_selection_is_explicit_user_configuration():
+    selection = CodexUserModelSelection(model="  gpt-user-choice  ", reasoning_effort=" high ")
+
+    assert MODEL_SELECTION_SOURCE == "USER_CONFIG"
+    assert selection.model == "gpt-user-choice"
+    assert selection.reasoning_effort == "high"
+    assert selection.evidence_identity == "codex-model:gpt-user-choice"
+
+
+def test_model_selection_rejects_blank_or_control_characters():
+    with pytest.raises(ValueError):
+        CodexUserModelSelection(model="   ")
+    with pytest.raises(ValueError):
+        CodexUserModelSelection(model="model\nother")
+    with pytest.raises(ValueError):
+        CodexUserModelSelection(model="model", reasoning_effort="   ")
+
+
+def test_read_only_config_uses_selected_model_without_widening_policy():
+    config = build_read_only_config(
+        CodexUserModelSelection(model="gpt-selected", reasoning_effort="medium")
+    )
+
+    assert config.model == "gpt-selected"
+    assert config.reasoning_effort == "medium"
+    assert config.approval_policy == "never"
+    assert config.sandbox_mode == "read-only"
+    assert config.network_access is False
+
+
+def test_mutation_assessment_config_uses_selected_model_without_widening_policy():
+    config = build_mutation_assessment_config(
+        CodexUserModelSelection(model="gpt-selected", reasoning_effort="low")
+    )
+
+    assert config.model == "gpt-selected"
+    assert config.reasoning_effort == "low"
+    assert config.approval_policy == "never"
+    assert config.sandbox_mode == "workspace-write"
+    assert config.network_access is False
+    assert config.writable_root == "mutation"
+    assert config.allowed_relative_paths == ("mutation/target.md",)
+
+
+def test_selection_cannot_widen_fixed_security_controls():
+    selection = CodexUserModelSelection(model="another-model")
+    read_only = build_read_only_config(selection)
+    mutation = build_mutation_assessment_config(selection)
+
+    assert read_only.approval_policy == mutation.approval_policy == "never"
+    assert read_only.network_access is False
+    assert mutation.network_access is False


### PR DESCRIPTION
Canonical promotion of the reviewed and signed Codex model-selection correction.

Reviewed source PR: #631 (closed unmerged after exact-head validation)
Signing transport PR: #633
Signed head: `151fb7024409308e124743b1b38dfa6ef7734bd7`
Signed tree: `2128d9532624ea8bd9ef586f352e2f41e4322160`
Canonical parent: `08588c9446a7148ee52bd44574bf58ce382de4c9`
Signature: GitHub verified valid

Scope remains the reviewed pre-E7 correction only: explicit user-selected Codex model configuration, focused regression tests, public documentation, and changelog parity. Historical E5/E6 Sol evidence remains frozen. Route-only defaults remain preserved; default runtime mutation remains disabled; MCP mutation E2E remains unclaimed; E7 promotion is not decided here.

This fresh signed head must independently pass the complete protected-main exact-head matrix. PIO work remains separately sequenced in PR #632 and must be reconciled only after this canonical transition is verified.

No release/publication, deployment, policy activation, installed-integration refresh, destructive cleanup, branch deletion, force push, or history rewrite is included.