### PR TITLE
fix(governance): correct OR-GOV-10 closeout records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Post-closeout OR-GOV record erratum candidate
+
+- Corrects post-closeout OR-GOV record inaccuracies without reopening the completed governance program or creating OR-GOV-11.
+- Restores canonical historical phase ledger in `docs/governance/or_gov_10_integration_closeout_disposition.v1.json` (OR-GOV-1 = Shared Machine Contracts and Schemas, OR-GOV-2 = The Steward, OR-GOV-3 = Clockwork; Scribe SSU recorded as separate initiative).
+- Corrects `ArchitectureGovernanceIntake.change_materiality` terminology in `docs/governance/OR_GOV_10_INTEGRATION_CLOSEOUT.md` to canonical enum (`TRIVIAL`, `STANDARD`, `ARCHITECTURAL`, `PRODUCTION_CRITICAL`), removing uncanonical `ISOLATED_REFACTOR` and `MULTI_SUBSYSTEM`.
+- Restores complete canonical `ArchitectureValidationContract` proof-state set (`PROVEN`, `NOT_PROVEN`, `NOT_REQUIRED`, `FAILED`) in closeout documentation.
+- Extends `tests/behavior/test_or_gov_10_e2e_integration_closeout.py` (22/22 PASS) covering all seven canonical machine contracts, enum regressions, document accuracy, phase ledger mapping, and status preservation.
+- Preserves OR-GOV completion state (`OR_GOV_PROGRAM_COMPLETE`), runtime behavior, frozen guidance, release hold (`v1.7.0`), and AR-3 boundary (`NOT_STARTED`).
+
 ## Post-v1.7 OR-GOV-10 final integration, parity, full regression, and program closeout candidate
 
 - Concludes the Orchestra Architecture & Governance Hardening Program (OR-GOV-1 through OR-GOV-10).

--- a/docs/governance/OR_GOV_10_INTEGRATION_CLOSEOUT.md
+++ b/docs/governance/OR_GOV_10_INTEGRATION_CLOSEOUT.md
@@ -31,15 +31,37 @@ All canonical architecture and governance contracts across the program were veri
 | :--- | :--- | :--- | :--- |
 | `CapacityEnvelope` | `machine/schemas/capacity-envelope.v1.schema.json` | The Steward | Volume, throughput, burst ratios; preserves `UNKNOWN` and `NOT_APPLICABLE` without fabricated metrics. |
 | `ProductIntentContract` | `machine/schemas/product-intent-contract.v1.schema.json` | The Steward | Product goals, problem statements, requirements traceability; gates architectural expansion. |
-| `ArchitectureComplexityDecision` | `skills/clockwork/ARCHITECTURE_COMPLEXITY_AND_SCALE_POSTURE_GUIDE.md` | Clockwork | Layering, package boundaries, ADR maintenance; distinguishes `SCALE_READY` from `SCALE_PROVISIONED`. |
+| `ArchitectureComplexityDecision` | `machine/schemas/architecture-complexity-decision.v1.schema.json` | Clockwork | Layering, package boundaries, ADR maintenance; distinguishes `SCALE_READY` from `SCALE_PROVISIONED`. |
 | `MigrationRiskContract` | `machine/schemas/migration-risk-contract.v1.schema.json` | Chronicler | DDL risk scoring, rollback plans, engine locking; preserves unknown-production pre-contract gap without coercion. |
