### PR TITLE
feat(cloak): freeze CUIR-0 corpus governance contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Post-v1.7 Cloak CUIR-0 corpus governance candidate
+
+- Added the bounded `CUIR-0` governance and intake contract for `CLOAK_UI_REFERENCE_CORPUS_V1`, freezing per-repository eligibility, provenance, exact source-revision pinning, reuse classifications, specialist ownership, and data-minimization rules before any broad corpus inventory or pattern extraction.
+- Added machine-validatable policy and source-record schemas that fail closed: missing or ambiguous licenses permit concept-level `REFERENCE_ONLY` treatment only and cannot authorize direct source or asset reuse; account-wide license inference and automatic ingestion are prohibited.
+- Added adversarial tests that reject malformed source revisions, missing non-copying provenance, invalid reuse classifications, missing `Nazia-99` attribution, authority widening, and external-execution widening.
+- CUIR-0 performs no `Nazia-99` repository inventory, hard-codes no repository count, copies no external source/assets, installs no external dependencies, executes no external project code, grants no Cloak implementation authority, and does not authorize provider routing/fallback, merge, release, deployment, policy activation, integration refresh, destructive cleanup, branch deletion, force push, or history rewrite.
+
 ## Post-v1.7 Priority 2 VS Code multi-harness provider qualification candidate
 
 - Added a bounded, non-authorizing VS Code provider-observation and qualification layer that keeps host, harness, provider source, provider, model, and authority identities separate across Local, Copilot, Claude, and Codex session paths.

--- a/README.json
+++ b/README.json
@@ -74,6 +74,19 @@
       "release_authorized": false,
       "authority_note": "P2.2B records and classifies evidence only. A configured model, successful VS Code response, provider-native harness observation, deterministic CI pass, or qualification receipt cannot grant provider execution, automatic routing/fallback, merge, release, deployment, policy activation, credential mutation, installed-integration refresh, or other protected-action authority."
     },
