### PR TITLE
refactor(architecture): extract AR-2 capability domain core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Post-v1.7 runtime architecture AR-2 capability core extraction candidate
+
+- Establishes `orchestra_runtime.domain.capabilities` as the inward-only owner of capability value objects, deterministic decision/enforcement semantics, and restrictive grant intersection.
+- Preserves legacy `orchestra_runtime.capabilities` symbol identity while deliberately retaining run-bound manifests, `RunIdentity` construction, application-port inheritance, filesystem policy loading, and runtime audit-event projection on the transitional legacy surface.
+- Adds direct compatibility, fail-closed evaluation/intersection, import-boundary regression coverage, detailed extraction documentation, and `README.json` machine-discovery parity.
+- Does not move correlation generation/validation, start AR-3/AR-4, alter provider/MCP behavior, retire public imports, or change release/deployment/policy authority.
+
 ## Post-v1.7 runtime architecture AR-2 governance authority extraction candidate
 
 - Establishes `orchestra_runtime.domain.governance.authority` as the inward-only owner of immutable authority entities and deterministic constraint/intersection semantics.

--- a/README.json
+++ b/README.json
@@ -32,7 +32,7 @@
     "runtime_architecture_refoundation": {
       "status": "AR_2_DOMAIN_EXTRACTIONS_ACTIVE",
       "purpose": "Incrementally refactor the Orchestra Python runtime into bounded clean/hexagonal architecture layers while preserving public behavior and legacy import compatibility.",
-      "human_sources": ["docs/project/ORCHESTRA_RUNTIME_ARCHITECTURE_REFOUNDATION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_CONTEXT_EXTRACTION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_GOVERNANCE_AUTHORITY_EXTRACTION.md", "docs/architecture/README.md"],
+      "human_sources": ["docs/project/ORCHESTRA_RUNTIME_ARCHITECTURE_REFOUNDATION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_CONTEXT_EXTRACTION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_GOVERNANCE_AUTHORITY_EXTRACTION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_CAPABILITIES_CORE_EXTRACTION.md", "docs/architecture/README.md"],
       "validation_surface": "tests/runtime/test_runtime_architecture_boundaries.py",
       "machine_policy": "machine/governance/runtime-architecture-boundaries.v1.json",
       "machine_policy_schema": "machine/schemas/runtime-architecture-boundaries.v1.schema.json",
@@ -48,6 +48,10 @@
       "governance_authority_domain_surface": "orchestra_runtime/domain/governance/authority.py",
       "governance_authority_legacy_compatibility_surface": "orchestra_runtime/authority.py",
       "governance_authority_validation_surface": "tests/runtime/test_domain_governance_authority.py",
+      "capabilities_domain_surface": "orchestra_runtime/domain/capabilities",
+      "capabilities_domain_core_surface": "orchestra_runtime/domain/capabilities/core.py",
+      "capabilities_legacy_compatibility_surface": "orchestra_runtime/capabilities.py",
+      "capabilities_domain_validation_surface": "tests/runtime/test_domain_capabilities_core.py",
       "ci_enforcement": ["Governance Check", "validate"],
       "canonical_layers": ["domain", "application", "infrastructure", "entrypoints", "bootstrap", "shared", "resources"],
       "application_subzones": ["use_cases", "services", "dto", "ports"],
@@ -1087,7 +1091,8 @@
     "publication_closeout_v1_7_0": "docs/validation/V1_7_0_PUBLICATION_CLOSEOUT.md",
     "codex_c2_portability_r1_preexecution": "docs/benchmarking/CODEX_C2_PORTABILITY_R1_PREEXECUTION.md",
     "cloak_ui_reference_cuir5_evaluation": "docs/project/CLOAK_UI_REFERENCE_CORPUS_CUIR5_EVALUATION.md",
-    "runtime_architecture_ar2_domain_governance_authority": "docs/project/ORCHESTRA_AR2_DOMAIN_GOVERNANCE_AUTHORITY_EXTRACTION.md"
+    "runtime_architecture_ar2_domain_governance_authority": "docs/project/ORCHESTRA_AR2_DOMAIN_GOVERNANCE_AUTHORITY_EXTRACTION.md",
+    "runtime_architecture_ar2_domain_capabilities_core": "docs/project/ORCHESTRA_AR2_DOMAIN_CAPABILITIES_CORE_EXTRACTION.md"
   },
   "representation_policy": {"markdown": "Human-readable explanation, rationale, examples, and nuanced specialist guidance", "json": "Canonical structured machine state, identity, routing, governance, receipts, manifests, provenance, presentation contracts, evidence, and indexes", "json_schema": "Validation contract for machine-readable records", "jsonl": "Append-only event/history records where incremental retrieval is preferable", "toon": "Derived validated non-authoritative model-context projection only when bounded compilation provides measured context benefit", "parity_rule": "When the same deterministic fact appears in more than one representation, CI must validate parity or derive the projection from one authoritative source."},
   "maturity": {
@@ -1183,7 +1188,7 @@
     "require_explicit_resource_ceiling_before_paid_live_benchmark_execution": true,
     "do_not_treat_b2_topology_identity_as_execution_without_the_benchmark_topology_adapter": true,
     "preserve_b2_a5_shadow_ranking_as_non-authorizing_and_separate_from_arm_scheduling": true,
-    "treat_b2_1_topology_executor_as_canonical_non_production_measurement_adapter": true,
+    "treat_b2_1_topology_executor_as_canonical_non-production_measurement_adapter": true,
     "require_b2_topology_sensitive_taskset_and_exact_manifest_before_live_execution": true,
     "do_not_equate_execution_allowed_task_payload_with_live_execution_authority": true,
     "require_b2_2_exact_host_zero_call_preflight_and_separate_human_authorization_before_model_calls": true,

--- a/README.json
+++ b/README.json
@@ -157,7 +157,7 @@
       "human_sources": [
         "docs/project/CLOAK_UI_REFERENCE_CORPUS_CUIR2_STATIC_ANALYSIS.md"
       ],
-      "validation_surface": "tests/runtime/test_cloak_ui_reference_corpus_cuir2.py",
+      "validation_surface": "tests/runtime/test_cloak-ui-reference-corpus-cuir2.py",
       "runtime_integration": false,
       "external_code_execution": false,
       "automatic_ingestion": false,
@@ -1188,7 +1188,7 @@
     "require_explicit_resource_ceiling_before_paid_live_benchmark_execution": true,
     "do_not_treat_b2_topology_identity_as_execution_without_the_benchmark_topology_adapter": true,
     "preserve_b2_a5_shadow_ranking_as_non-authorizing_and_separate_from_arm_scheduling": true,
-    "treat_b2_1_topology_executor_as_canonical_non-production_measurement_adapter": true,
+    "treat_b2_1_topology_executor_as_canonical_non_production_measurement_adapter": true,
     "require_b2_topology_sensitive_taskset_and_exact_manifest_before_live_execution": true,
     "do_not_equate_execution_allowed_task_payload_with_live_execution_authority": true,
     "require_b2_2_exact_host_zero_call_preflight_and_separate_human_authorization_before_model_calls": true,

--- a/README.json
+++ b/README.json
@@ -157,7 +157,7 @@
       "human_sources": [
         "docs/project/CLOAK_UI_REFERENCE_CORPUS_CUIR2_STATIC_ANALYSIS.md"
       ],
-      "validation_surface": "tests/runtime/test_cloak-ui-reference-corpus-cuir2.py",
+      "validation_surface": "tests/runtime/test_cloak_ui_reference_corpus_cuir2.py",
       "runtime_integration": false,
       "external_code_execution": false,
       "automatic_ingestion": false,
@@ -1170,7 +1170,7 @@
     "do_not_allow_a4_ranking_to_restore_or_create_eligibility": true,
     "do_not_repurpose_a3_strategy_evidence_as_model_or_worker_performance_evidence": true,
     "treat_a4_shadow_decisions_as_non_execution_effective_and_not_promoted": true,
-    "treat_a4_1_shadow_ranker_as_non-authorizing_and_separate_from_execution_control": true,
+    "treat_a4_1_shadow_topology_ranker_as_non-authorizing_and_separate_from_dispatch_execution": true,
     "treat_a4_execution_attachment_as_post_execution_observation_only": true,
     "do_not_use_a4_execution_attachment_to_influence_operation_inputs_or_attribute_runtime_outcomes": true,
     "do_not_allow_a5_topology_to_omit_required_specialists_or_change_domain_ownership": true,

--- a/README.json
+++ b/README.json
@@ -1170,7 +1170,7 @@
     "do_not_allow_a4_ranking_to_restore_or_create_eligibility": true,
     "do_not_repurpose_a3_strategy_evidence_as_model_or_worker_performance_evidence": true,
     "treat_a4_shadow_decisions_as_non_execution_effective_and_not_promoted": true,
-    "treat_a4_1_shadow_topology_ranker_as_non-authorizing_and_separate_from_dispatch_execution": true,
+    "treat_a4_1_shadow_ranker_as_non-authorizing_and_separate_from_execution_control": true,
     "treat_a4_execution_attachment_as_post_execution_observation_only": true,
     "do_not_use_a4_execution_attachment_to_influence_operation_inputs_or_attribute_runtime_outcomes": true,
     "do_not_allow_a5_topology_to_omit_required_specialists_or_change_domain_ownership": true,

--- a/docs/project/ORCHESTRA_AR2_DOMAIN_CAPABILITIES_CORE_EXTRACTION.md
+++ b/docs/project/ORCHESTRA_AR2_DOMAIN_CAPABILITIES_CORE_EXTRACTION.md
@@ -1,0 +1,78 @@
+# Orchestra AR-2 Domain Capabilities Core Extraction
+
+Status: `AR_2_DOMAIN_CAPABILITIES_CORE_CANDIDATE`
+
+Phase boundary: AR-2 remains active. AR-3 is not started.
+
+## Objective
+
+Move only the capability value objects and deterministic capability-decision semantics into the inward domain layer without pulling run identity, filesystem policy loading, application ports, or runtime audit projection into the domain.
+
+## Canonical inward ownership in this candidate
+
+`orchestra_runtime/domain/capabilities/core.py` owns:
+
+- `CapabilityReasonCode`;
+- `RuntimeCapability`;
+- `RuntimeCapabilityGrant`;
+- `CapabilityDecision`;
+- capability identifier/text normalization used by those domain objects;
+- deterministic grant evaluation;
+- fail-closed decision enforcement; and
+- restrictive delegated grant intersection.
+
+The domain capability core imports only standard-library value-object support, `orchestra_runtime.domain.governance.authority`, and `orchestra_runtime.shared.errors`.
+
+## Transitional legacy ownership retained
+
+`orchestra_runtime/capabilities.py` deliberately continues to own:
+
+- `RuntimeCapabilityManifest`, because it is run-bound through legacy `RunIdentity`;
+- `CapabilityResolver` application-port inheritance and run-bound manifest construction;
+- `load_trusted_capability_manifest`, because trusted policy loading performs filesystem I/O;
+- `capability_manifest_event` and `capability_decision_event`, because runtime audit projection remains outside the pure domain core.
+
+`RunIdentity` is not moved by this unit. Its current correlation validation dependency is coupled to a module that also owns UUID, clock, and entropy-backed correlation generation, so that boundary requires a separate classification and extraction rather than implicit migration here.
+
+## Compatibility contract
+
+Existing imports from `orchestra_runtime.capabilities` remain valid. The legacy module re-exports the same canonical class and enum objects for:
+
+- `RuntimeCapability`;
+- `RuntimeCapabilityGrant`;
+- `CapabilityDecision`; and
+- `CapabilityReasonCode`.
+
+The transitional `CapabilityResolver` delegates deterministic evaluation, enforcement, and grant intersection to the inward capability core while preserving its existing public method behavior and run-bound manifest construction.
+
+## Dependency direction
+
+The intended dependency direction for this unit is:
+
+`legacy/application transition -> domain.capabilities -> domain.governance + shared.errors`
+
+The domain capability core does not import `pathlib`, host/provider surfaces, MCP, application interfaces, legacy models, audit projections, persistence, or repository `internal/` modules.
+
+## Validation
+
+`tests/runtime/test_domain_capabilities_core.py` verifies:
+
+- legacy-to-domain symbol identity;
+- normalized allow/deny evaluation semantics;
+- fail-closed operation and constraint denial;
+- restrictive delegated grant intersection; and
+- inward-only import boundaries.
+
+The existing runtime capability, delegation, authority-integration, adversarial, and correlation tests remain the broader compatibility regression surface.
+
+## Non-goals
+
+This bounded AR-2 unit does not:
+
+- move `RunIdentity` or correlation generation/validation;
+- move filesystem-backed trusted policy loading;
+- move application ports or start AR-3;
+- move infrastructure concerns or start AR-4;
+- alter provider or MCP execution behavior;
+- retire legacy public imports;
+- change release, deployment, policy/ruleset, destructive-operation, installed-integration, or publication authority.

--- a/orchestra_runtime/capabilities.py
+++ b/orchestra_runtime/capabilities.py
@@ -1,160 +1,27 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from enum import Enum
-import re
-
 from pathlib import Path
 
-from .authority import (
-    AuthorityProvenance,
-    Constraint,
-    ProvenanceSource,
-    _constraints_permit,
-    _intersect_constraints,
-    _load_trusted_json,
+from .authority import AuthorityProvenance, Constraint, ProvenanceSource, _load_trusted_json
+from .domain.capabilities.core import (
+    IDENTIFIER_PATTERN,
+    CapabilityDecision,
+    CapabilityReasonCode,
+    RuntimeCapability,
+    RuntimeCapabilityGrant,
+    _identifier,
+    _text,
+    enforce_capability_decision,
+    evaluate_capability_grants,
+    intersect_capability_grants,
 )
 from .errors import (
     CapabilityCollisionError,
-    CapabilityDeniedError,
     InvalidAuthorityConfigurationError,
     InvalidCapabilityConfigurationError,
 )
 from .interfaces import ICapabilityResolver
 from .models import AuditEventType, RunIdentity, RuntimeAuditEvent
-
-
-IDENTIFIER_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_.:-]*$")
-
-
-class CapabilityReasonCode(str, Enum):
-    ALLOWED = "ALLOWED"
-    INVALID_MANIFEST = "INVALID_MANIFEST"
-    COLLISION = "COLLISION"
-    CAPABILITY_NOT_FOUND = "CAPABILITY_NOT_FOUND"
-    OPERATION_NOT_ALLOWED = "OPERATION_NOT_ALLOWED"
-    CONSTRAINT_DENIED = "CONSTRAINT_DENIED"
-    EMPTY_INTERSECTION = "EMPTY_INTERSECTION"
-
-
-def _text(value: object, field_name: str) -> str:
-    text = str(value).strip()
-    if not text:
-        raise InvalidCapabilityConfigurationError(
-            f"{field_name} must be non-empty",
-            CapabilityReasonCode.INVALID_MANIFEST,
-            {"field": field_name},
-        )
-    return text
-
-
-def _identifier(value: object, field_name: str) -> str:
-    text = _text(value, field_name).casefold()
-    if not IDENTIFIER_PATTERN.fullmatch(text):
-        raise InvalidCapabilityConfigurationError(
-            f"{field_name} must be a canonical identifier",
-            CapabilityReasonCode.INVALID_MANIFEST,
-            {"field": field_name},
-        )
-    return text
-
-
-@dataclass(frozen=True, slots=True)
-class RuntimeCapability:
-    capability_id: str
-    owner: str
-    operations: tuple[str, ...]
-    description: str
-
-    def __post_init__(self) -> None:
-        capability_id = _identifier(self.capability_id, "capability_id")
-        owner = _identifier(self.owner, "owner")
-        operations = tuple(sorted(_identifier(item, "operation") for item in self.operations))
-        if not operations or len(set(operations)) != len(operations):
-            raise InvalidCapabilityConfigurationError(
-                "capability operations must be non-empty and unique",
-                CapabilityReasonCode.INVALID_MANIFEST,
-                {"capability_id": capability_id},
-            )
-        object.__setattr__(self, "capability_id", capability_id)
-        object.__setattr__(self, "owner", owner)
-        object.__setattr__(self, "operations", operations)
-        object.__setattr__(self, "description", _text(self.description, "description"))
-
-    @classmethod
-    def from_dict(cls, data: dict[str, object]) -> RuntimeCapability:
-        operations = data.get("operations", ())
-        if not isinstance(operations, (list, tuple)):
-            operations = ()
-        return cls(
-            capability_id=str(data.get("capability_id", "")),
-            owner=str(data.get("owner", "")),
-            operations=tuple(str(item) for item in operations),
-            description=str(data.get("description", "")),
-        )
-
-    def to_dict(self) -> dict[str, object]:
-        return {
-            "capability_id": self.capability_id,
-            "owner": self.owner,
-            "operations": list(self.operations),
-            "description": self.description,
-        }
-
-
-@dataclass(frozen=True, slots=True)
-class RuntimeCapabilityGrant:
-    capability: RuntimeCapability
-    allowed_operations: tuple[str, ...]
-    provenance: AuthorityProvenance
-    constraints: tuple[Constraint, ...] = ()
-
-    def __post_init__(self) -> None:
-        operations = tuple(sorted(_identifier(item, "allowed operation") for item in self.allowed_operations))
-        constraints = tuple(sorted(tuple(self.constraints), key=lambda item: item.key))
-        if not operations or len(set(operations)) != len(operations):
-            raise InvalidCapabilityConfigurationError(
-                "grant operations must be non-empty and unique",
-                CapabilityReasonCode.INVALID_MANIFEST,
-                {"capability_id": self.capability.capability_id},
-            )
-        if not set(operations).issubset(self.capability.operations):
-            raise InvalidCapabilityConfigurationError(
-                "grant operations must be a subset of capability operations",
-                CapabilityReasonCode.INVALID_MANIFEST,
-                {"capability_id": self.capability.capability_id},
-            )
-        if len({item.key for item in constraints}) != len(constraints):
-            raise InvalidCapabilityConfigurationError(
-                "grant constraint keys must be unique",
-                CapabilityReasonCode.INVALID_MANIFEST,
-                {"capability_id": self.capability.capability_id},
-            )
-        object.__setattr__(self, "allowed_operations", operations)
-        object.__setattr__(self, "constraints", constraints)
-
-    @classmethod
-    def from_dict(cls, data: dict[str, object]) -> RuntimeCapabilityGrant:
-        capability = data.get("capability")
-        provenance = data.get("provenance")
-        operations = data.get("allowed_operations", ())
-        constraints = data.get("constraints", ())
-        if not isinstance(capability, dict) or not isinstance(provenance, dict):
-            raise InvalidCapabilityConfigurationError("malformed capability grant", CapabilityReasonCode.INVALID_MANIFEST)
-        return cls(
-            capability=RuntimeCapability.from_dict(capability),
-            allowed_operations=tuple(str(item) for item in operations) if isinstance(operations, (list, tuple)) else (),
-            provenance=AuthorityProvenance.from_dict(provenance),
-            constraints=tuple(Constraint.from_dict(item) for item in constraints if isinstance(item, dict)) if isinstance(constraints, list) else (),
-        )
-
-    def to_dict(self) -> dict[str, object]:
-        return {
-            "capability": self.capability.to_dict(),
-            "allowed_operations": list(self.allowed_operations),
-            "provenance": self.provenance.to_dict(),
-            "constraints": [item.to_dict() for item in self.constraints],
-        }
 
 
 @dataclass(frozen=True, slots=True)
@@ -167,7 +34,12 @@ class RuntimeCapabilityManifest:
 
     def __post_init__(self) -> None:
         manifest_id = _identifier(self.manifest_id, "manifest_id")
-        grants = tuple(sorted(tuple(self.grants), key=lambda item: (item.capability.capability_id.casefold(), item.capability.capability_id)))
+        grants = tuple(
+            sorted(
+                tuple(self.grants),
+                key=lambda item: (item.capability.capability_id.casefold(), item.capability.capability_id),
+            )
+        )
         identities = [item.capability.capability_id.casefold() for item in grants]
         if not grants:
             raise InvalidCapabilityConfigurationError(
@@ -192,48 +64,6 @@ class RuntimeCapabilityManifest:
             "policy_version": self.policy_version,
             "grants": [item.to_dict() for item in self.grants],
             "provenance": self.provenance.to_dict(),
-        }
-
-
-@dataclass(frozen=True, slots=True)
-class CapabilityDecision:
-    decision_id: str
-    run_id: str
-    manifest_id: str
-    capability_id: str
-    operation: str
-    requested_constraints: tuple[Constraint, ...]
-    allowed: bool
-    reason_code: CapabilityReasonCode
-    evaluated_grant_id: str | None = None
-    evaluated_constraints: tuple[str, ...] = ()
-
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "decision_id", _text(self.decision_id, "decision_id"))
-        object.__setattr__(self, "run_id", _text(self.run_id, "run_id"))
-        object.__setattr__(self, "manifest_id", _identifier(self.manifest_id, "manifest_id"))
-        object.__setattr__(self, "capability_id", _identifier(self.capability_id, "capability_id"))
-        object.__setattr__(self, "operation", _identifier(self.operation, "operation"))
-        constraints = tuple(sorted(tuple(self.requested_constraints), key=lambda item: item.key))
-        if len({item.key for item in constraints}) != len(constraints):
-            raise InvalidCapabilityConfigurationError("requested constraint keys must be unique", CapabilityReasonCode.INVALID_MANIFEST)
-        object.__setattr__(self, "requested_constraints", constraints)
-        object.__setattr__(self, "reason_code", CapabilityReasonCode(self.reason_code))
-        object.__setattr__(self, "evaluated_grant_id", self.evaluated_grant_id.strip() if self.evaluated_grant_id else None)
-        object.__setattr__(self, "evaluated_constraints", tuple(sorted(set(self.evaluated_constraints))))
-
-    def to_dict(self) -> dict[str, object]:
-        return {
-            "decision_id": self.decision_id,
-            "run_id": self.run_id,
-            "manifest_id": self.manifest_id,
-            "capability_id": self.capability_id,
-            "operation": self.operation,
-            "requested_constraints": [item.to_dict() for item in self.requested_constraints],
-            "allowed": self.allowed,
-            "reason_code": self.reason_code.value,
-            "evaluated_grant_id": self.evaluated_grant_id,
-            "evaluated_constraints": list(self.evaluated_constraints),
         }
 
 
