### PR TITLE
docs(profile): add release-only public PIO contract

### DIFF
--- a/profile-pio.json
+++ b/profile-pio.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": "1.0",
+  "project": "Orchestra",
+  "featured": true,
+  "summary": "Portable governance and orchestration runtime for structured AI-assisted software development.",
+  "status": "Latest release: v1.7.0",
+  "next": "Next release: not announced",
+  "url": "https://github.com/Baelfyre/Orchestra"
+}


### PR DESCRIPTION
Canonical promotion of the reviewed, reconciled, and signed release-only public-profile contract.

Source PR: #632 (closed unmerged after fresh exact-head validation)
Signing transport PR: #635
Signed head: `4856adaf827fa3c967a435234f0ae46bffbb3242`
Signed tree: `371efb5f3f4038049370d1cb7fc2abc85f6e9111`
Canonical parent: `60278af7c83e7385c64270c0164fe2458117c2c2`
PIO blob: `f94cbb91907a8f7e4e14360e278fb60c9d0c4578`
Signature: GitHub verified valid

The contract exposes release-facing state only:

```text
status = Latest release: v1.7.0
next = Next release: not announced
```

Internal post-release implementation, runtime/host work, promotion state, experiments, validation identities, authority records, and unpublished lifecycle detail remain excluded.

This fresh signed head must independently pass the complete protected-main exact-head matrix before merge. Human merge authorization is already present in the current thread, but it remains conditional on all governing checks, zero unresolved review threads, unchanged head/base identities, and expected-head protection.

No release/publication, deployment, policy activation, integration refresh, destructive cleanup, branch deletion, force push, or history rewrite is included.