### PR TITLE
refactor(architecture): extract AR-2 governance authority semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Post-v1.7 runtime architecture AR-2 governance authority extraction candidate
+
+- Establishes `orchestra_runtime.domain.governance.authority` as the inward-only owner of immutable authority entities and deterministic constraint/intersection semantics.
+- Preserves legacy `orchestra_runtime.authority` symbol identity while retaining repository-policy filesystem loading, application-port inheritance, and runtime audit-event projection on the transitional legacy surface for later AR-3/AR-4 placement.
+- Adds direct compatibility/import-boundary regression coverage, detailed extraction documentation, and `README.json` machine-discovery parity.
+- Does not alter authority scope/evaluation behavior, provider/MCP execution, public import retirement, release/deployment/policy authority, or start AR-3.
+
 ## Post-v1.7 runtime architecture AR-2 domain context extraction candidate
 
 - Establishes `orchestra_runtime.domain.context` as the inward-only owner of `CurrentProjectState`, `ContinuityEvent`, and deterministic `compile_context` semantics.

--- a/README.json
+++ b/README.json
@@ -1183,7 +1183,7 @@
     "require_explicit_resource_ceiling_before_paid_live_benchmark_execution": true,
     "do_not_treat_b2_topology_identity_as_execution_without_the_benchmark_topology_adapter": true,
     "preserve_b2_a5_shadow_ranking_as_non-authorizing_and_separate_from_arm_scheduling": true,
-    "treat_b2_1_topology_executor_as_canonical_non-production_measurement_adapter": true,
+    "treat_b2_1_topology_executor_as_canonical_non_production_measurement_adapter": true,
     "require_b2_topology_sensitive_taskset_and_exact_manifest_before_live_execution": true,
     "do_not_equate_execution_allowed_task_payload_with_live_execution_authority": true,
     "require_b2_2_exact_host_zero_call_preflight_and_separate_human_authorization_before_model_calls": true,