-| `ArchitectureGovernanceIntake` | `skills/conductor/ARCHITECTURE_GOVERNANCE_INTAKE_GUIDE.md` | Conductor | Scope classification (`TRIVIAL`, `ISOLATED_REFACTOR`, `MULTI_SUBSYSTEM`), fail-closed routing without ceremony explosion. |
-| `ArchitectureValidationContract` | `skills/overseer/ARCHITECTURE_VALIDATION_CONTRACT_GUIDE.md` | Overseer | Empirical verification of architecture claims; formal proof states (`PROVEN`, `NOT_PROVEN`, `FAILED`). |
+| `ArchitectureGovernanceIntake` | `machine/schemas/architecture-governance-intake.v1.schema.json` | Conductor | Scope classification (`TRIVIAL`, `STANDARD`, `ARCHITECTURAL`, `PRODUCTION_CRITICAL`), fail-closed routing without ceremony explosion. |
+| `ArchitectureValidationContract` | `machine/schemas/architecture-validation-contract.v1.schema.json` | Overseer | Empirical verification of architecture claims; formal proof states (`PROVEN`, `NOT_PROVEN`, `NOT_REQUIRED`, `FAILED`). |
 | `ProjectArchitectureGovernanceProfile` | `machine/schemas/project-architecture-governance-profile.v1.schema.json` | Shared / Governance | Tenancy model (`MULTI_TENANT`, `SINGLE_TENANT`), scale posture, runtime boundary references. |
 
 ---
 
-## 2. Specialist Ownership Chain Verification
+## 2. Canonical Phase Ledger
+
+The OR-GOV program consists of ten sequentially executed and verified phases:
+
+- **OR-GOV-1**: Shared Machine Contracts and Schemas
+- **OR-GOV-2**: The Steward — Product Intent and Capacity Envelope Governance (`ProductIntentContract`, `CapacityEnvelope`)
+- **OR-GOV-3**: Clockwork — Architecture Complexity Decisions and Scale Posture (`ArchitectureComplexityDecision`)
+- **OR-GOV-4**: Chronicler — Migration Risk Contract Governance (`MigrationRiskContract`)
+- **OR-GOV-5**: Conductor — Architecture Governance Intake Routing (`ArchitectureGovernanceIntake`)
+- **OR-GOV-6**: The Tuner — Governance Contract Invalidation & Minimal Re-entry (`CrossSpecialistCoordination`)
+- **OR-GOV-7**: Overseer — Contract-Derived Architecture Validation (`ArchitectureValidationContract`)
+- **OR-GOV-8A**: Cipher — Tenant-Security Governance Refinement (`ProjectArchitectureGovernanceProfile.tenancy_model`)
+- **OR-GOV-8B**: Arbiter — Contract and Evidence Freshness Governance (`ContinuityEvidenceFreshness`)
+- **OR-GOV-8C**: Ponytail — Upstream-Contract Enforcement Governance (`UpstreamContractEnforcement`)
+- **OR-GOV-8D**: Scribe — Post-SSU Governance Documentation Integration (`GovernanceDocumentationIntegration`)
+- **OR-GOV-9**: Conditional Specialist Governance Sufficiency Audit (The Governor, Weaver, Cloak, Dagger regression)
+- **OR-GOV-10**: Final Integration, Parity, Full Regression, and Program Closeout
+
+*Note*: The Scribe Specialist Upgrade (SSU) is a separate completed initiative and is distinct from OR-GOV-3.
+
+---
+
+## 3. Specialist Ownership Chain Verification
 
 Every specialist maintains strict domain ownership; no specialist silently absorbs or bypasses another:
 
@@ -60,7 +82,7 @@ Every specialist maintains strict domain ownership; no specialist silently absor
 
 ---
 
-## 3. End-to-End Governance Scenarios (Scenarios A – J)
+## 4. End-to-End Governance Scenarios (Scenarios A – J)
 
 | Scenario | Objective | Enforced Governance Flow | Verification Result |
 | :--- | :--- | :--- | :--- |
@@ -70,14 +92,14 @@ Every specialist maintains strict domain ownership; no specialist silently absor
 | **D: Empirical Performance Claim** | Verify throughput assertions | Assertion ("Supports 300 RPS") assigned to Overseer; remains `NOT_PROVEN` until verified by an executed benchmark receipt. | `PASS` |
 | **E: Multi-Tenant Persistence Change** | Full cross-specialist flow | Routes through Steward (intent) -> Clockwork (architecture) -> Chronicler (DDL) -> Cipher (tenant isolation) -> Ponytail (code) -> Overseer (validation). | `PASS` |
 | **F: Capacity Material Change** | Contract invalidation & re-entry | Material change in capacity triggers Tuner declared-edge invalidation; only affected specialists re-enter; Arbiter rejects stale evidence. | `PASS` |
