### PR TITLE
feat(priority2): add governed provider execution profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Post-v1.7 Priority 2 provider execution profile candidate
+
+- Added a deterministic, non-authorizing provider execution profile and trusted provider/model/capability requirement gate for explicit host-native specialist execution, while preserving existing route-only and provider-free deterministic runtime paths.
+- Added separate provider-aware MCP constructors and Codex App Server wrappers that map the existing explicit user-selected model configuration into `openai-codex` provider profiles without widening approval, sandbox, network, specialist, command, or mutation scope.
+- Added Draft 2020-12 provider profile/requirement schemas and focused regressions for deterministic identity, fail-closed mismatch and drift handling, authority-before-provider ordering, minimized provider evidence, and prompt/MCP metadata non-override.
+- P2.1 does not add automatic provider routing or fallback, direct provider SDKs/APIs, credential handling, a static model catalog, Registry mutation, release, deployment, policy activation, integration refresh, destructive operations, branch deletion, force push, or history rewrite.
+
 ## Post-v1.7 Unified Testing Mechanism Efficacy Calibration
 
 - Added a deterministic offline 15-case baseline-versus-UTM efficacy calibration, machine-readable result, qualification record, focused regression tests, and independent read-only audit for the canonical experimental UTM candidate.

--- a/README.json
+++ b/README.json
@@ -32,8 +32,8 @@
     "specialist_runtime_host_execution_design": {
       "status": "E1_E7_COMPLETE_ADOPT_OPTIONAL",
       "purpose": "Provide a supported optional post-gate typed specialist execution path with verified bounded Codex host execution while preserving route-only defaults, explicit user model configuration, and independent Orchestra authority boundaries.",
-      "machine_sources": ["machine/features/specialist-runtime-host-execution.v1.json", "machine/schemas/specialist-execution-request.v1.schema.json", "machine/schemas/specialist-execution-receipt.v1.schema.json"],
-      "human_sources": ["docs/project/SPECIALIST_RUNTIME_HOST_EXECUTION_ARCHITECTURE.md", "docs/project/SPECIALIST_RUNTIME_HOST_EXECUTION_IMPLEMENTATION_PLAN.md", "docs/validation/SPECIALIST_RUNTIME_HOST_EXECUTION_PRE_E7_EFFECTIVENESS_2026_08_29.md", "docs/validation/SPECIALIST_RUNTIME_HOST_EXECUTION_E7_PROMOTION_DECISION_2026_08_30.md", "docs/developer/MCP_STDIO_TRANSPORT.md"],
+      "machine_sources": ["machine/features/specialist-runtime-host-execution.v1.json", "machine/schemas/specialist-execution-request.v1.schema.json", "machine/schemas/specialist-execution-receipt.v1.schema.json", "machine/schemas/provider-execution-profile.v1.schema.json", "machine/schemas/provider-execution-requirement.v1.schema.json"],
+      "human_sources": ["docs/project/SPECIALIST_RUNTIME_HOST_EXECUTION_ARCHITECTURE.md", "docs/project/SPECIALIST_RUNTIME_HOST_EXECUTION_IMPLEMENTATION_PLAN.md", "docs/project/PRIORITY_2_PROVIDER_EXECUTION_PROFILE.md", "docs/validation/SPECIALIST_RUNTIME_HOST_EXECUTION_PRE_E7_EFFECTIVENESS_2026_08_29.md", "docs/validation/SPECIALIST_RUNTIME_HOST_EXECUTION_E7_PROMOTION_DECISION_2026_08_30.md", "docs/developer/MCP_STDIO_TRANSPORT.md"],
       "admission": "ADMIT",
       "promotion": "ADOPT_OPTIONAL",
       "runtime_integration": true,

--- a/docs/project/PRIORITY_2_PROVIDER_EXECUTION_PROFILE.md
+++ b/docs/project/PRIORITY_2_PROVIDER_EXECUTION_PROFILE.md
@@ -1,0 +1,182 @@
+# Priority 2 Provider Execution Profile and Requirement Gate
+
+Status: `P2_1_IMPLEMENTATION_CANDIDATE`
+
+Scope: bounded Priority 2 provider identity/capability representation and trusted requirement enforcement only.
+
+This increment does not implement automatic provider routing, provider fallback, direct provider APIs, credential management, pricing optimization, model discovery, a static model catalog, release publication, deployment, policy activation, or installed-integration refresh.
+
+## Purpose
+
+Orchestra already separates host adapters, runtime authority/capability grants, and optional host-native specialist execution. The Codex host bridge additionally carries model selection, structured output, sandbox, network, approval, cancellation, and host-activity controls, but those execution facts were previously Codex-specific implementation details rather than a reusable typed provider contract.
+
+P2.1 adds a fourth, explicitly non-authorizing concept:
+
+```text
+PROVIDER_EXECUTION_PROFILE = DESCRIPTIVE_EXECUTION_CAPABILITY
+PROVIDER_EXECUTION_PROFILE != RUNTIME_CAPABILITY_GRANT
+PROVIDER_EXECUTION_PROFILE != AUTHORITY
+PROVIDER_SELECTION != AUTHORITY
+MODEL_SELECTION != AUTHORITY
+```
+
+## Contracts
+
+`orchestra_runtime/provider_execution.py` defines:
+
+- `ProviderExecutionCapability`
+- `ProviderExecutionProfile`
+- `ProviderExecutionRequirement`
+- `IProviderExecutionEngine`
+- `ProviderSpecialistRuntimeExecutor`
+
+Machine schemas:
+
+- `machine/schemas/provider-execution-profile.v1.schema.json`
+- `machine/schemas/provider-execution-requirement.v1.schema.json`
+
+A profile binds:
+
+```text
+profile_version
+profile_id
+provider_id
+model_id
+capabilities
+profile_digest
+```
+
+`profile_id` and `profile_digest` are deterministic over the canonical provider/model/capability payload. Capability order therefore cannot change profile identity.
+
+The initial capability vocabulary is intentionally small and evidence-backed:
+
+```text
+STRUCTURED_OUTPUT
+CANCELLATION
+READ_ONLY_SANDBOX_CONTROL
+NETWORK_RESTRICTION
+APPROVAL_CONTROL
+HOST_ACTIVITY_OBSERVATION
+```
+
+No generic token limit, price, temperature, top-p, multimodality, latency, or provider-ranking contract is introduced by P2.1.
+
+## Trusted requirement gate
+
+`ProviderExecutionRequirement` can constrain any combination of:
+
+```text
+required_provider_id
+required_model_id
+required_capabilities
+```
+
+The provider-aware runtime is explicit and host-native. Requirement and engine selection are constructor-owned trusted configuration.
+
+Prompt text, specialist guidance, MCP client metadata, and tool arguments cannot select or override the provider profile or requirement.
+
+Execution remains ordered as:
+
+```text
+coordination
+-> routing / exact binding
+-> authority
+-> runtime capability
+-> governance
+-> lifecycle activation
+-> provider profile drift check
+-> trusted provider requirement match
+-> host execution engine
+-> receipt validation
+-> lifecycle terminal result
+```
+
+A provider/model/capability mismatch fails before provider-engine invocation. Authority, runtime capability, governance, and coordination denials continue to occur before the provider gate is reached.
+
+Provider mismatch does not fall back to another provider and does not degrade into successful route-only output.
+
+## Compatibility
+
+P2.1 is additive.
+
+The following remain unchanged:
+
+```text
+RuntimeExecutor default = route-only
+SpecialistRuntimeExecutor default contract = unchanged
+DETERMINISTIC_TEST_ENGINE = provider-free
+existing MCP builder = route-only
+existing specialist MCP builder = unchanged
+existing IDE/host adapters = unchanged
+```
+
+Provider-aware MCP execution uses the separate opt-in builders in `orchestra_runtime/provider_mcp_execution.py`.
+
+## Codex mapping
+
+`internal/codex_provider_execution.py` provides provider-aware wrappers over the existing Codex App Server engines.
+
+Provider identity:
+
+```text
+provider_id = openai-codex
+```
+
+Model identity remains the explicit trusted model selected through the existing `CodexUserModelSelection` configuration path.
+
+The read-only wrapper advertises the common bounded Codex capabilities plus `READ_ONLY_SANDBOX_CONTROL`. The bounded mutation-assessment wrapper advertises only the common capabilities and does not falsely claim a read-only sandbox.
+
+The wrappers do not modify approval, network, sandbox, write-path, specialist, or command controls in the existing Codex engines.
+
+## Evidence minimization
+
+Provider-aware terminal evidence adds only:
+
+```text
+execution-provider:<provider_id>
+model:<model_id>
+provider-profile:<profile_id>
+provider-profile-digest:<sha256>
+```
+
+Credentials, API keys, full host conversations, raw prompts, and file contents are not provider-profile fields and are not introduced into ordinary provider evidence by this increment.
+
+## Current routing boundary
+
+P2.1 does not claim a second current provider-native engine. Antigravity, Claude Code, and the other Orchestra host adapters remain distinct host-integration surfaces until separately revalidated or implemented against the provider execution contract.
+
+Therefore:
+
+```text
+EXPLICIT_PROVIDER_REPRESENTATION = IMPLEMENTED_CANDIDATE
+EXPLICIT_PROVIDER_REQUIREMENTS = IMPLEMENTED_CANDIDATE
+FAIL_CLOSED_PROFILE_MATCHING = IMPLEMENTED_CANDIDATE
+AUTOMATIC_MULTI_PROVIDER_ROUTING = NOT_IMPLEMENTED
+AUTOMATIC_PROVIDER_FALLBACK = NOT_IMPLEMENTED
+DIRECT_PROVIDER_API = NOT_IMPLEMENTED
+```
+
+A future automatic routing decision requires current evidence for at least one additional provider-native execution engine and a separately reviewed routing policy. Historical benchmark provider availability or adapter compatibility alone is insufficient.
+
+## Compliance boundary
+
+P2.1 does not mutate the Orchestra Compliance Registry. The Registry's existing provider vocabulary remains platform/distribution oriented and is not redefined by this runtime contract.
+
+Any future direct provider SDK/API integration requires separate dependency, provenance, credential, security, privacy, and compliance review.
+
+## Validation target
+
+P2.1 focused regression coverage proves:
+
+- deterministic profile identity and schema validity;
+- duplicate/invalid capability rejection;
+- exact trusted provider/model/capability requirement matching;
+- mismatch before engine invocation;
+- authority denial before the provider gate;
+- provider profile drift detection;
+- prompt/MCP metadata inability to override provider configuration;
+- minimized provider evidence;
+- explicit Codex user model mapping without security-policy widening;
+- provider-aware MCP opt-in behavior.
+
+Repository-wide required validation remains authoritative for merge readiness. Validation success does not create merge, release, deployment, policy, destructive, credential, or integration-refresh authority.

--- a/internal/codex_provider_execution.py
+++ b/internal/codex_provider_execution.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from internal.codex_app_server_bridge import CodexAppServerExecutionEngine
+from internal.codex_app_server_mutation_assessment import CodexAppServerMutationAssessmentEngine
+from orchestra_runtime.provider_execution import (
+    IProviderExecutionEngine,
+    ProviderExecutionCapability,
+    ProviderExecutionProfile,
+)
+
+
+CODEX_PROVIDER_ID = "openai-codex"
+_CODEX_COMMON_CAPABILITIES = (
+    ProviderExecutionCapability.APPROVAL_CONTROL,
+    ProviderExecutionCapability.CANCELLATION,
+    ProviderExecutionCapability.HOST_ACTIVITY_OBSERVATION,
+    ProviderExecutionCapability.NETWORK_RESTRICTION,
+    ProviderExecutionCapability.STRUCTURED_OUTPUT,
+)
+
+
+class CodexAppServerProviderExecutionEngine(
+    CodexAppServerExecutionEngine,
+    IProviderExecutionEngine,
+):
+    """Provider-aware wrapper over the existing bounded Codex read-only bridge."""
+
+    @property
+    def provider_execution_profile(self) -> ProviderExecutionProfile:
+        return ProviderExecutionProfile.create(
+            provider_id=CODEX_PROVIDER_ID,
+            model_id=self._config.model,
+            capabilities=(
+                *_CODEX_COMMON_CAPABILITIES,
+                ProviderExecutionCapability.READ_ONLY_SANDBOX_CONTROL,
+            ),
+        )
+
+
+class CodexAppServerProviderMutationAssessmentEngine(
+    CodexAppServerMutationAssessmentEngine,
+    IProviderExecutionEngine,
+):
+    """Provider-aware wrapper over the existing bounded Codex mutation assessment."""
+
+    @property
+    def provider_execution_profile(self) -> ProviderExecutionProfile:
+        return ProviderExecutionProfile.create(
+            provider_id=CODEX_PROVIDER_ID,
+            model_id=self._config.model,
+            capabilities=_CODEX_COMMON_CAPABILITIES,
+        )

--- a/machine/schemas/provider-execution-profile.v1.schema.json
+++ b/machine/schemas/provider-execution-profile.v1.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://orchestra.local/schemas/provider-execution-profile.v1.schema.json",
+  "title": "Orchestra Provider Execution Profile v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "profile_version",
+    "profile_id",
+    "provider_id",
+    "model_id",
+    "capabilities",
+    "profile_digest"
+  ],
+  "properties": {
+    "profile_version": {
+      "const": "orchestra.provider-execution-profile.v1"
+    },
+    "profile_id": {
+      "type": "string",
+      "pattern": "^provider-profile\\.[0-9a-f]{24}$"
+    },
+    "provider_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9_.:-]*$"
+    },
+    "model_id": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[^\\r\\n\\u0000]+$"
+    },
+    "capabilities": {
+      "type": "array",
+      "items": {
+        "enum": [
+          "APPROVAL_CONTROL",
+          "CANCELLATION",
+          "HOST_ACTIVITY_OBSERVATION",
+          "NETWORK_RESTRICTION",
+          "READ_ONLY_SANDBOX_CONTROL",
+          "STRUCTURED_OUTPUT"
+        ]
+      },
+      "uniqueItems": true
+    },
+    "profile_digest": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    }
+  }
+}