--- a/README.json
+++ b/README.json
@@ -30,9 +30,9 @@
     "specialist_orchestration": {"status": "IMPLEMENTED", "machine_sources": ["machine/specialists/registry.v1.json", "machine/routing/routes.v1.json"], "human_sources": ["SKILL_INDEX.md", "ROUTING_MAP.md"]},
     "governed_runtime": {"status": "IMPLEMENTED", "machine_sources": ["machine/governance/policy.v1.json"], "human_sources": ["docs/architecture/README.md", "docs/governance/GOVERNANCE_LAYER.md", "docs/project/AUTHORITY_CAPABILITY_RUNTIME_ARCHITECTURE.md"]},
     "runtime_architecture_refoundation": {
-      "status": "AR_2_FOUNDATION_CANONICAL_MERGED_VERIFIED",
+      "status": "AR_2_DOMAIN_EXTRACTIONS_ACTIVE",
       "purpose": "Incrementally refactor the Orchestra Python runtime into bounded clean/hexagonal architecture layers while preserving public behavior and legacy import compatibility.",
-      "human_sources": ["docs/project/ORCHESTRA_RUNTIME_ARCHITECTURE_REFOUNDATION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_CONTEXT_EXTRACTION.md", "docs/architecture/README.md"],
+      "human_sources": ["docs/project/ORCHESTRA_RUNTIME_ARCHITECTURE_REFOUNDATION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_CONTEXT_EXTRACTION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_GOVERNANCE_AUTHORITY_EXTRACTION.md", "docs/architecture/README.md"],
       "validation_surface": "tests/runtime/test_runtime_architecture_boundaries.py",
       "machine_policy": "machine/governance/runtime-architecture-boundaries.v1.json",
       "machine_policy_schema": "machine/schemas/runtime-architecture-boundaries.v1.schema.json",
@@ -45,6 +45,9 @@
       "context_domain_compiler_surface": "orchestra_runtime/domain/context/compiler.py",
       "context_legacy_compatibility_surface": "orchestra_runtime/context_state.py",
       "context_domain_validation_surface": "tests/runtime/test_domain_context.py",
+      "governance_authority_domain_surface": "orchestra_runtime/domain/governance/authority.py",
+      "governance_authority_legacy_compatibility_surface": "orchestra_runtime/authority.py",
+      "governance_authority_validation_surface": "tests/runtime/test_domain_governance_authority.py",
       "ci_enforcement": ["Governance Check", "validate"],
       "canonical_layers": ["domain", "application", "infrastructure", "entrypoints", "bootstrap", "shared", "resources"],
       "application_subzones": ["use_cases", "services", "dto", "ports"],
@@ -58,7 +61,7 @@
       "public_import_retirement": false,
       "ar3_started": false,
       "release_authorized": false,
-      "authority_note": "AR-2 establishes architectural destinations and migrates the shared runtime error boundary behind a compatibility facade. Architecture placement or validation success does not grant implementation beyond the approved refactor scope, release, deployment, policy activation, provider routing/fallback, destructive, installed-integration-refresh, force-push, or history-rewrite authority."
+      "authority_note": "AR-2 establishes architectural destinations and moves only qualified inward domain ownership while preserving compatibility facades. Architecture placement or validation success does not grant implementation beyond the approved refactor scope, release, deployment, policy activation, provider routing/fallback, destructive, installed-integration-refresh, force-push, or history-rewrite authority."
     },
     "specialist_runtime_host_execution_design": {
       "status": "E1_E7_COMPLETE_ADOPT_OPTIONAL",
@@ -1083,7 +1086,8 @@
     "release_candidate_v1_7_0": "docs/releases/v1.7.0-adaptive-intelligence-portable-memory-design-fidelity-release-candidate.md",
     "publication_closeout_v1_7_0": "docs/validation/V1_7_0_PUBLICATION_CLOSEOUT.md",
     "codex_c2_portability_r1_preexecution": "docs/benchmarking/CODEX_C2_PORTABILITY_R1_PREEXECUTION.md",
-    "cloak_ui_reference_cuir5_evaluation": "docs/project/CLOAK_UI_REFERENCE_CORPUS_CUIR5_EVALUATION.md"
+    "cloak_ui_reference_cuir5_evaluation": "docs/project/CLOAK_UI_REFERENCE_CORPUS_CUIR5_EVALUATION.md",
+    "runtime_architecture_ar2_domain_governance_authority": "docs/project/ORCHESTRA_AR2_DOMAIN_GOVERNANCE_AUTHORITY_EXTRACTION.md"
   },
   "representation_policy": {"markdown": "Human-readable explanation, rationale, examples, and nuanced specialist guidance", "json": "Canonical structured machine state, identity, routing, governance, receipts, manifests, provenance, presentation contracts, evidence, and indexes", "json_schema": "Validation contract for machine-readable records", "jsonl": "Append-only event/history records where incremental retrieval is preferable", "toon": "Derived validated non-authoritative model-context projection only when bounded compilation provides measured context benefit", "parity_rule": "When the same deterministic fact appears in more than one representation, CI must validate parity or derive the projection from one authoritative source."},
   "maturity": {
@@ -1179,7 +1183,7 @@
     "require_explicit_resource_ceiling_before_paid_live_benchmark_execution": true,
     "do_not_treat_b2_topology_identity_as_execution_without_the_benchmark_topology_adapter": true,
     "preserve_b2_a5_shadow_ranking_as_non-authorizing_and_separate_from_arm_scheduling": true,
-    "treat_b2_1_topology_executor_as_canonical_non_production_measurement_adapter": true,
+    "treat_b2_1_topology_executor_as_canonical_non-production_measurement_adapter": true,
     "require_b2_topology_sensitive_taskset_and_exact_manifest_before_live_execution": true,
     "do_not_equate_execution_allowed_task_payload_with_live_execution_authority": true,
     "require_b2_2_exact_host_zero_call_preflight_and_separate_human_authorization_before_model_calls": true,

--- a/docs/project/ORCHESTRA_AR2_DOMAIN_GOVERNANCE_AUTHORITY_EXTRACTION.md
+++ b/docs/project/ORCHESTRA_AR2_DOMAIN_GOVERNANCE_AUTHORITY_EXTRACTION.md
@@ -1,0 +1,99 @@
+# Orchestra AR-2 Domain Governance Authority Extraction
+
+## Status
+
+`AR_2_DOMAIN_GOVERNANCE_AUTHORITY_IMPLEMENTATION_CANDIDATE`
+
+This document describes the bounded AR-2 extraction that moves pure authority state and deterministic authority-value semantics inward to `orchestra_runtime.domain.governance` while preserving the legacy runtime surface.
+
+## Canonical domain ownership
+
+The following semantics are owned by `orchestra_runtime.domain.governance.authority` in this candidate:
+
+- `ProvenanceSource`
+- `TargetSelectorType`
+- `ConstraintKind`
+- `AuthorityReasonCode`
+- `AuthorityProvenance`
+- `TargetSelector`
+- `Constraint`
+- `AuthorityScope`
+- `AuthorityDecision`
+- deterministic identifier/text normalization used by those entities
+- deterministic constraint permission and intersection semantics
+
+These entities import only the standard library and `orchestra_runtime.shared.errors`. They do not read files, resolve repository paths, depend on application ports, construct runtime audit events, call providers, or perform host/MCP operations.
+
+## Legacy compatibility boundary
+
+`orchestra_runtime.authority` remains the compatibility and transitional integration surface. Existing imports of the moved authority symbols resolve to the exact canonical domain objects rather than duplicate wrappers or copied classes.
+
+The legacy module deliberately retains:
+
+- trusted repository-policy JSON loading and path-containment checks;
+- `AuthorityEvaluator` inheritance from the legacy `IAuthorityEvaluator` port;
+- authority evaluation/enforcement orchestration that is still coupled to that port;
+- `RuntimeAuditEvent` projection helpers.
+
+Those responsibilities are not pulled into the domain solely to make the legacy facade syntactically smaller. Their final placement belongs to later application and infrastructure phases.
+
+## Dependency rule
+
+The domain surface obeys the machine architecture policy:
+
+```text
+orchestra_runtime.domain -> orchestra_runtime.domain | orchestra_runtime.shared
+```
+
+The extracted module has no dependency on:
+
+```text
+orchestra_runtime.application
+orchestra_runtime.infrastructure
+orchestra_runtime.entrypoints
+orchestra_runtime.authority
+orchestra_runtime.interfaces
+orchestra_runtime.models
+pathlib / filesystem I/O
+provider or MCP execution
+```
+
+## Behavioral preservation
+
+The extraction preserves the existing authority-value contract, including:
+
+- canonical identifier normalization;
+- immutable dataclass state;
+- exact target selectors with wildcard rejection;
+- unique normalized operations and constraint keys;
+- trusted versus delegated provenance invariants;
+- deterministic constraint permission and intersection behavior;
+- stable dictionary serialization;
+- fail-closed malformed or empty authority construction.
+
+Repository-policy loading and authority event projection continue through the legacy module, so this AR-2 unit does not change external authority behavior or grant new authority.
+
+## Validation
+
+`tests/runtime/test_domain_governance_authority.py` verifies:
+
+1. legacy exports are identity-equal to the canonical domain symbols;
+2. normalization and deterministic constraint semantics are preserved;
+3. untrusted delegation and wildcard selectors still fail closed;
+4. the domain authority module has no filesystem or legacy-runtime imports.
+
+The existing authority/runtime suites remain the broader compatibility regression surface.
+
+## Explicit non-goals
+
+This bounded extraction does not:
+
+- start AR-3 application/use-case migration;
+- move repository-policy persistence into domain code;
+- move application ports into the domain;
+- move audit/event presentation into the domain;
+- retire the public `orchestra_runtime.authority` import surface;
+- alter authority scope, capability, routing, governance, provider, MCP, or execution semantics;
+- authorize release/tag publication, deployment, policy activation, integration refresh, destructive action, branch deletion, force push, or history rewrite.
+
+AR-2 remains active after this unit until the remaining qualified pure-domain ownership slices are completed.

--- a/orchestra_runtime/authority.py
+++ b/orchestra_runtime/authority.py
@@ -1,341 +1,34 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from enum import Enum
 import json
 from pathlib import Path
-import re
 
+from .domain.governance.authority import (
+    IDENTIFIER_PATTERN,
+    AuthorityDecision,
+    AuthorityProvenance,
+    AuthorityReasonCode,
+    AuthorityScope,
+    Constraint,
+    ConstraintKind,
+    ProvenanceSource,
+    TargetSelector,
+    TargetSelectorType,
+    _constraint_map,
+    _constraints_permit,
+    _identifier,
+    _intersect_constraints,
+    _text,
+)
 from .errors import AuthorityDeniedError, InvalidAuthorityConfigurationError
 from .interfaces import IAuthorityEvaluator
 from .models import AuditEventType, RuntimeAuditEvent
 
 
-IDENTIFIER_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_.:-]*$")
-
-
-class ProvenanceSource(str, Enum):
-    TRUSTED_COMPOSITION = "TRUSTED_COMPOSITION"
-    TRUSTED_REPOSITORY_POLICY = "TRUSTED_REPOSITORY_POLICY"
-    ACCEPTED_DELEGATION = "ACCEPTED_DELEGATION"
-
-
-class TargetSelectorType(str, Enum):
-    EXACT = "EXACT"
-
-
-class ConstraintKind(str, Enum):
-    EXACT = "EXACT"
-    ALLOWED_SET = "ALLOWED_SET"
-
-
-class AuthorityReasonCode(str, Enum):
-    ALLOWED = "ALLOWED"
-    INVALID_SCOPE = "INVALID_SCOPE"
-    UNTRUSTED_PROVENANCE = "UNTRUSTED_PROVENANCE"
-    TARGET_NOT_ALLOWED = "TARGET_NOT_ALLOWED"
-    OPERATION_NOT_ALLOWED = "OPERATION_NOT_ALLOWED"
-    CONSTRAINT_DENIED = "CONSTRAINT_DENIED"
-    EMPTY_INTERSECTION = "EMPTY_INTERSECTION"
-
-
-def _text(value: object, field_name: str) -> str:
-    text = str(value).strip()
-    if not text:
-        raise InvalidAuthorityConfigurationError(
-            f"{field_name} must be non-empty",
-            AuthorityReasonCode.INVALID_SCOPE,
-            {"field": field_name},
-        )
-    return text
-
-
-def _identifier(value: object, field_name: str) -> str:
-    text = _text(value, field_name).casefold()
-    if not IDENTIFIER_PATTERN.fullmatch(text):
-        raise InvalidAuthorityConfigurationError(
-            f"{field_name} must be a canonical identifier",
-            AuthorityReasonCode.INVALID_SCOPE,
-            {"field": field_name},
-        )
-    return text
-
-
-@dataclass(frozen=True, slots=True)
-class AuthorityProvenance:
-    source_type: ProvenanceSource
-    source_id: str
-    policy_version: str
-    loaded_by: str
-    parent_run_id: str | None = None
-    parent_decision_id: str | None = None
-
-    def __post_init__(self) -> None:
-        source_type = ProvenanceSource(self.source_type)
-        source_id = _identifier(self.source_id, "source_id")
-        policy_version = _text(self.policy_version, "policy_version")
-        loaded_by = _identifier(self.loaded_by, "loaded_by")
-        parent_run_id = self.parent_run_id.strip() if self.parent_run_id else None
-        parent_decision_id = self.parent_decision_id.strip() if self.parent_decision_id else None
-        if source_type is ProvenanceSource.ACCEPTED_DELEGATION:
-            if not parent_run_id or not parent_decision_id:
-                raise InvalidAuthorityConfigurationError(
-                    "accepted delegation provenance requires parent identifiers",
-                    AuthorityReasonCode.UNTRUSTED_PROVENANCE,
-                )
-        elif parent_run_id or parent_decision_id:
-            raise InvalidAuthorityConfigurationError(
-                "root provenance cannot contain parent identifiers",
-                AuthorityReasonCode.UNTRUSTED_PROVENANCE,
-            )
-        object.__setattr__(self, "source_type", source_type)
-        object.__setattr__(self, "source_id", source_id)
-        object.__setattr__(self, "policy_version", policy_version)
-        object.__setattr__(self, "loaded_by", loaded_by)
-        object.__setattr__(self, "parent_run_id", parent_run_id)
-        object.__setattr__(self, "parent_decision_id", parent_decision_id)
-
-    @classmethod
-    def from_dict(cls, data: dict[str, object]) -> AuthorityProvenance:
-        return cls(
-            source_type=ProvenanceSource(str(data.get("source_type", ""))),
-            source_id=str(data.get("source_id", "")),
-            policy_version=str(data.get("policy_version", "")),
-            loaded_by=str(data.get("loaded_by", "")),
-            parent_run_id=str(data["parent_run_id"]) if data.get("parent_run_id") else None,
-            parent_decision_id=str(data["parent_decision_id"]) if data.get("parent_decision_id") else None,
-        )
-
-    def to_dict(self) -> dict[str, str | None]:
-        return {
-            "source_type": self.source_type.value,
-            "source_id": self.source_id,
-            "policy_version": self.policy_version,
-            "loaded_by": self.loaded_by,
-            "parent_run_id": self.parent_run_id,
-            "parent_decision_id": self.parent_decision_id,
-        }
-
-
-@dataclass(frozen=True, slots=True)
-class TargetSelector:
-    value: str
-    selector_type: TargetSelectorType = TargetSelectorType.EXACT
-
-    def __post_init__(self) -> None:
-        value = _text(self.value, "target")
-        if any(token in value for token in ("*", "?")):
-            raise InvalidAuthorityConfigurationError(
-                "target selectors must be exact",
-                AuthorityReasonCode.INVALID_SCOPE,
-                {"target": value},
-            )
-        object.__setattr__(self, "value", value)
-        object.__setattr__(self, "selector_type", TargetSelectorType(self.selector_type))
-
-    def to_dict(self) -> dict[str, str]:
-        return {"selector_type": self.selector_type.value, "value": self.value}
-
-
-@dataclass(frozen=True, slots=True)
-class Constraint:
-    key: str
-    kind: ConstraintKind
-    values: tuple[str, ...]
-
-    def __post_init__(self) -> None:
-        key = _identifier(self.key, "constraint key")
-        kind = ConstraintKind(self.kind)
-        values = tuple(sorted({_text(value, "constraint value") for value in self.values}, key=lambda item: (item.casefold(), item)))
-        if not values or (kind is ConstraintKind.EXACT and len(values) != 1):
-            raise InvalidAuthorityConfigurationError(
-                "constraint values do not match constraint kind",
-                AuthorityReasonCode.INVALID_SCOPE,
-                {"constraint": key},
-            )
-        object.__setattr__(self, "key", key)
-        object.__setattr__(self, "kind", kind)
-        object.__setattr__(self, "values", values)
-
-    @classmethod
-    def exact(cls, key: str, value: str) -> Constraint:
-        return cls(key=key, kind=ConstraintKind.EXACT, values=(value,))
-
-    @classmethod
-    def allowed_set(cls, key: str, values: tuple[str, ...] | list[str]) -> Constraint:
-        return cls(key=key, kind=ConstraintKind.ALLOWED_SET, values=tuple(values))
-
-    def permits(self, requested: Constraint) -> bool:
-        if self.key != requested.key:
-            return False
-        return set(requested.values).issubset(self.values)
-
-    def intersect(self, other: Constraint) -> Constraint | None:
-        if self.key != other.key:
-            return None
-        values = tuple(sorted(set(self.values).intersection(other.values), key=lambda item: (item.casefold(), item)))
-        if not values:
-            return None
-        kind = ConstraintKind.EXACT if len(values) == 1 else ConstraintKind.ALLOWED_SET
-        return Constraint(self.key, kind, values)
-
-    @classmethod
-    def from_dict(cls, data: dict[str, object]) -> Constraint:
-        values = data.get("values", ())
-        if not isinstance(values, (list, tuple)):
-            values = ()
-        return cls(str(data.get("key", "")), ConstraintKind(str(data.get("kind", ""))), tuple(str(item) for item in values))
-
-    def to_dict(self) -> dict[str, object]:
-        return {"key": self.key, "kind": self.kind.value, "values": list(self.values)}
-
-
-@dataclass(frozen=True, slots=True)
-class AuthorityScope:
-    scope_id: str
-    targets: tuple[TargetSelector, ...]
-    operations: tuple[str, ...]
-    constraints: tuple[Constraint, ...]
-    provenance: AuthorityProvenance
-    parent_scope_id: str | None = None
-
-    def __post_init__(self) -> None:
-        scope_id = _identifier(self.scope_id, "scope_id")
-        targets = tuple(sorted(tuple(self.targets), key=lambda item: (item.value.casefold(), item.value)))
-        operations = tuple(sorted((_identifier(item, "operation") for item in self.operations)))
-        constraints = tuple(sorted(tuple(self.constraints), key=lambda item: item.key))
-        if not targets or not operations:
-            raise InvalidAuthorityConfigurationError(
-                "authority scope requires targets and operations",
-                AuthorityReasonCode.INVALID_SCOPE,
-                {"scope_id": scope_id},
-            )
-        if len({item.value for item in targets}) != len(targets) or len(set(operations)) != len(operations):
-            raise InvalidAuthorityConfigurationError("authority scope contains duplicates", AuthorityReasonCode.INVALID_SCOPE)
-        if len({item.key for item in constraints}) != len(constraints):
-            raise InvalidAuthorityConfigurationError("constraint keys must be unique", AuthorityReasonCode.INVALID_SCOPE)
-        parent_scope_id = _identifier(self.parent_scope_id, "parent_scope_id") if self.parent_scope_id else None
-        if self.provenance.source_type is ProvenanceSource.ACCEPTED_DELEGATION and not parent_scope_id:
-            raise InvalidAuthorityConfigurationError(
-                "delegated scope requires parent_scope_id",
-                AuthorityReasonCode.UNTRUSTED_PROVENANCE,
-            )
-        object.__setattr__(self, "scope_id", scope_id)
-        object.__setattr__(self, "targets", targets)
-        object.__setattr__(self, "operations", operations)
-        object.__setattr__(self, "constraints", constraints)
-        object.__setattr__(self, "parent_scope_id", parent_scope_id)
-
-    @classmethod
-    def from_dict(cls, data: dict[str, object]) -> AuthorityScope:
-        targets = data.get("targets", ())
-        operations = data.get("operations", ())
-        constraints = data.get("constraints", ())
-        provenance = data.get("provenance")
-        if not isinstance(targets, list) or not isinstance(operations, list) or not isinstance(constraints, list) or not isinstance(provenance, dict):
-            raise InvalidAuthorityConfigurationError("malformed authority scope", AuthorityReasonCode.INVALID_SCOPE)
-        return cls(
-            scope_id=str(data.get("scope_id", "")),
-            targets=tuple(TargetSelector(str(item)) if not isinstance(item, dict) else TargetSelector(str(item.get("value", "")), TargetSelectorType(str(item.get("selector_type", "EXACT")))) for item in targets),
-            operations=tuple(str(item) for item in operations),
-            constraints=tuple(Constraint.from_dict(item) for item in constraints if isinstance(item, dict)),
-            provenance=AuthorityProvenance.from_dict(provenance),
-            parent_scope_id=str(data["parent_scope_id"]) if data.get("parent_scope_id") else None,
-        )
-
-    def to_dict(self) -> dict[str, object]:
-        return {
-            "scope_id": self.scope_id,
-            "targets": [item.to_dict() for item in self.targets],
-            "operations": list(self.operations),
-            "constraints": [item.to_dict() for item in self.constraints],
-            "provenance": self.provenance.to_dict(),
-            "parent_scope_id": self.parent_scope_id,
-        }
-
-
-@dataclass(frozen=True, slots=True)
-class AuthorityDecision:
-    decision_id: str
-    run_id: str
-    scope_id: str
-    target: TargetSelector
-    operation: str
-    requested_constraints: tuple[Constraint, ...]
-    allowed: bool
-    reason_code: AuthorityReasonCode
-    matched_targets: tuple[str, ...] = ()
-    matched_operations: tuple[str, ...] = ()
-    evaluated_constraints: tuple[str, ...] = ()
-    provenance_id: str = ""
-
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "decision_id", _text(self.decision_id, "decision_id"))
-        object.__setattr__(self, "run_id", _text(self.run_id, "run_id"))
-        object.__setattr__(self, "scope_id", _identifier(self.scope_id, "scope_id"))
-        object.__setattr__(self, "operation", _identifier(self.operation, "operation"))
-        constraints = tuple(sorted(tuple(self.requested_constraints), key=lambda item: item.key))
-        if len({item.key for item in constraints}) != len(constraints):
-            raise InvalidAuthorityConfigurationError("requested constraint keys must be unique", AuthorityReasonCode.INVALID_SCOPE)
-        object.__setattr__(self, "requested_constraints", constraints)
-        object.__setattr__(self, "reason_code", AuthorityReasonCode(self.reason_code))
-        object.__setattr__(self, "matched_targets", tuple(sorted(set(self.matched_targets))))
-        object.__setattr__(self, "matched_operations", tuple(sorted(set(self.matched_operations))))
-        object.__setattr__(self, "evaluated_constraints", tuple(sorted(set(self.evaluated_constraints))))
-        object.__setattr__(self, "provenance_id", _identifier(self.provenance_id, "provenance_id"))
-
-    def to_dict(self) -> dict[str, object]:
-        return {
-            "decision_id": self.decision_id,
-            "run_id": self.run_id,
-            "scope_id": self.scope_id,
-            "target": self.target.to_dict(),
-            "operation": self.operation,
-            "requested_constraints": [item.to_dict() for item in self.requested_constraints],
-            "allowed": self.allowed,
-            "reason_code": self.reason_code.value,
-            "matched_targets": list(self.matched_targets),
-            "matched_operations": list(self.matched_operations),
-            "evaluated_constraints": list(self.evaluated_constraints),
-            "provenance_id": self.provenance_id,
-        }
-
-
-def _constraint_map(constraints: tuple[Constraint, ...]) -> dict[str, Constraint]:
-    result = {item.key: item for item in constraints}
-    if len(result) != len(constraints):
-        raise InvalidAuthorityConfigurationError("constraint keys must be unique", AuthorityReasonCode.INVALID_SCOPE)
-    return result
-
-
-def _constraints_permit(granted: tuple[Constraint, ...], requested: tuple[Constraint, ...]) -> bool:
-    granted_map = _constraint_map(granted)
-    requested_map = _constraint_map(requested)
-    if set(granted_map) != set(requested_map):
-        return not granted_map and not requested_map
-    return all(granted_map[key].permits(requested_map[key]) for key in granted_map)
-
-
-def _intersect_constraints(
-    parent: tuple[Constraint, ...],
-    requested: tuple[Constraint, ...],
-) -> tuple[Constraint, ...]:
-    parent_map = _constraint_map(parent)
-    requested_map = _constraint_map(requested)
-    result: list[Constraint] = []
-    for key in sorted(set(parent_map).union(requested_map)):
-        if key in parent_map and key in requested_map:
-            intersection = parent_map[key].intersect(requested_map[key])
-            if intersection is None:
-                raise InvalidAuthorityConfigurationError(
-                    "authority constraints do not intersect",
-                    AuthorityReasonCode.EMPTY_INTERSECTION,
-                    {"constraint": key},
-                )
-            result.append(intersection)
-        else:
-            result.append(parent_map.get(key) or requested_map[key])
-    return tuple(result)
+# The pure authority entities and deterministic constraint semantics now live in
+# orchestra_runtime.domain.governance.authority. This legacy module intentionally
+# retains repository-policy loading, application-port inheritance, and audit-event
+# projection until their later infrastructure/application extraction phases.
 
 
 def _load_trusted_json(repo_root: Path, policy_path: Path) -> dict[str, object]:
@@ -377,7 +70,10 @@ def _load_trusted_json(repo_root: Path, policy_path: Path) -> dict[str, object]:
             {"policy_path": relative.as_posix()},
         ) from exc
     if not isinstance(payload, dict):
-        raise InvalidAuthorityConfigurationError("trusted policy root must be an object", AuthorityReasonCode.INVALID_SCOPE)
+        raise InvalidAuthorityConfigurationError(
+            "trusted policy root must be an object",
+            AuthorityReasonCode.INVALID_SCOPE,
+        )
     return payload
 
 
@@ -472,13 +168,19 @@ def load_trusted_authority(repo_root: Path, policy_path: Path) -> AuthorityScope
     payload = _load_trusted_json(repo_root, policy_path)
     scope_data = payload.get("authority_scope")
     if not isinstance(scope_data, dict):
-        raise InvalidAuthorityConfigurationError("trusted policy is missing authority_scope", AuthorityReasonCode.INVALID_SCOPE)
+        raise InvalidAuthorityConfigurationError(
+            "trusted policy is missing authority_scope",
+            AuthorityReasonCode.INVALID_SCOPE,
+        )
     try:
         scope = AuthorityScope.from_dict(scope_data)
     except (KeyError, TypeError, ValueError) as exc:
         if isinstance(exc, InvalidAuthorityConfigurationError):
             raise
