### PR TITLE
refactor(architecture): extract AR-2 execution correlation semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Post-v1.7 runtime architecture AR-2 execution correlation extraction candidate
+
+- Establishes `orchestra_runtime.domain.execution.correlation` as the inward-only owner of deterministic RFC 9562 UUIDv7 validation while keeping clock and entropy backed correlation generation outside the domain.
+- Preserves legacy `orchestra_runtime.correlation` validation symbol identity and deliberately retains `generate_correlation_id`, `_generate_correlation_id`, `time.time_ns`, `secrets.token_bytes`, and UUIDv7 construction on the transitional legacy surface.
+- Adds direct compatibility and import-boundary coverage, detailed extraction documentation, and `README.json` machine-discovery parity for the execution-correlation surface.
+- Does not move `RunIdentity`, lifecycle state/controllers, audit events, or execution results; start AR-3/AR-4; alter provider/MCP behavior; retire public imports; or change release/deployment/policy authority.
+
 ## Post-v1.7 runtime architecture AR-2 capability core extraction candidate
 
 - Establishes `orchestra_runtime.domain.capabilities` as the inward-only owner of capability value objects, deterministic decision/enforcement semantics, and restrictive grant intersection.

--- a/README.json
+++ b/README.json
@@ -32,7 +32,7 @@
     "runtime_architecture_refoundation": {
       "status": "AR_2_DOMAIN_EXTRACTIONS_ACTIVE",
       "purpose": "Incrementally refactor the Orchestra Python runtime into bounded clean/hexagonal architecture layers while preserving public behavior and legacy import compatibility.",
-      "human_sources": ["docs/project/ORCHESTRA_RUNTIME_ARCHITECTURE_REFOUNDATION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_CONTEXT_EXTRACTION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_GOVERNANCE_AUTHORITY_EXTRACTION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_CAPABILITIES_CORE_EXTRACTION.md", "docs/architecture/README.md"],
+      "human_sources": ["docs/project/ORCHESTRA_RUNTIME_ARCHITECTURE_REFOUNDATION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_CONTEXT_EXTRACTION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_GOVERNANCE_AUTHORITY_EXTRACTION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_CAPABILITIES_CORE_EXTRACTION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_EXECUTION_CORRELATION_EXTRACTION.md", "docs/architecture/README.md"],
       "validation_surface": "tests/runtime/test_runtime_architecture_boundaries.py",
       "machine_policy": "machine/governance/runtime-architecture-boundaries.v1.json",
       "machine_policy_schema": "machine/schemas/runtime-architecture-boundaries.v1.schema.json",
@@ -52,6 +52,10 @@
       "capabilities_domain_core_surface": "orchestra_runtime/domain/capabilities/core.py",
       "capabilities_legacy_compatibility_surface": "orchestra_runtime/capabilities.py",
       "capabilities_domain_validation_surface": "tests/runtime/test_domain_capabilities_core.py",
+      "execution_domain_surface": "orchestra_runtime/domain/execution",
+      "execution_correlation_domain_surface": "orchestra_runtime/domain/execution/correlation.py",
+      "execution_correlation_legacy_compatibility_surface": "orchestra_runtime/correlation.py",
+      "execution_correlation_validation_surface": "tests/runtime/test_correlation.py",
       "ci_enforcement": ["Governance Check", "validate"],
       "canonical_layers": ["domain", "application", "infrastructure", "entrypoints", "bootstrap", "shared", "resources"],
       "application_subzones": ["use_cases", "services", "dto", "ports"],
@@ -1092,7 +1096,8 @@
     "codex_c2_portability_r1_preexecution": "docs/benchmarking/CODEX_C2_PORTABILITY_R1_PREEXECUTION.md",
     "cloak_ui_reference_cuir5_evaluation": "docs/project/CLOAK_UI_REFERENCE_CORPUS_CUIR5_EVALUATION.md",
     "runtime_architecture_ar2_domain_governance_authority": "docs/project/ORCHESTRA_AR2_DOMAIN_GOVERNANCE_AUTHORITY_EXTRACTION.md",
-    "runtime_architecture_ar2_domain_capabilities_core": "docs/project/ORCHESTRA_AR2_DOMAIN_CAPABILITIES_CORE_EXTRACTION.md"
+    "runtime_architecture_ar2_domain_capabilities_core": "docs/project/ORCHESTRA_AR2_DOMAIN_CAPABILITIES_CORE_EXTRACTION.md",
+    "runtime_architecture_ar2_domain_execution_correlation": "docs/project/ORCHESTRA_AR2_DOMAIN_EXECUTION_CORRELATION_EXTRACTION.md"
   },
   "representation_policy": {"markdown": "Human-readable explanation, rationale, examples, and nuanced specialist guidance", "json": "Canonical structured machine state, identity, routing, governance, receipts, manifests, provenance, presentation contracts, evidence, and indexes", "json_schema": "Validation contract for machine-readable records", "jsonl": "Append-only event/history records where incremental retrieval is preferable", "toon": "Derived validated non-authoritative model-context projection only when bounded compilation provides measured context benefit", "parity_rule": "When the same deterministic fact appears in more than one representation, CI must validate parity or derive the projection from one authoritative source."},
   "maturity": {
@@ -1142,7 +1147,7 @@
     "do_not_equate_reference_only_research_or_protocol_use_with_runtime_dependency_or_copied_source": true,
     "preserve_unknown_historical_revision_or_license_facts_as_unknown": true,
     "treat_mutation_scores_as_scope_specific_evidence": true,
-    "treat_generated_or_derived_views_as_non_authoritative_when_their_source_contract_is_available": true,
+    "treat_generated_or_derived_views_as_non-authoritative_when_their_source_contract_is_available": true,
     "treat_mergeable_boolean_without_clean_mergeable_state_as_insufficient": true,
     "treat_mcp_prap_adapters_and_host_maturity_as_transport_or_compatibility_not_authority": true,
     "treat_murmurs_as_presentation_only": true,

--- a/README.json
+++ b/README.json
@@ -1147,7 +1147,7 @@
     "do_not_equate_reference_only_research_or_protocol_use_with_runtime_dependency_or_copied_source": true,
     "preserve_unknown_historical_revision_or_license_facts_as_unknown": true,
     "treat_mutation_scores_as_scope_specific_evidence": true,
-    "treat_generated_or_derived_views_as_non-authoritative_when_their_source_contract_is_available": true,
+    "treat_generated_or_derived_views_as_non_authoritative_when_their_source_contract_is_available": true,
     "treat_mergeable_boolean_without_clean_mergeable_state_as_insufficient": true,
     "treat_mcp_prap_adapters_and_host_maturity_as_transport_or_compatibility_not_authority": true,
     "treat_murmurs_as_presentation_only": true,

--- a/docs/project/ORCHESTRA_AR2_DOMAIN_EXECUTION_CORRELATION_EXTRACTION.md
+++ b/docs/project/ORCHESTRA_AR2_DOMAIN_EXECUTION_CORRELATION_EXTRACTION.md
@@ -1,0 +1,81 @@
+# Orchestra AR-2 Domain Execution Correlation Extraction
+
+## Status
+
+`AR_2_DOMAIN_EXECUTION_CORRELATION_IMPLEMENTATION_CANDIDATE`
+
+This bounded AR-2 increment separates deterministic correlation-identifier validation from clock and entropy backed UUIDv7 generation.
+
+## Canonical domain ownership
+
+`orchestra_runtime.domain.execution.correlation` owns the pure correlation-identifier contract:
+
+- `validate_correlation_id`
+- `is_valid_correlation_id`
+
+The contract preserves the existing RFC 9562 UUIDv7 rules:
+
+- values must be strings;
+- values must be non-empty and unpadded;
+- malformed UUID input is rejected;
+- UUID versions other than version 7 are rejected;
+- non-RFC-4122/RFC-9562 variants are rejected;
+- non-hyphenated representations are rejected;
+- canonical uppercase UUID text is accepted and normalized to lowercase.
+
+The domain module uses only deterministic UUID parsing. It has no clock, entropy, filesystem, provider, MCP, host, application-port, persistence, or audit dependency.
+
+## Legacy compatibility boundary
+
+`orchestra_runtime.correlation` remains the public and transitional generation surface. Existing imports of `validate_correlation_id` and `is_valid_correlation_id` resolve to the exact canonical domain functions.
+
+The legacy module deliberately retains:
+
+- `generate_correlation_id`;
+- `_generate_correlation_id`;
+- clock access through `time.time_ns`;
+- entropy acquisition through `secrets.token_bytes`;
+- UUIDv7 construction.
+
+Generation is intentionally not moved into the domain because clock and entropy acquisition are environmental effects rather than deterministic domain validation.
+
+## Dependency rule
+
+The extracted execution-domain module obeys the AR-2 dependency direction:
+
+```text
+orchestra_runtime.domain -> orchestra_runtime.domain | orchestra_runtime.shared
+```
+
+Its only runtime dependency is the Python standard-library `uuid` module. It does not import legacy runtime modules or external layers.
+
+## Behavioral preservation
+
+The extraction changes ownership, not behavior. The existing correlation test suite continues to exercise generation, validation, run-identity integration, runtime composition, child propagation, envelopes, and adapters through the legacy/public surfaces.
+
+Additional assertions verify that:
+
+1. legacy and public validation exports are identity-equal to the canonical domain functions;
+2. the domain module contains no clock, entropy, filesystem, host, provider, application-port, or legacy-runtime imports;
+3. the domain module does not expose correlation-ID generation.
+
+## Sequencing value
+
+This separation establishes the deterministic execution-identity primitive needed before moving `RunIdentity` inward. `RunIdentity` currently resides in the mixed legacy `orchestra_runtime.models` module and depends on correlation validation. Making that validator canonical in `domain.execution` removes the legacy dependency that would otherwise invert the domain boundary.
+
+A later bounded AR-2 unit may therefore classify and move `RunIdentity` without importing `orchestra_runtime.correlation` into the domain. That later move is not part of this candidate and requires its own validation gate.
+
+## Explicit non-goals
+
+This bounded extraction does not:
+
+- move or alter UUIDv7 generation;
+- move `RunIdentity`;
+- move lifecycle state, lifecycle controllers, audit events, or execution results;
+- start AR-3 application/use-case extraction;
+- start AR-4 infrastructure extraction;
+- alter authority, capability, provider, MCP, routing, governance, or execution behavior;
+- retire the public `orchestra_runtime.correlation` surface;
+- authorize release or tag publication, deployment, production mutation, policy activation, installed-integration refresh, destructive cleanup, branch deletion, force push, or history rewrite.
+
+AR-2 remains active after this unit until the remaining qualified pure-domain ownership slices are completed.

--- a/orchestra_runtime/correlation.py
+++ b/orchestra_runtime/correlation.py
@@ -5,6 +5,8 @@ import time
 import uuid
 from typing import Callable
 
+from .domain.execution.correlation import is_valid_correlation_id, validate_correlation_id
+
 
 def generate_correlation_id() -> str:
     """Generate a valid RFC 9562 UUIDv7 correlation identifier string."""
@@ -47,48 +49,3 @@ def _generate_correlation_id(
 
     uuid_int = (now_ms << 80) | (ver_rand_a << 64) | (var_rand_b_high << 48) | rand_b_low
     return str(uuid.UUID(int=uuid_int))
-
-
-def validate_correlation_id(value: str) -> str:
-    """Validate that value is a valid RFC 9562 UUIDv7 string and return canonical lowercase string.
-
-    Rejects:
-    - Non-string input
-    - Empty or whitespace-padded string
-    - Malformed format (must be 36-character hyphenated UUID)
-    - Non-version-7 UUIDs
-    - Non-RFC-4122/9562-variant UUIDs
-    """
-    if not isinstance(value, str):
-        raise TypeError("correlation_id must be a string")
-    if not value or value != value.strip():
-        raise ValueError("correlation_id must be a non-empty, unpadded string")
-
-    try:
-        parsed = uuid.UUID(value)
-    except Exception as exc:
-        raise ValueError(f"malformed correlation_id: {value}") from exc
-
-    version_digit = (parsed.int >> 76) & 0xF
-    if version_digit != 7:
-        raise ValueError(f"correlation_id version must be 7, got {version_digit}")
-
-    if parsed.variant != uuid.RFC_4122:
-        raise ValueError("correlation_id variant must be RFC 4122 / RFC 9562 compatible")
-
-    canonical_str = str(parsed)
-    if value.lower() != canonical_str:
-        raise ValueError("correlation_id must use canonical hyphenated UUID format")
-
-    return canonical_str
-
-
-def is_valid_correlation_id(value: object) -> bool:
-    """Return True if value is a valid RFC 9562 UUIDv7 string, False otherwise."""
-    if not isinstance(value, str):
-        return False
-    try:
-        validate_correlation_id(value)
-        return True
-    except (ValueError, TypeError):
-        return False

--- a/orchestra_runtime/domain/execution/__init__.py
+++ b/orchestra_runtime/domain/execution/__init__.py
@@ -1,0 +1,5 @@
+"""Pure execution-domain identity semantics."""
+
+from .correlation import is_valid_correlation_id, validate_correlation_id
+
+__all__ = ("is_valid_correlation_id", "validate_correlation_id")

--- a/orchestra_runtime/domain/execution/correlation.py
+++ b/orchestra_runtime/domain/execution/correlation.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import uuid
+
+
+def validate_correlation_id(value: str) -> str:
+    """Validate an RFC 9562 UUIDv7 correlation identifier.
+
+    Validation is deterministic domain behavior. Clock and entropy backed UUIDv7
+    generation intentionally remains outside this module.
+    """
+    if not isinstance(value, str):
+        raise TypeError("correlation_id must be a string")
+    if not value or value != value.strip():
+        raise ValueError("correlation_id must be a non-empty, unpadded string")
+
+    try:
+        parsed = uuid.UUID(value)
+    except Exception as exc:
+        raise ValueError(f"malformed correlation_id: {value}") from exc
+
+    version_digit = (parsed.int >> 76) & 0xF
+    if version_digit != 7:
+        raise ValueError(f"correlation_id version must be 7, got {version_digit}")
+
+    if parsed.variant != uuid.RFC_4122:
+        raise ValueError("correlation_id variant must be RFC 4122 / RFC 9562 compatible")
+
+    canonical_str = str(parsed)
+    if value.lower() != canonical_str:
+        raise ValueError("correlation_id must use canonical hyphenated UUID format")
+
+    return canonical_str
+
+
+def is_valid_correlation_id(value: object) -> bool:
+    """Return whether value satisfies the canonical correlation identifier contract."""
+    if not isinstance(value, str):
+        return False
+    try:
+        validate_correlation_id(value)
+        return True
+    except (ValueError, TypeError):
+        return False

--- a/tests/runtime/test_correlation.py
+++ b/tests/runtime/test_correlation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import secrets
 import time
 import uuid
@@ -7,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+import orchestra_runtime.correlation as legacy_correlation
 from orchestra_runtime import (
     AntigravityAdapter,
     ClaudeCodeAdapter,
@@ -32,6 +34,7 @@ from orchestra_runtime import (
 )
 from orchestra_runtime.capabilities import CapabilityResolver
 from orchestra_runtime.correlation import _generate_correlation_id
+from orchestra_runtime.domain.execution import correlation as domain_correlation
 from orchestra_runtime.repositories import ManifestRepository, SkillSourceRepository
 
 
@@ -185,6 +188,43 @@ def test_is_valid_correlation_id_helper() -> None:
     assert is_valid_correlation_id(str(uuid.uuid4())) is False
     assert is_valid_correlation_id(None) is False
     assert is_valid_correlation_id(123) is False
+
+
+def test_domain_correlation_exports_are_legacy_identity_compatible() -> None:
+    assert legacy_correlation.validate_correlation_id is domain_correlation.validate_correlation_id
+    assert legacy_correlation.is_valid_correlation_id is domain_correlation.is_valid_correlation_id
+    assert validate_correlation_id is domain_correlation.validate_correlation_id
+    assert is_valid_correlation_id is domain_correlation.is_valid_correlation_id
+
+
+def test_domain_correlation_validation_is_pure_and_generation_free() -> None:
+    source_path = Path(domain_correlation.__file__)
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    imports: set[str] = set()
+    function_names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            function_names.add(node.name)
+
+    forbidden = {
+        "secrets",
+        "time",
+        "pathlib",
+        "os",
+        "subprocess",
+        "socket",
+        "orchestra_runtime.correlation",
+        "orchestra_runtime.models",
+        "orchestra_runtime.interfaces",
+    }
+    assert not imports.intersection(forbidden)
+    assert "generate_correlation_id" not in function_names
+    assert "_generate_correlation_id" not in function_names
+    assert not any(isinstance(node, ast.Name) and node.id == "open" for node in ast.walk(tree))
 
 
 def test_run_identity_correlation_integration_no_auto_generation() -> None:
@@ -347,7 +387,9 @@ def test_adapter_correlation_preservation() -> None:
 
     class DummyRepo:
         repo_root = "."
-        def load_manifest(self) -> None: return None
+
+        def load_manifest(self) -> None:
+            return None
 
     codex = CodexAdapter(DummyRepo())  # type: ignore[arg-type]
     antigravity = AntigravityAdapter(DummyRepo())  # type: ignore[arg-type]


### PR DESCRIPTION
## Scope

Bounded AR-2 `domain/execution` correlation-validation extraction only.

- moves deterministic UUIDv7 correlation validation into `orchestra_runtime.domain.execution.correlation`
- preserves legacy/public validation function identity through `orchestra_runtime.correlation`
- deliberately keeps clock and entropy backed UUIDv7 generation on the legacy transitional surface
- extends the existing correlation suite with compatibility and import-boundary assertions
- documents the sequencing boundary before a later `RunIdentity` extraction

## Qualification boundary

This non-draft PR is a qualification candidate. Merge remains held until the exact final head passes all applicable required validation. Documentation and machine-index parity will be remediated on this same candidate if repository governance requires additional current-state projections.

AR-2 remains active. AR-3 is not started. No release/tag publication, deployment, policy/ruleset activation, installed-integration refresh, destructive action, branch deletion, force push, or history rewrite is included.