### PR TITLE
refactor(architecture): extract AR-2 execution identity semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Post-v1.7 runtime architecture AR-2 execution identity extraction candidate
+
+- Establishes `orchestra_runtime.domain.execution.identity` as the inward-only owner of immutable `RunIdentity` normalization and serialization semantics.
+- Preserves exact legacy `orchestra_runtime.models.RunIdentity` and top-level `orchestra_runtime.RunIdentity` object identity while routing correlation validation through the canonical execution-domain correlation contract.
+- Adds direct compatibility, invariant, import-boundary regression coverage, detailed extraction documentation, and `README.json` machine-discovery parity.
+- Does not move lifecycle controllers/state, audit events, execution results, capability manifests, delegation/services behavior, start AR-3/AR-4, retire public imports, or change release/deployment/policy authority.
+
 ## Post-v1.7 runtime architecture AR-2 execution correlation extraction candidate
 
 - Establishes `orchestra_runtime.domain.execution.correlation` as the inward-only owner of deterministic RFC 9562 UUIDv7 validation while keeping clock and entropy backed correlation generation outside the domain.

--- a/README.json
+++ b/README.json
@@ -32,7 +32,7 @@
     "runtime_architecture_refoundation": {
       "status": "AR_2_DOMAIN_EXTRACTIONS_ACTIVE",
       "purpose": "Incrementally refactor the Orchestra Python runtime into bounded clean/hexagonal architecture layers while preserving public behavior and legacy import compatibility.",
-      "human_sources": ["docs/project/ORCHESTRA_RUNTIME_ARCHITECTURE_REFOUNDATION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_CONTEXT_EXTRACTION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_GOVERNANCE_AUTHORITY_EXTRACTION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_CAPABILITIES_CORE_EXTRACTION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_EXECUTION_CORRELATION_EXTRACTION.md", "docs/architecture/README.md"],
+      "human_sources": ["docs/project/ORCHESTRA_RUNTIME_ARCHITECTURE_REFOUNDATION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_CONTEXT_EXTRACTION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_GOVERNANCE_AUTHORITY_EXTRACTION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_CAPABILITIES_CORE_EXTRACTION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_EXECUTION_CORRELATION_EXTRACTION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_EXECUTION_IDENTITY_EXTRACTION.md", "docs/architecture/README.md"],
       "validation_surface": "tests/runtime/test_runtime_architecture_boundaries.py",
       "machine_policy": "machine/governance/runtime-architecture-boundaries.v1.json",
       "machine_policy_schema": "machine/schemas/runtime-architecture-boundaries.v1.schema.json",
@@ -56,6 +56,9 @@
       "execution_correlation_domain_surface": "orchestra_runtime/domain/execution/correlation.py",
       "execution_correlation_legacy_compatibility_surface": "orchestra_runtime/correlation.py",
       "execution_correlation_validation_surface": "tests/runtime/test_correlation.py",
+      "execution_identity_domain_surface": "orchestra_runtime/domain/execution/identity.py",
+      "execution_identity_legacy_compatibility_surface": "orchestra_runtime/models.py",
+      "execution_identity_validation_surface": "tests/runtime/test_domain_execution_identity.py",
       "ci_enforcement": ["Governance Check", "validate"],
       "canonical_layers": ["domain", "application", "infrastructure", "entrypoints", "bootstrap", "shared", "resources"],
       "application_subzones": ["use_cases", "services", "dto", "ports"],
@@ -1097,7 +1100,8 @@
     "cloak_ui_reference_cuir5_evaluation": "docs/project/CLOAK_UI_REFERENCE_CORPUS_CUIR5_EVALUATION.md",
     "runtime_architecture_ar2_domain_governance_authority": "docs/project/ORCHESTRA_AR2_DOMAIN_GOVERNANCE_AUTHORITY_EXTRACTION.md",
     "runtime_architecture_ar2_domain_capabilities_core": "docs/project/ORCHESTRA_AR2_DOMAIN_CAPABILITIES_CORE_EXTRACTION.md",
-    "runtime_architecture_ar2_domain_execution_correlation": "docs/project/ORCHESTRA_AR2_DOMAIN_EXECUTION_CORRELATION_EXTRACTION.md"
+    "runtime_architecture_ar2_domain_execution_correlation": "docs/project/ORCHESTRA_AR2_DOMAIN_EXECUTION_CORRELATION_EXTRACTION.md",
+    "runtime_architecture_ar2_domain_execution_identity": "docs/project/ORCHESTRA_AR2_DOMAIN_EXECUTION_IDENTITY_EXTRACTION.md"
   },
   "representation_policy": {"markdown": "Human-readable explanation, rationale, examples, and nuanced specialist guidance", "json": "Canonical structured machine state, identity, routing, governance, receipts, manifests, provenance, presentation contracts, evidence, and indexes", "json_schema": "Validation contract for machine-readable records", "jsonl": "Append-only event/history records where incremental retrieval is preferable", "toon": "Derived validated non-authoritative model-context projection only when bounded compilation provides measured context benefit", "parity_rule": "When the same deterministic fact appears in more than one representation, CI must validate parity or derive the projection from one authoritative source."},
   "maturity": {

--- a/docs/project/ORCHESTRA_AR2_DOMAIN_EXECUTION_IDENTITY_EXTRACTION.md
+++ b/docs/project/ORCHESTRA_AR2_DOMAIN_EXECUTION_IDENTITY_EXTRACTION.md
@@ -1,0 +1,81 @@
+# Orchestra AR-2 Domain Execution Identity Extraction
+
+## Status
+
+`AR_2_DOMAIN_EXECUTION_IDENTITY_IMPLEMENTATION_CANDIDATE`
+
+This bounded AR-2 increment moves immutable run-identity semantics from the mixed legacy model module into the canonical execution domain after correlation validation was independently extracted and qualified.
+
+## Canonical domain ownership
+
+`orchestra_runtime.domain.execution.identity` owns `RunIdentity`.
+
+The domain entity preserves the existing contract:
+
+- `run_id` is trimmed and must remain non-empty;
+- optional `parent_run_id` is trimmed;
+- a run cannot name itself as its parent;
+- optional `correlation_id` is validated and canonicalized by `orchestra_runtime.domain.execution.correlation`;
+- no correlation identifier is generated implicitly;
+- `to_dict()` always emits `run_id` and `parent_run_id` and emits `correlation_id` only when present.
+
+The entity is immutable and slot-backed exactly as before.
+
+## Legacy compatibility boundary
+
+`orchestra_runtime.models` remains a transitional mixed-model surface. It imports and re-exposes the canonical `RunIdentity` object rather than defining a second class.
+
+As a result:
+
+- `orchestra_runtime.models.RunIdentity` is the canonical domain class;
+- top-level `orchestra_runtime.RunIdentity` remains identity-equal because the public package continues importing through the legacy model surface;
+- existing callers in capabilities, lifecycle, delegation, services, and other legacy modules require no import migration in this bounded unit.
+
+The legacy model module also uses the canonical execution-domain correlation validator for its remaining envelope validation behavior.
+
+## Dependency rule
+
+The extracted identity module obeys the AR-2 domain dependency direction:
+
+```text
+orchestra_runtime.domain -> orchestra_runtime.domain | orchestra_runtime.shared
+```
+
+Its only dependencies are `dataclasses` and the sibling execution-domain correlation contract. It has no clock, entropy, filesystem, application-port, provider, MCP, host, persistence, audit, lifecycle-controller, or legacy-runtime dependency.
+
+## Behavioral preservation
+
+The extraction changes ownership, not runtime semantics.
+
+Focused regression coverage verifies:
+
+1. legacy and top-level `RunIdentity` exports are identity-equal to the canonical domain class;
+2. run and parent identifiers preserve existing normalization;
+3. correlation identifiers preserve canonical UUIDv7 normalization without implicit generation;
+4. invalid empty run identifiers, self-parenting identities, and malformed correlation identifiers fail closed;
+5. `to_dict()` preserves the existing serialized shape;
+6. the domain identity module contains no I/O, environmental-effect, application-port, or legacy-runtime imports.
+
+Existing runtime suites continue to exercise `RunIdentity` through capability manifests, lifecycle handling, delegation, runtime composition, correlation propagation, and public imports.
+
+## Sequencing value
+
+With correlation validation and `RunIdentity` now independently owned by `domain.execution`, later AR-2 work can classify lifecycle state, capability-manifest composition, and other execution semantics without forcing those domain candidates to depend on the mixed legacy `models.py` surface.
+
+Those later moves remain separate qualification units.
+
+## Explicit non-goals
+
+This bounded extraction does not:
+
+- move lifecycle states, signals, controllers, or terminal results;
+- move `RuntimeAuditEvent` or `AuditEventType`;
+- move `ExecutionResult` or `OrchestraRuntimeEnvelope`;
+- move `RuntimeCapabilityManifest` or capability resolver application behavior;
+- alter delegation, coordination, routing, provider, MCP, governance, or execution behavior;
+- start AR-3 application/use-case extraction;
+- start AR-4 infrastructure extraction;
+- retire `orchestra_runtime.models` or top-level public imports;
+- authorize release or tag publication, deployment, production mutation, policy activation, installed-integration refresh, destructive cleanup, branch deletion, force push, or history rewrite.
+
+AR-2 remains active after this unit until the remaining qualified pure-domain ownership slices are complete.

--- a/orchestra_runtime/domain/execution/__init__.py
+++ b/orchestra_runtime/domain/execution/__init__.py
@@ -1,5 +1,6 @@
 """Pure execution-domain identity semantics."""
 
 from .correlation import is_valid_correlation_id, validate_correlation_id
+from .identity import RunIdentity
 
-__all__ = ("is_valid_correlation_id", "validate_correlation_id")
+__all__ = ("RunIdentity", "is_valid_correlation_id", "validate_correlation_id")

--- a/orchestra_runtime/domain/execution/identity.py
+++ b/orchestra_runtime/domain/execution/identity.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .correlation import validate_correlation_id
+
+
+@dataclass(frozen=True, slots=True)
+class RunIdentity:
+    """Immutable execution-domain run identity."""
+
+    run_id: str
+    parent_run_id: str | None = None
+    correlation_id: str | None = None
+
+    def __post_init__(self) -> None:
+        run_id = self.run_id.strip()
+        parent_run_id = self.parent_run_id.strip() if self.parent_run_id else None
+        if not run_id:
+            raise ValueError("run_id must be non-empty")
+        if parent_run_id == run_id:
+            raise ValueError("parent_run_id must differ from run_id")
+        object.__setattr__(self, "run_id", run_id)
+        object.__setattr__(self, "parent_run_id", parent_run_id)
+        if self.correlation_id is not None:
+            cid = validate_correlation_id(self.correlation_id)
+            object.__setattr__(self, "correlation_id", cid)
+
+    def to_dict(self) -> dict[str, str | None]:
+        data: dict[str, str | None] = {"run_id": self.run_id, "parent_run_id": self.parent_run_id}
+        if self.correlation_id is not None:
+            data["correlation_id"] = self.correlation_id
+        return data

--- a/orchestra_runtime/models.py
+++ b/orchestra_runtime/models.py
@@ -5,7 +5,7 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from .correlation import validate_correlation_id
+from .domain.execution import RunIdentity, validate_correlation_id
 
 if TYPE_CHECKING:
     from .lifecycle import StructuredTerminalResult
@@ -412,32 +412,6 @@ class AuditEventType(str, Enum):
     SPECIALIST_REENTRY_RECOMMENDED = "SPECIALIST_REENTRY_RECOMMENDED"
     COLLABORATION_SESSION_CLOSED = "COLLABORATION_SESSION_CLOSED"
     COORDINATION_INPUT_REJECTED = "COORDINATION_INPUT_REJECTED"
-
-
-@dataclass(frozen=True, slots=True)
-class RunIdentity:
-    run_id: str
-    parent_run_id: str | None = None
-    correlation_id: str | None = None
-
-    def __post_init__(self) -> None:
-        run_id = self.run_id.strip()
-        parent_run_id = self.parent_run_id.strip() if self.parent_run_id else None
-        if not run_id:
-            raise ValueError("run_id must be non-empty")
-        if parent_run_id == run_id:
-            raise ValueError("parent_run_id must differ from run_id")
-        object.__setattr__(self, "run_id", run_id)
-        object.__setattr__(self, "parent_run_id", parent_run_id)
-        if self.correlation_id is not None:
-            cid = validate_correlation_id(self.correlation_id)
-            object.__setattr__(self, "correlation_id", cid)
-
-    def to_dict(self) -> dict[str, str | None]:
-        data: dict[str, str | None] = {"run_id": self.run_id, "parent_run_id": self.parent_run_id}
-        if self.correlation_id is not None:
-            data["correlation_id"] = self.correlation_id
-        return data
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/runtime/test_domain_execution_identity.py
+++ b/tests/runtime/test_domain_execution_identity.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+import orchestra_runtime.models as legacy_models
+from orchestra_runtime import RunIdentity as public_run_identity
+from orchestra_runtime.correlation import generate_correlation_id
+from orchestra_runtime.domain.execution import RunIdentity as domain_run_identity
+from orchestra_runtime.domain.execution import identity as domain_identity
+
+
+def test_domain_run_identity_exports_are_legacy_identity_compatible() -> None:
+    assert legacy_models.RunIdentity is domain_run_identity
+    assert public_run_identity is domain_run_identity
+
+
+def test_domain_run_identity_preserves_normalization_and_serialization() -> None:
+    cid = generate_correlation_id()
+    run = domain_run_identity("  run-1  ", "  parent-1  ", correlation_id=cid.upper())
+
+    assert run.run_id == "run-1"
+    assert run.parent_run_id == "parent-1"
+    assert run.correlation_id == cid
+    assert run.to_dict() == {
+        "run_id": "run-1",
+        "parent_run_id": "parent-1",
+        "correlation_id": cid,
+    }
+
+    root = domain_run_identity(" root ")
+    assert root.to_dict() == {"run_id": "root", "parent_run_id": None}
+
+
+def test_domain_run_identity_preserves_fail_closed_invariants() -> None:
+    with pytest.raises(ValueError, match="run_id must be non-empty"):
+        domain_run_identity("   ")
+
+    with pytest.raises(ValueError, match="parent_run_id must differ from run_id"):
+        domain_run_identity(" run-1 ", "run-1")
+
+    with pytest.raises(ValueError, match="malformed correlation_id"):
+        domain_run_identity("run-1", correlation_id="not-a-uuid")
+
+
+def test_domain_run_identity_is_pure_and_legacy_free() -> None:
+    source_path = Path(domain_identity.__file__)
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    imports: set[str] = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module)
+
+    forbidden = {
+        "secrets",
+        "time",
+        "pathlib",
+        "os",
+        "subprocess",
+        "socket",
+        "orchestra_runtime.correlation",
+        "orchestra_runtime.models",
+        "orchestra_runtime.interfaces",
+    }
+    assert not imports.intersection(forbidden)
+    assert not any(isinstance(node, ast.Name) and node.id == "open" for node in ast.walk(tree))


### PR DESCRIPTION
## Scope

Bounded AR-2 `domain/execution` RunIdentity extraction only.

- moves immutable `RunIdentity` normalization and serialization semantics into `orchestra_runtime.domain.execution.identity`
- preserves exact legacy `orchestra_runtime.models.RunIdentity` and top-level `orchestra_runtime.RunIdentity` symbol identity
- routes correlation validation through the already-canonical execution-domain correlation contract
- adds direct compatibility, invariant, serialization, and import-boundary regression coverage
- records detailed architecture and `README.json` machine-discovery parity

## Qualification boundary

This non-draft PR is a qualification candidate. Merge remains held until the exact final head passes all applicable required validation.

Lifecycle states/controllers, audit events, execution results, capability manifests, delegation/services behavior, AR-3, AR-4, public import retirement, release/tag publication, deployment, policy/ruleset activation, installed-integration refresh, destructive action, branch deletion, force push, and history rewrite are outside this unit.

AR-2 remains active. AR-3 is not started.