### PR TITLE
refactor(architecture): extract AR-2 capability value objects

### DIFF
--- a/docs/project/ORCHESTRA_AR2_DOMAIN_CAPABILITY_VALUE_OBJECT_EXTRACTION.md
+++ b/docs/project/ORCHESTRA_AR2_DOMAIN_CAPABILITY_VALUE_OBJECT_EXTRACTION.md
@@ -1,0 +1,94 @@
+# Orchestra AR-2 Domain Capability Value-Object Extraction
+
+## Status
+
+`AR_2_DOMAIN_CAPABILITY_VALUE_OBJECT_IMPLEMENTATION_CANDIDATE`
+
+This document describes the bounded AR-2 extraction that moves pure capability value objects and their deterministic normalization semantics inward to `orchestra_runtime.domain.capabilities` while preserving the legacy runtime surface.
+
+## Canonical domain ownership
+
+The following semantics are owned by `orchestra_runtime.domain.capabilities.core` in this candidate:
+
+- `CapabilityReasonCode`
+- `RuntimeCapability`
+- `RuntimeCapabilityGrant`
+- `CapabilityDecision`
+- deterministic capability identifier and text normalization used by those entities
+
+These entities depend only on standard-library types, canonical authority-domain value objects, and `orchestra_runtime.shared.errors`. They do not read files, create run identities, depend on application ports, construct runtime audit events, call providers, or perform host/MCP operations.
+
+## Legacy compatibility boundary
+
+`orchestra_runtime.capabilities` remains the compatibility and transitional integration surface. Existing imports of the moved capability symbols resolve to the exact canonical domain objects rather than duplicate wrappers or copied classes.
+
+The legacy module deliberately retains:
+
+- `RuntimeCapabilityManifest`, because it still depends on legacy `RunIdentity` placement;
+- `CapabilityResolver`, because it still inherits the legacy `ICapabilityResolver` application port and coordinates manifest construction/evaluation;
+- trusted repository-policy loading through `_load_trusted_json`;
+- capability manifest and decision audit-event projection.
+
+Those responsibilities are intentionally not pulled into the domain before their execution-identity, application-port, and infrastructure dependencies are classified in later bounded phases.
+
+## Dependency rule
+
+The extracted capability domain obeys the machine architecture policy:
+
+```text
+orchestra_runtime.domain -> orchestra_runtime.domain | orchestra_runtime.shared
+```
+
+The extracted module has no dependency on:
+
+```text
+orchestra_runtime.application
+orchestra_runtime.infrastructure
+orchestra_runtime.entrypoints
+orchestra_runtime.capabilities
+orchestra_runtime.authority
+orchestra_runtime.interfaces
+orchestra_runtime.models
+pathlib / filesystem I/O
+provider or MCP execution
+```
+
+## Behavioral preservation
+
+The extraction preserves the existing capability-value contract, including:
+
+- canonical case-folded capability, owner, operation, and manifest identifiers;
+- immutable dataclass state;
+- sorted unique capability operations;
+- grant operations constrained to the parent capability operation set;
+- unique sorted grant constraint keys;
+- stable authority provenance and constraint serialization through canonical authority-domain objects;
+- deterministic decision normalization and evaluated-constraint de-duplication;
+- fail-closed malformed capability and grant construction.
+
+Manifest loading, resolver behavior, and audit-event projection continue through the legacy module, so this AR-2 unit does not change external capability resolution behavior or grant new authority.
+
+## Validation
+
+`tests/runtime/test_domain_capabilities_core.py` verifies:
+
+1. legacy capability exports are identity-equal to the canonical domain symbols;
+2. capability, grant, and decision normalization semantics are preserved;
+3. the extracted domain module has no filesystem, provider, application-port, or legacy-runtime imports.
+
+The existing capability and runtime-authority suites remain the broader compatibility regression surface.
+
+## Explicit non-goals
+
+This bounded extraction does not:
+
+- start AR-3 application/use-case migration;
+- move `RuntimeCapabilityManifest` before `RunIdentity` placement is classified;
+- move `CapabilityResolver` or `ICapabilityResolver` into the domain;
+- move trusted policy persistence into domain code;
+- move capability audit-event projection into the domain;
+- retire the public `orchestra_runtime.capabilities` import surface;
+- alter authority scope, capability resolution, routing, governance, provider, MCP, or execution semantics;
+- authorize release/tag publication, deployment, policy activation, integration refresh, destructive action, branch deletion, force push, or history rewrite.
+
+AR-2 remains active after this unit until the remaining qualified pure-domain ownership slices are completed.

