### PR TITLE
chore(cuir): reconcile canonical CUIR-5/CUIR-6 lifecycle state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Post-v1.7 Cloak CUIR lifecycle projection reconciliation candidate
+
+- Reconciles the current `README.json` machine projection with the verified canonical CUIR-5 controlled evaluation and CUIR-6 `ADOPT_OPTIONAL` closeout.
+- Records the verified CUIR-5 commit/tree `0736517fc59f3979ec76d642bc2d8ed5c7b858b1` / `b0e5d89db6f3c9642465704ecc1ace8c3b905291` and CUIR-6 commit/tree `2f11f17742e68560d2a435bcab3f247b52d351ab` / `0f114c13d8f5f54ee5ecf1e9deb156ae6fe6e24b` while preserving phase-era candidate artifacts as historical evidence.
+- Adds regression coverage ensuring the optional closeout does not become runtime expansion, mandatory full-corpus injection, automatic host injection, or new authority.
+- Does not change Cloak runtime behavior, retrieval limits, provenance or licensing rules, AR state, release/deployment/provider/policy authority, or delete branches.
+
 ## Post-v1.7 runtime architecture AR-2 execution identity extraction candidate
 
 - Establishes `orchestra_runtime.domain.execution.identity` as the inward-only owner of immutable `RunIdentity` normalization and serialization semantics.
@@ -133,7 +140,7 @@
 ## Post-v1.7 Priority 2 provider execution profile candidate
 
 - Added a deterministic, non-authorizing provider execution profile and trusted provider/model/capability requirement gate for explicit host-native specialist execution, while preserving existing route-only and provider-free deterministic runtime paths.
-- Added separate provider-aware MCP constructors and Codex App Server wrappers that map the existing explicit user-selected model configuration into `openai-codex` provider profiles without widening approval, sandbox, network, specialist, command, or mutation scope.
+- Added separate provider-aware MCP constructors and Codex App Server wrappers that map the existing explicit user-selected model configuration into `openai-codex` provider profiles without widening approval, sandbox, network, write-scope, specialist, command, or mutation scope.
 - Added Draft 2020-12 provider profile/requirement schemas and focused regressions for deterministic identity, fail-closed mismatch and drift handling, authority-before-provider ordering, minimized provider evidence, and prompt/MCP metadata non-override.
 - P2.1 does not add automatic provider routing or fallback, direct provider SDKs/APIs, credential handling, a static model catalog, Registry mutation, release, deployment, policy activation, integration refresh, destructive operations, branch deletion, force push, or history rewrite.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,7 +140,7 @@
 ## Post-v1.7 Priority 2 provider execution profile candidate
 
 - Added a deterministic, non-authorizing provider execution profile and trusted provider/model/capability requirement gate for explicit host-native specialist execution, while preserving existing route-only and provider-free deterministic runtime paths.
-- Added separate provider-aware MCP constructors and Codex App Server wrappers that map the existing explicit user-selected model configuration into `openai-codex` provider profiles without widening approval, sandbox, network, write-scope, specialist, command, or mutation scope.
+- Added separate provider-aware MCP constructors and Codex App Server wrappers that map the existing explicit user-selected model configuration into `openai-codex` provider profiles without widening approval, sandbox, network, specialist, command, or mutation scope.
 - Added Draft 2020-12 provider profile/requirement schemas and focused regressions for deterministic identity, fail-closed mismatch and drift handling, authority-before-provider ordering, minimized provider evidence, and prompt/MCP metadata non-override.
 - P2.1 does not add automatic provider routing or fallback, direct provider SDKs/APIs, credential handling, a static model catalog, Registry mutation, release, deployment, policy activation, integration refresh, destructive operations, branch deletion, force push, or history rewrite.
 

--- a/README.json
+++ b/README.json
@@ -206,10 +206,10 @@
       "source_copying": false,
       "asset_copying": false,
       "cuir5_started": true,