+    "cloak_ui_reference_corpus_cuir0": {
+      "status": "CUIR_0_IMPLEMENTED_CANDIDATE_PENDING_CANONICALIZATION",
+      "purpose": "Freeze provenance-aware external UI and icon corpus eligibility, per-repository licensing and reuse, non-execution, data-minimization, source-record, and specialist-handoff rules before inventory or pattern extraction.",
+      "machine_sources": ["machine/governance/cloak-ui-reference-corpus-policy.v1.json", "machine/schemas/cloak-ui-reference-corpus-policy.v1.schema.json", "machine/schemas/cloak-ui-reference-source-record.v1.schema.json"],
+      "human_sources": ["docs/project/CLOAK_UI_REFERENCE_CORPUS_PLAN.md", "docs/project/CLOAK_UI_REFERENCE_CORPUS_CUIR0_CONTRACT.md"],
+      "validation_surface": "tests/runtime/test_cloak_ui_reference_corpus_governance.py",
+      "runtime_integration": false,
+      "current_inventory": "NOT_STARTED_CUIR_1",
+      "external_code_execution": false,
+      "automatic_ingestion": false,
+      "code_implementation_authority": false,
+      "authority_note": "CUIR-0 freezes source-intake and reuse boundaries only. It does not inventory or ingest repositories, authorize copying, execute external code, grant Cloak implementation authority, or grant merge, release, deployment, policy, provider-routing, or other protected-action authority."
+    },
     "cross_specialist_coordination": {"status": "IMPLEMENTED", "human_sources": ["docs/governance/TUNER_PROTOCOL.md", "ROUTING_MAP.md"]},
     "validation_and_evidence": {"status": "IMPLEMENTED", "machine_sources": ["machine/schemas/", "machine/release-evidence/"], "human_sources": ["docs/setup/VALIDATION.md", "docs/validation/"]},
     "unified_testing_mechanism_t0_t9": {

--- a/docs/project/CLOAK_UI_REFERENCE_CORPUS_CUIR0_CONTRACT.md
+++ b/docs/project/CLOAK_UI_REFERENCE_CORPUS_CUIR0_CONTRACT.md
@@ -1,0 +1,250 @@
+# Cloak UI Reference Corpus — CUIR-0 Governance and Intake Contract
+
+Status: `CUIR_0_IMPLEMENTED_CANDIDATE`
+
+Plan ID: `CLOAK_UI_REFERENCE_CORPUS_V1`
+
+Phase: `CUIR-0`
+
+Canonical planning source: `docs/project/CLOAK_UI_REFERENCE_CORPUS_PLAN.md`
+
+Machine policy: `machine/governance/cloak-ui-reference-corpus-policy.v1.json`
+
+Source-record schema: `machine/schemas/cloak-ui-reference-source-record.v1.schema.json`
+
+Policy schema: `machine/schemas/cloak-ui-reference-corpus-policy.v1.schema.json`
+
+## Purpose
+
+CUIR-0 freezes the governance and intake rules for the Cloak UI Reference Corpus before broad repository inventory or pattern extraction begins.
+
+This unit does **not** inventory the current `Nazia-99` repositories, pin individual corpus repositories, execute external projects, ingest source into Cloak, or promote any pattern into supported behavior. Those activities begin only in later governed CUIR phases.
+
+The governing invariant is:
+
+```text
+REFERENCE TO PATTERN OR LOGIC != COPYING SOURCE CODE
+PUBLIC REPOSITORY != AUTOMATIC REUSE PERMISSION
+DESIGN INSPIRATION != SOURCE OWNERSHIP
+```
+
+## CUIR-0 eligibility contract
+
+A source is eligible to proceed toward CUIR-1 classification only when all of the following hold:
+
+1. the source is publicly visible at the time of inspection;
+2. the repository or artifact has material UI, UX, icon, interaction, layout, responsive, visual-hierarchy, accessibility, or frontend-pattern relevance;
+3. repository identity is unambiguous;
+4. each repository is licensed and classified independently rather than inheriting a license from an account or neighboring repository;
+5. a retained source is pinned to an exact source revision before deep CUIR-2 analysis;
+6. relevant provenance evidence can be retained without mirroring the full repository;
+7. no external execution is required to establish the intended static evidence.
+
+The historical approximate repository count is not an intake constant:
+
+```text
+UI_CORPUS_ACCOUNT = Nazia-99
+UI_CORPUS_COUNT = DISCOVER_AT_CUIR_1
+```
+
+CUIR-0 therefore contains no hard-coded repository count and no inventory result.
+
+## Corpus separation
+
+### UI reference corpus
+
+Initial account:
+
+```text
+Nazia-99
+```
+
+Default treatment:
+
+```text
+PATTERN_REFERENCE_FIRST
+```
+
+The default purpose is concept-level pattern study, not source acquisition.
+
+### Icon reference corpus
+
+The icon corpus remains a separate asset-oriented sub-corpus:
+
+- `simple-icons/simple-icons`
+- `tabler/tabler-icons`
+- `lucide-icons/lucide`
+
+Their current license assertions remain planning inputs until CUIR-1 pins exact repository revisions and authoritative license evidence. CUIR-0 does not convert those planning assertions into fresh empirical license evidence.
+
+## Reuse classifications
+
+Every retained source or asset must receive exactly one of these dispositions:
+
+### `REFERENCE_ONLY`
+
+Concepts, patterns, behavior, layout techniques, or general logic may be studied. Original source expression and assets are not copied.
+
+### `REUSE_WITH_NOTICE`
+
+Direct reuse or modification may occur only after a verified permissive license and applicable notice obligations are recorded for the pinned source revision.
+
+### `REUSE_WITH_RIGHTS_REVIEW`
+
+Copyright permission may exist, but trademark, brand, patent, asset-origin, or other rights require separate review before the intended use.
+
+### `PROHIBITED`
+
+The source or asset must not be used when provenance, licensing, rights, integrity, or safety cannot establish an acceptable basis for the intended use.
+
+## Fail-closed licensing matrix
+
+| Evidence state | Pattern study | Direct reuse |
+| --- | --- | --- |
+| Verified permissive license | Allowed within recorded scope | Only under `REUSE_WITH_NOTICE` or separately reviewed rights classification |
+| No license detected | `REFERENCE_ONLY` | `PROHIBITED` |
+| License scope ambiguous | `REFERENCE_ONLY` | `PROHIBITED` |
+| Copyright permission exists but other rights are unresolved | Concept-level study allowed when provenance is adequate | `PROHIBITED` until rights review completes |
+| Provenance or integrity is unacceptable | `PROHIBITED` | `PROHIBITED` |
+
+A public repository is never treated as permission to copy.
+
+## Source-record contract
+
+Each retained CUIR source record must include at minimum:
+
+```text
+repository
+owner
+source_revision
+source_paths_or_artifact_ids
+source_category
+license_identifier
+license_evidence
+reuse_classification
+attribution_or_notice_requirements
+pattern_or_asset_summary
+what_was_learned_or_reused
+what_was_not_copied
+review_owner
+```
+
+The machine schema also requires a record identifier and schema version.
+
+For a missing license, use an explicit evidence state such as `NONE_DETECTED`; do not omit the license field. For ambiguous license scope, use an explicit state such as `AMBIGUOUS`. Either state limits the record to `REFERENCE_ONLY` or `PROHIBITED`.
+
+For retained `Nazia-99` UI pattern records, attribution must name `Nazia-99` and the specific repository. Account-level attribution alone is insufficient.
+
+If the upstream repository changes after the pinned revision, the previous record remains historical and the changed revision requires a new or explicitly refreshed record.
+
+## External-code non-execution rule
+
+CUIR corpus analysis is static by default. During CUIR-0 and subsequent static corpus analysis:
+
+```text
+RUN_EXTERNAL_BUILD_SCRIPTS = FALSE
+INSTALL_EXTERNAL_PROJECT_DEPENDENCIES = FALSE
+EXECUTE_EXTERNAL_APPLICATION_CODE = FALSE
+EXECUTE_UNKNOWN_REPOSITORY_SCRIPTS = FALSE
+```
+
+Permitted evidence collection includes repository metadata, source text inspection, asset inspection, documentation review, structure analysis, and authoritative license/provenance files.
+
+A screenshot, demo, or generated output does not itself establish ownership or reuse rights.
+
+## Data minimization and evidence rules
+
+CUIR records must retain the smallest evidence set needed to establish provenance, relevance, and licensing decisions.
+
+Required behavior:
+
+- retain exact repository identity and pinned revision;
+- retain only relevant source paths or artifact identifiers;
+- retain authoritative license evidence or an explicit absence/ambiguity check;
+- retain concept-level pattern summaries by default;
+- retain required attribution or license notices;
+- retain what was learned or reused and what was deliberately not copied.
+
+Prohibited behavior:
+
+- mirroring an entire repository merely for corpus storage;
+- retaining unrelated assets or source files;
+- treating corpus size as evidence of specialist quality;
+- automatically injecting all retained patterns into Cloak context.
+
+## Specialist ownership and handoff
+
+### Artificer
+
+Owns source intake, repository pinning, static-inspection boundaries, license/provenance evidence collection, and external-source records.
+
+Artificer cannot approve its own findings for implementation.
+
+### Cloak
+
+Owns UI/UX interpretation, pattern taxonomy, pattern selection, icon suitability, accessibility/user consequences, and provenance-aware design recommendations.
+
+Cloak receives no code implementation authority from the corpus.
+
+### Governor
+
+Owns licensing/governance review when reuse obligations or rights are ambiguous or material.
+
+### Clockwork
+
+Owns architecture and component-boundary decisions when a pattern affects shared frontend architecture or ownership.
+
+### Ponytail
+
+Owns separately authorized implementation of Orchestra-native or project-native changes.
+
+### Overseer
+
+Owns evaluation evidence, regression evidence, and readiness verification.
+
+### Arbiter
+
+Owns evidence-based disposition between governed CUIR phases.
+
+## Authority boundary
+
+CUIR-0 grants no authority for:
+
+- external code execution;
+- automatic corpus ingestion;
+- code implementation;
+- automatic provider routing or fallback;
+- direct provider API integration;
+- credential/settings mutation;
+- installed-integration refresh;
+- Registry mutation;
+- merge or release;
+- deployment or production mutation;
+- policy/ruleset activation or bypass;
+- destructive cleanup;
+- branch deletion;
+- force push or history rewrite.
+
+The machine policy encodes the CUIR-specific authority fields as constant `false` values.
+
+## CUIR-0 exit gate
+
+CUIR-0 is ready for closeout only when:
+
+1. the machine governance policy validates against its schema;
+2. the source-record schema contains the required provenance fields;
+3. missing or ambiguous licenses cannot authorize direct reuse;
+4. repository-count discovery remains deferred to CUIR-1;
+5. account-wide license inference is disabled;
+6. external execution remains prohibited;
+7. data-minimization rules prevent full-repository mirroring by default;
+8. Artificer/Cloak/Governor/Clockwork/Ponytail/Overseer/Arbiter ownership boundaries are preserved;
+9. tests demonstrate the contract fails closed for malformed source revisions, missing provenance fields, and invalid reuse claims.
+
+Passing CUIR-0 authorizes only the next bounded inventory/classification phase defined by the canonical plan:
+
+```text
+CUIR-1 = CURRENT_INVENTORY_AND_LICENSE_PROVENANCE_CLASSIFICATION
+```
+
+It does not authorize CUIR-2 static pattern extraction until CUIR-1 establishes the retained corpus and exact revision/license evidence.

--- a/machine/governance/cloak-ui-reference-corpus-policy.v1.json
+++ b/machine/governance/cloak-ui-reference-corpus-policy.v1.json
@@ -1,0 +1,131 @@
+{
+  "schema_version": "orchestra.cloak-ui-reference-corpus-policy.v1",
+  "plan_id": "CLOAK_UI_REFERENCE_CORPUS_V1",
+  "phase": "CUIR-0",
+  "status": "ACTIVE_GOVERNANCE_CONTRACT",
+  "source_of_truth": {
+    "planning_document": "docs/project/CLOAK_UI_REFERENCE_CORPUS_PLAN.md",
+    "implementation_contract": "docs/project/CLOAK_UI_REFERENCE_CORPUS_CUIR0_CONTRACT.md",
+    "padayon_role": "MIRROR_CONTINUITY_ONLY"
+  },
+  "corpus": {
+    "ui_reference": {
+      "initial_account": "Nazia-99",
+      "repository_count": "DISCOVER_AT_CUIR_1",
+      "default_treatment": "PATTERN_REFERENCE_FIRST"
+    },
+    "icon_reference": {
+      "repositories": [
+        "simple-icons/simple-icons",
+        "tabler/tabler-icons",
+        "lucide-icons/lucide"
+      ],
+      "separate_subcorpus": true
+    }
+  },
+  "eligibility": {
+    "public_visibility_required": true,
+    "ui_or_icon_relevance_required": true,
+    "repository_identity_required": true,
+    "exact_revision_required_before_deep_analysis": true,
+    "license_classified_per_repository": true,
+    "automatic_ingestion": false,
+    "account_wide_license_inference": false
+  },
+  "reuse": {
+    "classifications": [
+      "REFERENCE_ONLY",
+      "REUSE_WITH_NOTICE",
+      "REUSE_WITH_RIGHTS_REVIEW",
+      "PROHIBITED"
+    ],
+    "license_fail_closed": {
+      "missing_or_ambiguous_license_pattern_treatment": "REFERENCE_ONLY",
+      "missing_or_ambiguous_license_direct_reuse": "PROHIBITED",
+      "unresolved_rights_direct_reuse": "PROHIBITED"
+    },
+    "direct_reuse_requires_verified_permission": true
+  },
+  "external_execution": {
+    "allowed": false,
+    "run_build_scripts": false,
+    "install_project_dependencies": false,
+    "execute_application_code": false,
+    "execute_unknown_scripts": false
+  },
+  "data_minimization": {
+    "retain_only_relevant_evidence": true,
+    "mirror_entire_repository": false,
+    "retain_unneeded_assets": false,
+    "pattern_records_must_be_concept_level_by_default": true
+  },
+  "provenance": {
+    "source_record_schema": "machine/schemas/cloak-ui-reference-source-record.v1.schema.json",
+    "required_fields": [
+      "repository",
+      "owner",
+      "source_revision",
+      "source_paths_or_artifact_ids",
+      "source_category",
+      "license_identifier",
+      "license_evidence",
+      "reuse_classification",
+      "attribution_or_notice_requirements",
+      "pattern_or_asset_summary",
+      "what_was_learned_or_reused",
+      "what_was_not_copied",
+      "review_owner"
+    ],
+    "specific_repository_attribution_required": true,
+    "source_revision_refresh_required_on_change": true
+  },
+  "roles": {
+    "Artificer": [
+      "source intake",
+      "pinned repository identity",
+      "static inspection boundary",
+      "license and provenance evidence collection",
+      "external pattern records"
+    ],
+    "Cloak": [
+      "UI and UX interpretation",
+      "pattern taxonomy",
+      "pattern selection",
+      "icon design suitability",
+      "accessibility and user-facing consequences",
+      "provenance-aware design recommendations"
+    ],
+    "Governor": [
+      "licensing and governance review for ambiguous or material reuse obligations"
+    ],
+    "Clockwork": [
+      "architecture and component-boundary review when a pattern affects shared frontend ownership"
+    ],
+    "Ponytail": [
+      "separately authorized Orchestra-native or project-native implementation"
+    ],
+    "Overseer": [
+      "evaluation evidence",
+      "regression evidence",
+      "readiness verification"
+    ],
+    "Arbiter": [
+      "evidence-based transition disposition between governed CUIR phases"
+    ]
+  },
+  "handoff": {
+    "artificer_cannot_self_approve_implementation": true,
+    "cloak_has_code_implementation_authority": false,
+    "cuir1_requires_cuir0_pass": true
+  },
+  "authority": {
+    "external_code_execution_authorized": false,
+    "automatic_ingestion_authorized": false,
+    "code_implementation_authorized": false,
+    "merge_authorized": false,
+    "release_authorized": false,
+    "deployment_authorized": false,
+    "policy_activation_authorized": false,
+    "automatic_provider_routing_authorized": false
+  }
+}

--- a/machine/schemas/cloak-ui-reference-corpus-policy.v1.schema.json
+++ b/machine/schemas/cloak-ui-reference-corpus-policy.v1.schema.json
@@ -1,0 +1,209 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "orchestra://schemas/cloak-ui-reference-corpus-policy.v1",
+  "title": "Orchestra Cloak UI Reference Corpus Policy v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "plan_id",
+    "phase",
+    "status",
+    "source_of_truth",
+    "corpus",
+    "eligibility",
+    "reuse",
+    "external_execution",
+    "data_minimization",
+    "provenance",
+    "roles",
+    "handoff",
+    "authority"
+  ],
+  "properties": {
+    "schema_version": {"const": "orchestra.cloak-ui-reference-corpus-policy.v1"},
+    "plan_id": {"const": "CLOAK_UI_REFERENCE_CORPUS_V1"},
+    "phase": {"const": "CUIR-0"},
+    "status": {"enum": ["ACTIVE_GOVERNANCE_CONTRACT", "SUPERSEDED"]},
+    "source_of_truth": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["planning_document", "implementation_contract", "padayon_role"],
+      "properties": {
+        "planning_document": {"const": "docs/project/CLOAK_UI_REFERENCE_CORPUS_PLAN.md"},
+        "implementation_contract": {"const": "docs/project/CLOAK_UI_REFERENCE_CORPUS_CUIR0_CONTRACT.md"},
+        "padayon_role": {"const": "MIRROR_CONTINUITY_ONLY"}
+      }
+    },
+    "corpus": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ui_reference", "icon_reference"],
+      "properties": {
+        "ui_reference": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["initial_account", "repository_count", "default_treatment"],
+          "properties": {
+            "initial_account": {"const": "Nazia-99"},
+            "repository_count": {"const": "DISCOVER_AT_CUIR_1"},
+            "default_treatment": {"const": "PATTERN_REFERENCE_FIRST"}
+          }
+        },
+        "icon_reference": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["repositories", "separate_subcorpus"],
+          "properties": {
+            "repositories": {
+              "type": "array",
+              "uniqueItems": true,
+              "minItems": 3,
+              "maxItems": 3,
+              "items": {"enum": ["simple-icons/simple-icons", "tabler/tabler-icons", "lucide-icons/lucide"]}
+            },
+            "separate_subcorpus": {"const": true}
+          }
+        }
+      }
+    },
+    "eligibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "public_visibility_required",
+        "ui_or_icon_relevance_required",
+        "repository_identity_required",
+        "exact_revision_required_before_deep_analysis",
+        "license_classified_per_repository",
+        "automatic_ingestion",
+        "account_wide_license_inference"
+      ],
+      "properties": {
+        "public_visibility_required": {"const": true},
+        "ui_or_icon_relevance_required": {"const": true},
+        "repository_identity_required": {"const": true},
+        "exact_revision_required_before_deep_analysis": {"const": true},
+        "license_classified_per_repository": {"const": true},
+        "automatic_ingestion": {"const": false},
+        "account_wide_license_inference": {"const": false}
+      }
+    },
+    "reuse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["classifications", "license_fail_closed", "direct_reuse_requires_verified_permission"],
+      "properties": {
+        "classifications": {
+          "type": "array",
+          "uniqueItems": true,
+          "minItems": 4,
+          "maxItems": 4,
+          "items": {"enum": ["REFERENCE_ONLY", "REUSE_WITH_NOTICE", "REUSE_WITH_RIGHTS_REVIEW", "PROHIBITED"]}
+        },
+        "license_fail_closed": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "missing_or_ambiguous_license_pattern_treatment",
+            "missing_or_ambiguous_license_direct_reuse",
+            "unresolved_rights_direct_reuse"
+          ],
+          "properties": {
+            "missing_or_ambiguous_license_pattern_treatment": {"const": "REFERENCE_ONLY"},
+            "missing_or_ambiguous_license_direct_reuse": {"const": "PROHIBITED"},
+            "unresolved_rights_direct_reuse": {"const": "PROHIBITED"}
+          }
+        },
+        "direct_reuse_requires_verified_permission": {"const": true}
+      }
+    },
+    "external_execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["allowed", "run_build_scripts", "install_project_dependencies", "execute_application_code", "execute_unknown_scripts"],
+      "properties": {
+        "allowed": {"const": false},
+        "run_build_scripts": {"const": false},
+        "install_project_dependencies": {"const": false},
+        "execute_application_code": {"const": false},
+        "execute_unknown_scripts": {"const": false}
+      }
+    },
+    "data_minimization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["retain_only_relevant_evidence", "mirror_entire_repository", "retain_unneeded_assets", "pattern_records_must_be_concept_level_by_default"],
+      "properties": {
+        "retain_only_relevant_evidence": {"const": true},
+        "mirror_entire_repository": {"const": false},
+        "retain_unneeded_assets": {"const": false},
+        "pattern_records_must_be_concept_level_by_default": {"const": true}
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_record_schema", "required_fields", "specific_repository_attribution_required", "source_revision_refresh_required_on_change"],
+      "properties": {
+        "source_record_schema": {"const": "machine/schemas/cloak-ui-reference-source-record.v1.schema.json"},
+        "required_fields": {
+          "type": "array",
+          "uniqueItems": true,
+          "minItems": 12,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "specific_repository_attribution_required": {"const": true},
+        "source_revision_refresh_required_on_change": {"const": true}
+      }
+    },
+    "roles": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["Artificer", "Cloak", "Governor", "Clockwork", "Ponytail", "Overseer", "Arbiter"],
+      "properties": {
+        "Artificer": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+        "Cloak": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+        "Governor": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+        "Clockwork": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+        "Ponytail": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+        "Overseer": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+        "Arbiter": {"type": "array", "minItems": 1, "items": {"type": "string"}}
+      }
+    },
+    "handoff": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artificer_cannot_self_approve_implementation", "cloak_has_code_implementation_authority", "cuir1_requires_cuir0_pass"],
+      "properties": {
+        "artificer_cannot_self_approve_implementation": {"const": true},
+        "cloak_has_code_implementation_authority": {"const": false},
+        "cuir1_requires_cuir0_pass": {"const": true}
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "external_code_execution_authorized",
+        "automatic_ingestion_authorized",
+        "code_implementation_authorized",
+        "merge_authorized",
+        "release_authorized",
+        "deployment_authorized",
+        "policy_activation_authorized",
+        "automatic_provider_routing_authorized"
+      ],
+      "properties": {
+        "external_code_execution_authorized": {"const": false},
+        "automatic_ingestion_authorized": {"const": false},
+        "code_implementation_authorized": {"const": false},
+        "merge_authorized": {"const": false},
+        "release_authorized": {"const": false},
+        "deployment_authorized": {"const": false},
+        "policy_activation_authorized": {"const": false},
+        "automatic_provider_routing_authorized": {"const": false}
+      }
+    }
+  }
+}