--- a/orchestra_runtime/capabilities.py
+++ b/orchestra_runtime/capabilities.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import Enum
-import re
-
 from pathlib import Path
 
 from .authority import (
@@ -14,6 +11,14 @@ from .authority import (
     _intersect_constraints,
     _load_trusted_json,
 )
+from .domain.capabilities.core import (
+    CapabilityDecision,
+    CapabilityReasonCode,
+    RuntimeCapability,
+    RuntimeCapabilityGrant,
+    _identifier,
+    _text,
+)
 from .errors import (
     CapabilityCollisionError,
     CapabilityDeniedError,
@@ -22,139 +27,6 @@ from .errors import (
 )
 from .interfaces import ICapabilityResolver
 from .models import AuditEventType, RunIdentity, RuntimeAuditEvent
-
-
-IDENTIFIER_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_.:-]*$")
-
-
-class CapabilityReasonCode(str, Enum):
-    ALLOWED = "ALLOWED"
-    INVALID_MANIFEST = "INVALID_MANIFEST"
-    COLLISION = "COLLISION"
-    CAPABILITY_NOT_FOUND = "CAPABILITY_NOT_FOUND"
-    OPERATION_NOT_ALLOWED = "OPERATION_NOT_ALLOWED"
-    CONSTRAINT_DENIED = "CONSTRAINT_DENIED"
-    EMPTY_INTERSECTION = "EMPTY_INTERSECTION"
-
-
-def _text(value: object, field_name: str) -> str:
-    text = str(value).strip()
-    if not text:
-        raise InvalidCapabilityConfigurationError(
-            f"{field_name} must be non-empty",
-            CapabilityReasonCode.INVALID_MANIFEST,
-            {"field": field_name},
-        )
-    return text
-
-
-def _identifier(value: object, field_name: str) -> str:
-    text = _text(value, field_name).casefold()
-    if not IDENTIFIER_PATTERN.fullmatch(text):
-        raise InvalidCapabilityConfigurationError(
-            f"{field_name} must be a canonical identifier",
-            CapabilityReasonCode.INVALID_MANIFEST,
-            {"field": field_name},
-        )
-    return text
-
-
-@dataclass(frozen=True, slots=True)
-class RuntimeCapability:
-    capability_id: str
-    owner: str
-    operations: tuple[str, ...]
-    description: str
-
-    def __post_init__(self) -> None:
-        capability_id = _identifier(self.capability_id, "capability_id")
-        owner = _identifier(self.owner, "owner")
-        operations = tuple(sorted(_identifier(item, "operation") for item in self.operations))
-        if not operations or len(set(operations)) != len(operations):
-            raise InvalidCapabilityConfigurationError(
-                "capability operations must be non-empty and unique",
-                CapabilityReasonCode.INVALID_MANIFEST,
-                {"capability_id": capability_id},
-            )
-        object.__setattr__(self, "capability_id", capability_id)
-        object.__setattr__(self, "owner", owner)
-        object.__setattr__(self, "operations", operations)
-        object.__setattr__(self, "description", _text(self.description, "description"))
-
-    @classmethod
-    def from_dict(cls, data: dict[str, object]) -> RuntimeCapability:
-        operations = data.get("operations", ())
-        if not isinstance(operations, (list, tuple)):
-            operations = ()
-        return cls(
-            capability_id=str(data.get("capability_id", "")),
-            owner=str(data.get("owner", "")),
-            operations=tuple(str(item) for item in operations),
-            description=str(data.get("description", "")),
-        )
-
-    def to_dict(self) -> dict[str, object]:
-        return {
-            "capability_id": self.capability_id,
-            "owner": self.owner,
-            "operations": list(self.operations),
-            "description": self.description,
-        }
-
-
-@dataclass(frozen=True, slots=True)
-class RuntimeCapabilityGrant:
-    capability: RuntimeCapability
-    allowed_operations: tuple[str, ...]
-    provenance: AuthorityProvenance
-    constraints: tuple[Constraint, ...] = ()
-
-    def __post_init__(self) -> None:
-        operations = tuple(sorted(_identifier(item, "allowed operation") for item in self.allowed_operations))
-        constraints = tuple(sorted(tuple(self.constraints), key=lambda item: item.key))
-        if not operations or len(set(operations)) != len(operations):
-            raise InvalidCapabilityConfigurationError(
-                "grant operations must be non-empty and unique",
-                CapabilityReasonCode.INVALID_MANIFEST,
-                {"capability_id": self.capability.capability_id},
-            )
-        if not set(operations).issubset(self.capability.operations):
-            raise InvalidCapabilityConfigurationError(
-                "grant operations must be a subset of capability operations",
-                CapabilityReasonCode.INVALID_MANIFEST,
-                {"capability_id": self.capability.capability_id},
-            )
-        if len({item.key for item in constraints}) != len(constraints):
-            raise InvalidCapabilityConfigurationError(
-                "grant constraint keys must be unique",
-                CapabilityReasonCode.INVALID_MANIFEST,
-                {"capability_id": self.capability.capability_id},
-            )
-        object.__setattr__(self, "allowed_operations", operations)
-        object.__setattr__(self, "constraints", constraints)
-
-    @classmethod
-    def from_dict(cls, data: dict[str, object]) -> RuntimeCapabilityGrant:
-        capability = data.get("capability")
-        provenance = data.get("provenance")
-        operations = data.get("allowed_operations", ())
-        constraints = data.get("constraints", ())
-        if not isinstance(capability, dict) or not isinstance(provenance, dict):
-            raise InvalidCapabilityConfigurationError("malformed capability grant", CapabilityReasonCode.INVALID_MANIFEST)
-        return cls(
-            capability=RuntimeCapability.from_dict(capability),
-            allowed_operations=tuple(str(item) for item in operations) if isinstance(operations, (list, tuple)) else (),
-            provenance=AuthorityProvenance.from_dict(provenance),
-            constraints=tuple(Constraint.from_dict(item) for item in constraints if isinstance(item, dict)) if isinstance(constraints, list) else (),
-        )
-
-    def to_dict(self) -> dict[str, object]:
-        return {
-            "capability": self.capability.to_dict(),
-            "allowed_operations": list(self.allowed_operations),
-            "provenance": self.provenance.to_dict(),
-            "constraints": [item.to_dict() for item in self.constraints],
-        }
 
 
 @dataclass(frozen=True, slots=True)
@@ -167,7 +39,12 @@ class RuntimeCapabilityManifest:
 
     def __post_init__(self) -> None:
         manifest_id = _identifier(self.manifest_id, "manifest_id")
-        grants = tuple(sorted(tuple(self.grants), key=lambda item: (item.capability.capability_id.casefold(), item.capability.capability_id)))
+        grants = tuple(
+            sorted(
+                tuple(self.grants),
+                key=lambda item: (item.capability.capability_id.casefold(), item.capability.capability_id),
+            )
+        )
         identities = [item.capability.capability_id.casefold() for item in grants]
         if not grants:
             raise InvalidCapabilityConfigurationError(
@@ -192,48 +69,6 @@ class RuntimeCapabilityManifest:
             "policy_version": self.policy_version,
             "grants": [item.to_dict() for item in self.grants],
             "provenance": self.provenance.to_dict(),
-        }
-
-
-@dataclass(frozen=True, slots=True)
-class CapabilityDecision:
-    decision_id: str
-    run_id: str
-    manifest_id: str
-    capability_id: str
-    operation: str
-    requested_constraints: tuple[Constraint, ...]
-    allowed: bool
-    reason_code: CapabilityReasonCode
-    evaluated_grant_id: str | None = None
-    evaluated_constraints: tuple[str, ...] = ()
-
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "decision_id", _text(self.decision_id, "decision_id"))
-        object.__setattr__(self, "run_id", _text(self.run_id, "run_id"))
-        object.__setattr__(self, "manifest_id", _identifier(self.manifest_id, "manifest_id"))
-        object.__setattr__(self, "capability_id", _identifier(self.capability_id, "capability_id"))
-        object.__setattr__(self, "operation", _identifier(self.operation, "operation"))
-        constraints = tuple(sorted(tuple(self.requested_constraints), key=lambda item: item.key))
-        if len({item.key for item in constraints}) != len(constraints):
-            raise InvalidCapabilityConfigurationError("requested constraint keys must be unique", CapabilityReasonCode.INVALID_MANIFEST)
-        object.__setattr__(self, "requested_constraints", constraints)
-        object.__setattr__(self, "reason_code", CapabilityReasonCode(self.reason_code))
-        object.__setattr__(self, "evaluated_grant_id", self.evaluated_grant_id.strip() if self.evaluated_grant_id else None)
-        object.__setattr__(self, "evaluated_constraints", tuple(sorted(set(self.evaluated_constraints))))
-
-    def to_dict(self) -> dict[str, object]:
-        return {
-            "decision_id": self.decision_id,
-            "run_id": self.run_id,
-            "manifest_id": self.manifest_id,
-            "capability_id": self.capability_id,
-            "operation": self.operation,
-            "requested_constraints": [item.to_dict() for item in self.requested_constraints],
-            "allowed": self.allowed,
-            "reason_code": self.reason_code.value,
-            "evaluated_grant_id": self.evaluated_grant_id,
-            "evaluated_constraints": list(self.evaluated_constraints),
         }
 
 

