### PR TITLE
chore(cuir2): close canonical lifecycle state

### DIFF
--- a/README.json
+++ b/README.json
@@ -103,11 +103,11 @@
       "external_code_execution": false,
       "automatic_ingestion": false,
       "source_copying_from_reference_only_records": false,
-      "cuir2_started": false,
+      "cuir2_started": true,
       "authority_note": "CUIR-1 is canonical inventory and provenance classification only. The phase_boundary inside the dated inventory record preserves preparation-time source state; current lifecycle state is the verified canonical Git state and this machine index. CUIR-1 does not authorize source or asset copying from reference-only records, external project execution, automatic ingestion, CUIR-2 pattern extraction, provider routing or fallback, release, deployment, policy activation, or other protected-action authority."
     },
     "cloak_ui_reference_corpus_cuir2": {
-      "status": "CUIR_2_STATIC_ANALYSIS_CANDIDATE_PENDING_CANONICALIZATION",
+      "status": "CUIR_2_CANONICAL_MERGED_VERIFIED",
       "purpose": "Static concept-level UI, interaction, information-hierarchy, accessibility, and icon-suitability analysis over the 23 canonical CUIR-1 retained source records.",
       "machine_sources": [
         "machine/provenance/cloak-ui-reference-cuir2.v1.json",


### PR DESCRIPTION
Canonical README-only CUIR-2 lifecycle closeout.

Source evidence:
- Original canonical CUIR-2 implementation was merged and independently verified at main 298f7be98b4d2c55cb48f98c0ddeafaf848e53b0.
- Closeout source PR #672 was exact-head qualified at 46243879c1fcf7661ee336784c06b6781dbb5bfa.
- Signed materialization PR #673 produced verified commit 2c92a37c1dec0b5de22853d2a7062d69863556d9.
- Source and signed materialization trees are exactly equal: c6034dec375f8dc62554fbc957833bd85c8249de.

This PR independently qualifies the signed exact head. The only content change is README.json lifecycle projection parity:
- CUIR-1 records CUIR-2 as started.
- CUIR-2 status records canonical merged verification.
- CUIR-1/CUIR-2 evidence, counts, sources, batches, schema, validation, and authority boundaries are unchanged.
- CUIR-3 remains not started.
- No copying, external execution, automatic ingestion, runtime integration, provider routing, release, deployment, production, or policy authority is created.

No bypass is requested. Squash-only canonicalization is required.