### PR TITLE
chore(cuir4): canonicalize lifecycle closeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Post-v1.7 Cloak CUIR-4 canonical lifecycle closeout
+
+- Reconciles machine discovery with the verified canonical CUIR-4 integration at `67dc4a70159346cea903761373412829f7677fcf`.
+- Marks CUIR-4 as `CUIR_4_CANONICAL_MERGED_VERIFIED` while preserving bounded progressive retrieval, project-native precedence, provenance/reuse classifications, and the frozen UIX-9 core guidance.
+- Keeps `cuir5_started=false`; CUIR-4 canonicalization does not itself authorize CUIR-5 evaluation or any provider, release, deployment, production, policy, destructive, force-push, or history-rewrite action.
+
 ## Post-v1.7 Cloak CUIR-4 pattern intelligence integration candidate
 
 - Integrates the canonical 16-pattern CUIR-3 catalog into Cloak through progressive disclosure instead of default full-corpus prompt injection.

--- a/README.json
+++ b/README.json
@@ -146,7 +146,7 @@
       "authority_note": "CUIR-3 is normalized reference knowledge only. It does not authorize runtime or automatic retrieval integration, source or asset copying, external execution, implementation, provider routing or fallback, release, deployment, production mutation, or policy activation."
     },
     "cloak_ui_reference_corpus_cuir4": {
-      "status": "CUIR_4_PATTERN_INTELLIGENCE_CANDIDATE_PENDING_CANONICALIZATION",
+      "status": "CUIR_4_CANONICAL_MERGED_VERIFIED",
       "purpose": "Integrate canonical CUIR-3 normalized UI knowledge into Cloak through bounded progressive disclosure and deterministic provenance-aware retrieval.",
       "machine_sources": ["machine/knowledge/cloak-ui-pattern-intelligence-cuir4.v1.json", "machine/schemas/cloak-ui-pattern-intelligence-cuir4.v1.schema.json"],
       "human_sources": ["docs/project/CLOAK_UI_REFERENCE_CORPUS_CUIR4_INTEGRATION.md", "skills/cloak/CUIR_PATTERN_INTELLIGENCE_GUIDE.md"],
@@ -161,7 +161,7 @@
       "source_copying": false,
       "asset_copying": false,
       "cuir5_started": false,
-      "authority_note": "CUIR-4 adds advisory progressive pattern retrieval only. It does not transfer implementation, architecture, security, merge, release, deployment, provider-routing, production-mutation, or policy authority and does not start CUIR-5."
+      "authority_note": "CUIR-4 is canonical advisory progressive pattern retrieval only. Canonicalization does not transfer implementation, architecture, security, merge, release, deployment, provider-routing, production-mutation, or policy authority and does not start CUIR-5."
     },
     "cross_specialist_coordination": {"status": "IMPLEMENTED", "human_sources": ["docs/governance/TUNER_PROTOCOL.md", "ROUTING_MAP.md"]},
     "validation_and_evidence": {"status": "IMPLEMENTED", "machine_sources": ["machine/schemas/", "machine/release-evidence/"], "human_sources": ["docs/setup/VALIDATION.md", "docs/validation/"]},
@@ -1072,7 +1072,7 @@
     "cloak_ui_reference_corpus_cuir1": "CUIR_1_CANONICAL_MERGED_VERIFIED",
     "cloak_ui_reference_corpus_cuir2": "CUIR_2_CANONICAL_MERGED_VERIFIED",
     "cloak_ui_reference_corpus_cuir3": "CUIR_3_CANONICAL_MERGED_VERIFIED",
-    "cloak_ui_reference_corpus_cuir4": "CUIR_4_PATTERN_INTELLIGENCE_CANDIDATE_PENDING_CANONICALIZATION"
+    "cloak_ui_reference_corpus_cuir4": "CUIR_4_CANONICAL_MERGED_VERIFIED"
   },
   "ai_review_guidance": {
     "preferred_entrypoint": "README.json",
@@ -1174,7 +1174,7 @@
     "do_not_treat_cuir2_reference_findings_as_copy_or_execution_authority": true,
     "treat_cuir3_as_canonical_normalized_reference_knowledge_only": true,
     "do_not_infer_cuir4_authority_from_cuir3_canonicalization": true,
-    "treat_cuir4_as_bounded_progressive_pattern_intelligence_until_canonicalized": true,
-    "do_not_infer_cuir5_authority_from_cuir4_candidate_state": true
+    "treat_cuir4_as_canonical_bounded_progressive_pattern_intelligence": true,
+    "do_not_infer_cuir5_authority_from_cuir4_canonicalization": true
   }
 }

--- a/tests/runtime/test_cloak_ui_reference_corpus_cuir4.py
+++ b/tests/runtime/test_cloak_ui_reference_corpus_cuir4.py
@@ -87,7 +87,7 @@ def test_readme_machine_projection_tracks_candidate_without_granting_cuir5():
     cuir3 = readme["capabilities"]["cloak_ui_reference_corpus_cuir3"]
     cuir4 = readme["capabilities"]["cloak_ui_reference_corpus_cuir4"]
     assert cuir3["cuir4_started"] is True
-    assert cuir4["status"] == "CUIR_4_PATTERN_INTELLIGENCE_CANDIDATE_PENDING_CANONICALIZATION"
+    assert cuir4["status"] == "CUIR_4_CANONICAL_MERGED_VERIFIED"
     assert cuir4["progressive_retrieval"] is True
     assert cuir4["cuir5_started"] is False
     assert cuir4["implementation_authority"] is False


### PR DESCRIPTION
Canonical signed CUIR-4 lifecycle closeout.

Qualified source PR #684 head: `eb9a3f64d6c3bdd7389761e04a1b271763a0c398`
Qualified source tree: `9a8370d6c4df5f98e6f558df702a0013918af717`
Signing-only PR #685 result: `9f42ac8e9dfbdc25c358c6cb6687297622e0cd8e`
Signed materialization tree: `9a8370d6c4df5f98e6f558df702a0013918af717`
Signature: verified/valid.

This PR independently requalifies the signed exact lifecycle-closeout tree. It changes only `README.json`, `CHANGELOG.md`, and the deterministic CUIR-4 lifecycle assertion. It preserves `cuir5_started=false` and all CUIR-4 non-authorizing boundaries.

No CUIR-5 evaluation, release, deployment, provider routing/fallback, policy activation, destructive action, branch deletion, force push, or history rewrite is introduced here.