--- a/orchestra_runtime/domain/capabilities/__init__.py
+++ b/orchestra_runtime/domain/capabilities/__init__.py
@@ -1,0 +1,15 @@
+"""Domain capability contracts and value objects."""
+
+from .core import (
+    CapabilityDecision,
+    CapabilityReasonCode,
+    RuntimeCapability,
+    RuntimeCapabilityGrant,
+)
+
+__all__ = (
+    "CapabilityDecision",
+    "CapabilityReasonCode",
+    "RuntimeCapability",
+    "RuntimeCapabilityGrant",
+)

--- a/orchestra_runtime/domain/capabilities/core.py
+++ b/orchestra_runtime/domain/capabilities/core.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import re
+
+from ..governance.authority import AuthorityProvenance, Constraint
+from ...shared.errors import InvalidCapabilityConfigurationError
+
+
+IDENTIFIER_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_.:-]*$")
+
+
+class CapabilityReasonCode(str, Enum):
+    ALLOWED = "ALLOWED"
+    INVALID_MANIFEST = "INVALID_MANIFEST"
+    COLLISION = "COLLISION"
+    CAPABILITY_NOT_FOUND = "CAPABILITY_NOT_FOUND"
+    OPERATION_NOT_ALLOWED = "OPERATION_NOT_ALLOWED"
+    CONSTRAINT_DENIED = "CONSTRAINT_DENIED"
+    EMPTY_INTERSECTION = "EMPTY_INTERSECTION"
+
+
+def _text(value: object, field_name: str) -> str:
+    text = str(value).strip()
+    if not text:
+        raise InvalidCapabilityConfigurationError(
+            f"{field_name} must be non-empty",
+            CapabilityReasonCode.INVALID_MANIFEST,
+            {"field": field_name},
+        )
+    return text
+
+
+def _identifier(value: object, field_name: str) -> str:
+    text = _text(value, field_name).casefold()
+    if not IDENTIFIER_PATTERN.fullmatch(text):
+        raise InvalidCapabilityConfigurationError(
+            f"{field_name} must be a canonical identifier",
+            CapabilityReasonCode.INVALID_MANIFEST,
+            {"field": field_name},
+        )
+    return text
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeCapability:
+    capability_id: str
+    owner: str
+    operations: tuple[str, ...]
+    description: str
+
+    def __post_init__(self) -> None:
+        capability_id = _identifier(self.capability_id, "capability_id")
+        owner = _identifier(self.owner, "owner")
+        operations = tuple(sorted(_identifier(item, "operation") for item in self.operations))
+        if not operations or len(set(operations)) != len(operations):
+            raise InvalidCapabilityConfigurationError(
+                "capability operations must be non-empty and unique",
+                CapabilityReasonCode.INVALID_MANIFEST,
+                {"capability_id": capability_id},
+            )
+        object.__setattr__(self, "capability_id", capability_id)
+        object.__setattr__(self, "owner", owner)
+        object.__setattr__(self, "operations", operations)
+        object.__setattr__(self, "description", _text(self.description, "description"))
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> RuntimeCapability:
+        operations = data.get("operations", ())
+        if not isinstance(operations, (list, tuple)):
+            operations = ()
+        return cls(
+            capability_id=str(data.get("capability_id", "")),
+            owner=str(data.get("owner", "")),
+            operations=tuple(str(item) for item in operations),
+            description=str(data.get("description", "")),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "capability_id": self.capability_id,
+            "owner": self.owner,
+            "operations": list(self.operations),
+            "description": self.description,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeCapabilityGrant:
+    capability: RuntimeCapability
+    allowed_operations: tuple[str, ...]
+    provenance: AuthorityProvenance
+    constraints: tuple[Constraint, ...] = ()
+
+    def __post_init__(self) -> None:
+        operations = tuple(sorted(_identifier(item, "allowed operation") for item in self.allowed_operations))
+        constraints = tuple(sorted(tuple(self.constraints), key=lambda item: item.key))
+        if not operations or len(set(operations)) != len(operations):
+            raise InvalidCapabilityConfigurationError(
+                "grant operations must be non-empty and unique",
+                CapabilityReasonCode.INVALID_MANIFEST,
+                {"capability_id": self.capability.capability_id},
+            )
+        if not set(operations).issubset(self.capability.operations):
+            raise InvalidCapabilityConfigurationError(
+                "grant operations must be a subset of capability operations",
+                CapabilityReasonCode.INVALID_MANIFEST,
+                {"capability_id": self.capability.capability_id},
+            )
+        if len({item.key for item in constraints}) != len(constraints):
+            raise InvalidCapabilityConfigurationError(
+                "grant constraint keys must be unique",
+                CapabilityReasonCode.INVALID_MANIFEST,
+                {"capability_id": self.capability.capability_id},
+            )
+        object.__setattr__(self, "allowed_operations", operations)
+        object.__setattr__(self, "constraints", constraints)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> RuntimeCapabilityGrant:
+        capability = data.get("capability")
+        provenance = data.get("provenance")
+        operations = data.get("allowed_operations", ())
+        constraints = data.get("constraints", ())
+        if not isinstance(capability, dict) or not isinstance(provenance, dict):
+            raise InvalidCapabilityConfigurationError("malformed capability grant", CapabilityReasonCode.INVALID_MANIFEST)
+        return cls(
+            capability=RuntimeCapability.from_dict(capability),
+            allowed_operations=tuple(str(item) for item in operations) if isinstance(operations, (list, tuple)) else (),
+            provenance=AuthorityProvenance.from_dict(provenance),
+            constraints=(
+                tuple(Constraint.from_dict(item) for item in constraints if isinstance(item, dict))
+                if isinstance(constraints, list)
+                else ()
+            ),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "capability": self.capability.to_dict(),
+            "allowed_operations": list(self.allowed_operations),
+            "provenance": self.provenance.to_dict(),
+            "constraints": [item.to_dict() for item in self.constraints],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityDecision:
+    decision_id: str
+    run_id: str
+    manifest_id: str
+    capability_id: str
+    operation: str
+    requested_constraints: tuple[Constraint, ...]
+    allowed: bool
+    reason_code: CapabilityReasonCode
+    evaluated_grant_id: str | None = None
+    evaluated_constraints: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "decision_id", _text(self.decision_id, "decision_id"))
+        object.__setattr__(self, "run_id", _text(self.run_id, "run_id"))
+        object.__setattr__(self, "manifest_id", _identifier(self.manifest_id, "manifest_id"))
+        object.__setattr__(self, "capability_id", _identifier(self.capability_id, "capability_id"))
+        object.__setattr__(self, "operation", _identifier(self.operation, "operation"))
+        constraints = tuple(sorted(tuple(self.requested_constraints), key=lambda item: item.key))
+        if len({item.key for item in constraints}) != len(constraints):
+            raise InvalidCapabilityConfigurationError(
+                "requested constraint keys must be unique",
+                CapabilityReasonCode.INVALID_MANIFEST,
+            )
+        object.__setattr__(self, "requested_constraints", constraints)
+        object.__setattr__(self, "reason_code", CapabilityReasonCode(self.reason_code))
+        object.__setattr__(self, "evaluated_grant_id", self.evaluated_grant_id.strip() if self.evaluated_grant_id else None)
+        object.__setattr__(self, "evaluated_constraints", tuple(sorted(set(self.evaluated_constraints))))
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "decision_id": self.decision_id,
+            "run_id": self.run_id,
+            "manifest_id": self.manifest_id,
+            "capability_id": self.capability_id,
+            "operation": self.operation,
+            "requested_constraints": [item.to_dict() for item in self.requested_constraints],
+            "allowed": self.allowed,
+            "reason_code": self.reason_code.value,
+            "evaluated_grant_id": self.evaluated_grant_id,
+            "evaluated_constraints": list(self.evaluated_constraints),
+        }