-      "authority_note": "CUIR-4 is canonical advisory progressive pattern retrieval only. CUIR-5 has been started by a separately authorized controlled evaluation candidate; CUIR-4 canonicalization itself did not transfer implementation, architecture, security, merge, release, deployment, provider-routing, production-mutation, or policy authority."
+      "authority_note": "CUIR-4 is canonical advisory progressive pattern retrieval only. CUIR-5 controlled evaluation and CUIR-6 optional-adoption closeout are now canonical; neither transferred implementation, architecture, security, merge, release, deployment, provider-routing, production-mutation, or policy authority."
     },
     "cloak_ui_reference_corpus_cuir5": {
-      "status": "CUIR_5_CONTROLLED_EVALUATION_CANDIDATE",
+      "status": "CUIR_5_CANONICAL_CONTROLLED_EVALUATION_VERIFIED",
       "purpose": "Measure the incremental contribution of bounded CUIR-4 progressive retrieval against a no-CUIR-retrieval baseline using deterministic representative fixtures without claiming end-to-end model, rendered UI, human-usability, or production effectiveness.",
       "machine_sources": ["machine/evaluation/cloak-ui-reference-cuir5-benchmark.v1.json"],
       "human_sources": ["docs/project/CLOAK_UI_REFERENCE_CORPUS_CUIR5_EVALUATION.md"],
@@ -217,8 +217,30 @@
       "validation_surface": "tests/runtime/test_cloak_ui_reference_corpus_cuir5.py",
       "runtime_integration": false,
       "provider_calls": 0,
+      "evaluation_result": "CONTROLLED_EVALUATION_PASS",
+      "recommendation": "ADOPT_OPTIONAL",
       "recommendation_ceiling": "ADOPT_OPTIONAL_FOR_CUIR6_CONSIDERATION",
-      "authority_note": "CUIR-5 is controlled evaluation evidence only. It cannot grant implementation, architecture, security, merge, release, deployment, provider routing or fallback, production mutation, policy, destructive, or installed-integration-refresh authority."
+      "canonical_commit": "0736517fc59f3979ec76d642bc2d8ed5c7b858b1",
+      "canonical_tree": "b0e5d89db6f3c9642465704ecc1ace8c3b905291",
+      "cuir6_closed": true,
+      "authority_note": "CUIR-5 is canonical controlled evaluation evidence only. It cannot grant implementation, architecture, security, merge, release, deployment, provider routing or fallback, production mutation, policy, destructive, or installed-integration-refresh authority."
+    },
+    "cloak_ui_reference_corpus_cuir6": {
+      "status": "CUIR_6_CANONICAL_ADOPT_OPTIONAL_CLOSEOUT_VERIFIED",
+      "purpose": "Close the CUIR phase family by adopting the existing bounded CUIR-4 progressive retrieval capability as supported optional Cloak behavior after canonical CUIR-5 controlled-evaluation evidence.",
+      "human_sources": ["docs/project/CLOAK_UI_REFERENCE_CORPUS_CUIR6_ADOPTION.md", "docs/project/CLOAK_UI_REFERENCE_CORPUS_CUIR5_CUIR6_LIFECYCLE_RECONCILIATION.md"],
+      "canonical_input_commit": "0736517fc59f3979ec76d642bc2d8ed5c7b858b1",
+      "canonical_input_tree": "b0e5d89db6f3c9642465704ecc1ace8c3b905291",
+      "canonical_commit": "2f11f17742e68560d2a435bcab3f247b52d351ab",
+      "canonical_tree": "0f114c13d8f5f54ee5ecf1e9deb156ae6fe6e24b",
+      "adoption": "ADOPT_OPTIONAL",
+      "family_closed": true,
+      "runtime_expansion": false,
+      "mandatory_full_corpus_injection": false,
+      "automatic_host_injection": false,
+      "implementation_authority": false,
+      "release_authorized": false,
+      "authority_note": "CUIR-6 canonically closes the CUIR family with optional bounded retrieval only. Closeout does not grant implementation, architecture, security, merge, release, deployment, provider routing or fallback, production mutation, policy, destructive, installed-integration-refresh, branch-deletion, force-push, or history-rewrite authority."
     },
     "cross_specialist_coordination": {"status": "IMPLEMENTED", "human_sources": ["docs/governance/TUNER_PROTOCOL.md", "ROUTING_MAP.md"]},
     "validation_and_evidence": {"status": "IMPLEMENTED", "machine_sources": ["machine/schemas/", "machine/release-evidence/"], "human_sources": ["docs/setup/VALIDATION.md", "docs/validation/"]},
