### PR TITLE
refactor(architecture): extract AR-2 execution lifecycle core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Post-v1.7 runtime architecture AR-2 execution lifecycle core extraction candidate
+
+- Establishes `orchestra_runtime.domain.execution.lifecycle` as the inward-only owner of immutable lifecycle state, signal, snapshot, terminal-result, deterministic fingerprint, initialization, and transition semantics.
+- Preserves exact legacy `orchestra_runtime.lifecycle` and top-level lifecycle symbol identity while retaining `LifecycleController(ILifecycleController)` plus runtime audit-event projection on the transitional legacy surface for later AR-3/AR-4 placement.
+- Adds direct compatibility, transition/replay, fail-closed, controller-delegation, import-boundary regression coverage, detailed extraction documentation, and `README.json` machine-discovery parity.
+- Does not alter provider/MCP behavior, runtime policy, audit-event semantics, public import compatibility, release/deployment/policy authority, or start AR-3.
+
 ## Post-v1.7 Cloak CUIR lifecycle projection reconciliation candidate
 
 - Reconciles the current `README.json` machine projection with the verified canonical CUIR-5 controlled evaluation and CUIR-6 `ADOPT_OPTIONAL` closeout.

--- a/README.json
+++ b/README.json
@@ -32,7 +32,7 @@
     "runtime_architecture_refoundation": {
       "status": "AR_2_DOMAIN_EXTRACTIONS_ACTIVE",
       "purpose": "Incrementally refactor the Orchestra Python runtime into bounded clean/hexagonal architecture layers while preserving public behavior and legacy import compatibility.",
-      "human_sources": ["docs/project/ORCHESTRA_RUNTIME_ARCHITECTURE_REFOUNDATION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_CONTEXT_EXTRACTION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_GOVERNANCE_AUTHORITY_EXTRACTION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_CAPABILITIES_CORE_EXTRACTION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_EXECUTION_CORRELATION_EXTRACTION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_EXECUTION_IDENTITY_EXTRACTION.md", "docs/architecture/README.md"],
+      "human_sources": ["docs/project/ORCHESTRA_RUNTIME_ARCHITECTURE_REFOUNDATION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_CONTEXT_EXTRACTION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_GOVERNANCE_AUTHORITY_EXTRACTION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_CAPABILITIES_CORE_EXTRACTION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_EXECUTION_CORRELATION_EXTRACTION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_EXECUTION_IDENTITY_EXTRACTION.md", "docs/project/ORCHESTRA_AR2_DOMAIN_EXECUTION_LIFECYCLE_CORE_EXTRACTION.md", "docs/architecture/README.md"],
       "validation_surface": "tests/runtime/test_runtime_architecture_boundaries.py",
       "machine_policy": "machine/governance/runtime-architecture-boundaries.v1.json",
       "machine_policy_schema": "machine/schemas/runtime-architecture-boundaries.v1.schema.json",
@@ -59,6 +59,9 @@
       "execution_identity_domain_surface": "orchestra_runtime/domain/execution/identity.py",
       "execution_identity_legacy_compatibility_surface": "orchestra_runtime/models.py",
       "execution_identity_validation_surface": "tests/runtime/test_domain_execution_identity.py",
+      "execution_lifecycle_domain_surface": "orchestra_runtime/domain/execution/lifecycle.py",
+      "execution_lifecycle_legacy_compatibility_surface": "orchestra_runtime/lifecycle.py",
+      "execution_lifecycle_validation_surface": "tests/runtime/test_domain_execution_lifecycle.py",
       "ci_enforcement": ["Governance Check", "validate"],
       "canonical_layers": ["domain", "application", "infrastructure", "entrypoints", "bootstrap", "shared", "resources"],
       "application_subzones": ["use_cases", "services", "dto", "ports"],
@@ -1125,7 +1128,8 @@
     "runtime_architecture_ar2_domain_governance_authority": "docs/project/ORCHESTRA_AR2_DOMAIN_GOVERNANCE_AUTHORITY_EXTRACTION.md",
     "runtime_architecture_ar2_domain_capabilities_core": "docs/project/ORCHESTRA_AR2_DOMAIN_CAPABILITIES_CORE_EXTRACTION.md",
     "runtime_architecture_ar2_domain_execution_correlation": "docs/project/ORCHESTRA_AR2_DOMAIN_EXECUTION_CORRELATION_EXTRACTION.md",
-    "runtime_architecture_ar2_domain_execution_identity": "docs/project/ORCHESTRA_AR2_DOMAIN_EXECUTION_IDENTITY_EXTRACTION.md"
+    "runtime_architecture_ar2_domain_execution_identity": "docs/project/ORCHESTRA_AR2_DOMAIN_EXECUTION_IDENTITY_EXTRACTION.md",
+    "runtime_architecture_ar2_domain_execution_lifecycle_core": "docs/project/ORCHESTRA_AR2_DOMAIN_EXECUTION_LIFECYCLE_CORE_EXTRACTION.md"
   },
   "representation_policy": {"markdown": "Human-readable explanation, rationale, examples, and nuanced specialist guidance", "json": "Canonical structured machine state, identity, routing, governance, receipts, manifests, provenance, presentation contracts, evidence, and indexes", "json_schema": "Validation contract for machine-readable records", "jsonl": "Append-only event/history records where incremental retrieval is preferable", "toon": "Derived validated non-authoritative model-context projection only when bounded compilation provides measured context benefit", "parity_rule": "When the same deterministic fact appears in more than one representation, CI must validate parity or derive the projection from one authoritative source."},
   "maturity": {

--- a/docs/project/ORCHESTRA_AR2_DOMAIN_EXECUTION_LIFECYCLE_CORE_EXTRACTION.md
+++ b/docs/project/ORCHESTRA_AR2_DOMAIN_EXECUTION_LIFECYCLE_CORE_EXTRACTION.md
@@ -1,0 +1,82 @@
+# Orchestra AR-2 Domain Execution Lifecycle Core Extraction
+
+Status: `AR_2_DOMAIN_EXECUTION_LIFECYCLE_CORE_IMPLEMENTATION_CANDIDATE`
+
+Phase: `AR-2`
+
+Canonical source baseline: `a451bca21b3a9d8c470ff357daec59fddd335ff1`.
+
+## Purpose
+
+Move deterministic lifecycle state, signal, snapshot, terminal-result, fingerprint, initialization, and transition semantics inward to the execution domain without moving application ports, audit-event projection, or runtime orchestration.
+
+## Canonical domain surface
+
+`orchestra_runtime/domain/execution/lifecycle.py` owns:
+
+- `LifecycleState`;
+- `LifecycleSignalType`;
+- immutable lifecycle transition maps;
+- `StructuredTerminalResult`;
+- `LifecycleSignal`;
+- `LifecycleSnapshot`;
+- `lifecycle_signal_fingerprint`;
+- `initialize_lifecycle_snapshot`;
+- `apply_lifecycle_signal`.
+
+The domain surface depends only on standard-library deterministic primitives, `orchestra_runtime.domain`, and `orchestra_runtime.shared`.
+
+## Compatibility surface
+
+`orchestra_runtime/lifecycle.py` remains the transitional legacy surface.
+
+It re-exports the same lifecycle domain class and transition objects, retains `LifecycleController(ILifecycleController)`, and delegates controller initialization and transition application to the domain functions. Existing top-level `orchestra_runtime` exports continue to resolve through the legacy module and therefore remain object-identity compatible.
+
+## Deliberately retained outside the domain
+
+The legacy module continues to own:
+
+- `LifecycleController` application-port inheritance;
+- runtime audit-event projection;
+- `AuditEventType` and `RuntimeAuditEvent` coupling;
+- stable audit-event ID construction.
+
+These concerns require later AR-3 or AR-4 placement and are not pulled inward merely to reduce the legacy file size.
+
+## Preserved lifecycle behavior
+
+The extraction preserves:
+
+- `INITIALIZING -> ACTIVE | FAILED | CANCELLED | TIMED_OUT | BLOCKED`;
+- `ACTIVE -> WAITING | COMPLETED | FAILED | CANCELLED | TIMED_OUT | BLOCKED`;
+- `WAITING -> ACTIVE | FAILED | CANCELLED | TIMED_OUT | BLOCKED`;
+- terminal-state immutability;
+- explicit `WAIT` and `RESUME` source-state requirements;
+- structured terminal-result matching;
+- deterministic signal fingerprints;
+- exact terminal-signal replay idempotence;
+- conflicting terminal-signal rejection;
+- fail-closed run/state/signal validation;
+- public and legacy object identity.
+
+## Validation
+
+Focused regression coverage is added in `tests/runtime/test_domain_execution_lifecycle.py` for legacy/public identity, deterministic transitions, terminal replay/conflict behavior, controller delegation, and import-boundary purity. Existing lifecycle, delegation, runtime, presentation, provider, specialist-execution, and adaptive tests remain the compatibility surface.
+
+Repository qualification remains authoritative. Passing tests do not grant phase progression or protected-action authority.
+
+## Non-goals
+
+This unit does not:
+
+- move `ILifecycleController` into the domain;
+- move lifecycle audit events into the domain;
+- move `AuditEventType` or `RuntimeAuditEvent`;
+- alter runtime execution, delegation, provider, MCP, or presentation behavior;
+- retire `orchestra_runtime.lifecycle`;
+- start AR-3 or AR-4;
+- authorize release, deployment, production mutation, policy activation, provider routing/fallback, installed-integration refresh, destructive cleanup, branch deletion, force push, or history rewrite.
+
+## Sequencing
+
+If this candidate becomes canonical and post-merge verified, AR-2 remains active. The next bounded extraction must be selected from a fresh dependency audit rather than inferred from lifecycle-core completion.

--- a/orchestra_runtime/domain/execution/__init__.py
+++ b/orchestra_runtime/domain/execution/__init__.py
@@ -1,6 +1,34 @@
-"""Pure execution-domain identity semantics."""
+"""Pure execution-domain identity and lifecycle semantics."""
 
 from .correlation import is_valid_correlation_id, validate_correlation_id
 from .identity import RunIdentity
+from .lifecycle import (
+    LIFECYCLE_TRANSITIONS,
+    SIGNAL_DESTINATIONS,
+    SIGNAL_SOURCE_STATES,
+    LifecycleSignal,
+    LifecycleSignalType,
+    LifecycleSnapshot,
+    LifecycleState,
+    StructuredTerminalResult,
+    apply_lifecycle_signal,
+    initialize_lifecycle_snapshot,
+    lifecycle_signal_fingerprint,
+)
 
-__all__ = ("RunIdentity", "is_valid_correlation_id", "validate_correlation_id")
+__all__ = (
+    "LIFECYCLE_TRANSITIONS",
+    "SIGNAL_DESTINATIONS",
+    "SIGNAL_SOURCE_STATES",
+    "LifecycleSignal",
+    "LifecycleSignalType",
+    "LifecycleSnapshot",
+    "LifecycleState",
+    "RunIdentity",
+    "StructuredTerminalResult",
+    "apply_lifecycle_signal",
+    "initialize_lifecycle_snapshot",
+    "is_valid_correlation_id",
+    "lifecycle_signal_fingerprint",
+    "validate_correlation_id",
+)

--- a/orchestra_runtime/domain/execution/lifecycle.py
+++ b/orchestra_runtime/domain/execution/lifecycle.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from hashlib import sha256
+import json
+import re
+from types import MappingProxyType
+
+from ...shared.errors import (
+    ConflictingTerminalSignalError,
+    InvalidLifecycleSignalError,
+    InvalidLifecycleTransitionError,
+)
+from ..governance.authority import AuthorityProvenance
+from .identity import RunIdentity
+
+
+class LifecycleState(str, Enum):
+    INITIALIZING = "INITIALIZING"
+    ACTIVE = "ACTIVE"
+    WAITING = "WAITING"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+    CANCELLED = "CANCELLED"
+    TIMED_OUT = "TIMED_OUT"
+    BLOCKED = "BLOCKED"
+
+    @property
+    def terminal(self) -> bool:
+        return self in {
+            LifecycleState.COMPLETED,
+            LifecycleState.FAILED,
+            LifecycleState.CANCELLED,
+            LifecycleState.TIMED_OUT,
+            LifecycleState.BLOCKED,
+        }
+
+
+class LifecycleSignalType(str, Enum):
+    ACTIVATE = "ACTIVATE"
+    WAIT = "WAIT"
+    RESUME = "RESUME"
+    COMPLETE = "COMPLETE"
+    FAIL = "FAIL"
+    CANCEL = "CANCEL"
+    TIME_OUT = "TIME_OUT"
+    BLOCK = "BLOCK"
+
+
+SIGNAL_DESTINATIONS = MappingProxyType({
+    LifecycleSignalType.ACTIVATE: LifecycleState.ACTIVE,
+    LifecycleSignalType.WAIT: LifecycleState.WAITING,
+    LifecycleSignalType.RESUME: LifecycleState.ACTIVE,
+    LifecycleSignalType.COMPLETE: LifecycleState.COMPLETED,
+    LifecycleSignalType.FAIL: LifecycleState.FAILED,
+    LifecycleSignalType.CANCEL: LifecycleState.CANCELLED,
+    LifecycleSignalType.TIME_OUT: LifecycleState.TIMED_OUT,
+    LifecycleSignalType.BLOCK: LifecycleState.BLOCKED,
+})
+
+SIGNAL_SOURCE_STATES = MappingProxyType({
+    LifecycleSignalType.ACTIVATE: LifecycleState.INITIALIZING,
+    LifecycleSignalType.WAIT: LifecycleState.ACTIVE,
+    LifecycleSignalType.RESUME: LifecycleState.WAITING,
+})
+
+LIFECYCLE_TRANSITIONS = MappingProxyType(
+    {
+        LifecycleState.INITIALIZING: frozenset(
+            {
+                LifecycleState.ACTIVE,
+                LifecycleState.FAILED,
+                LifecycleState.CANCELLED,
+                LifecycleState.TIMED_OUT,
+                LifecycleState.BLOCKED,
+            }
+        ),
+        LifecycleState.ACTIVE: frozenset(
+            {
+                LifecycleState.WAITING,
+                LifecycleState.COMPLETED,
+                LifecycleState.FAILED,
+                LifecycleState.CANCELLED,
+                LifecycleState.TIMED_OUT,
+                LifecycleState.BLOCKED,
+            }
+        ),
+        LifecycleState.WAITING: frozenset(
+            {
+                LifecycleState.ACTIVE,
+                LifecycleState.FAILED,
+                LifecycleState.CANCELLED,
+                LifecycleState.TIMED_OUT,
+                LifecycleState.BLOCKED,
+            }
+        ),
+        LifecycleState.COMPLETED: frozenset(),
+        LifecycleState.FAILED: frozenset(),
+        LifecycleState.CANCELLED: frozenset(),
+        LifecycleState.TIMED_OUT: frozenset(),
+        LifecycleState.BLOCKED: frozenset(),
+    }
+)
+
+FINGERPRINT_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _text(value: object, field_name: str) -> str:
+    text = "" if value is None else str(value).strip()
+    if not text:
+        raise InvalidLifecycleSignalError(
+            f"{field_name} must be non-empty",
+            "INVALID_SIGNAL",
+            {"field": field_name},
+        )
+    return text
+
+
+@dataclass(frozen=True, slots=True)
+class StructuredTerminalResult:
+    run_id: str
+    state: LifecycleState
+    reason_code: str
+    output: str = ""
+    evidence_refs: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        state = LifecycleState(self.state)
+        if not state.terminal:
+            raise InvalidLifecycleSignalError("terminal result requires terminal state", "INVALID_TERMINAL_RESULT")
+        object.__setattr__(self, "run_id", _text(self.run_id, "run_id"))
+        object.__setattr__(self, "state", state)
+        object.__setattr__(self, "reason_code", _text(self.reason_code, "reason_code"))
+        object.__setattr__(self, "output", str(self.output))
+        object.__setattr__(self, "evidence_refs", tuple(sorted({_text(item, "evidence_ref") for item in self.evidence_refs})))
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "run_id": self.run_id,
+            "state": self.state.value,
+            "reason_code": self.reason_code,
+            "output": self.output,
+            "evidence_refs": list(self.evidence_refs),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class LifecycleSignal:
+    signal_id: str
+    run_id: str
+    signal_type: LifecycleSignalType
+    expected_state: LifecycleState
+    requested_state: LifecycleState
+    reason_code: str
+    source_component: str
+    provenance: AuthorityProvenance
+    evidence_refs: tuple[str, ...] = ()
+    terminal_result: StructuredTerminalResult | None = None
+
+    def __post_init__(self) -> None:
+        signal_type = LifecycleSignalType(self.signal_type)
+        expected_state = LifecycleState(self.expected_state)
+        requested_state = LifecycleState(self.requested_state)
+        run_id = _text(self.run_id, "run_id")
+        if SIGNAL_DESTINATIONS[signal_type] is not requested_state:
+            raise InvalidLifecycleSignalError(
+                "signal type does not match requested state",
+                "STATE_SIGNAL_MISMATCH",
+                {"signal_type": signal_type.value, "requested_state": requested_state.value},
+            )
+        if requested_state.terminal:
+            if self.terminal_result is None or self.terminal_result.run_id != run_id or self.terminal_result.state is not requested_state:
+                raise InvalidLifecycleSignalError("terminal signal requires matching terminal result", "INVALID_TERMINAL_RESULT")
+        elif self.terminal_result is not None:
+            raise InvalidLifecycleSignalError("non-terminal signal cannot carry terminal result", "INVALID_TERMINAL_RESULT")
+        object.__setattr__(self, "signal_id", _text(self.signal_id, "signal_id"))
+        object.__setattr__(self, "run_id", run_id)
+        object.__setattr__(self, "signal_type", signal_type)
+        object.__setattr__(self, "expected_state", expected_state)
+        object.__setattr__(self, "requested_state", requested_state)
+        object.__setattr__(self, "reason_code", _text(self.reason_code, "reason_code"))
+        object.__setattr__(self, "source_component", _text(self.source_component, "source_component"))
+        object.__setattr__(self, "evidence_refs", tuple(sorted({_text(item, "evidence_ref") for item in self.evidence_refs})))
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "signal_id": self.signal_id,
+            "run_id": self.run_id,
+            "signal_type": self.signal_type.value,
+            "expected_state": self.expected_state.value,
+            "requested_state": self.requested_state.value,
+            "reason_code": self.reason_code,
+            "source_component": self.source_component,
+            "provenance": self.provenance.to_dict(),
+            "evidence_refs": list(self.evidence_refs),
+            "terminal_result": self.terminal_result.to_dict() if self.terminal_result else None,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class LifecycleSnapshot:
+    run_identity: RunIdentity
+    state: LifecycleState
+    last_signal_id: str | None = None
+    terminal_result: StructuredTerminalResult | None = None
+    accepted_signal_fingerprint: str | None = None
+
+    def __post_init__(self) -> None:
+        state = LifecycleState(self.state)
+        last_signal_id = self.last_signal_id.strip() if self.last_signal_id else None
+        fingerprint = self.accepted_signal_fingerprint.strip() if self.accepted_signal_fingerprint else None
+        if bool(last_signal_id) != bool(fingerprint) or (fingerprint and not FINGERPRINT_PATTERN.fullmatch(fingerprint)):
+            raise InvalidLifecycleSignalError(
+                "accepted signal identity requires a deterministic fingerprint",
+                "INVALID_SIGNAL_IDENTITY",
+            )
+        if state.terminal:
+            if self.terminal_result is None or self.terminal_result.run_id != self.run_identity.run_id or self.terminal_result.state is not state:
+                raise InvalidLifecycleSignalError("terminal snapshot requires matching result", "INVALID_TERMINAL_RESULT")
+            if last_signal_id is None:
+                raise InvalidLifecycleSignalError("terminal snapshot requires accepted signal identity", "INVALID_SIGNAL_IDENTITY")
+        elif self.terminal_result is not None:
+            raise InvalidLifecycleSignalError("non-terminal snapshot cannot carry terminal result", "INVALID_TERMINAL_RESULT")
+        object.__setattr__(self, "state", state)
+        object.__setattr__(self, "last_signal_id", last_signal_id)
+        object.__setattr__(self, "accepted_signal_fingerprint", fingerprint)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "run_identity": self.run_identity.to_dict(),
+            "state": self.state.value,
+            "last_signal_id": self.last_signal_id,
+            "terminal_result": self.terminal_result.to_dict() if self.terminal_result else None,
+            "accepted_signal_fingerprint": self.accepted_signal_fingerprint,
+        }
+
+
+def lifecycle_signal_fingerprint(signal: LifecycleSignal) -> str:
+    return sha256(
+        json.dumps(signal.to_dict(), sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+    ).hexdigest()
+
+
+def initialize_lifecycle_snapshot(run_id: str, correlation_id: str | None = None) -> LifecycleSnapshot:
+    return LifecycleSnapshot(
+        RunIdentity(_text(run_id, "run_id"), correlation_id=correlation_id),
+        LifecycleState.INITIALIZING,
+    )
+
+
+def apply_lifecycle_signal(snapshot: LifecycleSnapshot, signal: object) -> LifecycleSnapshot:
+    if not isinstance(signal, LifecycleSignal):
+        raise InvalidLifecycleSignalError("lifecycle input must be a structured signal", "INVALID_SIGNAL")
+    if signal.run_id != snapshot.run_identity.run_id:
+        raise InvalidLifecycleSignalError(
+            "signal run_id does not match lifecycle snapshot",
+            "RUN_ID_MISMATCH",
+            {"run_id": signal.run_id},
+        )
+    fingerprint = lifecycle_signal_fingerprint(signal)
+    if snapshot.state.terminal:
+        if signal.requested_state.terminal:
+            if signal.signal_id == snapshot.last_signal_id and fingerprint == snapshot.accepted_signal_fingerprint:
+                return snapshot
+            raise ConflictingTerminalSignalError(
+                "terminal signal conflicts with accepted terminal result",
+                "CONFLICTING_TERMINAL_SIGNAL",
+                {"signal_id": signal.signal_id},
+            )
+        raise InvalidLifecycleTransitionError(
+            "terminal lifecycle state cannot transition",
+            "TERMINAL_STATE",
+            {"state": snapshot.state.value},
+        )
+    if signal.expected_state is not snapshot.state:
+        raise InvalidLifecycleSignalError(
+            "signal expected state does not match lifecycle snapshot",
+            "EXPECTED_STATE_MISMATCH",
+            {"expected_state": signal.expected_state.value, "state": snapshot.state.value},
+        )
+    if signal.requested_state not in LIFECYCLE_TRANSITIONS[snapshot.state]:
+        raise InvalidLifecycleTransitionError(
+            "lifecycle transition is not allowed",
+            "INVALID_TRANSITION",
+            {"from_state": snapshot.state.value, "to_state": signal.requested_state.value},
+        )
+    required_state = SIGNAL_SOURCE_STATES.get(signal.signal_type)
+    if required_state is not None and snapshot.state is not required_state:
+        raise InvalidLifecycleSignalError(
+            "lifecycle signal is invalid for the current source state",
+            "INVALID_SIGNAL_SOURCE_STATE",
+            {
+                "signal_type": signal.signal_type.value,
+                "current_state": snapshot.state.value,
+                "required_state": required_state.value,
+            },
+        )
+    return LifecycleSnapshot(
+        snapshot.run_identity,
+        signal.requested_state,
+        signal.signal_id,
+        signal.terminal_result,
+        fingerprint,
+    )

--- a/orchestra_runtime/lifecycle.py
+++ b/orchestra_runtime/lifecycle.py
@@ -1,13 +1,23 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from enum import Enum
 from hashlib import sha256
 import json
-import re
-from types import MappingProxyType
 
 from .authority import AuthorityProvenance
+from .domain.execution.lifecycle import (
+    FINGERPRINT_PATTERN,
+    LIFECYCLE_TRANSITIONS,
+    SIGNAL_DESTINATIONS,
+    SIGNAL_SOURCE_STATES,
+    LifecycleSignal,
+    LifecycleSignalType,
+    LifecycleSnapshot,
+    LifecycleState,
+    StructuredTerminalResult,
+    apply_lifecycle_signal,
+    initialize_lifecycle_snapshot,
+    lifecycle_signal_fingerprint,
+)
 from .errors import (
     ConflictingTerminalSignalError,
     InvalidLifecycleSignalError,
@@ -18,298 +28,17 @@ from .interfaces import ILifecycleController
 from .models import AuditEventType, RunIdentity, RuntimeAuditEvent
 
 
-class LifecycleState(str, Enum):
-    INITIALIZING = "INITIALIZING"
-    ACTIVE = "ACTIVE"
-    WAITING = "WAITING"
-    COMPLETED = "COMPLETED"
-    FAILED = "FAILED"
-    CANCELLED = "CANCELLED"
-    TIMED_OUT = "TIMED_OUT"
-    BLOCKED = "BLOCKED"
-
-    @property
-    def terminal(self) -> bool:
-        return self in {
-            LifecycleState.COMPLETED,
-            LifecycleState.FAILED,
-            LifecycleState.CANCELLED,
-            LifecycleState.TIMED_OUT,
-            LifecycleState.BLOCKED,
-        }
-
-
-class LifecycleSignalType(str, Enum):
-    ACTIVATE = "ACTIVATE"
-    WAIT = "WAIT"
-    RESUME = "RESUME"
-    COMPLETE = "COMPLETE"
-    FAIL = "FAIL"
-    CANCEL = "CANCEL"
-    TIME_OUT = "TIME_OUT"
-    BLOCK = "BLOCK"
-
-
-SIGNAL_DESTINATIONS = MappingProxyType({
-    LifecycleSignalType.ACTIVATE: LifecycleState.ACTIVE,
-    LifecycleSignalType.WAIT: LifecycleState.WAITING,
-    LifecycleSignalType.RESUME: LifecycleState.ACTIVE,
-    LifecycleSignalType.COMPLETE: LifecycleState.COMPLETED,
-    LifecycleSignalType.FAIL: LifecycleState.FAILED,
-    LifecycleSignalType.CANCEL: LifecycleState.CANCELLED,
-    LifecycleSignalType.TIME_OUT: LifecycleState.TIMED_OUT,
-    LifecycleSignalType.BLOCK: LifecycleState.BLOCKED,
-})
-
-SIGNAL_SOURCE_STATES = MappingProxyType({
-    LifecycleSignalType.ACTIVATE: LifecycleState.INITIALIZING,
-    LifecycleSignalType.WAIT: LifecycleState.ACTIVE,
-    LifecycleSignalType.RESUME: LifecycleState.WAITING,
-})
-
-LIFECYCLE_TRANSITIONS = MappingProxyType(
-    {
-        LifecycleState.INITIALIZING: frozenset(
-            {
-                LifecycleState.ACTIVE,
-                LifecycleState.FAILED,
-                LifecycleState.CANCELLED,
-                LifecycleState.TIMED_OUT,
-                LifecycleState.BLOCKED,
-            }
-        ),
-        LifecycleState.ACTIVE: frozenset(
-            {
-                LifecycleState.WAITING,
-                LifecycleState.COMPLETED,
-                LifecycleState.FAILED,
-                LifecycleState.CANCELLED,
-                LifecycleState.TIMED_OUT,
-                LifecycleState.BLOCKED,
-            }
-        ),
-        LifecycleState.WAITING: frozenset(
-            {
-                LifecycleState.ACTIVE,
-                LifecycleState.FAILED,
-                LifecycleState.CANCELLED,
-                LifecycleState.TIMED_OUT,
-                LifecycleState.BLOCKED,
-            }
-        ),
-        LifecycleState.COMPLETED: frozenset(),
-        LifecycleState.FAILED: frozenset(),
-        LifecycleState.CANCELLED: frozenset(),
-        LifecycleState.TIMED_OUT: frozenset(),
-        LifecycleState.BLOCKED: frozenset(),
-    }
-)
-
-FINGERPRINT_PATTERN = re.compile(r"^[0-9a-f]{64}$")
-
-
 def _stable_id(prefix: str, payload: object) -> str:
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
     return f"{prefix}.{sha256(encoded).hexdigest()[:24]}"
 
 
-def _text(value: object, field_name: str) -> str:
-    text = "" if value is None else str(value).strip()
-    if not text:
-        raise InvalidLifecycleSignalError(
-            f"{field_name} must be non-empty",
-            "INVALID_SIGNAL",
-            {"field": field_name},
-        )
-    return text
-
-
-@dataclass(frozen=True, slots=True)
-class StructuredTerminalResult:
-    run_id: str
-    state: LifecycleState
-    reason_code: str
-    output: str = ""
-    evidence_refs: tuple[str, ...] = ()
-
-    def __post_init__(self) -> None:
-        state = LifecycleState(self.state)
-        if not state.terminal:
-            raise InvalidLifecycleSignalError("terminal result requires terminal state", "INVALID_TERMINAL_RESULT")
-        object.__setattr__(self, "run_id", _text(self.run_id, "run_id"))
-        object.__setattr__(self, "state", state)
-        object.__setattr__(self, "reason_code", _text(self.reason_code, "reason_code"))
-        object.__setattr__(self, "output", str(self.output))
-        object.__setattr__(self, "evidence_refs", tuple(sorted({_text(item, "evidence_ref") for item in self.evidence_refs})))
-
-    def to_dict(self) -> dict[str, object]:
-        return {
-            "run_id": self.run_id,
-            "state": self.state.value,
-            "reason_code": self.reason_code,
-            "output": self.output,
-            "evidence_refs": list(self.evidence_refs),
-        }
-
-
-@dataclass(frozen=True, slots=True)
-class LifecycleSignal:
-    signal_id: str
-    run_id: str
-    signal_type: LifecycleSignalType
-    expected_state: LifecycleState
-    requested_state: LifecycleState
-    reason_code: str
-    source_component: str
-    provenance: AuthorityProvenance
-    evidence_refs: tuple[str, ...] = ()
-    terminal_result: StructuredTerminalResult | None = None
-
-    def __post_init__(self) -> None:
-        signal_type = LifecycleSignalType(self.signal_type)
-        expected_state = LifecycleState(self.expected_state)
-        requested_state = LifecycleState(self.requested_state)
-        run_id = _text(self.run_id, "run_id")
-        if SIGNAL_DESTINATIONS[signal_type] is not requested_state:
-            raise InvalidLifecycleSignalError(
-                "signal type does not match requested state",
-                "STATE_SIGNAL_MISMATCH",
-                {"signal_type": signal_type.value, "requested_state": requested_state.value},
-            )
-        if requested_state.terminal:
-            if self.terminal_result is None or self.terminal_result.run_id != run_id or self.terminal_result.state is not requested_state:
-                raise InvalidLifecycleSignalError("terminal signal requires matching terminal result", "INVALID_TERMINAL_RESULT")
-        elif self.terminal_result is not None:
-            raise InvalidLifecycleSignalError("non-terminal signal cannot carry terminal result", "INVALID_TERMINAL_RESULT")
-        object.__setattr__(self, "signal_id", _text(self.signal_id, "signal_id"))
-        object.__setattr__(self, "run_id", run_id)
-        object.__setattr__(self, "signal_type", signal_type)
-        object.__setattr__(self, "expected_state", expected_state)
-        object.__setattr__(self, "requested_state", requested_state)
-        object.__setattr__(self, "reason_code", _text(self.reason_code, "reason_code"))
-        object.__setattr__(self, "source_component", _text(self.source_component, "source_component"))
-        object.__setattr__(self, "evidence_refs", tuple(sorted({_text(item, "evidence_ref") for item in self.evidence_refs})))
-
-    def to_dict(self) -> dict[str, object]:
-        return {
-            "signal_id": self.signal_id,
-            "run_id": self.run_id,
-            "signal_type": self.signal_type.value,
-            "expected_state": self.expected_state.value,
-            "requested_state": self.requested_state.value,
-            "reason_code": self.reason_code,
-            "source_component": self.source_component,
-            "provenance": self.provenance.to_dict(),
-            "evidence_refs": list(self.evidence_refs),
-            "terminal_result": self.terminal_result.to_dict() if self.terminal_result else None,
-        }
-
-
-@dataclass(frozen=True, slots=True)
-class LifecycleSnapshot:
-    run_identity: RunIdentity
-    state: LifecycleState
-    last_signal_id: str | None = None
-    terminal_result: StructuredTerminalResult | None = None
-    accepted_signal_fingerprint: str | None = None
-
-    def __post_init__(self) -> None:
-        state = LifecycleState(self.state)
-        last_signal_id = self.last_signal_id.strip() if self.last_signal_id else None
-        fingerprint = self.accepted_signal_fingerprint.strip() if self.accepted_signal_fingerprint else None
-        if bool(last_signal_id) != bool(fingerprint) or (fingerprint and not FINGERPRINT_PATTERN.fullmatch(fingerprint)):
-            raise InvalidLifecycleSignalError(
-                "accepted signal identity requires a deterministic fingerprint",
-                "INVALID_SIGNAL_IDENTITY",
-            )
-        if state.terminal:
-            if self.terminal_result is None or self.terminal_result.run_id != self.run_identity.run_id or self.terminal_result.state is not state:
-                raise InvalidLifecycleSignalError("terminal snapshot requires matching result", "INVALID_TERMINAL_RESULT")
-            if last_signal_id is None:
-                raise InvalidLifecycleSignalError("terminal snapshot requires accepted signal identity", "INVALID_SIGNAL_IDENTITY")
-        elif self.terminal_result is not None:
-            raise InvalidLifecycleSignalError("non-terminal snapshot cannot carry terminal result", "INVALID_TERMINAL_RESULT")
-        object.__setattr__(self, "state", state)
-        object.__setattr__(self, "last_signal_id", last_signal_id)
-        object.__setattr__(self, "accepted_signal_fingerprint", fingerprint)
-
-    def to_dict(self) -> dict[str, object]:
-        return {
-            "run_identity": self.run_identity.to_dict(),
-            "state": self.state.value,
-            "last_signal_id": self.last_signal_id,
-            "terminal_result": self.terminal_result.to_dict() if self.terminal_result else None,
-            "accepted_signal_fingerprint": self.accepted_signal_fingerprint,
-        }
-
-
-def lifecycle_signal_fingerprint(signal: LifecycleSignal) -> str:
-    return sha256(
-        json.dumps(signal.to_dict(), sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
-    ).hexdigest()
-
-
 class LifecycleController(ILifecycleController):
     def initialize(self, run_id: str, correlation_id: str | None = None) -> LifecycleSnapshot:
-        return LifecycleSnapshot(
-            RunIdentity(_text(run_id, "run_id"), correlation_id=correlation_id),
-            LifecycleState.INITIALIZING,
-        )
+        return initialize_lifecycle_snapshot(run_id, correlation_id)
 
     def apply(self, snapshot: LifecycleSnapshot, signal: object) -> LifecycleSnapshot:
-        if not isinstance(signal, LifecycleSignal):
-            raise InvalidLifecycleSignalError("lifecycle input must be a structured signal", "INVALID_SIGNAL")
-        if signal.run_id != snapshot.run_identity.run_id:
-            raise InvalidLifecycleSignalError(
-                "signal run_id does not match lifecycle snapshot",
-                "RUN_ID_MISMATCH",
-                {"run_id": signal.run_id},
-            )
-        fingerprint = lifecycle_signal_fingerprint(signal)
-        if snapshot.state.terminal:
-            if signal.requested_state.terminal:
-                if signal.signal_id == snapshot.last_signal_id and fingerprint == snapshot.accepted_signal_fingerprint:
-                    return snapshot
-                raise ConflictingTerminalSignalError(
-                    "terminal signal conflicts with accepted terminal result",
-                    "CONFLICTING_TERMINAL_SIGNAL",
-                    {"signal_id": signal.signal_id},
-                )
-            raise InvalidLifecycleTransitionError(
-                "terminal lifecycle state cannot transition",
-                "TERMINAL_STATE",
-                {"state": snapshot.state.value},
-            )
-        if signal.expected_state is not snapshot.state:
-            raise InvalidLifecycleSignalError(
-                "signal expected state does not match lifecycle snapshot",
-                "EXPECTED_STATE_MISMATCH",
-                {"expected_state": signal.expected_state.value, "state": snapshot.state.value},
-            )
-        if signal.requested_state not in LIFECYCLE_TRANSITIONS[snapshot.state]:
-            raise InvalidLifecycleTransitionError(
-                "lifecycle transition is not allowed",
-                "INVALID_TRANSITION",
-                {"from_state": snapshot.state.value, "to_state": signal.requested_state.value},
-            )
-        required_state = SIGNAL_SOURCE_STATES.get(signal.signal_type)
-        if required_state is not None and snapshot.state is not required_state:
-            raise InvalidLifecycleSignalError(
-                "lifecycle signal is invalid for the current source state",
-                "INVALID_SIGNAL_SOURCE_STATE",
-                {
-                    "signal_type": signal.signal_type.value,
-                    "current_state": snapshot.state.value,
-                    "required_state": required_state.value,
-                },
-            )
-        return LifecycleSnapshot(
-            snapshot.run_identity,
-            signal.requested_state,
-            signal.signal_id,
-            signal.terminal_result,
-            fingerprint,
-        )
+        return apply_lifecycle_signal(snapshot, signal)
 
     def terminal_result(self, snapshot: LifecycleSnapshot) -> StructuredTerminalResult | None:
         return snapshot.terminal_result

--- a/tests/runtime/test_domain_execution_lifecycle.py
+++ b/tests/runtime/test_domain_execution_lifecycle.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+import orchestra_runtime.lifecycle as legacy_lifecycle
+from orchestra_runtime import (
+    LifecycleSignal as public_lifecycle_signal,
+    LifecycleSignalType as public_lifecycle_signal_type,
+    LifecycleSnapshot as public_lifecycle_snapshot,
+    LifecycleState as public_lifecycle_state,
+    StructuredTerminalResult as public_terminal_result,
+)
+from orchestra_runtime.domain.execution import lifecycle as domain_lifecycle
+from orchestra_runtime.domain.governance.authority import AuthorityProvenance, ProvenanceSource
+from orchestra_runtime.shared.errors import (
+    ConflictingTerminalSignalError,
+    InvalidLifecycleSignalError,
+    InvalidLifecycleTransitionError,
+)
+
+
+def _provenance() -> AuthorityProvenance:
+    return AuthorityProvenance(ProvenanceSource.TRUSTED_COMPOSITION, "runtime.policy", "1", "runtime")
+
+
+def _signal(
+    signal_id: str,
+    signal_type: domain_lifecycle.LifecycleSignalType,
+    expected: domain_lifecycle.LifecycleState,
+    requested: domain_lifecycle.LifecycleState,
+    *,
+    output: str = "",
+) -> domain_lifecycle.LifecycleSignal:
+    terminal = (
+        domain_lifecycle.StructuredTerminalResult("run-1", requested, requested.value, output)
+        if requested.terminal
+        else None
+    )
+    return domain_lifecycle.LifecycleSignal(
+        signal_id,
+        "run-1",
+        signal_type,
+        expected,
+        requested,
+        requested.value,
+        "runtime",
+        _provenance(),
+        terminal_result=terminal,
+    )
+
+
+def test_domain_lifecycle_exports_are_legacy_and_public_identity_compatible() -> None:
+    assert legacy_lifecycle.LifecycleState is domain_lifecycle.LifecycleState
+    assert legacy_lifecycle.LifecycleSignalType is domain_lifecycle.LifecycleSignalType
+    assert legacy_lifecycle.LifecycleSignal is domain_lifecycle.LifecycleSignal
+    assert legacy_lifecycle.LifecycleSnapshot is domain_lifecycle.LifecycleSnapshot
+    assert legacy_lifecycle.StructuredTerminalResult is domain_lifecycle.StructuredTerminalResult
+    assert legacy_lifecycle.LIFECYCLE_TRANSITIONS is domain_lifecycle.LIFECYCLE_TRANSITIONS
+    assert legacy_lifecycle.lifecycle_signal_fingerprint is domain_lifecycle.lifecycle_signal_fingerprint
+    assert public_lifecycle_state is domain_lifecycle.LifecycleState
+    assert public_lifecycle_signal_type is domain_lifecycle.LifecycleSignalType
+    assert public_lifecycle_signal is domain_lifecycle.LifecycleSignal
+    assert public_lifecycle_snapshot is domain_lifecycle.LifecycleSnapshot
+    assert public_terminal_result is domain_lifecycle.StructuredTerminalResult
+
+
+def test_domain_lifecycle_initialization_wait_resume_and_terminal_transition() -> None:
+    initial = domain_lifecycle.initialize_lifecycle_snapshot("  run-1  ")
+    activate = _signal(
+        "activate-1",
+        domain_lifecycle.LifecycleSignalType.ACTIVATE,
+        domain_lifecycle.LifecycleState.INITIALIZING,
+        domain_lifecycle.LifecycleState.ACTIVE,
+    )
+    active = domain_lifecycle.apply_lifecycle_signal(initial, activate)
+    waiting = domain_lifecycle.apply_lifecycle_signal(
+        active,
+        _signal(
+            "wait-1",
+            domain_lifecycle.LifecycleSignalType.WAIT,
+            domain_lifecycle.LifecycleState.ACTIVE,
+            domain_lifecycle.LifecycleState.WAITING,
+        ),
+    )
+    resumed = domain_lifecycle.apply_lifecycle_signal(
+        waiting,
+        _signal(
+            "resume-1",
+            domain_lifecycle.LifecycleSignalType.RESUME,
+            domain_lifecycle.LifecycleState.WAITING,
+            domain_lifecycle.LifecycleState.ACTIVE,
+        ),
+    )
+    complete = _signal(
+        "complete-1",
+        domain_lifecycle.LifecycleSignalType.COMPLETE,
+        domain_lifecycle.LifecycleState.ACTIVE,
+        domain_lifecycle.LifecycleState.COMPLETED,
+        output="done",
+    )
+    completed = domain_lifecycle.apply_lifecycle_signal(resumed, complete)
+
+    assert initial.run_identity.run_id == "run-1"
+    assert active.state is domain_lifecycle.LifecycleState.ACTIVE
+    assert waiting.state is domain_lifecycle.LifecycleState.WAITING
+    assert resumed.state is domain_lifecycle.LifecycleState.ACTIVE
+    assert completed.state is domain_lifecycle.LifecycleState.COMPLETED
+    assert completed.terminal_result is not None
+    assert completed.terminal_result.output == "done"
+    assert completed.accepted_signal_fingerprint == domain_lifecycle.lifecycle_signal_fingerprint(complete)
+
+
+def test_domain_lifecycle_preserves_fail_closed_transition_and_replay_semantics() -> None:
+    initial = domain_lifecycle.initialize_lifecycle_snapshot("run-1")
+    activate = _signal(
+        "activate-1",
+        domain_lifecycle.LifecycleSignalType.ACTIVATE,
+        domain_lifecycle.LifecycleState.INITIALIZING,
+        domain_lifecycle.LifecycleState.ACTIVE,
+    )
+    active = domain_lifecycle.apply_lifecycle_signal(initial, activate)
+    complete = _signal(
+        "complete-1",
+        domain_lifecycle.LifecycleSignalType.COMPLETE,
+        domain_lifecycle.LifecycleState.ACTIVE,
+        domain_lifecycle.LifecycleState.COMPLETED,
+        output="first",
+    )
+    completed = domain_lifecycle.apply_lifecycle_signal(active, complete)
+
+    assert domain_lifecycle.apply_lifecycle_signal(completed, complete) is completed
+    with pytest.raises(ConflictingTerminalSignalError):
+        domain_lifecycle.apply_lifecycle_signal(
+            completed,
+            _signal(
+                "complete-1",
+                domain_lifecycle.LifecycleSignalType.COMPLETE,
+                domain_lifecycle.LifecycleState.ACTIVE,
+                domain_lifecycle.LifecycleState.COMPLETED,
+                output="changed",
+            ),
+        )
+    with pytest.raises(InvalidLifecycleTransitionError, match="terminal"):
+        domain_lifecycle.apply_lifecycle_signal(
+            completed,
+            _signal(
+                "wait-after",
+                domain_lifecycle.LifecycleSignalType.WAIT,
+                domain_lifecycle.LifecycleState.COMPLETED,
+                domain_lifecycle.LifecycleState.WAITING,
+            ),
+        )
+    with pytest.raises(InvalidLifecycleSignalError, match="structured"):
+        domain_lifecycle.apply_lifecycle_signal(initial, "ACTIVE")
+    with pytest.raises(InvalidLifecycleSignalError, match="expected state"):
+        domain_lifecycle.apply_lifecycle_signal(
+            initial,
+            _signal(
+                "complete-early",
+                domain_lifecycle.LifecycleSignalType.COMPLETE,
+                domain_lifecycle.LifecycleState.ACTIVE,
+                domain_lifecycle.LifecycleState.COMPLETED,
+            ),
+        )
+
+
+def test_legacy_controller_delegates_to_domain_lifecycle_functions(monkeypatch: pytest.MonkeyPatch) -> None:
+    initialized = domain_lifecycle.initialize_lifecycle_snapshot("run-1")
+    applied = domain_lifecycle.LifecycleSnapshot(initialized.run_identity, domain_lifecycle.LifecycleState.ACTIVE)
+    calls: list[tuple[str, object]] = []
+
+    def fake_initialize(run_id: str, correlation_id: str | None = None):
+        calls.append(("initialize", (run_id, correlation_id)))
+        return initialized
+
+    def fake_apply(snapshot, signal):
+        calls.append(("apply", (snapshot, signal)))
+        return applied
+
+    monkeypatch.setattr(legacy_lifecycle, "initialize_lifecycle_snapshot", fake_initialize)
+    monkeypatch.setattr(legacy_lifecycle, "apply_lifecycle_signal", fake_apply)
+
+    controller = legacy_lifecycle.LifecycleController()
+    assert controller.initialize("run-1") is initialized
+    assert controller.apply(initialized, object()) is applied
+    assert calls[0] == ("initialize", ("run-1", None))
+    assert calls[1][0] == "apply"
+
+
+def test_domain_lifecycle_is_pure_and_legacy_free() -> None:
+    source_path = Path(domain_lifecycle.__file__)
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    imports: set[str] = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module)
+
+    forbidden = {
+        "pathlib",
+        "os",
+        "subprocess",
+        "socket",
+        "sqlite3",
+        "orchestra_runtime.lifecycle",
+        "orchestra_runtime.interfaces",
+        "orchestra_runtime.models",
+        "orchestra_runtime.services",
+        "orchestra_runtime.infrastructure",
+        "orchestra_runtime.application",
+        "orchestra_runtime.entrypoints",
+    }
+    assert not imports.intersection(forbidden)
+    assert not any(isinstance(node, ast.Name) and node.id == "open" for node in ast.walk(tree))


### PR DESCRIPTION
## Scope

Extract deterministic execution lifecycle semantics inward under AR-2 while preserving the existing runtime and public compatibility surface.

Included:
- add `orchestra_runtime.domain.execution.lifecycle` for lifecycle state, signal, snapshot, terminal-result, fingerprint, initialization, and transition semantics;
- re-export the same lifecycle value objects through `orchestra_runtime.lifecycle` and existing top-level exports;
- keep `LifecycleController(ILifecycleController)` and runtime audit-event projection on the transitional legacy surface for later AR-3/AR-4 placement;
- add focused compatibility, transition/replay, fail-closed, controller-delegation, and import-purity coverage;
- add detailed extraction documentation and `README.json` machine-discovery parity.

No provider/MCP/runtime policy behavior, audit-event semantics, public import retirement, release/deployment/policy authority, branch deletion, force push, or history rewrite. AR-2 remains active. AR-3 has not started.

Canonical base at branch creation: `a451bca21b3a9d8c470ff357daec59fddd335ff1`.