-        raise InvalidAuthorityConfigurationError("trusted authority is malformed", AuthorityReasonCode.INVALID_SCOPE) from exc
+        raise InvalidAuthorityConfigurationError(
+            "trusted authority is malformed",
+            AuthorityReasonCode.INVALID_SCOPE,
+        ) from exc
     if scope.provenance.source_type is not ProvenanceSource.TRUSTED_REPOSITORY_POLICY:
         raise InvalidAuthorityConfigurationError(
             "file policy requires trusted repository provenance",
@@ -507,7 +209,11 @@ def authority_decision_event(event_id: str, decision: AuthorityDecision) -> Runt
         decision.decision_id,
         decision.reason_code.value,
         provenance_ids=(decision.provenance_id,),
-        details=(("allowed", str(decision.allowed).lower()), ("operation", decision.operation), ("target", decision.target.value)),
+        details=(
+            ("allowed", str(decision.allowed).lower()),
+            ("operation", decision.operation),
+            ("target", decision.target.value),
+        ),
     )
 
 

--- a/orchestra_runtime/domain/governance/__init__.py
+++ b/orchestra_runtime/domain/governance/__init__.py
@@ -1,0 +1,25 @@
+"""Governance-domain semantics for Orchestra runtime architecture."""
+
+from .authority import (
+    AuthorityDecision,
+    AuthorityProvenance,
+    AuthorityReasonCode,
+    AuthorityScope,
+    Constraint,
+    ConstraintKind,
+    ProvenanceSource,
+    TargetSelector,
+    TargetSelectorType,
+)
+
+__all__ = [
+    "AuthorityDecision",
+    "AuthorityProvenance",
+    "AuthorityReasonCode",
+    "AuthorityScope",
+    "Constraint",
+    "ConstraintKind",
+    "ProvenanceSource",
+    "TargetSelector",
+    "TargetSelectorType",
+]