@@ -274,40 +104,19 @@ class CapabilityResolver(ICapabilityResolver):
         *,
         decision_id: str,
     ) -> CapabilityDecision:
-        capability_id = _identifier(capability_id, "capability_id")
-        operation = _identifier(operation, "operation")
-        constraints = tuple(sorted(tuple(constraints), key=lambda item: item.key))
-        grant = next((item for item in manifest.grants if item.capability.capability_id == capability_id), None)
-        if grant is None:
-            reason = CapabilityReasonCode.CAPABILITY_NOT_FOUND
-        elif operation not in grant.allowed_operations:
-            reason = CapabilityReasonCode.OPERATION_NOT_ALLOWED
-        elif not _constraints_permit(grant.constraints, constraints):
-            reason = CapabilityReasonCode.CONSTRAINT_DENIED
-        else:
-            reason = CapabilityReasonCode.ALLOWED
-        return CapabilityDecision(
-            decision_id,
-            manifest.run_identity.run_id,
-            manifest.manifest_id,
-            capability_id,
-            operation,
-            constraints,
-            reason is CapabilityReasonCode.ALLOWED,
-            reason,
-            grant.capability.capability_id if grant else None,
-            tuple(item.key for item in constraints),
+        return evaluate_capability_grants(
+            manifest.grants,
+            run_id=manifest.run_identity.run_id,
+            manifest_id=manifest.manifest_id,
+            capability_id=capability_id,
+            operation=operation,
+            constraints=constraints,
+            decision_id=decision_id,
         )
 
     @staticmethod
     def enforce(decision: CapabilityDecision) -> CapabilityDecision:
-        if not decision.allowed:
-            raise CapabilityDeniedError(
-                "capability decision denied",
-                decision.reason_code,
-                {"capability_id": decision.capability_id, "operation": decision.operation},
-            )
-        return decision
+        return enforce_capability_decision(decision)
 
     def intersect(
         self,
@@ -318,37 +127,10 @@ class CapabilityResolver(ICapabilityResolver):
         *,
         manifest_id: str,
     ) -> RuntimeCapabilityManifest:
-        if provenance.source_type is not ProvenanceSource.ACCEPTED_DELEGATION:
-            raise InvalidCapabilityConfigurationError(
-                "child manifest requires accepted delegation provenance",
-                CapabilityReasonCode.INVALID_MANIFEST,
-            )
-        parent_grants = {item.capability.capability_id: item for item in parent_manifest.grants}
-        effective: list[RuntimeCapabilityGrant] = []
-        for requested in requested_grants:
-            parent = parent_grants.get(requested.capability.capability_id)
-            if parent is None:
-                continue
-            operations = tuple(sorted(set(parent.allowed_operations).intersection(requested.allowed_operations)))
-            if not operations:
-                continue
-            try:
-                constraints = _intersect_constraints(parent.constraints, requested.constraints)
-            except InvalidAuthorityConfigurationError as exc:
-                raise InvalidCapabilityConfigurationError(
-                    "capability constraints do not intersect",
-                    CapabilityReasonCode.EMPTY_INTERSECTION,
-                    {"capability_id": requested.capability.capability_id},
-                ) from exc
-            effective.append(RuntimeCapabilityGrant(parent.capability, operations, provenance, constraints))
-        if not effective:
-            raise InvalidCapabilityConfigurationError(
-                "capability intersection is empty",
-                CapabilityReasonCode.EMPTY_INTERSECTION,
-            )
+        effective = intersect_capability_grants(parent_manifest.grants, requested_grants, provenance)
         return self.build_manifest(
             child_run_id,
-            tuple(effective),
+            effective,
             provenance,
             manifest_id=manifest_id,
             policy_version=parent_manifest.policy_version,
@@ -373,7 +155,10 @@ def load_trusted_capability_manifest(repo_root: Path, policy_path: Path) -> Runt
     provenance_data = manifest_data.get("provenance")
     grants_data = manifest_data.get("grants")
     if not isinstance(provenance_data, dict) or not isinstance(grants_data, list):
-        raise InvalidCapabilityConfigurationError("trusted manifest is malformed", CapabilityReasonCode.INVALID_MANIFEST)
+        raise InvalidCapabilityConfigurationError(
+            "trusted manifest is malformed",
+            CapabilityReasonCode.INVALID_MANIFEST,
+        )
     try:
         provenance = AuthorityProvenance.from_dict(provenance_data)
         grants = tuple(RuntimeCapabilityGrant.from_dict(item) for item in grants_data if isinstance(item, dict))
@@ -389,7 +174,10 @@ def load_trusted_capability_manifest(repo_root: Path, policy_path: Path) -> Runt
     except (KeyError, TypeError, ValueError) as exc:
         if isinstance(exc, (InvalidCapabilityConfigurationError, CapabilityCollisionError)):
             raise
-        raise InvalidCapabilityConfigurationError("trusted manifest is malformed", CapabilityReasonCode.INVALID_MANIFEST) from exc
+        raise InvalidCapabilityConfigurationError(
+            "trusted manifest is malformed",
+            CapabilityReasonCode.INVALID_MANIFEST,
+        ) from exc
     if provenance.source_type is not ProvenanceSource.TRUSTED_REPOSITORY_POLICY:
         raise InvalidCapabilityConfigurationError(
             "file policy requires trusted repository provenance",

--- a/orchestra_runtime/capabilities.py
+++ b/orchestra_runtime/capabilities.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 
 from .authority import AuthorityProvenance, Constraint, ProvenanceSource, _load_trusted_json

--- a/orchestra_runtime/domain/capabilities/__init__.py
+++ b/orchestra_runtime/domain/capabilities/__init__.py
@@ -1,0 +1,19 @@
+from .core import (
+    CapabilityDecision,
+    CapabilityReasonCode,
+    RuntimeCapability,
+    RuntimeCapabilityGrant,
+    enforce_capability_decision,
+    evaluate_capability_grants,
+    intersect_capability_grants,
+)
+
+__all__ = [
+    "CapabilityDecision",
+    "CapabilityReasonCode",
+    "RuntimeCapability",
+    "RuntimeCapabilityGrant",
+    "enforce_capability_decision",
+    "evaluate_capability_grants",
+    "intersect_capability_grants",
+]

--- a/orchestra_runtime/domain/capabilities/core.py
+++ b/orchestra_runtime/domain/capabilities/core.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import re
+
+from ..governance.authority import (
+    AuthorityProvenance,
+    Constraint,
+    ProvenanceSource,
+    _constraints_permit,
+    _intersect_constraints,
+)
+from ...shared.errors import (
+    CapabilityDeniedError,
+    InvalidAuthorityConfigurationError,
+    InvalidCapabilityConfigurationError,
+)
+
+
+IDENTIFIER_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_.:-]*$")
+
+
+class CapabilityReasonCode(str, Enum):
+    ALLOWED = "ALLOWED"
+    INVALID_MANIFEST = "INVALID_MANIFEST"
+    COLLISION = "COLLISION"
+    CAPABILITY_NOT_FOUND = "CAPABILITY_NOT_FOUND"
+    OPERATION_NOT_ALLOWED = "OPERATION_NOT_ALLOWED"
+    CONSTRAINT_DENIED = "CONSTRAINT_DENIED"
+    EMPTY_INTERSECTION = "EMPTY_INTERSECTION"
+
+
+def _text(value: object, field_name: str) -> str:
+    text = str(value).strip()
+    if not text:
+        raise InvalidCapabilityConfigurationError(
+            f"{field_name} must be non-empty",
+            CapabilityReasonCode.INVALID_MANIFEST,
+            {"field": field_name},
+        )
+    return text
+
+
+def _identifier(value: object, field_name: str) -> str:
+    text = _text(value, field_name).casefold()
+    if not IDENTIFIER_PATTERN.fullmatch(text):
+        raise InvalidCapabilityConfigurationError(
+            f"{field_name} must be a canonical identifier",
+            CapabilityReasonCode.INVALID_MANIFEST,
+            {"field": field_name},
+        )
+    return text
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeCapability:
+    capability_id: str
+    owner: str
+    operations: tuple[str, ...]
+    description: str
+
+    def __post_init__(self) -> None:
+        capability_id = _identifier(self.capability_id, "capability_id")
+        owner = _identifier(self.owner, "owner")
+        operations = tuple(sorted(_identifier(item, "operation") for item in self.operations))
+        if not operations or len(set(operations)) != len(operations):
+            raise InvalidCapabilityConfigurationError(
+                "capability operations must be non-empty and unique",
+                CapabilityReasonCode.INVALID_MANIFEST,
+                {"capability_id": capability_id},
+            )
+        object.__setattr__(self, "capability_id", capability_id)
+        object.__setattr__(self, "owner", owner)
+        object.__setattr__(self, "operations", operations)
+        object.__setattr__(self, "description", _text(self.description, "description"))
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> RuntimeCapability:
+        operations = data.get("operations", ())
+        if not isinstance(operations, (list, tuple)):
+            operations = ()
+        return cls(
+            capability_id=str(data.get("capability_id", "")),
+            owner=str(data.get("owner", "")),
+            operations=tuple(str(item) for item in operations),
+            description=str(data.get("description", "")),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "capability_id": self.capability_id,
+            "owner": self.owner,
+            "operations": list(self.operations),
+            "description": self.description,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeCapabilityGrant:
+    capability: RuntimeCapability
+    allowed_operations: tuple[str, ...]
+    provenance: AuthorityProvenance
+    constraints: tuple[Constraint, ...] = ()
+
+    def __post_init__(self) -> None:
+        operations = tuple(sorted(_identifier(item, "allowed operation") for item in self.allowed_operations))
+        constraints = tuple(sorted(tuple(self.constraints), key=lambda item: item.key))
+        if not operations or len(set(operations)) != len(operations):
+            raise InvalidCapabilityConfigurationError(
+                "grant operations must be non-empty and unique",
+                CapabilityReasonCode.INVALID_MANIFEST,
+                {"capability_id": self.capability.capability_id},
+            )
+        if not set(operations).issubset(self.capability.operations):
+            raise InvalidCapabilityConfigurationError(
+                "grant operations must be a subset of capability operations",
+                CapabilityReasonCode.INVALID_MANIFEST,
+                {"capability_id": self.capability.capability_id},
+            )
+        if len({item.key for item in constraints}) != len(constraints):
+            raise InvalidCapabilityConfigurationError(
+                "grant constraint keys must be unique",
+                CapabilityReasonCode.INVALID_MANIFEST,
+                {"capability_id": self.capability.capability_id},
+            )
+        object.__setattr__(self, "allowed_operations", operations)
+        object.__setattr__(self, "constraints", constraints)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> RuntimeCapabilityGrant:
+        capability = data.get("capability")
+        provenance = data.get("provenance")
+        operations = data.get("allowed_operations", ())
+        constraints = data.get("constraints", ())
+        if not isinstance(capability, dict) or not isinstance(provenance, dict):
+            raise InvalidCapabilityConfigurationError("malformed capability grant", CapabilityReasonCode.INVALID_MANIFEST)
+        return cls(
+            capability=RuntimeCapability.from_dict(capability),
+            allowed_operations=tuple(str(item) for item in operations) if isinstance(operations, (list, tuple)) else (),
+            provenance=AuthorityProvenance.from_dict(provenance),
+            constraints=tuple(Constraint.from_dict(item) for item in constraints if isinstance(item, dict))
+            if isinstance(constraints, list)
+            else (),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "capability": self.capability.to_dict(),
+            "allowed_operations": list(self.allowed_operations),
+            "provenance": self.provenance.to_dict(),
+            "constraints": [item.to_dict() for item in self.constraints],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityDecision:
+    decision_id: str
+    run_id: str
+    manifest_id: str
+    capability_id: str
+    operation: str
+    requested_constraints: tuple[Constraint, ...]
+    allowed: bool
+    reason_code: CapabilityReasonCode
+    evaluated_grant_id: str | None = None
+    evaluated_constraints: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "decision_id", _text(self.decision_id, "decision_id"))
+        object.__setattr__(self, "run_id", _text(self.run_id, "run_id"))
+        object.__setattr__(self, "manifest_id", _identifier(self.manifest_id, "manifest_id"))
+        object.__setattr__(self, "capability_id", _identifier(self.capability_id, "capability_id"))
+        object.__setattr__(self, "operation", _identifier(self.operation, "operation"))
+        constraints = tuple(sorted(tuple(self.requested_constraints), key=lambda item: item.key))
+        if len({item.key for item in constraints}) != len(constraints):
+            raise InvalidCapabilityConfigurationError(
+                "requested constraint keys must be unique",
+                CapabilityReasonCode.INVALID_MANIFEST,
+            )
+        object.__setattr__(self, "requested_constraints", constraints)
+        object.__setattr__(self, "reason_code", CapabilityReasonCode(self.reason_code))
+        object.__setattr__(
+            self,
+            "evaluated_grant_id",
+            self.evaluated_grant_id.strip() if self.evaluated_grant_id else None,
+        )
+        object.__setattr__(self, "evaluated_constraints", tuple(sorted(set(self.evaluated_constraints))))
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "decision_id": self.decision_id,
+            "run_id": self.run_id,
+            "manifest_id": self.manifest_id,
+            "capability_id": self.capability_id,
+            "operation": self.operation,
+            "requested_constraints": [item.to_dict() for item in self.requested_constraints],
+            "allowed": self.allowed,
+            "reason_code": self.reason_code.value,
+            "evaluated_grant_id": self.evaluated_grant_id,
+            "evaluated_constraints": list(self.evaluated_constraints),
+        }
+
+
+def evaluate_capability_grants(
+    grants: tuple[RuntimeCapabilityGrant, ...],
+    *,
+    run_id: str,
+    manifest_id: str,
+    capability_id: str,
+    operation: str,
+    constraints: tuple[Constraint, ...] = (),
+    decision_id: str,
+) -> CapabilityDecision:
+    capability_id = _identifier(capability_id, "capability_id")
+    operation = _identifier(operation, "operation")
+    constraints = tuple(sorted(tuple(constraints), key=lambda item: item.key))
+    grant = next((item for item in grants if item.capability.capability_id == capability_id), None)
+    if grant is None:
+        reason = CapabilityReasonCode.CAPABILITY_NOT_FOUND
+    elif operation not in grant.allowed_operations:
+        reason = CapabilityReasonCode.OPERATION_NOT_ALLOWED
+    elif not _constraints_permit(grant.constraints, constraints):
+        reason = CapabilityReasonCode.CONSTRAINT_DENIED
+    else:
+        reason = CapabilityReasonCode.ALLOWED
+    return CapabilityDecision(
+        decision_id,
+        run_id,
+        manifest_id,
+        capability_id,
+        operation,
+        constraints,
+        reason is CapabilityReasonCode.ALLOWED,
+        reason,
+        grant.capability.capability_id if grant else None,
+        tuple(item.key for item in constraints),
+    )
+
+
+def enforce_capability_decision(decision: CapabilityDecision) -> CapabilityDecision:
+    if not decision.allowed:
+        raise CapabilityDeniedError(
+            "capability decision denied",
+            decision.reason_code,
+            {"capability_id": decision.capability_id, "operation": decision.operation},
+        )
+    return decision
+
+
+def intersect_capability_grants(
+    parent_grants: tuple[RuntimeCapabilityGrant, ...],
+    requested_grants: tuple[RuntimeCapabilityGrant, ...],
+    provenance: AuthorityProvenance,
+) -> tuple[RuntimeCapabilityGrant, ...]:
+    if provenance.source_type is not ProvenanceSource.ACCEPTED_DELEGATION:
+        raise InvalidCapabilityConfigurationError(
+            "child manifest requires accepted delegation provenance",
+            CapabilityReasonCode.INVALID_MANIFEST,
+        )
+    parent_by_id = {item.capability.capability_id: item for item in parent_grants}
+    effective: list[RuntimeCapabilityGrant] = []
+    for requested in requested_grants:
+        parent = parent_by_id.get(requested.capability.capability_id)
+        if parent is None:
+            continue
+        operations = tuple(sorted(set(parent.allowed_operations).intersection(requested.allowed_operations)))
+        if not operations:
+            continue
+        try:
+            constraints = _intersect_constraints(parent.constraints, requested.constraints)
+        except InvalidAuthorityConfigurationError as exc:
+            raise InvalidCapabilityConfigurationError(
+                "capability constraints do not intersect",
+                CapabilityReasonCode.EMPTY_INTERSECTION,
+                {"capability_id": requested.capability.capability_id},
+            ) from exc
+        effective.append(RuntimeCapabilityGrant(parent.capability, operations, provenance, constraints))
+    if not effective:
+        raise InvalidCapabilityConfigurationError(
+            "capability intersection is empty",
+            CapabilityReasonCode.EMPTY_INTERSECTION,
+        )
+    return tuple(effective)

--- a/tests/runtime/test_domain_capabilities_core.py
+++ b/tests/runtime/test_domain_capabilities_core.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import ast
+import inspect
+
+import pytest
+
+from orchestra_runtime.authority import AuthorityProvenance, Constraint, ProvenanceSource
+from orchestra_runtime.capabilities import (
+    CapabilityDecision as LegacyCapabilityDecision,
+    CapabilityReasonCode as LegacyCapabilityReasonCode,
+    RuntimeCapability as LegacyRuntimeCapability,
+    RuntimeCapabilityGrant as LegacyRuntimeCapabilityGrant,
+)
+from orchestra_runtime.domain.capabilities import (
+    CapabilityDecision,
+    CapabilityReasonCode,
+    RuntimeCapability,
+    RuntimeCapabilityGrant,
+    evaluate_capability_grants,
+    intersect_capability_grants,
+)
+from orchestra_runtime.domain.capabilities import core
+from orchestra_runtime.errors import InvalidCapabilityConfigurationError
+
+
+def _root_provenance() -> AuthorityProvenance:
+    return AuthorityProvenance(
+        ProvenanceSource.TRUSTED_COMPOSITION,
+        "runtime.policy",
+        "1",
+        "conductor",
+    )
+
+
+def _delegated_provenance() -> AuthorityProvenance:
+    return AuthorityProvenance(
+        ProvenanceSource.ACCEPTED_DELEGATION,
+        "runtime.delegation",
+        "1",
+        "conductor",
+        parent_run_id="run-parent",
+        parent_decision_id="decision-parent",
+    )
+
+
+def _capability() -> RuntimeCapability:
+    return RuntimeCapability(
+        "runtime.read",
+        "conductor",
+        ("read", "write"),
+        "Read runtime state.",
+    )
+
+
+def test_legacy_capability_symbols_are_canonical_domain_symbols() -> None:
+    assert LegacyRuntimeCapability is RuntimeCapability
+    assert LegacyRuntimeCapabilityGrant is RuntimeCapabilityGrant
+    assert LegacyCapabilityDecision is CapabilityDecision
+    assert LegacyCapabilityReasonCode is CapabilityReasonCode
+
+
+def test_domain_capability_evaluation_preserves_fail_closed_semantics() -> None:
+    grant = RuntimeCapabilityGrant(
+        _capability(),
+        ("read",),
+        _root_provenance(),
+        (Constraint.allowed_set("region", ("ph", "us")),),
+    )
+
+    allowed = evaluate_capability_grants(
+        (grant,),
+        run_id="run-1",
+        manifest_id="manifest-1",
+        capability_id="RUNTIME.READ",
+        operation="READ",
+        constraints=(Constraint.exact("region", "ph"),),
+        decision_id="decision-1",
+    )
+    assert allowed.allowed is True
+    assert allowed.reason_code is CapabilityReasonCode.ALLOWED
+    assert allowed.capability_id == "runtime.read"
+    assert allowed.operation == "read"
+
+    denied_operation = evaluate_capability_grants(
+        (grant,),
+        run_id="run-1",
+        manifest_id="manifest-1",
+        capability_id="runtime.read",
+        operation="write",
+        constraints=(Constraint.exact("region", "ph"),),
+        decision_id="decision-2",
+    )
+    assert denied_operation.allowed is False
+    assert denied_operation.reason_code is CapabilityReasonCode.OPERATION_NOT_ALLOWED
+
+    denied_constraint = evaluate_capability_grants(
+        (grant,),
+        run_id="run-1",
+        manifest_id="manifest-1",
+        capability_id="runtime.read",
+        operation="read",
+        constraints=(Constraint.exact("region", "eu"),),
+        decision_id="decision-3",
+    )
+    assert denied_constraint.allowed is False
+    assert denied_constraint.reason_code is CapabilityReasonCode.CONSTRAINT_DENIED
+
+
+def test_domain_capability_intersection_is_restrictive() -> None:
+    parent = RuntimeCapabilityGrant(
+        _capability(),
+        ("read", "write"),
+        _root_provenance(),
+        (Constraint.allowed_set("region", ("ph", "us")),),
+    )
+    requested = RuntimeCapabilityGrant(
+        _capability(),
+        ("read",),
+        _root_provenance(),
+        (Constraint.exact("region", "ph"),),
+    )
+
+    effective = intersect_capability_grants((parent,), (requested,), _delegated_provenance())
+    assert len(effective) == 1
+    assert effective[0].allowed_operations == ("read",)
+    assert effective[0].constraints == (Constraint.exact("region", "ph"),)
+    assert effective[0].provenance.source_type is ProvenanceSource.ACCEPTED_DELEGATION
+
+    with pytest.raises(InvalidCapabilityConfigurationError, match="accepted delegation provenance"):
+        intersect_capability_grants((parent,), (requested,), _root_provenance())
+
+
+def test_capability_domain_core_has_only_inward_runtime_dependencies() -> None:
+    tree = ast.parse(inspect.getsource(core))
+    forbidden_stdlib = {"os", "pathlib", "socket", "sqlite3", "subprocess"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            assert all(alias.name.split(".", 1)[0] not in forbidden_stdlib for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level == 0 and node.module:
+                assert node.module.split(".", 1)[0] not in forbidden_stdlib
+            elif node.level:
+                assert node.module is not None
+                assert node.module.startswith(("governance.", "shared."))


### PR DESCRIPTION
## Scope

Bounded AR-2 `domain/capabilities` core extraction only.

- moves capability value objects, decision semantics, enforcement, and grant intersection into `orchestra_runtime.domain.capabilities`
- preserves legacy `orchestra_runtime.capabilities` symbol identity for `RuntimeCapability`, `RuntimeCapabilityGrant`, `CapabilityDecision`, and `CapabilityReasonCode`
- keeps `RuntimeCapabilityManifest`, `RunIdentity`, filesystem policy loading, `ICapabilityResolver` inheritance, and runtime audit-event projection on the transitional legacy surface
- adds focused compatibility, fail-closed, intersection, and import-boundary tests

## Phase boundary

AR-2 remains active. AR-3 is not started. No release/tag publication, deployment, policy/ruleset activation, installed-integration refresh, destructive action, branch deletion, force push, or history rewrite is included.

This non-draft PR is a qualification candidate because the connected GitHub ready-for-review mutation is currently broken. It will not be merged unless the exact final head is fully green.