--- a/machine/schemas/cloak-ui-reference-source-record.v1.schema.json
+++ b/machine/schemas/cloak-ui-reference-source-record.v1.schema.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "orchestra://schemas/cloak-ui-reference-source-record.v1",
+  "title": "Orchestra Cloak UI Reference Source Record v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "record_id",
+    "repository",
+    "owner",
+    "source_revision",
+    "source_paths_or_artifact_ids",
+    "source_category",
+    "license_identifier",
+    "license_evidence",
+    "reuse_classification",
+    "attribution_or_notice_requirements",
+    "pattern_or_asset_summary",
+    "what_was_learned_or_reused",
+    "what_was_not_copied",
+    "review_owner"
+  ],
+  "properties": {
+    "schema_version": {"const": "orchestra.cloak-ui-reference-source-record.v1"},
+    "record_id": {"type": "string", "minLength": 1, "maxLength": 160, "pattern": "^[a-z0-9][a-z0-9._-]*$"},
+    "repository": {"type": "string", "minLength": 3, "maxLength": 200, "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"},
+    "owner": {"type": "string", "minLength": 1, "maxLength": 100},
+    "source_revision": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+    "source_paths_or_artifact_ids": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1, "maxLength": 500}
+    },
+    "source_category": {
+      "enum": ["UI_REFERENCE", "BRAND_ICONS", "GENERAL_UI_ICONS"]
+    },
+    "license_identifier": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 100,
+      "description": "Use an SPDX identifier when verified or an explicit sentinel such as NONE_DETECTED or AMBIGUOUS when reuse rights are not established."
+    },
+    "license_evidence": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type", "reference", "source_revision"],
+        "properties": {
+          "type": {"enum": ["LICENSE_FILE", "REPOSITORY_METADATA", "UPSTREAM_NOTICE", "ARTIFACT_LICENSE_MAP", "ABSENCE_CHECK"]},
+          "reference": {"type": "string", "minLength": 1, "maxLength": 1000},
+          "source_revision": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+          "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+          "notes": {"type": "string", "maxLength": 2000}
+        }
+      }
+    },
+    "reuse_classification": {
+      "enum": ["REFERENCE_ONLY", "REUSE_WITH_NOTICE", "REUSE_WITH_RIGHTS_REVIEW", "PROHIBITED"]
+    },
+    "attribution_or_notice_requirements": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1, "maxLength": 1000}
+    },
+    "pattern_or_asset_summary": {"type": "string", "minLength": 1, "maxLength": 4000},
+    "what_was_learned_or_reused": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"type": "string", "minLength": 1, "maxLength": 2000}
+    },
+    "what_was_not_copied": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"type": "string", "minLength": 1, "maxLength": 2000}
+    },
+    "review_owner": {
+      "enum": ["Artificer", "Cloak", "Governor", "Clockwork", "Ponytail", "Overseer", "Arbiter"]
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {"license_identifier": {"enum": ["NONE_DETECTED", "AMBIGUOUS"]}},
+        "required": ["license_identifier"]
+      },
+      "then": {
+        "properties": {"reuse_classification": {"enum": ["REFERENCE_ONLY", "PROHIBITED"]}}
+      }
+    },
+    {
+      "if": {
+        "properties": {"source_category": {"const": "UI_REFERENCE"}, "owner": {"const": "Nazia-99"}},
+        "required": ["source_category", "owner"]
+      },
+      "then": {
+        "properties": {
+          "attribution_or_notice_requirements": {
+            "contains": {"type": "string", "pattern": "Nazia-99"}
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/runtime/test_cloak_ui_reference_corpus_governance.py
+++ b/tests/runtime/test_cloak_ui_reference_corpus_governance.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
+
+
+ROOT = Path(__file__).resolve().parents[2]
+POLICY_PATH = ROOT / "machine/governance/cloak-ui-reference-corpus-policy.v1.json"
+POLICY_SCHEMA_PATH = ROOT / "machine/schemas/cloak-ui-reference-corpus-policy.v1.schema.json"
+SOURCE_SCHEMA_PATH = ROOT / "machine/schemas/cloak-ui-reference-source-record.v1.schema.json"
+
+
+def load_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def valid_reference_record(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": "orchestra.cloak-ui-reference-source-record.v1",
+        "record_id": "nazia-99.example-ui.0123456789ab",
+        "repository": "Nazia-99/Example-UI",
+        "owner": "Nazia-99",
+        "source_revision": "1" * 40,
+        "source_paths_or_artifact_ids": ["index.html", "style.css"],
+        "source_category": "UI_REFERENCE",
+        "license_identifier": "NONE_DETECTED",
+        "license_evidence": [
+            {
+                "type": "ABSENCE_CHECK",
+                "reference": "No license file or repository license metadata detected at pinned revision",
+                "source_revision": "1" * 40,
+            }
+        ],
+        "reuse_classification": "REFERENCE_ONLY",
+        "attribution_or_notice_requirements": [
+            "Acknowledge Nazia-99 and repository Nazia-99/Example-UI in the retained pattern record"
+        ],
+        "pattern_or_asset_summary": "Reference-only layout and interaction concepts.",
+        "what_was_learned_or_reused": ["General card hierarchy and state grouping concept"],
+        "what_was_not_copied": ["No original source code, assets, or substantial implementation expression copied"],
+        "review_owner": "Artificer",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_machine_policy_validates_against_cuir0_schema() -> None:
+    policy = load_json(POLICY_PATH)
+    schema = load_json(POLICY_SCHEMA_PATH)
+
+    Draft202012Validator(schema).validate(policy)
+    assert policy["schema_version"] == "orchestra.cloak-ui-reference-corpus-policy.v1"
+    assert policy["plan_id"] == "CLOAK_UI_REFERENCE_CORPUS_V1"
+    assert policy["phase"] == "CUIR-0"
+
+
+def test_ui_repository_count_is_discovered_in_cuir1_not_hard_coded() -> None:
+    policy = load_json(POLICY_PATH)
+    ui_reference = policy["corpus"]["ui_reference"]
+
+    assert ui_reference["initial_account"] == "Nazia-99"
+    assert ui_reference["repository_count"] == "DISCOVER_AT_CUIR_1"
+    assert not isinstance(ui_reference["repository_count"], int)
+
+
+def test_icon_corpus_remains_separate_and_exactly_scoped() -> None:
+    policy = load_json(POLICY_PATH)
+    icon_reference = policy["corpus"]["icon_reference"]
+
+    assert icon_reference["separate_subcorpus"] is True
+    assert icon_reference["repositories"] == [
+        "simple-icons/simple-icons",
+        "tabler/tabler-icons",
+        "lucide-icons/lucide",
+    ]
+
+
+def test_account_wide_license_inference_and_automatic_ingestion_are_disabled() -> None:
+    policy = load_json(POLICY_PATH)
+    eligibility = policy["eligibility"]
+
+    assert eligibility["license_classified_per_repository"] is True
+    assert eligibility["account_wide_license_inference"] is False
+    assert eligibility["automatic_ingestion"] is False
+    assert eligibility["exact_revision_required_before_deep_analysis"] is True
+
+
+def test_missing_or_ambiguous_license_fails_closed_for_direct_reuse() -> None:
+    policy = load_json(POLICY_PATH)
+    fail_closed = policy["reuse"]["license_fail_closed"]
+
+    assert fail_closed["missing_or_ambiguous_license_pattern_treatment"] == "REFERENCE_ONLY"
+    assert fail_closed["missing_or_ambiguous_license_direct_reuse"] == "PROHIBITED"
+    assert fail_closed["unresolved_rights_direct_reuse"] == "PROHIBITED"
+    assert policy["reuse"]["direct_reuse_requires_verified_permission"] is True
+
+
+def test_external_repository_execution_is_completely_disabled() -> None:
+    policy = load_json(POLICY_PATH)
+    execution = policy["external_execution"]
+
+    assert execution == {
+        "allowed": False,
+        "run_build_scripts": False,
+        "install_project_dependencies": False,
+        "execute_application_code": False,
+        "execute_unknown_scripts": False,
+    }
+
+
+def test_data_minimization_prevents_default_repository_mirroring() -> None:
+    policy = load_json(POLICY_PATH)
+    minimization = policy["data_minimization"]
+
+    assert minimization["retain_only_relevant_evidence"] is True
+    assert minimization["mirror_entire_repository"] is False
+    assert minimization["retain_unneeded_assets"] is False
+    assert minimization["pattern_records_must_be_concept_level_by_default"] is True
+
+
+def test_source_record_schema_preserves_plan_required_fields() -> None:
+    policy = load_json(POLICY_PATH)
+    schema = load_json(SOURCE_SCHEMA_PATH)
+    required = set(schema["required"])
+
+    assert set(policy["provenance"]["required_fields"]).issubset(required)
+    assert {
+        "repository",
+        "owner",
+        "source_revision",
+        "source_paths_or_artifact_ids",
+        "source_category",
+        "license_identifier",
+        "license_evidence",
+        "reuse_classification",
+        "attribution_or_notice_requirements",
+        "pattern_or_asset_summary",
+        "what_was_learned_or_reused",
+        "what_was_not_copied",
+        "review_owner",
+    }.issubset(required)
+
+
+def test_reference_only_unlicensed_nazia_record_is_valid() -> None:
+    schema = load_json(SOURCE_SCHEMA_PATH)
+
+    Draft202012Validator(schema).validate(valid_reference_record())
+
+
+def test_unlicensed_record_cannot_claim_reuse_with_notice() -> None:
+    schema = load_json(SOURCE_SCHEMA_PATH)
+
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(
+            valid_reference_record(reuse_classification="REUSE_WITH_NOTICE")
+        )
+
+
+def test_ambiguous_license_cannot_claim_rights_review_reuse() -> None:
+    schema = load_json(SOURCE_SCHEMA_PATH)
+
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(
+            valid_reference_record(
+                license_identifier="AMBIGUOUS",
+                reuse_classification="REUSE_WITH_RIGHTS_REVIEW",
+            )
+        )
+
+
+def test_nazia_reference_record_requires_nazia_attribution() -> None:
+    schema = load_json(SOURCE_SCHEMA_PATH)
+
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(
+            valid_reference_record(
+                attribution_or_notice_requirements=["Specific repository acknowledgement required"]
+            )
+        )
+
+
+def test_source_revision_must_be_exact_commit_sha() -> None:
+    schema = load_json(SOURCE_SCHEMA_PATH)
+
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(valid_reference_record(source_revision="main"))
+
+
+def test_source_record_fails_when_non_copying_evidence_is_missing() -> None:
+    schema = load_json(SOURCE_SCHEMA_PATH)
+    record = valid_reference_record()
+    record.pop("what_was_not_copied")
+
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(record)
+
+
+def test_source_record_rejects_unknown_reuse_classification() -> None:
+    schema = load_json(SOURCE_SCHEMA_PATH)
+
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(
+            valid_reference_record(reuse_classification="PUBLIC_REPO_FREE_TO_COPY")
+        )
+
+
+def test_policy_authority_is_non_authorizing() -> None:
+    policy = load_json(POLICY_PATH)
+
+    assert policy["authority"] == {
+        "external_code_execution_authorized": False,
+        "automatic_ingestion_authorized": False,
+        "code_implementation_authorized": False,
+        "merge_authorized": False,
+        "release_authorized": False,
+        "deployment_authorized": False,
+        "policy_activation_authorized": False,
+        "automatic_provider_routing_authorized": False,
+    }
+
+
+def test_specialist_ownership_keeps_artificer_and_cloak_non_implementing() -> None:
+    policy = load_json(POLICY_PATH)
+
+    assert set(policy["roles"]) == {
+        "Artificer",
+        "Cloak",
+        "Governor",
+        "Clockwork",
+        "Ponytail",
+        "Overseer",
+        "Arbiter",
+    }
+    assert policy["handoff"]["artificer_cannot_self_approve_implementation"] is True
+    assert policy["handoff"]["cloak_has_code_implementation_authority"] is False
+    assert policy["handoff"]["cuir1_requires_cuir0_pass"] is True
+
+
+def test_policy_schema_prevents_authority_widening() -> None:
+    policy = load_json(POLICY_PATH)
+    schema = load_json(POLICY_SCHEMA_PATH)
+    widened = copy.deepcopy(policy)
+    widened["authority"]["code_implementation_authorized"] = True
+
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(widened)
+
+
+def test_policy_schema_prevents_external_execution_widening() -> None:
+    policy = load_json(POLICY_PATH)
+    schema = load_json(POLICY_SCHEMA_PATH)
+    widened = copy.deepcopy(policy)
+    widened["external_execution"]["allowed"] = True
+
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(widened)


### PR DESCRIPTION
Implements the bounded `CUIR-0` unit from the canonical `CLOAK_UI_REFERENCE_CORPUS_V1` plan.

Scope:
- freeze UI/icon corpus eligibility and intake rules;
- define exact reuse classes: `REFERENCE_ONLY`, `REUSE_WITH_NOTICE`, `REUSE_WITH_RIGHTS_REVIEW`, `PROHIBITED`;
- fail closed so missing/ambiguous licenses permit concept-level reference only and cannot authorize direct reuse;
- prohibit external build/dependency/application/unknown-script execution during corpus analysis;
- prohibit account-wide license inference and automatic corpus ingestion;
- require exact repository revision pinning before deep analysis;
- define a strict source-record schema with provenance, attribution/notice, learned/reused, and explicitly-not-copied fields;
- preserve Artificer/Cloak/Governor/Clockwork/Ponytail/Overseer/Arbiter ownership boundaries;
- encode non-authorizing authority fields as constant false values;
- add adversarial runtime tests for authority widening, malformed revision identity, missing provenance, invalid reuse classifications, Nazia-99 attribution, and external execution widening.

Explicitly not included:
- CUIR-1 repository inventory or a hard-coded Nazia-99 repository count;
- source/code/assets copied from external repositories;
- external project execution or dependency installation;
- Cloak pattern ingestion/integration;
- automatic provider routing/fallback;
- direct provider API integration;
- release/tag movement, deployment/production mutation, credential/settings mutation, installed-integration refresh, Registry mutation, policy/ruleset activation or bypass, branch deletion, force push, or history rewrite.

Base: `4c5f73e36a0792de245754c4ea45bed940115bf2`.