--- a/orchestra_runtime/domain/governance/authority.py
+++ b/orchestra_runtime/domain/governance/authority.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import re
+
+from ...shared.errors import InvalidAuthorityConfigurationError
+
+
+IDENTIFIER_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_.:-]*$")
+
+
+class ProvenanceSource(str, Enum):
+    TRUSTED_COMPOSITION = "TRUSTED_COMPOSITION"
+    TRUSTED_REPOSITORY_POLICY = "TRUSTED_REPOSITORY_POLICY"
+    ACCEPTED_DELEGATION = "ACCEPTED_DELEGATION"
+
+
+class TargetSelectorType(str, Enum):
+    EXACT = "EXACT"
+
+
+class ConstraintKind(str, Enum):
+    EXACT = "EXACT"
+    ALLOWED_SET = "ALLOWED_SET"
+
+
+class AuthorityReasonCode(str, Enum):
+    ALLOWED = "ALLOWED"
+    INVALID_SCOPE = "INVALID_SCOPE"
+    UNTRUSTED_PROVENANCE = "UNTRUSTED_PROVENANCE"
+    TARGET_NOT_ALLOWED = "TARGET_NOT_ALLOWED"
+    OPERATION_NOT_ALLOWED = "OPERATION_NOT_ALLOWED"
+    CONSTRAINT_DENIED = "CONSTRAINT_DENIED"
+    EMPTY_INTERSECTION = "EMPTY_INTERSECTION"
+
+
+def _text(value: object, field_name: str) -> str:
+    text = str(value).strip()
+    if not text:
+        raise InvalidAuthorityConfigurationError(
+            f"{field_name} must be non-empty",
+            AuthorityReasonCode.INVALID_SCOPE,
+            {"field": field_name},
+        )
+    return text
+
+
+def _identifier(value: object, field_name: str) -> str:
+    text = _text(value, field_name).casefold()
+    if not IDENTIFIER_PATTERN.fullmatch(text):
+        raise InvalidAuthorityConfigurationError(
+            f"{field_name} must be a canonical identifier",
+            AuthorityReasonCode.INVALID_SCOPE,
+            {"field": field_name},
+        )
+    return text
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorityProvenance:
+    source_type: ProvenanceSource
+    source_id: str
+    policy_version: str
+    loaded_by: str
+    parent_run_id: str | None = None
+    parent_decision_id: str | None = None
+
+    def __post_init__(self) -> None:
+        source_type = ProvenanceSource(self.source_type)
+        source_id = _identifier(self.source_id, "source_id")
+        policy_version = _text(self.policy_version, "policy_version")
+        loaded_by = _identifier(self.loaded_by, "loaded_by")
+        parent_run_id = self.parent_run_id.strip() if self.parent_run_id else None
+        parent_decision_id = self.parent_decision_id.strip() if self.parent_decision_id else None
+        if source_type is ProvenanceSource.ACCEPTED_DELEGATION:
+            if not parent_run_id or not parent_decision_id:
+                raise InvalidAuthorityConfigurationError(
+                    "accepted delegation provenance requires parent identifiers",
+                    AuthorityReasonCode.UNTRUSTED_PROVENANCE,
+                )
+        elif parent_run_id or parent_decision_id:
+            raise InvalidAuthorityConfigurationError(
+                "root provenance cannot contain parent identifiers",
+                AuthorityReasonCode.UNTRUSTED_PROVENANCE,
+            )
+        object.__setattr__(self, "source_type", source_type)
+        object.__setattr__(self, "source_id", source_id)
+        object.__setattr__(self, "policy_version", policy_version)
+        object.__setattr__(self, "loaded_by", loaded_by)
+        object.__setattr__(self, "parent_run_id", parent_run_id)
+        object.__setattr__(self, "parent_decision_id", parent_decision_id)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> AuthorityProvenance:
+        return cls(
+            source_type=ProvenanceSource(str(data.get("source_type", ""))),
+            source_id=str(data.get("source_id", "")),
+            policy_version=str(data.get("policy_version", "")),
+            loaded_by=str(data.get("loaded_by", "")),
+            parent_run_id=str(data["parent_run_id"]) if data.get("parent_run_id") else None,
+            parent_decision_id=str(data["parent_decision_id"]) if data.get("parent_decision_id") else None,
+        )
+
+    def to_dict(self) -> dict[str, str | None]:
+        return {
+            "source_type": self.source_type.value,
+            "source_id": self.source_id,
+            "policy_version": self.policy_version,
+            "loaded_by": self.loaded_by,
+            "parent_run_id": self.parent_run_id,
+            "parent_decision_id": self.parent_decision_id,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class TargetSelector:
+    value: str
+    selector_type: TargetSelectorType = TargetSelectorType.EXACT
+
+    def __post_init__(self) -> None:
+        value = _text(self.value, "target")
+        if any(token in value for token in ("*", "?")):
+            raise InvalidAuthorityConfigurationError(
+                "target selectors must be exact",
+                AuthorityReasonCode.INVALID_SCOPE,
+                {"target": value},
+            )
+        object.__setattr__(self, "value", value)
+        object.__setattr__(self, "selector_type", TargetSelectorType(self.selector_type))
+
+    def to_dict(self) -> dict[str, str]:
+        return {"selector_type": self.selector_type.value, "value": self.value}
+
+
+@dataclass(frozen=True, slots=True)
+class Constraint:
+    key: str
+    kind: ConstraintKind
+    values: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        key = _identifier(self.key, "constraint key")
+        kind = ConstraintKind(self.kind)
+        values = tuple(
+            sorted(
+                {_text(value, "constraint value") for value in self.values},
+                key=lambda item: (item.casefold(), item),
+            )
+        )
+        if not values or (kind is ConstraintKind.EXACT and len(values) != 1):
+            raise InvalidAuthorityConfigurationError(
+                "constraint values do not match constraint kind",
+                AuthorityReasonCode.INVALID_SCOPE,
+                {"constraint": key},
+            )
+        object.__setattr__(self, "key", key)
+        object.__setattr__(self, "kind", kind)
+        object.__setattr__(self, "values", values)
+
+    @classmethod
+    def exact(cls, key: str, value: str) -> Constraint:
+        return cls(key=key, kind=ConstraintKind.EXACT, values=(value,))
+
+    @classmethod
+    def allowed_set(cls, key: str, values: tuple[str, ...] | list[str]) -> Constraint:
+        return cls(key=key, kind=ConstraintKind.ALLOWED_SET, values=tuple(values))
+
+    def permits(self, requested: Constraint) -> bool:
+        if self.key != requested.key:
+            return False
+        return set(requested.values).issubset(self.values)
+
+    def intersect(self, other: Constraint) -> Constraint | None:
+        if self.key != other.key:
+            return None
+        values = tuple(
+            sorted(
+                set(self.values).intersection(other.values),
+                key=lambda item: (item.casefold(), item),
+            )
+        )
+        if not values:
+            return None
+        kind = ConstraintKind.EXACT if len(values) == 1 else ConstraintKind.ALLOWED_SET
+        return Constraint(self.key, kind, values)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> Constraint:
+        values = data.get("values", ())
+        if not isinstance(values, (list, tuple)):
+            values = ()
+        return cls(
+            str(data.get("key", "")),
+            ConstraintKind(str(data.get("kind", ""))),
+            tuple(str(item) for item in values),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {"key": self.key, "kind": self.kind.value, "values": list(self.values)}
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorityScope:
+    scope_id: str
+    targets: tuple[TargetSelector, ...]
+    operations: tuple[str, ...]
+    constraints: tuple[Constraint, ...]
+    provenance: AuthorityProvenance
+    parent_scope_id: str | None = None
+
+    def __post_init__(self) -> None:
+        scope_id = _identifier(self.scope_id, "scope_id")
+        targets = tuple(sorted(tuple(self.targets), key=lambda item: (item.value.casefold(), item.value)))
+        operations = tuple(sorted((_identifier(item, "operation") for item in self.operations)))
+        constraints = tuple(sorted(tuple(self.constraints), key=lambda item: item.key))
+        if not targets or not operations:
+            raise InvalidAuthorityConfigurationError(
+                "authority scope requires targets and operations",
+                AuthorityReasonCode.INVALID_SCOPE,
+                {"scope_id": scope_id},
+            )
+        if len({item.value for item in targets}) != len(targets) or len(set(operations)) != len(operations):
+            raise InvalidAuthorityConfigurationError(
+                "authority scope contains duplicates",
+                AuthorityReasonCode.INVALID_SCOPE,
+            )
+        if len({item.key for item in constraints}) != len(constraints):
+            raise InvalidAuthorityConfigurationError(
+                "constraint keys must be unique",
+                AuthorityReasonCode.INVALID_SCOPE,
+            )
+        parent_scope_id = _identifier(self.parent_scope_id, "parent_scope_id") if self.parent_scope_id else None
+        if self.provenance.source_type is ProvenanceSource.ACCEPTED_DELEGATION and not parent_scope_id:
+            raise InvalidAuthorityConfigurationError(
+                "delegated scope requires parent_scope_id",
+                AuthorityReasonCode.UNTRUSTED_PROVENANCE,
+            )
+        object.__setattr__(self, "scope_id", scope_id)
+        object.__setattr__(self, "targets", targets)
+        object.__setattr__(self, "operations", operations)
+        object.__setattr__(self, "constraints", constraints)
+        object.__setattr__(self, "parent_scope_id", parent_scope_id)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> AuthorityScope:
+        targets = data.get("targets", ())
+        operations = data.get("operations", ())
+        constraints = data.get("constraints", ())
+        provenance = data.get("provenance")
+        if (
+            not isinstance(targets, list)
+            or not isinstance(operations, list)
+            or not isinstance(constraints, list)
+            or not isinstance(provenance, dict)
+        ):
+            raise InvalidAuthorityConfigurationError(
+                "malformed authority scope",
+                AuthorityReasonCode.INVALID_SCOPE,
+            )
+        return cls(
+            scope_id=str(data.get("scope_id", "")),
+            targets=tuple(
+                TargetSelector(str(item))
+                if not isinstance(item, dict)
+                else TargetSelector(
+                    str(item.get("value", "")),
+                    TargetSelectorType(str(item.get("selector_type", "EXACT"))),
+                )
+                for item in targets
+            ),
+            operations=tuple(str(item) for item in operations),
+            constraints=tuple(Constraint.from_dict(item) for item in constraints if isinstance(item, dict)),
+            provenance=AuthorityProvenance.from_dict(provenance),
+            parent_scope_id=str(data["parent_scope_id"]) if data.get("parent_scope_id") else None,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "scope_id": self.scope_id,
+            "targets": [item.to_dict() for item in self.targets],
+            "operations": list(self.operations),
+            "constraints": [item.to_dict() for item in self.constraints],
+            "provenance": self.provenance.to_dict(),
+            "parent_scope_id": self.parent_scope_id,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorityDecision:
+    decision_id: str
+    run_id: str
+    scope_id: str
+    target: TargetSelector
+    operation: str
+    requested_constraints: tuple[Constraint, ...]
+    allowed: bool
+    reason_code: AuthorityReasonCode
+    matched_targets: tuple[str, ...] = ()
+    matched_operations: tuple[str, ...] = ()
+    evaluated_constraints: tuple[str, ...] = ()
+    provenance_id: str = ""
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "decision_id", _text(self.decision_id, "decision_id"))
+        object.__setattr__(self, "run_id", _text(self.run_id, "run_id"))
+        object.__setattr__(self, "scope_id", _identifier(self.scope_id, "scope_id"))
+        object.__setattr__(self, "operation", _identifier(self.operation, "operation"))
+        constraints = tuple(sorted(tuple(self.requested_constraints), key=lambda item: item.key))
+        if len({item.key for item in constraints}) != len(constraints):
+            raise InvalidAuthorityConfigurationError(
+                "requested constraint keys must be unique",
+                AuthorityReasonCode.INVALID_SCOPE,
+            )
+        object.__setattr__(self, "requested_constraints", constraints)
+        object.__setattr__(self, "reason_code", AuthorityReasonCode(self.reason_code))
+        object.__setattr__(self, "matched_targets", tuple(sorted(set(self.matched_targets))))
+        object.__setattr__(self, "matched_operations", tuple(sorted(set(self.matched_operations))))
+        object.__setattr__(self, "evaluated_constraints", tuple(sorted(set(self.evaluated_constraints))))
+        object.__setattr__(self, "provenance_id", _identifier(self.provenance_id, "provenance_id"))
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "decision_id": self.decision_id,
+            "run_id": self.run_id,
+            "scope_id": self.scope_id,
+            "target": self.target.to_dict(),
+            "operation": self.operation,
+            "requested_constraints": [item.to_dict() for item in self.requested_constraints],
+            "allowed": self.allowed,
+            "reason_code": self.reason_code.value,
+            "matched_targets": list(self.matched_targets),
+            "matched_operations": list(self.matched_operations),
+            "evaluated_constraints": list(self.evaluated_constraints),
+            "provenance_id": self.provenance_id,
+        }
+
+
+def _constraint_map(constraints: tuple[Constraint, ...]) -> dict[str, Constraint]:
+    result = {item.key: item for item in constraints}
+    if len(result) != len(constraints):
+        raise InvalidAuthorityConfigurationError(
+            "constraint keys must be unique",
+            AuthorityReasonCode.INVALID_SCOPE,
+        )
+    return result
+
+
+def _constraints_permit(
+    granted: tuple[Constraint, ...],
+    requested: tuple[Constraint, ...],
+) -> bool:
+    granted_map = _constraint_map(granted)
+    requested_map = _constraint_map(requested)
+    if set(granted_map) != set(requested_map):
+        return not granted_map and not requested_map
+    return all(granted_map[key].permits(requested_map[key]) for key in granted_map)
+
+
+def _intersect_constraints(
+    parent: tuple[Constraint, ...],
+    requested: tuple[Constraint, ...],
+) -> tuple[Constraint, ...]:
+    parent_map = _constraint_map(parent)
+    requested_map = _constraint_map(requested)
+    result: list[Constraint] = []
+    for key in sorted(set(parent_map).union(requested_map)):
+        if key in parent_map and key in requested_map:
+            intersection = parent_map[key].intersect(requested_map[key])
+            if intersection is None:
+                raise InvalidAuthorityConfigurationError(
+                    "authority constraints do not intersect",
+                    AuthorityReasonCode.EMPTY_INTERSECTION,
+                    {"constraint": key},
+                )
+            result.append(intersection)
+        else:
+            result.append(parent_map.get(key) or requested_map[key])
+    return tuple(result)

--- a/tests/runtime/test_domain_governance_authority.py
+++ b/tests/runtime/test_domain_governance_authority.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from orchestra_runtime import authority as legacy_authority
+from orchestra_runtime.domain.governance import authority as domain_authority
+from orchestra_runtime.errors import InvalidAuthorityConfigurationError
+
+
+def _provenance() -> domain_authority.AuthorityProvenance:
+    return domain_authority.AuthorityProvenance(
+        domain_authority.ProvenanceSource.TRUSTED_REPOSITORY_POLICY,
+        "policy.root",
+        "1.0",
+        "runtime.composition",
+    )
+
+
+def _scope() -> domain_authority.AuthorityScope:
+    return domain_authority.AuthorityScope(
+        "scope.root",
+        (domain_authority.TargetSelector("repository:orchestra"),),
+        ("read", "write"),
+        (domain_authority.Constraint.allowed_set("environment", ["dev", "test"]),),
+        _provenance(),
+    )
+
+
+def test_legacy_authority_exports_are_canonical_domain_symbols():
+    assert legacy_authority.AuthorityProvenance is domain_authority.AuthorityProvenance
+    assert legacy_authority.TargetSelector is domain_authority.TargetSelector
+    assert legacy_authority.Constraint is domain_authority.Constraint
+    assert legacy_authority.AuthorityScope is domain_authority.AuthorityScope
+    assert legacy_authority.AuthorityDecision is domain_authority.AuthorityDecision
+    assert legacy_authority.AuthorityReasonCode is domain_authority.AuthorityReasonCode
+    assert legacy_authority.ProvenanceSource is domain_authority.ProvenanceSource
+
+
+def test_domain_authority_preserves_normalization_and_intersection_semantics():
+    scope = _scope()
+    assert scope.scope_id == "scope.root"
+    assert scope.operations == ("read", "write")
+    assert scope.constraints == (
+        domain_authority.Constraint.allowed_set("environment", ["dev", "test"]),
+    )
+    assert domain_authority._constraints_permit(
+        scope.constraints,
+        (domain_authority.Constraint.exact("environment", "dev"),),
+    )
+    assert domain_authority._intersect_constraints(
+        scope.constraints,
+        (domain_authority.Constraint.allowed_set("environment", ["test", "prod"]),),
+    ) == (domain_authority.Constraint.exact("environment", "test"),)
+
+
+def test_domain_authority_fails_closed_on_untrusted_or_wildcard_scope():
+    with pytest.raises(InvalidAuthorityConfigurationError):
+        domain_authority.AuthorityProvenance(
+            domain_authority.ProvenanceSource.ACCEPTED_DELEGATION,
+            "delegation",
+            "1",
+            "runtime",
+        )
+    with pytest.raises(InvalidAuthorityConfigurationError, match="exact"):
+        domain_authority.TargetSelector("repository:*")
+
+
+def test_domain_authority_has_no_io_or_legacy_runtime_imports():
+    source_path = Path(domain_authority.__file__)
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module)
+
+    forbidden = {
+        "pathlib",
+        "os",
+        "subprocess",
+        "socket",
+        "orchestra_runtime.authority",
+        "orchestra_runtime.interfaces",
+        "orchestra_runtime.models",
+    }
+    assert not imports.intersection(forbidden)