--- a/machine/schemas/provider-execution-requirement.v1.schema.json
+++ b/machine/schemas/provider-execution-requirement.v1.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://orchestra.local/schemas/provider-execution-requirement.v1.schema.json",
+  "title": "Orchestra Provider Execution Requirement v1",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "required_provider_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9_.:-]*$"
+    },
+    "required_model_id": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[^\\r\\n\\u0000]+$"
+    },
+    "required_capabilities": {
+      "type": "array",
+      "items": {
+        "enum": [
+          "APPROVAL_CONTROL",
+          "CANCELLATION",
+          "HOST_ACTIVITY_OBSERVATION",
+          "NETWORK_RESTRICTION",
+          "READ_ONLY_SANDBOX_CONTROL",
+          "STRUCTURED_OUTPUT"
+        ]
+      },
+      "uniqueItems": true
+    }
+  }
+}

--- a/orchestra_runtime/provider_execution.py
+++ b/orchestra_runtime/provider_execution.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+from hashlib import sha256
+import json
+import re
+
+from .errors import RuntimeContractError, RuntimeInitializationError
+from .interfaces import ISpecialistExecutionEngine
+from .lifecycle import LifecycleState
+from .services import ContextAssembler, RuntimeComposition, RuntimeOperationResult
+from .specialist_execution import (
+    SpecialistExecutionMode,
+    SpecialistRuntimeExecutor,
+)
+
+
+PROVIDER_EXECUTION_PROFILE_VERSION = "orchestra.provider-execution-profile.v1"
+PROVIDER_IDENTIFIER_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_.:-]*$")
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+
+class ProviderExecutionCapability(str, Enum):
+    STRUCTURED_OUTPUT = "STRUCTURED_OUTPUT"
+    CANCELLATION = "CANCELLATION"
+    READ_ONLY_SANDBOX_CONTROL = "READ_ONLY_SANDBOX_CONTROL"
+    NETWORK_RESTRICTION = "NETWORK_RESTRICTION"
+    APPROVAL_CONTROL = "APPROVAL_CONTROL"
+    HOST_ACTIVITY_OBSERVATION = "HOST_ACTIVITY_OBSERVATION"
+
+
+class ProviderExecutionContractError(RuntimeContractError):
+    pass
+
+
+def _provider_id(value: object, field_name: str) -> str:
+    text = str(value or "").strip().casefold()
+    if not text or not PROVIDER_IDENTIFIER_PATTERN.fullmatch(text):
+        raise ProviderExecutionContractError(
+            f"{field_name} must be a canonical provider identifier",
+            "INVALID_PROVIDER_EXECUTION_PROFILE",
+            {"field": field_name},
+        )
+    return text
+
+
+def _model_id(value: object, field_name: str) -> str:
+    text = str(value or "").strip()
+    if not text or any(character in text for character in ("\r", "\n", "\x00")):
+        raise ProviderExecutionContractError(
+            f"{field_name} must be a non-empty safe model identifier",
+            "INVALID_PROVIDER_EXECUTION_PROFILE",
+            {"field": field_name},
+        )
+    return text
+
+
+def _capabilities(values: tuple[ProviderExecutionCapability | str, ...]) -> tuple[ProviderExecutionCapability, ...]:
+    try:
+        normalized = tuple(ProviderExecutionCapability(item) for item in values)
+    except (TypeError, ValueError) as exc:
+        raise ProviderExecutionContractError(
+            "provider execution capability is unsupported",
+            "UNSUPPORTED_PROVIDER_CAPABILITY",
+        ) from exc
+    if len(set(normalized)) != len(normalized):
+        raise ProviderExecutionContractError(
+            "provider execution capabilities must be unique",
+            "DUPLICATE_PROVIDER_CAPABILITY",
+        )
+    return tuple(sorted(normalized, key=lambda item: item.value))
+
+
+def _digest(payload: object) -> str:
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+    return sha256(encoded).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderExecutionProfile:
+    profile_version: str
+    profile_id: str
+    provider_id: str
+    model_id: str
+    capabilities: tuple[ProviderExecutionCapability, ...]
+    profile_digest: str
+
+    def __post_init__(self) -> None:
+        if self.profile_version != PROVIDER_EXECUTION_PROFILE_VERSION:
+            raise ProviderExecutionContractError(
+                "unsupported provider execution profile version",
+                "UNSUPPORTED_PROVIDER_EXECUTION_PROFILE_VERSION",
+            )
+        provider_id = _provider_id(self.provider_id, "provider_id")
+        model_id = _model_id(self.model_id, "model_id")
+        capabilities = _capabilities(tuple(self.capabilities))
+        profile_digest = str(self.profile_digest or "").strip().casefold()
+        if not SHA256_PATTERN.fullmatch(profile_digest):
+            raise ProviderExecutionContractError(
+                "profile_digest must be a SHA-256 digest",
+                "INVALID_PROVIDER_PROFILE_DIGEST",
+            )
+        object.__setattr__(self, "provider_id", provider_id)
+        object.__setattr__(self, "model_id", model_id)
+        object.__setattr__(self, "capabilities", capabilities)
+        object.__setattr__(self, "profile_digest", profile_digest)
+        if self.profile_digest != self.compute_digest():
+            raise ProviderExecutionContractError(
+                "provider execution profile digest does not match its payload",
+                "PROVIDER_PROFILE_DIGEST_MISMATCH",
+            )
+        expected_id = f"provider-profile.{self.profile_digest[:24]}"
+        if self.profile_id != expected_id:
+            raise ProviderExecutionContractError(
+                "provider execution profile identifier does not match its digest",
+                "PROVIDER_PROFILE_IDENTITY_MISMATCH",
+            )
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        provider_id: str,
+        model_id: str,
+        capabilities: tuple[ProviderExecutionCapability | str, ...],
+    ) -> ProviderExecutionProfile:
+        normalized_provider = _provider_id(provider_id, "provider_id")
+        normalized_model = _model_id(model_id, "model_id")
+        normalized_capabilities = _capabilities(capabilities)
+        payload = {
+            "profile_version": PROVIDER_EXECUTION_PROFILE_VERSION,
+            "provider_id": normalized_provider,
+            "model_id": normalized_model,
+            "capabilities": [item.value for item in normalized_capabilities],
+        }
+        profile_digest = _digest(payload)
+        return cls(
+            PROVIDER_EXECUTION_PROFILE_VERSION,
+            f"provider-profile.{profile_digest[:24]}",
+            normalized_provider,
+            normalized_model,
+            normalized_capabilities,
+            profile_digest,
+        )
+
+    def digest_payload(self) -> dict[str, object]:
+        return {
+            "profile_version": self.profile_version,
+            "provider_id": self.provider_id,
+            "model_id": self.model_id,
+            "capabilities": [item.value for item in self.capabilities],
+        }
+
+    def compute_digest(self) -> str:
+        return _digest(self.digest_payload())
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "profile_version": self.profile_version,
+            "profile_id": self.profile_id,
+            "provider_id": self.provider_id,
+            "model_id": self.model_id,
+            "capabilities": [item.value for item in self.capabilities],
+            "profile_digest": self.profile_digest,
+        }
+
+    @property
+    def evidence_refs(self) -> tuple[str, ...]:
+        return tuple(
+            sorted(
+                (
+                    f"execution-provider:{self.provider_id}",
+                    f"model:{self.model_id}",
+                    f"provider-profile:{self.profile_id}",
+                    f"provider-profile-digest:{self.profile_digest}",
+                )
+            )
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderExecutionRequirement:
+    required_provider_id: str | None = None
+    required_model_id: str | None = None
+    required_capabilities: tuple[ProviderExecutionCapability, ...] = ()
+
+    def __post_init__(self) -> None:
+        provider_id = (
+            _provider_id(self.required_provider_id, "required_provider_id")
+            if self.required_provider_id is not None
+            else None
+        )
+        model_id = (
+            _model_id(self.required_model_id, "required_model_id")
+            if self.required_model_id is not None
+            else None
+        )
+        capabilities = _capabilities(tuple(self.required_capabilities))
+        object.__setattr__(self, "required_provider_id", provider_id)
+        object.__setattr__(self, "required_model_id", model_id)
+        object.__setattr__(self, "required_capabilities", capabilities)
+
+    @property
+    def empty(self) -> bool:
+        return (
+            self.required_provider_id is None
+            and self.required_model_id is None
+            and not self.required_capabilities
+        )
+
+    def enforce(self, profile: ProviderExecutionProfile) -> ProviderExecutionProfile:
+        if not isinstance(profile, ProviderExecutionProfile):
+            raise ProviderExecutionContractError(
+                "provider requirement requires a valid provider execution profile",
+                "INVALID_PROVIDER_EXECUTION_PROFILE",
+            )
+        if self.required_provider_id is not None and profile.provider_id != self.required_provider_id:
+            raise ProviderExecutionContractError(
+                "configured execution provider does not satisfy the trusted requirement",
+                "PROVIDER_ID_MISMATCH",
+                {
+                    "required_provider_id": self.required_provider_id,
+                    "configured_provider_id": profile.provider_id,
+                },
+            )
+        if self.required_model_id is not None and profile.model_id != self.required_model_id:
+            raise ProviderExecutionContractError(
+                "configured model does not satisfy the trusted requirement",
+                "MODEL_ID_MISMATCH",
+                {
+                    "required_model_id": self.required_model_id,
+                    "configured_model_id": profile.model_id,
+                },
+            )
+        missing = tuple(
+            item.value for item in self.required_capabilities if item not in profile.capabilities
+        )
+        if missing:
+            raise ProviderExecutionContractError(
+                "configured provider is missing a required execution capability",
+                "PROVIDER_CAPABILITY_MISSING",
+                {"missing_capabilities": ",".join(missing)},
+            )
+        return profile
+
+    def to_dict(self) -> dict[str, object]:
+        data: dict[str, object] = {
+            "required_capabilities": [item.value for item in self.required_capabilities],
+        }
+        if self.required_provider_id is not None:
+            data["required_provider_id"] = self.required_provider_id
+        if self.required_model_id is not None:
+            data["required_model_id"] = self.required_model_id
+        return data
+
+
+class IProviderExecutionEngine(ISpecialistExecutionEngine, ABC):
+    """Provider-aware host engine whose profile is descriptive and non-authorizing."""
+
+    @property
+    @abstractmethod
+    def provider_execution_profile(self) -> ProviderExecutionProfile:
+        raise NotImplementedError
+
+
+class ProviderSpecialistRuntimeExecutor(SpecialistRuntimeExecutor):
+    """Explicit host-native specialist executor with a trusted provider requirement gate.
+
+    Provider capability describes what the configured host engine can represent. It
+    never creates or widens Orchestra authority, runtime capability grants, governance
+    disposition, specialist scope, sandbox permission, or protected-action authority.
+    """
+
+    def __init__(
+        self,
+        skill_registry,
+        router,
+        governance,
+        context_assembler: ContextAssembler,
+        composition: RuntimeComposition,
+        *,
+        execution_engine: IProviderExecutionEngine,
+        provider_requirement: ProviderExecutionRequirement | None = None,
+    ) -> None:
+        if not isinstance(execution_engine, IProviderExecutionEngine):
+            raise RuntimeInitializationError(
+                "provider specialist execution requires IProviderExecutionEngine",
+                "INVALID_PROVIDER_EXECUTION_ENGINE",
+            )
+        profile = execution_engine.provider_execution_profile
+        if not isinstance(profile, ProviderExecutionProfile):
+            raise RuntimeInitializationError(
+                "provider execution engine returned an invalid provider profile",
+                "INVALID_PROVIDER_EXECUTION_PROFILE",
+            )
+        if provider_requirement is not None and not isinstance(
+            provider_requirement, ProviderExecutionRequirement
+        ):
+            raise RuntimeInitializationError(
+                "provider requirement must be ProviderExecutionRequirement",
+                "INVALID_PROVIDER_EXECUTION_REQUIREMENT",
+            )
+        self._provider_execution_profile = profile
+        self._provider_requirement = provider_requirement or ProviderExecutionRequirement()
+        super().__init__(
+            skill_registry,
+            router,
+            governance,
+            context_assembler,
+            composition,
+            execution_engine=execution_engine,
+            execution_mode=SpecialistExecutionMode.HOST_NATIVE,
+        )
+
+    @property
+    def provider_execution_profile(self) -> ProviderExecutionProfile:
+        return self._provider_execution_profile
+
+    @property
+    def provider_requirement(self) -> ProviderExecutionRequirement:
+        return self._provider_requirement
+
+    def _execute_specialist(self, adapter_name, decision, validation) -> RuntimeOperationResult:
+        engine = self.execution_engine
+        try:
+            if not isinstance(engine, IProviderExecutionEngine):
+                raise ProviderExecutionContractError(
+                    "provider execution engine is unavailable at the operation boundary",
+                    "INVALID_PROVIDER_EXECUTION_ENGINE",
+                )
+            current_profile = engine.provider_execution_profile
+            if not isinstance(current_profile, ProviderExecutionProfile):
+                raise ProviderExecutionContractError(
+                    "provider execution engine returned an invalid profile",
+                    "INVALID_PROVIDER_EXECUTION_PROFILE",
+                )
+            if current_profile != self._provider_execution_profile:
+                raise ProviderExecutionContractError(
+                    "provider execution profile changed after runtime initialization",
+                    "PROVIDER_PROFILE_DRIFT",
+                    {
+                        "expected_profile_id": self._provider_execution_profile.profile_id,
+                        "current_profile_id": current_profile.profile_id,
+                    },
+                )
+            self._provider_requirement.enforce(current_profile)
+        except ProviderExecutionContractError as exc:
+            return RuntimeOperationResult(
+                LifecycleState.FAILED,
+                "provider execution requirement failed closed",
+                exc.reason_code,
+                self._provider_execution_profile.evidence_refs,
+            )
+
+        result = super()._execute_specialist(adapter_name, decision, validation)
+        return RuntimeOperationResult(
+            result.state,
+            result.output,
+            result.reason_code,
+            (*result.evidence_refs, *current_profile.evidence_refs),
+        )

--- a/orchestra_runtime/provider_mcp_execution.py
+++ b/orchestra_runtime/provider_mcp_execution.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import TextIO
+from uuid import uuid4
+
+from .factories import AdapterFactory
+from .interfaces import IIDEAdapter
+from .mcp_transport import McpToolTransport, RuntimeFactory
+from .provider_execution import (
+    IProviderExecutionEngine,
+    ProviderExecutionRequirement,
+    ProviderSpecialistRuntimeExecutor,
+)
+from .repositories import ManifestRepository, SkillSourceRepository
+from .services import (
+    ContextAssembler,
+    GovernanceValidator,
+    InMemoryAuditSink,
+    RouterService,
+    SkillRegistry,
+    build_compatibility_composition,
+)
+
+
+ProviderExecutionEngineFactory = Callable[[], IProviderExecutionEngine]
+
+
+def build_mcp_provider_runtime_factory(
+    repo_root: Path | str,
+    *,
+    execution_engine_factory: ProviderExecutionEngineFactory,
+    provider_requirement: ProviderExecutionRequirement | None = None,
+    backing_adapter: str = "codex",
+) -> RuntimeFactory:
+    """Build an explicit provider-aware MCP specialist runtime.
+
+    Provider/engine selection remains constructor-owned trusted configuration. MCP
+    client metadata, prompt content, and tool arguments cannot select a provider,
+    model, capability profile, or fallback route.
+    """
+
+    root = Path(repo_root).resolve()
+    adapter_name = str(backing_adapter).strip().casefold()
+    if not adapter_name:
+        raise ValueError("backing_adapter must be non-empty")
+    if not callable(execution_engine_factory):
+        raise TypeError("execution_engine_factory must be callable")
+    if provider_requirement is not None and not isinstance(
+        provider_requirement, ProviderExecutionRequirement
+    ):
+        raise TypeError("provider_requirement must be ProviderExecutionRequirement")
+
+    def factory() -> tuple[ProviderSpecialistRuntimeExecutor, IIDEAdapter]:
+        manifest_repository = ManifestRepository(root)
+        skill_repository = SkillSourceRepository(root)
+        skill_registry = SkillRegistry(manifest_repository, skill_repository)
+        audit_sink = InMemoryAuditSink()
+        composition = build_compatibility_composition(
+            skill_registry,
+            audit_sink,
+            run_id=f"mcp-{uuid4().hex}",
+        )
+        engine = execution_engine_factory()
+        if not isinstance(engine, IProviderExecutionEngine):
+            raise TypeError("execution_engine_factory must return IProviderExecutionEngine")
+        executor = ProviderSpecialistRuntimeExecutor(
+            skill_registry,
+            RouterService(skill_registry),
+            GovernanceValidator(),
+            ContextAssembler(manifest_repository),
+            composition,
+            execution_engine=engine,
+            provider_requirement=provider_requirement,
+        )
+        adapter = AdapterFactory.create(adapter_name, root)
+        return executor, adapter
+
+    return factory
+
+
+def build_mcp_stdio_transport_with_provider_execution(
+    repo_root: Path | str,
+    *,
+    execution_engine_factory: ProviderExecutionEngineFactory,
+    provider_requirement: ProviderExecutionRequirement | None = None,
+    backing_adapter: str = "codex",
+    error_stream: TextIO | None = None,
+) -> McpToolTransport:
+    """Explicit opt-in MCP transport for provider-aware host execution."""
+
+    root = Path(repo_root).resolve()
+    manifest = ManifestRepository(root).load_manifest()
+    server_version = str(manifest.get("version", "")).strip()
+    if not server_version:
+        raise ValueError("plugin.json must declare a non-empty version")
+    return McpToolTransport(
+        build_mcp_provider_runtime_factory(
+            root,
+            execution_engine_factory=execution_engine_factory,
+            provider_requirement=provider_requirement,
+            backing_adapter=backing_adapter,
+        ),
+        server_name="orchestra",
+        server_version=server_version,
+        error_stream=error_stream,
+    )

--- a/tests/runtime/test_codex_provider_execution.py
+++ b/tests/runtime/test_codex_provider_execution.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from internal.codex_provider_execution import (
+    CODEX_PROVIDER_ID,
+    CodexAppServerProviderExecutionEngine,
+    CodexAppServerProviderMutationAssessmentEngine,
+)
+from internal.codex_user_model_selection import (
+    CodexUserModelSelection,
+    build_mutation_assessment_config,
+    build_read_only_config,
+)
+from orchestra_runtime.provider_execution import ProviderExecutionCapability
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_codex_read_only_wrapper_maps_explicit_user_model_to_provider_profile() -> None:
+    config = build_read_only_config(
+        CodexUserModelSelection(model="gpt-user-choice", reasoning_effort="high")
+    )
+    engine = CodexAppServerProviderExecutionEngine(ROOT, config=config)
+
+    profile = engine.provider_execution_profile
+
+    assert profile.provider_id == CODEX_PROVIDER_ID == "openai-codex"
+    assert profile.model_id == "gpt-user-choice"
+    assert ProviderExecutionCapability.STRUCTURED_OUTPUT in profile.capabilities
+    assert ProviderExecutionCapability.CANCELLATION in profile.capabilities
+    assert ProviderExecutionCapability.NETWORK_RESTRICTION in profile.capabilities
+    assert ProviderExecutionCapability.APPROVAL_CONTROL in profile.capabilities
+    assert ProviderExecutionCapability.HOST_ACTIVITY_OBSERVATION in profile.capabilities
+    assert ProviderExecutionCapability.READ_ONLY_SANDBOX_CONTROL in profile.capabilities
+    assert config.reasoning_effort == "high"
+    assert config.approval_policy == "never"
+    assert config.sandbox_mode == "read-only"
+    assert config.network_access is False
+
+
+def test_codex_mutation_wrapper_preserves_bounded_controls_without_claiming_read_only() -> None:
+    config = build_mutation_assessment_config(
+        CodexUserModelSelection(model="gpt-user-choice", reasoning_effort="low")
+    )
+    engine = CodexAppServerProviderMutationAssessmentEngine(ROOT, config=config)
+
+    profile = engine.provider_execution_profile
+
+    assert profile.provider_id == CODEX_PROVIDER_ID
+    assert profile.model_id == "gpt-user-choice"
+    assert ProviderExecutionCapability.STRUCTURED_OUTPUT in profile.capabilities
+    assert ProviderExecutionCapability.CANCELLATION in profile.capabilities
+    assert ProviderExecutionCapability.NETWORK_RESTRICTION in profile.capabilities
+    assert ProviderExecutionCapability.APPROVAL_CONTROL in profile.capabilities
+    assert ProviderExecutionCapability.HOST_ACTIVITY_OBSERVATION in profile.capabilities
+    assert ProviderExecutionCapability.READ_ONLY_SANDBOX_CONTROL not in profile.capabilities
+    assert config.reasoning_effort == "low"
+    assert config.approval_policy == "never"
+    assert config.sandbox_mode == "workspace-write"
+    assert config.network_access is False
+    assert config.allowed_relative_paths == ("mutation/target.md",)
+
+
+def test_codex_provider_profile_identity_changes_with_explicit_model_selection() -> None:
+    first = CodexAppServerProviderExecutionEngine(
+        ROOT,
+        config=build_read_only_config(CodexUserModelSelection(model="model-a")),
+    ).provider_execution_profile
+    second = CodexAppServerProviderExecutionEngine(
+        ROOT,
+        config=build_read_only_config(CodexUserModelSelection(model="model-b")),
+    ).provider_execution_profile
+
+    assert first.provider_id == second.provider_id
+    assert first.model_id != second.model_id
+    assert first.profile_id != second.profile_id
+    assert first.profile_digest != second.profile_digest

--- a/tests/runtime/test_provider_execution.py
+++ b/tests/runtime/test_provider_execution.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from orchestra_runtime.authority import TargetSelector
+from orchestra_runtime.errors import RuntimeInitializationError
+from orchestra_runtime.provider_execution import (
+    IProviderExecutionEngine,
+    ProviderExecutionCapability,
+    ProviderExecutionContractError,
+    ProviderExecutionProfile,
+    ProviderExecutionRequirement,
+    ProviderSpecialistRuntimeExecutor,
+)
+from orchestra_runtime.services import ContextAssembler, GovernanceValidator, RouterService
+from orchestra_runtime.specialist_execution import (
+    SPECIALIST_EXECUTION_RECEIPT_VERSION,
+    SpecialistExecutionReceipt,
+    SpecialistExecutionRequest,
+    SpecialistExecutionStatus,
+    SpecialistSideEffectClass,
+)
+
+from test_runtime_authority_integration import build_active_environment
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PROFILE_SCHEMA = ROOT / "machine" / "schemas" / "provider-execution-profile.v1.schema.json"
+REQUIREMENT_SCHEMA = ROOT / "machine" / "schemas" / "provider-execution-requirement.v1.schema.json"
+
+
+def _load_schema(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _profile(*, model: str = "gpt-test") -> ProviderExecutionProfile:
+    return ProviderExecutionProfile.create(
+        provider_id="openai-codex",
+        model_id=model,
+        capabilities=(
+            ProviderExecutionCapability.STRUCTURED_OUTPUT,
+            ProviderExecutionCapability.CANCELLATION,
+            ProviderExecutionCapability.NETWORK_RESTRICTION,
+            ProviderExecutionCapability.APPROVAL_CONTROL,
+            ProviderExecutionCapability.HOST_ACTIVITY_OBSERVATION,
+            ProviderExecutionCapability.READ_ONLY_SANDBOX_CONTROL,
+        ),
+    )
+
+
+class RecordingProviderEngine(IProviderExecutionEngine):
+    def __init__(self, profile: ProviderExecutionProfile | None = None) -> None:
+        self.profile = profile or _profile()
+        self.requests: list[SpecialistExecutionRequest] = []
+        self.profile_reads = 0
+
+    @property
+    def engine_id(self) -> str:
+        return "orchestra.test.provider-engine"
+
+    @property
+    def engine_version(self) -> str:
+        return "1"
+
+    @property
+    def provider_execution_profile(self) -> ProviderExecutionProfile:
+        self.profile_reads += 1
+        return self.profile
+
+    def execute(self, request: SpecialistExecutionRequest) -> SpecialistExecutionReceipt:
+        self.requests.append(request)
+        return SpecialistExecutionReceipt(
+            receipt_version=SPECIALIST_EXECUTION_RECEIPT_VERSION,
+            receipt_id=f"provider-receipt.{request.request_digest[:24]}",
+            request_id=request.request_id,
+            request_digest=request.request_digest,
+            run_id=request.run_id,
+            adapter_name=request.adapter_name,
+            command_name=request.command_name,
+            specialist=request.specialist,
+            engine_id=self.engine_id,
+            engine_version=self.engine_version,
+            host_execution_id=f"provider-test.{request.request_digest[:16]}",
+            status=SpecialistExecutionStatus.COMPLETED,
+            reason_code="PROVIDER_TEST_COMPLETED",
+            output="provider execution completed",
+            evidence_refs=("fixture:provider-engine",),
+            side_effect_class=SpecialistSideEffectClass.NONE,
+        )
+
+
+def _executor(
+    engine: RecordingProviderEngine,
+    requirement: ProviderExecutionRequirement | None = None,
+    *,
+    environment=None,
+):
+    environment = environment or build_active_environment(run_id="provider-execution-run")
+    executor = ProviderSpecialistRuntimeExecutor(
+        environment.registry,
+        RouterService(environment.registry),
+        GovernanceValidator(),
+        ContextAssembler(environment.repository),
+        environment.composition,
+        execution_engine=engine,
+        provider_requirement=requirement,
+    )
+    return environment, executor
+
+
+def test_provider_profile_is_deterministic_schema_valid_and_order_independent() -> None:
+    capabilities = (
+        ProviderExecutionCapability.STRUCTURED_OUTPUT,
+        ProviderExecutionCapability.CANCELLATION,
+        ProviderExecutionCapability.NETWORK_RESTRICTION,
+    )
+    first = ProviderExecutionProfile.create(
+        provider_id=" OpenAI-Codex ",
+        model_id="gpt-test",
+        capabilities=capabilities,
+    )
+    second = ProviderExecutionProfile.create(
+        provider_id="openai-codex",
+        model_id="gpt-test",
+        capabilities=tuple(reversed(capabilities)),
+    )
+
+    assert first.provider_id == "openai-codex"
+    assert first == second
+    assert first.compute_digest() == first.profile_digest
+    assert first.profile_id == f"provider-profile.{first.profile_digest[:24]}"
+    jsonschema.Draft202012Validator(_load_schema(PROFILE_SCHEMA)).validate(first.to_dict())
+
+
+def test_provider_profile_rejects_duplicates_controls_and_identity_drift() -> None:
+    with pytest.raises(ProviderExecutionContractError) as error:
+        ProviderExecutionProfile.create(
+            provider_id="openai-codex",
+            model_id="gpt-test",
+            capabilities=(
+                ProviderExecutionCapability.STRUCTURED_OUTPUT,
+                ProviderExecutionCapability.STRUCTURED_OUTPUT,
+            ),
+        )
+    assert error.value.reason_code == "DUPLICATE_PROVIDER_CAPABILITY"
+
+    with pytest.raises(ProviderExecutionContractError) as error:
+        ProviderExecutionProfile.create(
+            provider_id="openai-codex",
+            model_id="model\nother",
+            capabilities=(),
+        )
+    assert error.value.reason_code == "INVALID_PROVIDER_EXECUTION_PROFILE"
+
+    valid = _profile()
+    with pytest.raises(ProviderExecutionContractError) as error:
+        replace(valid, model_id="different-model")
+    assert error.value.reason_code == "PROVIDER_PROFILE_DIGEST_MISMATCH"
+
+    with pytest.raises(ProviderExecutionContractError) as error:
+        replace(valid, profile_id="provider-profile." + "0" * 24)
+    assert error.value.reason_code == "PROVIDER_PROFILE_IDENTITY_MISMATCH"
+
+
+def test_provider_requirement_is_schema_valid_and_enforces_exact_trusted_constraints() -> None:
+    profile = _profile()
+    requirement = ProviderExecutionRequirement(
+        required_provider_id="OPENAI-CODEX",
+        required_model_id="gpt-test",
+        required_capabilities=(
+            ProviderExecutionCapability.STRUCTURED_OUTPUT,
+            ProviderExecutionCapability.READ_ONLY_SANDBOX_CONTROL,
+        ),
+    )
+
+    assert requirement.enforce(profile) is profile
+    jsonschema.Draft202012Validator(_load_schema(REQUIREMENT_SCHEMA)).validate(
+        requirement.to_dict()
+    )
+
+    with pytest.raises(ProviderExecutionContractError) as error:
+        ProviderExecutionRequirement(required_provider_id="anthropic").enforce(profile)
+    assert error.value.reason_code == "PROVIDER_ID_MISMATCH"
+
+    with pytest.raises(ProviderExecutionContractError) as error:
+        ProviderExecutionRequirement(required_model_id="other-model").enforce(profile)
+    assert error.value.reason_code == "MODEL_ID_MISMATCH"
+
+    with pytest.raises(ProviderExecutionContractError) as error:
+        ProviderExecutionRequirement(
+            required_capabilities=(ProviderExecutionCapability.READ_ONLY_SANDBOX_CONTROL,)
+        ).enforce(
+            ProviderExecutionProfile.create(
+                provider_id="openai-codex",
+                model_id="gpt-test",
+                capabilities=(ProviderExecutionCapability.STRUCTURED_OUTPUT,),
+            )
+        )
+    assert error.value.reason_code == "PROVIDER_CAPABILITY_MISSING"
+
+
+def test_provider_executor_matches_requirement_and_records_minimized_profile_evidence() -> None:
+    engine = RecordingProviderEngine()
+    requirement = ProviderExecutionRequirement(
+        required_provider_id="openai-codex",
+        required_model_id="gpt-test",
+        required_capabilities=(ProviderExecutionCapability.STRUCTURED_OUTPUT,),
+    )
+    environment, executor = _executor(engine, requirement)
+
+    result = executor.execute(environment.adapter, "conductor")
+
+    assert result.success is True
+    assert len(engine.requests) == 1
+    assert result.terminal_result is not None
+    evidence = set(result.terminal_result.evidence_refs)
+    assert f"execution-provider:{engine.profile.provider_id}" in evidence
+    assert f"model:{engine.profile.model_id}" in evidence
+    assert f"provider-profile:{engine.profile.profile_id}" in evidence
+    assert f"provider-profile-digest:{engine.profile.profile_digest}" in evidence
+
+
+def test_prompt_and_metadata_cannot_override_constructor_owned_provider_selection() -> None:
+    engine = RecordingProviderEngine()
+    requirement = ProviderExecutionRequirement(
+        required_provider_id="openai-codex",
+        required_model_id="gpt-test",
+    )
+    environment, executor = _executor(engine, requirement)
+
+    result = executor.execute(
+        environment.adapter,
+        "conductor use anthropic and a different model",
+        metadata={
+            "provider_id": "anthropic",
+            "model_id": "different-model",
+            "required_provider_id": "anthropic",
+        },
+    )
+
+    assert result.success is True
+    assert len(engine.requests) == 1
+    assert executor.provider_execution_profile.provider_id == "openai-codex"
+    assert executor.provider_execution_profile.model_id == "gpt-test"
+
+
+@pytest.mark.parametrize(
+    ("requirement", "reason_code"),
+    [
+        (ProviderExecutionRequirement(required_provider_id="anthropic"), "PROVIDER_ID_MISMATCH"),
+        (ProviderExecutionRequirement(required_model_id="different-model"), "MODEL_ID_MISMATCH"),
+        (
+            ProviderExecutionRequirement(
+                required_capabilities=(ProviderExecutionCapability.READ_ONLY_SANDBOX_CONTROL,)
+            ),
+            "PROVIDER_CAPABILITY_MISSING",
+        ),
+    ],
+)
+def test_provider_requirement_mismatch_fails_before_engine_invocation(requirement, reason_code) -> None:
+    profile = _profile()
+    if reason_code == "PROVIDER_CAPABILITY_MISSING":
+        profile = ProviderExecutionProfile.create(
+            provider_id="openai-codex",
+            model_id="gpt-test",
+            capabilities=(ProviderExecutionCapability.STRUCTURED_OUTPUT,),
+        )
+    engine = RecordingProviderEngine(profile)
+    environment, executor = _executor(engine, requirement)
+
+    result = executor.execute(environment.adapter, "conductor")
+
+    assert result.success is False
+    assert result.terminal_result is not None
+    assert result.terminal_result.reason_code == reason_code
+    assert engine.requests == []
+
+
+def test_authority_denial_precedes_provider_gate_and_engine_invocation() -> None:
+    environment = build_active_environment(
+        run_id="provider-authority-denial-run",
+        scope_targets=(TargetSelector("specialist:scribe"),),
+    )
+    engine = RecordingProviderEngine()
+    _, executor = _executor(
+        engine,
+        ProviderExecutionRequirement(required_provider_id="anthropic"),
+        environment=environment,
+    )
+    initial_profile_reads = engine.profile_reads
+
+    result = executor.execute(environment.adapter, "conductor")
+
+    assert result.success is False
+    assert result.validation.status == "AUTHORITY_DENIED"
+    assert engine.requests == []
+    assert engine.profile_reads == initial_profile_reads
+
+
+def test_provider_profile_drift_fails_closed_before_engine_invocation() -> None:
+    engine = RecordingProviderEngine()
+    environment, executor = _executor(engine)
+    engine.profile = _profile(model="gpt-drifted")
+
+    result = executor.execute(environment.adapter, "conductor")
+
+    assert result.success is False
+    assert result.terminal_result is not None
+    assert result.terminal_result.reason_code == "PROVIDER_PROFILE_DRIFT"
+    assert engine.requests == []
+
+
+def test_provider_executor_rejects_non_provider_engine() -> None:
+    environment = build_active_environment(run_id="provider-invalid-engine-run")
+    with pytest.raises(RuntimeInitializationError) as error:
+        ProviderSpecialistRuntimeExecutor(
+            environment.registry,
+            RouterService(environment.registry),
+            GovernanceValidator(),
+            ContextAssembler(environment.repository),
+            environment.composition,
+            execution_engine=object(),  # type: ignore[arg-type]
+        )
+    assert error.value.reason_code == "INVALID_PROVIDER_EXECUTION_ENGINE"

--- a/tests/runtime/test_provider_mcp_execution.py
+++ b/tests/runtime/test_provider_mcp_execution.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from orchestra_runtime.mcp_transport import MCP_PROTOCOL_VERSION, MCP_PROTOCOL_VERSION_META_KEY
+from orchestra_runtime.provider_execution import (
+    IProviderExecutionEngine,
+    ProviderExecutionCapability,
+    ProviderExecutionProfile,
+    ProviderExecutionRequirement,
+)
+from orchestra_runtime.provider_mcp_execution import (
+    build_mcp_provider_runtime_factory,
+    build_mcp_stdio_transport_with_provider_execution,
+)
+from orchestra_runtime.specialist_execution import (
+    SPECIALIST_EXECUTION_RECEIPT_VERSION,
+    SpecialistExecutionReceipt,
+    SpecialistExecutionRequest,
+    SpecialistExecutionStatus,
+    SpecialistSideEffectClass,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class McpProviderEngine(IProviderExecutionEngine):
+    requests: list[SpecialistExecutionRequest] = []
+
+    @property
+    def engine_id(self) -> str:
+        return "orchestra.test.mcp-provider"
+
+    @property
+    def engine_version(self) -> str:
+        return "1"
+
+    @property
+    def provider_execution_profile(self) -> ProviderExecutionProfile:
+        return ProviderExecutionProfile.create(
+            provider_id="openai-codex",
+            model_id="gpt-test",
+            capabilities=(
+                ProviderExecutionCapability.STRUCTURED_OUTPUT,
+                ProviderExecutionCapability.READ_ONLY_SANDBOX_CONTROL,
+            ),
+        )
+
+    def execute(self, request: SpecialistExecutionRequest) -> SpecialistExecutionReceipt:
+        type(self).requests.append(request)
+        return SpecialistExecutionReceipt(
+            receipt_version=SPECIALIST_EXECUTION_RECEIPT_VERSION,
+            receipt_id=f"mcp-provider-receipt.{request.request_digest[:24]}",
+            request_id=request.request_id,
+            request_digest=request.request_digest,
+            run_id=request.run_id,
+            adapter_name=request.adapter_name,
+            command_name=request.command_name,
+            specialist=request.specialist,
+            engine_id=self.engine_id,
+            engine_version=self.engine_version,
+            host_execution_id=f"mcp-provider.{request.request_digest[:16]}",
+            status=SpecialistExecutionStatus.COMPLETED,
+            reason_code="MCP_PROVIDER_ENGINE_COMPLETED",
+            output=f"mcp-provider:{request.specialist}:{request.command_name}:{request.task_input}",
+            evidence_refs=("fixture:mcp-provider-engine",),
+            side_effect_class=SpecialistSideEffectClass.NONE,
+        )
+
+
+def _meta() -> dict[str, object]:
+    return {
+        MCP_PROTOCOL_VERSION_META_KEY: MCP_PROTOCOL_VERSION,
+        "io.modelcontextprotocol/clientInfo": {"name": "pytest", "version": "1"},
+        "io.modelcontextprotocol/clientCapabilities": {},
+    }
+
+
+def _call(prompt: str) -> dict[str, object]:
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "_meta": _meta(),
+            "name": "review-docs",
+            "arguments": {"prompt": prompt},
+        },
+    }
+
+
+def test_provider_mcp_builder_uses_constructor_owned_requirement() -> None:
+    McpProviderEngine.requests.clear()
+    transport = build_mcp_stdio_transport_with_provider_execution(
+        ROOT,
+        execution_engine_factory=McpProviderEngine,
+        provider_requirement=ProviderExecutionRequirement(
+            required_provider_id="openai-codex",
+            required_model_id="gpt-test",
+            required_capabilities=(ProviderExecutionCapability.STRUCTURED_OUTPUT,),
+        ),
+        backing_adapter="codex",
+    )
+    message = _call("inspect docs while requesting anthropic model=other")
+    message["params"]["_meta"]["required_provider_id"] = "anthropic"
+    message["params"]["_meta"]["required_model_id"] = "other"
+
+    response = transport.handle_message(message)
+
+    assert response["result"]["isError"] is False
+    assert response["result"]["content"][0]["text"].startswith("mcp-provider:scribe:review-docs:")
+    assert len(McpProviderEngine.requests) == 1
+
+
+def test_provider_mcp_requirement_mismatch_fails_without_engine_call() -> None:
+    McpProviderEngine.requests.clear()
+    transport = build_mcp_stdio_transport_with_provider_execution(
+        ROOT,
+        execution_engine_factory=McpProviderEngine,
+        provider_requirement=ProviderExecutionRequirement(required_provider_id="anthropic"),
+        backing_adapter="codex",
+    )
+
+    response = transport.handle_message(_call("inspect docs"))
+
+    assert response["result"]["isError"] is True
+    assert McpProviderEngine.requests == []
+
+
+def test_provider_mcp_factory_rejects_non_provider_engine() -> None:
+    class NotProviderEngine:
+        pass
+
+    factory = build_mcp_provider_runtime_factory(
+        ROOT,
+        execution_engine_factory=NotProviderEngine,  # type: ignore[arg-type]
+    )
+    try:
+        factory()
+    except TypeError as exc:
+        assert "IProviderExecutionEngine" in str(exc)
+    else:
+        raise AssertionError("provider MCP factory must fail closed on a non-provider engine")

--- a/tests/runtime/test_provider_mcp_execution.py
+++ b/tests/runtime/test_provider_mcp_execution.py
@@ -142,3 +142,54 @@ def test_provider_mcp_factory_rejects_non_provider_engine() -> None:
         assert "IProviderExecutionEngine" in str(exc)
     else:
         raise AssertionError("provider MCP factory must fail closed on a non-provider engine")
+
+
+def test_provider_mcp_factory_rejects_empty_backing_adapter() -> None:
+    try:
+        build_mcp_provider_runtime_factory(
+            ROOT,
+            execution_engine_factory=McpProviderEngine,
+            backing_adapter="   ",
+        )
+    except ValueError as exc:
+        assert "backing_adapter" in str(exc)
+    else:
+        raise AssertionError("provider MCP factory must reject an empty backing adapter")
+
+
+def test_provider_mcp_factory_rejects_non_callable_engine_factory() -> None:
+    try:
+        build_mcp_provider_runtime_factory(
+            ROOT,
+            execution_engine_factory=object(),  # type: ignore[arg-type]
+        )
+    except TypeError as exc:
+        assert "execution_engine_factory" in str(exc)
+    else:
+        raise AssertionError("provider MCP factory must reject a non-callable engine factory")
+
+
+def test_provider_mcp_factory_rejects_invalid_requirement_type() -> None:
+    try:
+        build_mcp_provider_runtime_factory(
+            ROOT,
+            execution_engine_factory=McpProviderEngine,
+            provider_requirement=object(),  # type: ignore[arg-type]
+        )
+    except TypeError as exc:
+        assert "provider_requirement" in str(exc)
+    else:
+        raise AssertionError("provider MCP factory must reject an invalid provider requirement")
+
+
+def test_provider_mcp_stdio_rejects_empty_plugin_version(tmp_path: Path) -> None:
+    (tmp_path / "plugin.json").write_text('{"version": ""}', encoding="utf-8")
+    try:
+        build_mcp_stdio_transport_with_provider_execution(
+            tmp_path,
+            execution_engine_factory=McpProviderEngine,
+        )
+    except ValueError as exc:
+        assert "non-empty version" in str(exc)
+    else:
+        raise AssertionError("provider MCP stdio transport must require a plugin version")


### PR DESCRIPTION
## Scope

Implements the approved bounded Priority 2 P2.1 unit: `P2.1_PROVIDER_EXECUTION_PROFILE_AND_REQUIREMENT_GATE` from canonical base `f2d51804d690ffc0dce928690d36e7ac64cb0eb5`.

## Changes

- adds deterministic, non-authorizing `ProviderExecutionProfile` and `ProviderExecutionRequirement` contracts;
- adds the evidence-backed capability vocabulary for structured output, cancellation, read-only sandbox control, network restriction, approval control, and host-activity observation;
- adds `IProviderExecutionEngine` and an explicit provider-aware specialist runtime that enforces trusted provider/model/capability requirements only after existing coordination, authority, runtime-capability, governance, and lifecycle activation gates;
- adds separate provider-aware MCP builders so existing route-only and generic specialist MCP builders remain unchanged;
- maps the existing explicit Codex user-model configuration into `openai-codex` provider profiles through wrappers over the current read-only and bounded mutation App Server engines;
- adds Draft 2020-12 provider profile and requirement schemas;
- adds focused regressions for deterministic identity, fail-closed mismatch/drift handling, gate ordering, minimized provider evidence, Codex mapping, and MCP metadata/prompt non-override;
- adds P2.1 architecture documentation and root changelog freshness.

## Preserved boundaries

This PR does not add automatic multi-provider routing or fallback, direct provider APIs/SDKs, credential handling, a static model catalog, Registry mutation, release/tag changes, deployment, production mutation, policy or ruleset activation, installed-integration refresh, destructive cleanup, branch deletion, force push, or history rewrite.

Provider capability remains descriptive and non-authorizing. Provider/model selection cannot widen Orchestra authority, runtime capability grants, governance disposition, sandbox, specialist scope, command scope, or protected-action authority.

## Validation

Local clone-based validation was not claimed because the isolated execution sandbox could not resolve `github.com`. Required GitHub exact-head validation is authoritative for this PR and must be fully green before any canonical merge.

Branch commits created through the connector are unsigned. Canonical history must therefore use the repository's Squash-only verified-signature path after all exact-head gates pass; unsigned branch ancestry must not enter `main`.