@@ -1098,6 +1120,8 @@
     "publication_closeout_v1_7_0": "docs/validation/V1_7_0_PUBLICATION_CLOSEOUT.md",
     "codex_c2_portability_r1_preexecution": "docs/benchmarking/CODEX_C2_PORTABILITY_R1_PREEXECUTION.md",
     "cloak_ui_reference_cuir5_evaluation": "docs/project/CLOAK_UI_REFERENCE_CORPUS_CUIR5_EVALUATION.md",
+    "cloak_ui_reference_cuir6_adoption": "docs/project/CLOAK_UI_REFERENCE_CORPUS_CUIR6_ADOPTION.md",
+    "cloak_ui_reference_cuir5_cuir6_lifecycle_reconciliation": "docs/project/CLOAK_UI_REFERENCE_CORPUS_CUIR5_CUIR6_LIFECYCLE_RECONCILIATION.md",
     "runtime_architecture_ar2_domain_governance_authority": "docs/project/ORCHESTRA_AR2_DOMAIN_GOVERNANCE_AUTHORITY_EXTRACTION.md",
     "runtime_architecture_ar2_domain_capabilities_core": "docs/project/ORCHESTRA_AR2_DOMAIN_CAPABILITIES_CORE_EXTRACTION.md",
     "runtime_architecture_ar2_domain_execution_correlation": "docs/project/ORCHESTRA_AR2_DOMAIN_EXECUTION_CORRELATION_EXTRACTION.md",
@@ -1136,7 +1160,8 @@
     "cloak_ui_reference_corpus_cuir2": "CUIR_2_CANONICAL_MERGED_VERIFIED",
     "cloak_ui_reference_corpus_cuir3": "CUIR_3_CANONICAL_MERGED_VERIFIED",
     "cloak_ui_reference_corpus_cuir4": "CUIR_4_CANONICAL_MERGED_VERIFIED",
-    "cloak_ui_reference_corpus_cuir5": "CUIR_5_CONTROLLED_EVALUATION_CANDIDATE"
+    "cloak_ui_reference_corpus_cuir5": "CUIR_5_CANONICAL_CONTROLLED_EVALUATION_VERIFIED",
+    "cloak_ui_reference_corpus_cuir6": "CUIR_6_CANONICAL_ADOPT_OPTIONAL_CLOSEOUT_VERIFIED"
   },
   "ai_review_guidance": {
     "preferred_entrypoint": "README.json",
@@ -1240,6 +1265,8 @@
     "do_not_infer_cuir4_authority_from_cuir3_canonicalization": true,
     "treat_cuir4_as_canonical_bounded_progressive_pattern_intelligence": true,
     "do_not_infer_cuir5_authority_from_cuir4_canonicalization": true,
-    "treat_cuir5_controlled_evaluation_as_bounded_non_authorizing_evidence_only": true
+    "treat_cuir5_controlled_evaluation_as_bounded_non_authorizing_evidence_only": true,
+    "treat_cuir6_as_canonical_optional_closeout_not_runtime_expansion": true,
+    "do_not_infer_mandatory_cuir_injection_or_new_authority_from_cuir6_adoption": true
   }
 }