### PR DESCRIPTION
## Scope

Bounded AR-2 `domain/governance` authority extraction only.

- moves immutable authority entities and deterministic constraint/intersection semantics into `orchestra_runtime.domain.governance.authority`
- preserves legacy `orchestra_runtime.authority` symbol identity
- deliberately retains repository-policy filesystem loading, `IAuthorityEvaluator` inheritance, and `RuntimeAuditEvent` projection on the legacy surface for later AR-3/AR-4 placement
- adds direct boundary and compatibility tests

## Lifecycle disposition

SUPERSEDED_BY_EXACT_TREE_MATERIALIZATION

Source exact head: `2bb1b1dd49bfaca7f1094f81d5d25607c20e3685`
Materialization PR: #718
Canonical merge: `4bd4b218511ee531978a2f60cdf6e96525807ff5`
Canonical tree: `52bcbf97acf014710f6126eb85c90746c554de2f`

The source candidate passed Governance Check, validate, Required Analysis Compatibility, Cross-platform Validation, GitHub CodeQL, and cosmic-ray-confidence. The connected GitHub ready-for-review mutation remained unusable because of the `Repository.fullDatabaseId` GraphQL response-schema incompatibility, so the exact validated tree was materialized through non-draft PR #718 and squash-merged with no source delta.

AR-2 remains active. AR-3 is not started. No release/tag publication, deployment, policy/ruleset activation, installed-integration refresh, destructive action, branch deletion, force push, or history rewrite is included.