--- a/tests/runtime/test_domain_capabilities_core.py
+++ b/tests/runtime/test_domain_capabilities_core.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from orchestra_runtime import capabilities as legacy_capabilities
+from orchestra_runtime.domain.capabilities import core as domain_capabilities
+from orchestra_runtime.domain.governance import authority as domain_authority
+
+
+def _provenance() -> domain_authority.AuthorityProvenance:
+    return domain_authority.AuthorityProvenance(
+        domain_authority.ProvenanceSource.TRUSTED_REPOSITORY_POLICY,
+        "policy.root",
+        "1.0",
+        "runtime.composition",
+    )
+
+
+def test_legacy_capability_exports_are_canonical_domain_symbols():
+    assert legacy_capabilities.CapabilityReasonCode is domain_capabilities.CapabilityReasonCode
+    assert legacy_capabilities.RuntimeCapability is domain_capabilities.RuntimeCapability
+    assert legacy_capabilities.RuntimeCapabilityGrant is domain_capabilities.RuntimeCapabilityGrant
+    assert legacy_capabilities.CapabilityDecision is domain_capabilities.CapabilityDecision
+
+
+def test_domain_capability_value_objects_preserve_normalization_semantics():
+    capability = domain_capabilities.RuntimeCapability(
+        "Capability.Read",
+        "Runtime.Owner",
+        ("WRITE", "read"),
+        "  Read and write runtime state  ",
+    )
+    assert capability.capability_id == "capability.read"
+    assert capability.owner == "runtime.owner"
+    assert capability.operations == ("read", "write")
+    assert capability.description == "Read and write runtime state"
+
+    grant = domain_capabilities.RuntimeCapabilityGrant(
+        capability,
+        ("WRITE",),
+        _provenance(),
+        (domain_authority.Constraint.exact("environment", "test"),),
+    )
+    assert grant.allowed_operations == ("write",)
+    assert grant.constraints == (domain_authority.Constraint.exact("environment", "test"),)
+
+    decision = domain_capabilities.CapabilityDecision(
+        " decision.1 ",
+        " run.1 ",
+        "Manifest.Root",
+        "Capability.Read",
+        "WRITE",
+        grant.constraints,
+        True,
+        domain_capabilities.CapabilityReasonCode.ALLOWED,
+        " capability.read ",
+        ("environment", "environment"),
+    )
+    assert decision.decision_id == "decision.1"
+    assert decision.run_id == "run.1"
+    assert decision.manifest_id == "manifest.root"
+    assert decision.capability_id == "capability.read"
+    assert decision.operation == "write"
+    assert decision.evaluated_grant_id == "capability.read"
+    assert decision.evaluated_constraints == ("environment",)
+
+
+def test_domain_capability_core_has_no_io_or_legacy_runtime_imports():
+    source_path = Path(domain_capabilities.__file__)
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module)
+
+    forbidden = {
+        "pathlib",
+        "os",
+        "subprocess",
+        "socket",
+        "authority",
+        "capabilities",
+        "interfaces",
+        "models",
+        "orchestra_runtime.authority",
+        "orchestra_runtime.capabilities",
+        "orchestra_runtime.interfaces",
+        "orchestra_runtime.models",
+    }
+    assert not imports.intersection(forbidden)
+    assert not any(isinstance(node, ast.Name) and node.id == "open" for node in ast.walk(tree))


### PR DESCRIPTION
## Scope

Bounded AR-2 `domain/capabilities` value-object extraction only.

- moves `CapabilityReasonCode`, `RuntimeCapability`, `RuntimeCapabilityGrant`, `CapabilityDecision`, and deterministic capability normalization into `orchestra_runtime.domain.capabilities.core`
- preserves legacy `orchestra_runtime.capabilities` symbol identity
- deliberately retains `RuntimeCapabilityManifest`, legacy `RunIdentity` coupling, `ICapabilityResolver`, trusted repository-policy loading, and runtime audit-event projection on the transitional legacy surface
- adds direct boundary and compatibility tests plus detailed extraction documentation

## Qualification boundary

This PR is opened non-draft because the connected GitHub ready-for-review mutation is currently incompatible with GitHub's GraphQL response schema. Non-draft status is not merge authority. Merge remains held until the exact head passes all applicable required validation.

AR-2 remains active. AR-3 is not started. No release/tag publication, deployment, policy/ruleset activation, installed-integration refresh, destructive action, branch deletion, force push, or history rewrite is included.