-| **G: Stale Validation Evidence** | Lineage and commit binding | Commit boundary changes invalidate prior evidence; Arbiter transitions to `WAIT_FOR_EVIDENCE` or `AUTO_REMEDIATE_AND_REVALIDATE`. | `PASS` |
+| **G: Stale Validation Evidence** | Lineage and commit boundary binding | Commit boundary changes invalidate prior evidence; Arbiter transitions to `WAIT_FOR_EVIDENCE` or `AUTO_REMEDIATE_AND_REVALIDATE`. | `PASS` |
 | **H: Migration Production State Unknown** | Handle schema limitations | Unknown production state preserved without false boolean coercion; pre-contract schema gap documented explicitly. | `PASS` |
-| **I: Documentation Reconciliation** | Maintain proof truth in docs | Scribe records exact proof states (`PROVEN`, `NOT_PROVEN`, `FAILED`, `MISSING_EVIDENCE`, `STALE_INVALIDATED`); prohibits silent status promotion. | `PASS` |
+| **I: Documentation Reconciliation** | Maintain proof truth in docs | Scribe records exact proof states (`PROVEN`, `NOT_PROVEN`, `NOT_REQUIRED`, `FAILED`); anomaly states (`MISSING_EVIDENCE`, `STALE_INVALIDATED`); prohibits silent status promotion. | `PASS` |
 | **J: Dagger Request Without Authority** | Block destructive testing | Destructive chaos/load testing blocked without explicit authorized envelope; simulation-first behavior verified. | `PASS` |
 
 ---
 
-## 4. Adapter Parity and Prompt Load Budget
+## 5. Adapter Parity and Prompt Load Budget
 
 - **Codex Adapter Parity**: Validated via `python adapters/codex/validate_codex_export.py` with zero discrepancies. All mirrored guides, contracts, and output formats maintain exact source parity.
 - **Prompt Load Budget**: Validated via `python scripts/validate_prompt_load_budget.py --repo-root .`. All specialist prompt loads remain strictly within character and token budgets.
@@ -85,7 +107,7 @@ Every specialist maintains strict domain ownership; no specialist silently absor
 
 ---
 
-## 5. Non-Authorizing Constraints & Program Termination
+## 6. Non-Authorizing Constraints & Program Termination
 
 1. **Program Conclusion**: With OR-GOV-10 complete, the OR-GOV program concludes. All requirements across OR-GOV-1 through OR-GOV-10 are fully satisfied and verified.
 2. **Release Hold**: Public release remains held at `v1.7.0`. Publication of `v1.8` is **NOT AUTHORIZED**.

--- a/docs/governance/or_gov_10_integration_closeout_disposition.v1.json
+++ b/docs/governance/or_gov_10_integration_closeout_disposition.v1.json
@@ -10,22 +10,22 @@
   "baseline_sha": "48af26607ae1f589971c2f79460329dd859438a0",
   "program_phases": {
     "or_gov_1": {
-      "phase_name": "Capacity & Product Intent Contracts",
-      "specialist": "the-steward",
+      "phase_name": "Shared Machine Contracts and Schemas",
+      "specialist": "shared / cross-specialist",
       "status": "COMPLETE_CANONICAL_VERIFIED",
-      "contract": "CapacityEnvelope, ProductIntentContract"
+      "contract": "Canonical machine schemas and governance profiles"
     },
     "or_gov_2": {
-      "phase_name": "Architecture Complexity Decisions & Boundaries",
+      "phase_name": "Product Intent and Capacity Envelope Governance",
+      "specialist": "the-steward",
+      "status": "COMPLETE_CANONICAL_VERIFIED",
+      "contract": "ProductIntentContract, CapacityEnvelope"
+    },
+    "or_gov_3": {
+      "phase_name": "Architecture Complexity Decisions and Scale Posture",
       "specialist": "clockwork",
       "status": "COMPLETE_CANONICAL_VERIFIED",
       "contract": "ArchitectureComplexityDecision"
-    },
-    "or_gov_3": {
-      "phase_name": "SSU Traceability & Documentation Foundation",
-      "specialist": "scribe",
-      "status": "COMPLETE_CANONICAL_VERIFIED",
-      "contract": "SSU Foundation"
     },
     "or_gov_4": {
       "phase_name": "Migration Risk Contract Governance",
@@ -88,6 +88,14 @@
       "disposition": "OR_GOV_SYSTEM_INTEGRATED_AND_VERIFIED"
     }
   },