--- a/docs/project/CLOAK_UI_REFERENCE_CORPUS_CUIR5_CUIR6_LIFECYCLE_RECONCILIATION.md
+++ b/docs/project/CLOAK_UI_REFERENCE_CORPUS_CUIR5_CUIR6_LIFECYCLE_RECONCILIATION.md
@@ -1,0 +1,77 @@
+# Cloak UI Reference Corpus CUIR-5 / CUIR-6 Lifecycle Reconciliation
+
+Status: `LIFECYCLE_RECONCILIATION_CANDIDATE`
+
+Scope: current-state projection only. No CUIR evaluation is re-executed and no Cloak runtime behavior is changed.
+
+## Purpose
+
+Reconcile Orchestra's current machine-facing CUIR lifecycle projection with the already verified canonical CUIR-5 controlled evaluation and CUIR-6 optional-adoption closeout.
+
+The historical phase documents and benchmark records intentionally retain their phase-era candidate wording. Orchestra's `README.json` historical-status policy permits that wording to remain historical while current exact state is projected from verified Git identity and current machine state.
+
+## Canonical evidence
+
+CUIR-5 controlled evaluation:
+
+- canonical PR: `#689`;
+- canonical commit: `0736517fc59f3979ec76d642bc2d8ed5c7b858b1`;
+- canonical tree: `b0e5d89db6f3c9642465704ecc1ace8c3b905291`;
+- GitHub signature: verified / valid;
+- disposition: `CONTROLLED_EVALUATION_PASS`;
+- recommendation: `ADOPT_OPTIONAL` for CUIR-6 consideration only.
+
+CUIR-6 optional-adoption closeout:
+
+- canonical PR: `#692`;
+- canonical commit: `2f11f17742e68560d2a435bcab3f247b52d351ab`;
+- canonical tree: `0f114c13d8f5f54ee5ecf1e9deb156ae6fe6e24b`;
+- GitHub signature: verified / valid;
+- disposition: canonical closeout of the CUIR phase family with bounded progressive retrieval supported optionally.
+
+## Current-state reconciliation
+
+The current machine projection records:
+
+- CUIR-5 as canonical controlled-evaluation evidence with `CONTROLLED_EVALUATION_PASS` and `ADOPT_OPTIONAL` recommendation;
+- CUIR-6 as canonical `ADOPT_OPTIONAL` closeout;
+- the CUIR phase family as closed;
+- the existing CUIR-4 progressive retrieval limits and project-native precedence as unchanged;
+- default full-corpus injection as disabled;
+- automatic host injection as disabled;
+- no new runtime, implementation, provider, release, deployment, policy, destructive, or integration-refresh authority.
+
+## Historical records
+
+The following are deliberately preserved as historical phase artifacts rather than rewritten to appear post-canonical:
+
+- `docs/project/CLOAK_UI_REFERENCE_CORPUS_CUIR5_EVALUATION.md`;
+- `machine/evaluation/cloak-ui-reference-cuir5-benchmark.v1.json`;
+- `docs/project/CLOAK_UI_REFERENCE_CORPUS_CUIR6_ADOPTION.md`.
+
+Their candidate-era status text records the state in which those artifacts were reviewed. The canonical PR, commit, tree, signature, and current `README.json` projection establish the later lifecycle outcome.
+
+## Residual pull requests
+
+The remaining open CUIR source-candidate pull requests are historical workflow residue and are not additional implementation work:
+
+- `#675` was superseded by canonical CUIR-3 normalization PR `#677`;
+- `#678` was superseded by canonical CUIR-3 lifecycle closeout PR `#680`;
+- `#681` was superseded by canonical CUIR-4 integration PR `#683`;
+- `#684` was superseded by canonical CUIR-4 lifecycle closeout PR `#686`;
+- `#687` was superseded by canonical CUIR-5 evaluation PR `#689`.
+
+They may be closed after this reconciliation is canonical. Their branches are retained because branch deletion is a separately protected action.
+
+## Non-goals and authority boundary
+
+This reconciliation does not:
+
+- re-run CUIR-5 evaluation or widen its claims;
+- modify CUIR retrieval semantics, limits, provenance, licensing, or source-copying rules;
+- make CUIR mandatory for Cloak tasks;
+- enable full-corpus or automatic host injection;
+- create implementation, architecture, security, provider-routing, merge, release, deployment, production-mutation, policy, destructive, installed-integration-refresh, branch-deletion, force-push, or history-rewrite authority;
+- change AR-2 or start AR-3.
+
+Validation and canonical merge evidence remain required before this reconciliation becomes current canonical state.

