### PR TITLE
chore(cuir3): canonicalize lifecycle closeout

### DIFF
--- a/README.json
+++ b/README.json
@@ -129,7 +129,7 @@
       "authority_note": "CUIR-2 is analysis evidence only. It does not authorize source or asset copying, external code or dependency execution, CUIR-3 normalization, runtime integration, provider routing or fallback, release, deployment, production mutation, or policy activation."
     },
     "cloak_ui_reference_corpus_cuir3": {
-      "status": "CUIR_3_NORMALIZATION_CANDIDATE_PENDING_CANONICALIZATION",
+      "status": "CUIR_3_CANONICAL_MERGED_VERIFIED",
       "purpose": "Normalize canonical CUIR-2 static findings into a compact Orchestra-native, provenance-aware Cloak pattern vocabulary without runtime integration or automatic retrieval.",
       "machine_sources": ["machine/knowledge/cloak-ui-reference-cuir3.v1.json", "machine/schemas/cloak-ui-normalized-pattern.v1.schema.json"],
       "human_sources": ["docs/project/CLOAK_UI_REFERENCE_CORPUS_CUIR3_NORMALIZATION.md"],
@@ -1053,7 +1053,7 @@
     "cloak_ui_reference_corpus_cuir0": "CUIR_0_CANONICAL_MERGED_VERIFIED",
     "cloak_ui_reference_corpus_cuir1": "CUIR_1_CANONICAL_MERGED_VERIFIED",
     "cloak_ui_reference_corpus_cuir2": "CUIR_2_CANONICAL_MERGED_VERIFIED",
-    "cloak_ui_reference_corpus_cuir3": "CUIR_3_NORMALIZATION_CANDIDATE_PENDING_CANONICALIZATION"
+    "cloak_ui_reference_corpus_cuir3": "CUIR_3_CANONICAL_MERGED_VERIFIED"
   },
   "ai_review_guidance": {
     "preferred_entrypoint": "README.json",
@@ -1153,7 +1153,7 @@
     "do_not_infer_cuir2_authority_from_cuir1_canonicalization": true,
     "treat_cuir2_as_canonical_static_analysis_only": true,
     "do_not_treat_cuir2_reference_findings_as_copy_or_execution_authority": true,
-    "treat_cuir3_as_normalized_reference_knowledge_only_until_canonicalized": true,
-    "do_not_infer_cuir4_authority_from_cuir3_candidate_state": true
+    "treat_cuir3_as_canonical_normalized_reference_knowledge_only": true,
+    "do_not_infer_cuir4_authority_from_cuir3_canonicalization": true
   }
 }


### PR DESCRIPTION
Canonical signed CUIR-3 lifecycle closeout.

Canonical CUIR-3 implementation base: `5d3ff818c875c94355b906d65165dcaa2eeb1ef3`
Source closeout PR #678 head: `de72eb24c50a25eec0007e28bd9729c8a7eed47a`
Source closeout tree: `9fbd9932377ac1727b9b22a29b5e9594cd674113`
Signing-only PR #679 result: `ed4c49f8ad5439e5b9651961f18e43a5e53f160d`
Signed materialization tree: `9fbd9932377ac1727b9b22a29b5e9594cd674113`
Signature: GitHub verified/valid.

Source and materialization tree identities are exactly equal. Source-head qualification is historical only and is not reused as canonical merge evidence. This signed exact head must independently pass the full live required-check set.

Net scope is README.json lifecycle state only:
- CUIR-3 capability and maturity -> `CUIR_3_CANONICAL_MERGED_VERIFIED`;
- canonical normalized-reference-knowledge guidance;
- explicit guard that CUIR-3 canonicalization grants no CUIR-4 authority.

`cuir4_started=false`, runtime integration and automatic retrieval remain disabled. No CUIR-4 implementation, external execution/ingestion, source/asset copying, provider routing/fallback, release, deployment, production mutation, policy activation, or ruleset bypass is authorized.