+  "separate_initiatives": {
+    "scribe_ssu": {
+      "initiative_name": "Scribe Specialist Upgrade (SSU)",
+      "specialist": "scribe",
+      "status": "COMPLETE_CANONICAL_VERIFIED",
+      "relationship": "Separate completed initiative, not OR-GOV-3"
+    }
+  },
   "e2e_scenarios_verified": [
     "SCENARIO_A_SIMPLE_TRIVIAL_CHANGE_MINIMAL_ROUTING",
     "SCENARIO_B_PREMATURE_SCALING_REQUEST_STEWARD_CLOCKWORK_EVALUATION",
@@ -103,10 +111,10 @@
   "contract_inventory_verified": {
     "CapacityEnvelope": "machine/schemas/capacity-envelope.v1.schema.json",
     "ProductIntentContract": "machine/schemas/product-intent-contract.v1.schema.json",
-    "ArchitectureComplexityDecision": "skills/clockwork/ARCHITECTURE_COMPLEXITY_AND_SCALE_POSTURE_GUIDE.md",
+    "ArchitectureComplexityDecision": "machine/schemas/architecture-complexity-decision.v1.schema.json",
     "MigrationRiskContract": "machine/schemas/migration-risk-contract.v1.schema.json",
-    "ArchitectureGovernanceIntake": "skills/conductor/ARCHITECTURE_GOVERNANCE_INTAKE_GUIDE.md",
-    "ArchitectureValidationContract": "skills/overseer/ARCHITECTURE_VALIDATION_CONTRACT_GUIDE.md",
+    "ArchitectureGovernanceIntake": "machine/schemas/architecture-governance-intake.v1.schema.json",
+    "ArchitectureValidationContract": "machine/schemas/architecture-validation-contract.v1.schema.json",
     "ProjectArchitectureGovernanceProfile": "machine/schemas/project-architecture-governance-profile.v1.schema.json"
   },
   "non_authorizing_constraints": {

--- a/tests/behavior/test_or_gov_10_e2e_integration_closeout.py
+++ b/tests/behavior/test_or_gov_10_e2e_integration_closeout.py
@@ -2,7 +2,7 @@
 """Deterministic end-to-end integration and closeout tests for OR-GOV-10.
 
 Proves that OR-GOV-1 through OR-GOV-9 operate as one coherent governance system:
-1. Contract Inventory and ownership validation.
+1. Contract Inventory and ownership validation across all seven canonical machine contracts.
 2. Specialist ownership chain and non-absorption boundaries.
 3. Scenarios A through J:
    - Scenario A: Simple trivial change (minimum route, no ceremony explosion).
@@ -16,6 +16,7 @@ Proves that OR-GOV-1 through OR-GOV-9 operate as one coherent governance system:
    - Scenario I: Documentation reconciliation (Scribe proof/value preservation, no silent promotion).
    - Scenario J: Dagger request (blocked without explicit authority, simulation-first).
 4. Adapter parity, prompt budget, frozen guidance, and architecture boundaries.
+5. Post-closeout record accuracy regressions (canonical enums, document accuracy, historical phase ledger, status preservation).
 """
 
 import hashlib
@@ -33,12 +34,15 @@ class TestOrGov10E2EIntegrationCloseout(unittest.TestCase):
     """E2E integration test suite for the complete OR-GOV program closeout."""
 
     def test_01_contract_inventory_and_ownership(self):
-        """Verify all canonical schemas, ownership, and required fields."""
+        """Verify all seven canonical machine schemas, ownership, and required fields."""
         schemas_dir = REPO_ROOT / "machine" / "schemas"
         contracts = {
             "capacity-envelope.v1.schema.json": ("CapacityEnvelope", "the-steward"),
             "product-intent-contract.v1.schema.json": ("ProductIntentContract", "the-steward"),
+            "architecture-complexity-decision.v1.schema.json": ("ArchitectureComplexityDecision", "clockwork"),
             "migration-risk-contract.v1.schema.json": ("MigrationRiskContract", "chronicler"),
+            "architecture-governance-intake.v1.schema.json": ("ArchitectureGovernanceIntake", "conductor"),
+            "architecture-validation-contract.v1.schema.json": ("ArchitectureValidationContract", "overseer"),
             "project-architecture-governance-profile.v1.schema.json": ("ProjectArchitectureGovernanceProfile", None),
         }
         for filename, (expected_name, expected_owner) in contracts.items():
@@ -46,8 +50,12 @@ class TestOrGov10E2EIntegrationCloseout(unittest.TestCase):
             self.assertTrue(schema_path.exists(), f"Missing schema: {filename}")
             schema = json.loads(schema_path.read_text(encoding="utf-8"))
             self.assertEqual(schema["properties"]["contract_name"]["const"], expected_name)
+            self.assertIn("schema_version", schema["properties"])
+            self.assertTrue(len(schema.get("required", [])) > 0, f"Schema {filename} missing required fields")
             if expected_owner:
                 self.assertEqual(schema["properties"]["owner"]["const"], expected_owner)
+            else:
+                self.assertNotIn("owner", schema.get("properties", {}), f"Schema {filename} should not define owner")
 
     def test_02_specialist_ownership_chain(self):
         """Verify strict ownership chain: no specialist silently absorbs another's authority."""
@@ -82,7 +90,6 @@ class TestOrGov10E2EIntegrationCloseout(unittest.TestCase):
         """Scenario A: Simple trivial change routes minimally without governance explosion."""
         routes = json.loads((REPO_ROOT / "machine" / "routing" / "routes.v1.json").read_text(encoding="utf-8"))
         self.assertIn("direct_routes", routes)
-        # Trivial work stays focused on implementation without mandatory heavy ceremony
         intake_guide = (REPO_ROOT / "skills" / "conductor" / "ARCHITECTURE_GOVERNANCE_INTAKE_GUIDE.md").read_text(encoding="utf-8")
         self.assertIn("TRIVIAL", intake_guide)
 
@@ -91,7 +98,6 @@ class TestOrGov10E2EIntegrationCloseout(unittest.TestCase):
         complexity_guide = (REPO_ROOT / "skills" / "clockwork" / "ARCHITECTURE_COMPLEXITY_AND_SCALE_POSTURE_GUIDE.md").read_text(encoding="utf-8")
         self.assertIn("SCALE_READY", complexity_guide)
         self.assertIn("SCALE_PROVISIONED", complexity_guide)
-        # Scalability alone does not justify adding unneeded infrastructure
         self.assertIn("ProductIntentContract", complexity_guide)
 
     def test_05_scenario_c_unknown_capacity(self):
@@ -113,7 +119,6 @@ class TestOrGov10E2EIntegrationCloseout(unittest.TestCase):
         tenant_guide = (REPO_ROOT / "skills" / "cipher" / "TENANT_SECURITY_GOVERNANCE_GUIDE.md").read_text(encoding="utf-8")
         self.assertIn("MULTI_TENANT", tenant_guide)
         self.assertIn("tenant isolation", tenant_guide.lower())
-        # Chronicler owns persistence enforcement
         chronicler_skill = (REPO_ROOT / "skills" / "chronicler" / "SKILL.md").read_text(encoding="utf-8")
         self.assertIn("migration", chronicler_skill)
 
@@ -133,7 +138,6 @@ class TestOrGov10E2EIntegrationCloseout(unittest.TestCase):
         """Scenario H: Unknown production presence preserves schema gap without false coercion."""
         migration_schema = json.loads((REPO_ROOT / "machine" / "schemas" / "migration-risk-contract.v1.schema.json").read_text(encoding="utf-8"))
         self.assertEqual(migration_schema["properties"]["production_data"]["type"], "boolean")
-        # Ensure documentation explicitly notes the pre-contract gap
         chronicler_guide = (REPO_ROOT / "skills" / "chronicler" / "MIGRATION_RISK_CONTRACT_GUIDE.md").read_text(encoding="utf-8")
         self.assertIn("pre-contract", chronicler_guide)
 
@@ -202,6 +206,83 @@ class TestOrGov10E2EIntegrationCloseout(unittest.TestCase):
         res = subprocess.run([sys.executable, str(REPO_ROOT / "scripts" / "validation" / "validate_architecture_boundaries.py")], cwd=str(REPO_ROOT), capture_output=True, text=True)
         self.assertEqual(res.returncode, 0)
         self.assertIn("RUNTIME_ARCHITECTURE_BOUNDARIES=PASS", res.stdout)
+
+    def test_18_architecture_governance_intake_enum_regression(self):
+        """Verify ArchitectureGovernanceIntake.change_materiality canonical enum exactly."""
+        schema_path = REPO_ROOT / "machine" / "schemas" / "architecture-governance-intake.v1.schema.json"
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        change_mat = schema["properties"]["change_materiality"]["enum"]
+        self.assertEqual(change_mat, ["TRIVIAL", "STANDARD", "ARCHITECTURAL", "PRODUCTION_CRITICAL"])
+        self.assertNotIn("ISOLATED_REFACTOR", change_mat)
+        self.assertNotIn("MULTI_SUBSYSTEM", change_mat)
+
+    def test_19_architecture_validation_contract_proof_states_enum_regression(self):
+        """Verify ArchitectureValidationContract proof-state enum completeness."""
+        schema_path = REPO_ROOT / "machine" / "schemas" / "architecture-validation-contract.v1.schema.json"
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        proof_states = schema["$defs"]["validation_result"]["enum"]
+        self.assertEqual(proof_states, ["PROVEN", "NOT_PROVEN", "NOT_REQUIRED", "FAILED"])
+        self.assertNotIn("MISSING_EVIDENCE", proof_states)
+        self.assertNotIn("STALE_INVALIDATED", proof_states)
+
+    def test_20_closeout_document_accuracy(self):
+        """Verify docs/governance/OR_GOV_10_INTEGRATION_CLOSEOUT.md has accurate terms and enums."""
+        doc_path = REPO_ROOT / "docs" / "governance" / "OR_GOV_10_INTEGRATION_CLOSEOUT.md"
+        self.assertTrue(doc_path.exists())
+        doc = doc_path.read_text(encoding="utf-8")
+
+        for term in ["TRIVIAL", "STANDARD", "ARCHITECTURAL", "PRODUCTION_CRITICAL"]:
+            self.assertIn(term, doc, f"Missing canonical term {term} in closeout document")
+
+        self.assertNotIn("ISOLATED_REFACTOR", doc)
+        self.assertNotIn("MULTI_SUBSYSTEM", doc)
+
+        for term in ["PROVEN", "NOT_PROVEN", "NOT_REQUIRED", "FAILED"]:
+            self.assertIn(term, doc, f"Missing validation proof state {term} in closeout document")
+
+    def test_21_historical_phase_ledger_regression(self):
+        """Verify canonical historical phase mapping in closeout disposition."""
+        disp_path = REPO_ROOT / "docs" / "governance" / "or_gov_10_integration_closeout_disposition.v1.json"
+        self.assertTrue(disp_path.exists())
+        disp = json.loads(disp_path.read_text(encoding="utf-8"))
+        phases = disp["program_phases"]
+
+        # Verify OR-GOV-1 is shared machine contracts, not Steward product intent
+        self.assertNotEqual(phases["or_gov_1"]["specialist"], "the-steward")
+        self.assertIn("machine contracts", phases["or_gov_1"]["phase_name"].lower())
+
+        # Verify OR-GOV-2 is Steward
+        self.assertEqual(phases["or_gov_2"]["specialist"], "the-steward")
+        self.assertIn("product intent", phases["or_gov_2"]["phase_name"].lower())
+
+        # Verify OR-GOV-3 is Clockwork complexity/scale, NOT Scribe SSU
+        self.assertEqual(phases["or_gov_3"]["specialist"], "clockwork")
+        self.assertIn("complexity", phases["or_gov_3"]["phase_name"].lower())
+        self.assertNotIn("ssu", phases["or_gov_3"]["phase_name"].lower())
+        self.assertNotEqual(phases["or_gov_3"]["specialist"], "scribe")
+
+        # Verify Scribe SSU is recorded as separate initiative
+        self.assertIn("separate_initiatives", disp)
+        self.assertEqual(disp["separate_initiatives"]["scribe_ssu"]["status"], "COMPLETE_CANONICAL_VERIFIED")
+        self.assertIn("separate", disp["separate_initiatives"]["scribe_ssu"]["relationship"].lower())
+
+    def test_22_status_preservation(self):
+        """Verify that closeout erratum preserves completion status without reopening phases."""
+        disp_path = REPO_ROOT / "docs" / "governance" / "or_gov_10_integration_closeout_disposition.v1.json"
+        disp = json.loads(disp_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(disp["status"], "OR_GOV_PROGRAM_COMPLETE")
+        phases = disp["program_phases"]
+        for phase_key in ["or_gov_1", "or_gov_2", "or_gov_3", "or_gov_4", "or_gov_5", "or_gov_6", "or_gov_7", "or_gov_8a", "or_gov_8b", "or_gov_8c", "or_gov_8d", "or_gov_9", "or_gov_10"]:
+            self.assertEqual(phases[phase_key]["status"], "COMPLETE_CANONICAL_VERIFIED", f"Phase {phase_key} status drifted")
+
+        constraints = disp["non_authorizing_constraints"]
+        self.assertTrue(constraints["public_release_held"])
+        self.assertEqual(constraints["current_public_release"], "v1.7.0")
+        self.assertFalse(constraints["v1_8_publication_authorized"])
+        self.assertFalse(constraints["ar_3_authorized"])
+        self.assertFalse(constraints["ar_4_authorized"])
+        self.assertTrue(constraints["execution_stops_after_or_gov_10"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
POST-CLOSEOUT ERRATUM ONLY

NO OR-GOV PHASE REOPENED
NO RUNTIME CHANGE
NO SCHEMA CHANGE
NO ROUTING CHANGE
NO SPECIALIST AUTHORITY CHANGE
NO RELEASE AUTHORITY

This pull request corrects post-closeout OR-GOV record inaccuracies without reopening the completed governance program:
1. Restores canonical OR-GOV-1/2/3 historical phase mapping in \docs/governance/or_gov_10_integration_closeout_disposition.v1.json\ (OR-GOV-1 = Shared Machine Contracts and Schemas, OR-GOV-2 = The Steward, OR-GOV-3 = Clockwork; Scribe SSU recorded as separate initiative).
2. Corrects \ArchitectureGovernanceIntake.change_materiality\ terminology in \docs/governance/OR_GOV_10_INTEGRATION_CLOSEOUT.md\ to canonical enum (\TRIVIAL\, \STANDARD\, \ARCHITECTURAL\, \PRODUCTION_CRITICAL\), removing uncanonical \ISOLATED_REFACTOR\ and \MULTI_SUBSYSTEM\.
3. Restores complete canonical \ArchitectureValidationContract\ proof-state set (\PROVEN\, \NOT_PROVEN\, \NOT_REQUIRED\, \FAILED\) in closeout documentation.
4. Extends \	ests/behavior/test_or_gov_10_e2e_integration_closeout.py\ (22/22 PASS) covering all seven canonical machine contracts, enum regressions, document accuracy, phase ledger mapping, and status preservation.
5. Preserves OR-GOV completion state (\OR_GOV_PROGRAM_COMPLETE\), runtime behavior, frozen guidance, release hold (\1.7.0\), and AR-3 boundary (\NOT_STARTED\).