--- a/tests/runtime/test_cloak_ui_reference_corpus_cuir4.py
+++ b/tests/runtime/test_cloak_ui_reference_corpus_cuir4.py
@@ -82,16 +82,27 @@ def test_adjacent_progressive_disclosure_guide_preserves_frozen_core_skill():
     assert index["retrieval_policy"]["default_catalog_injection"] is False
 
 
-def test_readme_machine_projection_tracks_separately_started_cuir5_without_authority_widening():
+def test_readme_machine_projection_tracks_cuir5_cuir6_canonical_closeout_without_authority_widening():
     readme = _json(ROOT / "README.json")
     cuir3 = readme["capabilities"]["cloak_ui_reference_corpus_cuir3"]
     cuir4 = readme["capabilities"]["cloak_ui_reference_corpus_cuir4"]
     cuir5 = readme["capabilities"]["cloak_ui_reference_corpus_cuir5"]
+    cuir6 = readme["capabilities"]["cloak_ui_reference_corpus_cuir6"]
     assert cuir3["cuir4_started"] is True
     assert cuir4["status"] == "CUIR_4_CANONICAL_MERGED_VERIFIED"
     assert cuir4["progressive_retrieval"] is True
     assert cuir4["cuir5_started"] is True
     assert cuir4["implementation_authority"] is False
-    assert cuir5["status"] == "CUIR_5_CONTROLLED_EVALUATION_CANDIDATE"
+    assert cuir5["status"] == "CUIR_5_CANONICAL_CONTROLLED_EVALUATION_VERIFIED"
+    assert cuir5["evaluation_result"] == "CONTROLLED_EVALUATION_PASS"
+    assert cuir5["recommendation"] == "ADOPT_OPTIONAL"
     assert cuir5["runtime_integration"] is False
-    assert "cannot grant implementation" in cuir5["authority_note"]
+    assert cuir5["cuir6_closed"] is True
+    assert cuir6["status"] == "CUIR_6_CANONICAL_ADOPT_OPTIONAL_CLOSEOUT_VERIFIED"
+    assert cuir6["adoption"] == "ADOPT_OPTIONAL"
+    assert cuir6["family_closed"] is True
+    assert cuir6["runtime_expansion"] is False
+    assert cuir6["mandatory_full_corpus_injection"] is False
+    assert cuir6["automatic_host_injection"] is False
+    assert cuir6["implementation_authority"] is False
+    assert cuir6["release_authorized"] is False


### PR DESCRIPTION
## Scope

Reconcile the current machine-facing CUIR lifecycle projection with the already canonical CUIR-5 controlled evaluation and CUIR-6 `ADOPT_OPTIONAL` closeout.

Included:
- update `README.json` current CUIR-5/CUIR-6 lifecycle state and canonical Git identities;
- add a bounded lifecycle reconciliation record;
- update regression coverage for the current projection;
- add focused changelog parity.

Historical CUIR-5/CUIR-6 phase documents and the CUIR-5 benchmark retain their candidate-era status text intentionally under the repository historical-status policy. This PR does not re-run the evaluation or rewrite historical evidence.

No Cloak retrieval behavior, limits, provenance/licensing policy, runtime integration, provider routing, release/deployment/policy authority, AR-2 state, or AR-3 state changes. No branch deletion, force push, or history rewrite.

After this reconciliation is canonical and post-merge verified, residual source-candidate PRs #675, #678, #681, #684, and #687 may be closed as superseded by their already canonical materialization PRs. Their branches will not be deleted.

Canonical base at branch creation: `aa936a93e742090f3f7da3ea81bec614d4ea2b0e`.