### PR TITLE
docs(release): close out Orchestra v1.8.0 publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **Registry O7 Query Optimization**: Delivers governed registry query optimization with full backward-compatibility fallback to O1-O6 query patterns.
 - **Cloak Reference Intelligence (CUIR)**: Introduces optional normalized UI pattern reference intelligence (`ADOPT_OPTIONAL`) with project-native precedence.
 - **Deterministic Release Assurance**: 11/11 package version surfaces unified at `1.8.0`, with extensive cross-platform, CodeQL, governance check, architecture boundary, prompt-budget, and behavioral test coverage.
+- **Developer Portal & Release Surface Synchronization**: Reconciles developer portal catalog and test fixtures (`tests/runtime/test_developer_portal.py`) with the published v1.8.0 release identity and exact canonical release commit `dad1f153f1be6522a8a7964258a2122a8d057596`.
 
 ## Post-closeout OR-GOV record erratum candidate
 

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -10,7 +10,7 @@ A governance-first specialist orchestration framework that routes complex AI-ass
 Open-source developer tooling and AI orchestration framework
 
 ## Current Stage
-v1.8.0 - Governance Hardening, Runtime Refoundation & Traceability (`RELEASE_CANDIDATE_PREPARATION`). Prior public release is v1.7.0 (canonical signed commit `e5305ef3e160209a0345bd2c7843c923940e62c5` with tree `7b7a0f6d5dd5376a62125ed1c6b037284e519c69`), which remains the active public release until v1.8.0 release publication is finalized and verified. Package and host integration surfaces are unified at version 1.8.0. Incorporates Prime Directive / Lifecycle V2, completed runtime refoundation milestones AR-0 through AR-2, Scribe Specialist Upgrade (SSU), the complete architecture governance program OR-GOV-1 through OR-GOV-10, Registry O7, Cloak CUIR reference intelligence, and expanded deterministic validation.
+v1.8.0 - Governance Hardening, Runtime Refoundation & Traceability (`PUBLISHED_VERIFIED`). The immutable GitHub Release (id `RE_kwDOS_4UtM4WyusI`) and lightweight `v1.8.0` tag resolve to canonical signed commit `dad1f153f1be6522a8a7964258a2122a8d057596` with tree `4effcd97e15f843c8c0d9d45217870ee9d6480ff` and sole parent `b601c2d853ad0dcdc68b8dc652578f19ef663c79`. Post-publication verification independently confirmed tag target, release body, immutable/latest state, canonical SHA/tree/parent/signature, and preservation of prior tags (v1.7.0, v1.6.0). Later commits on `main` are post-release maintenance and do not move the v1.8.0 release identity.
 
 ## Primary Users
 Developers and maintainers who install Orchestra as a plugin, skill set, or runtime package inside supported or scaffold-only coding hosts.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -5,10 +5,10 @@
 - **Canonical Branch:** `main`
 - **Base Branch:** `main`
 - **Stable Continuation Branch:** `main`
-- **Current Public Release:** `v1.7.0`
-- **Release Status:** `v1.7.0 PUBLISHED_VERIFIED`
+- **Current Public Release:** `v1.8.0`
+- **Release Status:** `v1.8.0 PUBLISHED_VERIFIED`
 - **Target Release:** `NONE_DECLARED`
-- **Release-Candidate Metadata:** `1.7.0` (`PUBLISHED`)
+- **Release-Candidate Metadata:** `1.8.0` (`PUBLISHED`)
 - **v1.2.0 Release State:** `PUBLISHED_VERIFIED`
 - **v1.3.0 Release State:** `PUBLISHED_VERIFIED`
 - **v1.4.0 Release State:** `PUBLISHED_VERIFIED`
@@ -23,9 +23,26 @@
 - **v1.7.0 Tag Ref:** lightweight `commit` ref targeting the exact release commit
 - **v1.7.0 GitHub Release:** id `376713145`, immutable, non-draft, non-prerelease, independently verified latest
 - **v1.7.0 Post-Publication Verification:** run `32898750932` PASS
+- **v1.8.0 Release State:** `PUBLISHED_VERIFIED`
+- **v1.8.0 Release Commit:** `dad1f153f1be6522a8a7964258a2122a8d057596`
+- **v1.8.0 Release Tree:** `4effcd97e15f843c8c0d9d45217870ee9d6480ff`
+- **v1.8.0 Sole Parent:** `b601c2d853ad0dcdc68b8dc652578f19ef663c79`
+- **v1.8.0 Tag Ref:** lightweight `commit` ref targeting the exact release commit
+- **v1.8.0 GitHub Release:** id `RE_kwDOS_4UtM4WyusI`, immutable, non-draft, non-prerelease, independently verified latest
+- **v1.8.0 Post-Publication Verification:** PASS
 - **Control Plane State:** `V1_7_0_CURRENT`
 - **MCP State:** `PUBLISHED_V1_6_STABLE_RETAINED_V1_7`
 - **Policy Activation State:** `NOT_PERFORMED`
+
+## v1.8.0 Governance Hardening, Runtime Refoundation & Traceability Publication
+
+Orchestra `v1.8.0` is `PUBLISHED_VERIFIED`. Immutable GitHub Release id `RE_kwDOS_4UtM4WyusI` and lightweight tag `v1.8.0` resolve to exact signed canonical release commit `dad1f153f1be6522a8a7964258a2122a8d057596` with tree `4effcd97e15f843c8c0d9d45217870ee9d6480ff` and sole parent `b601c2d853ad0dcdc68b8dc652578f19ef663c79`. Canonical Governance, validate/runtime, Required Analysis Compatibility/CodeQL, native Windows/Ubuntu/macOS validation, bounded-pilot confidence, signed materialization, expected-head Squash, and zero unresolved review-thread gates passed before publication. Read-only post-publication verification independently confirmed the exact tag, release body, latest/immutable release state, and prior-tag preservation.
+
+The release incorporates Prime Directive / Lifecycle V2, completed runtime refoundation milestones AR-0 through AR-2, Scribe Specialist Upgrade (SSU), the complete architecture governance program OR-GOV-1 through OR-GOV-10, Registry O7, Cloak CUIR reference intelligence, and expanded deterministic validation.
+
+No AR-3/AR-4 implementation, deployment, production mutation, policy activation, installed-integration refresh, destructive cleanup, force push, or history rewrite was performed. Later `main` changes are post-release maintenance and do not move the immutable v1.8.0 identity.
+
+See `docs/validation/V1_8_0_PUBLICATION_CLOSEOUT.md`.
 
 ## v1.7.0 Adaptive Intelligence, Portable Memory & Design Fidelity Publication
 

--- a/README.json
+++ b/README.json
@@ -13,12 +13,12 @@
     "license": "MIT",
     "package_version": "1.8.0",
     "package_version_source": "plugin.json#/version",
-    "current_public_release": "v1.7.0",
-    "current_public_release_commit": "e5305ef3e160209a0345bd2c7843c923940e62c5",
+    "current_public_release": "v1.8.0",
+    "current_public_release_commit": "dad1f153f1be6522a8a7964258a2122a8d057596",
     "current_public_release_state_scope": "LIVE_VERIFIED_PUBLICATION",
     "main_contains_post_release_work": true,
-    "next_release_plan": "v1.8.0",
-    "next_release_plan_status": "V1_8_0_RELEASE_CANDIDATE_PREPARATION"
+    "next_release_plan": "NONE_DECLARED",
+    "next_release_plan_status": "V1_8_0_PUBLISHED_VERIFIED_COMPLETE"
   },
   "purpose": {
     "summary": "Portable orchestration runtime for structured AI-assisted software development.",

--- a/README.md
+++ b/README.md
@@ -135,9 +135,9 @@ See [Portable Adaptive Memory](docs/architecture/PORTABLE_ADAPTIVE_MEMORY.md).
 
 ## Current release state
 
-The latest published release is **[v1.7.0: Adaptive Intelligence, Portable Memory & Design Fidelity](https://github.com/Baelfyre/Orchestra/releases/tag/v1.7.0)**. The immutable release resolves to canonical commit `e5305ef3e160209a0345bd2c7843c923940e62c5` with tree `7b7a0f6d5dd5376a62125ed1c6b037284e519c69` and a GitHub verified/valid signature.
+The latest published release is **[v1.8.0: Governance Hardening, Runtime Refoundation & Traceability](https://github.com/Baelfyre/Orchestra/releases/tag/v1.8.0)**. The immutable release resolves to canonical commit `dad1f153f1be6522a8a7964258a2122a8d057596` with tree `4effcd97e15f843c8c0d9d45217870ee9d6480ff` and a GitHub verified/valid signature.
 
-v1.7.0 consolidates adaptive intelligence through bounded shadow maturity, storage-agnostic portable adaptive memory, Registry O1-O6 adaptive consumption, governed UI design fidelity through UIX-9A proof preparation, and the post-v1.6 documentation/research closeout. The `v1.7.0` tag remains fixed even when `main` receives later post-release maintenance.
+v1.8.0 consolidates governance hardening, seven architecture governance contracts (OR-GOV-1 through OR-GOV-10), Scribe's documentation and traceability upgrade (SSU), the validated AR-0/AR-1/AR-2 runtime architecture foundation, Registry O7 query optimization, and Cloak CUIR reference intelligence. The `v1.8.0` tag remains fixed even when `main` receives later post-release maintenance.
 
 The v1.7.0 release itself did not include a live UIX-9 model/provider proof. Post-release UIX-9C V3 later completed as a controlled six-observation study. Its terminal result is **`NO_BENEFIT_ESTABLISHED`**: all three corrected pairs were valid and all 39 primary governed-versus-baseline metric comparisons were unchanged, establishing neither a repeatable governed advantage nor harm under the frozen experiment.
 

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -3,8 +3,8 @@
 - **Canonical Repo:** `Baelfyre/Orchestra`
 - **Canonical Branch:** `main`
 - **Base Branch:** `main`
-- **Current Public Release:** `v1.7.0`
-- **Release-Candidate Metadata:** `v1.7.0` (`PUBLISHED`)
+- **Current Public Release:** `v1.8.0`
+- **Release-Candidate Metadata:** `v1.8.0` (`PUBLISHED`)
 - **Target Release:** `NONE_DECLARED`
 - **v1.2.0 Release State:** `PUBLISHED_VERIFIED`
 - **v1.3.0 Release State:** `PUBLISHED_VERIFIED`
@@ -19,9 +19,21 @@
 - **v1.7.0 Tag Ref:** lightweight `commit` ref targeting the exact release commit
 - **v1.7.0 GitHub Release:** id `376713145`, immutable, non-draft, non-prerelease, independently verified latest
 - **v1.7.0 Post-Publication Verification:** run `32898750932` PASS
+- **v1.8.0 Release State:** `PUBLISHED_VERIFIED`
+- **v1.8.0 Release Commit:** `dad1f153f1be6522a8a7964258a2122a8d057596`
+- **v1.8.0 Release Tree:** `4effcd97e15f843c8c0d9d45217870ee9d6480ff`
+- **v1.8.0 Tag Ref:** lightweight `commit` ref targeting the exact release commit
+- **v1.8.0 GitHub Release:** id `RE_kwDOS_4UtM4WyusI`, immutable, non-draft, non-prerelease, independently verified latest
+- **v1.8.0 Post-Publication Verification:** PASS
 - **Control Plane State:** `V1_7_0_CURRENT`
 - **MCP State:** `PUBLISHED_V1_6_STABLE_RETAINED_V1_7`
 - **Policy Activation:** `NOT_PERFORMED`
+
+## v1.8.0 Governance Hardening, Runtime Refoundation & Traceability Publication Continuity
+
+Orchestra `v1.8.0` is `PUBLISHED_VERIFIED`. Release id `RE_kwDOS_4UtM4WyusI` and lightweight tag `v1.8.0` resolve to exact signed canonical commit `dad1f153f1be6522a8a7964258a2122a8d057596` with tree `4effcd97e15f843c8c0d9d45217870ee9d6480ff`. The complete exact-head release matrix and signed-materialization path passed before publication. Post-publication verification independently confirmed the exact immutable/latest release identity and preserved the prior `v1.7.0` and `v1.6.0` tags.
+
+Evidence: `docs/validation/V1_8_0_PUBLICATION_CLOSEOUT.md`.
 
 ## v1.7.0 Adaptive Intelligence, Portable Memory & Design Fidelity Publication Continuity
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -135,7 +135,7 @@ Murmurs changes presentation only. It does not alter authority, governance, vali
 - `../machine/release-evidence/`: structured release evidence.
 - [Decision Log](../DECISION_LOG.md): architectural and governance decisions.
 
-The current public release is immutable `v1.7.0`. Later canonical commits on `main` are post-release maintenance until a separately governed future release is published.
+The current public release is immutable `v1.8.0`. Later canonical commits on `main` are post-release maintenance until a separately governed future release is published.
 
 ## Developer extension path
 

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -1,6 +1,6 @@
 # Orchestra Developer Portal
 
-The Developer Portal is Orchestra's repository-native discovery surface for developers extending or integrating with the current v1.7 contracts. It is documentation and indexing only. It is not a hosted service, marketplace, package registry, deployment plane, policy authority, or runtime permission source.
+The Developer Portal is Orchestra's repository-native discovery surface for developers extending or integrating with the current v1.8 contracts. It is documentation and indexing only. It is not a hosted service, marketplace, package registry, deployment plane, policy authority, or runtime permission source.
 
 ## Start here
 

--- a/docs/setup/COMPATIBILITY.md
+++ b/docs/setup/COMPATIBILITY.md
@@ -1,8 +1,8 @@
 # Compatibility
 
-The current public GitHub Release is Orchestra `v1.7.0: Adaptive Intelligence, Portable Memory & Design Fidelity`, published from lightweight tag `v1.7.0` at exact GitHub-verified signed release commit `e5305ef3e160209a0345bd2c7843c923940e62c5`. The release is non-draft, non-prerelease, immutable, and independently verified as latest.
+The current public GitHub Release is Orchestra `v1.8.0: Governance Hardening, Runtime Refoundation & Traceability`, published from lightweight tag `v1.8.0` at exact GitHub-verified signed release commit `dad1f153f1be6522a8a7964258a2122a8d057596`. The release is non-draft, non-prerelease, immutable, and independently verified as latest.
 
-The `v1.7.0` tag resolves directly to the exact release commit. v1.7.0 retains the bounded MCP stdio transport and PRAP/Adapter SDK introduced in v1.6.0, while adding adaptive intelligence, storage-agnostic portable memory, Registry O1-O6 adaptive consumption, and governed UI design-fidelity contracts. Publication did not graduate scaffold-only hosts or publish those scaffold surfaces to marketplaces.
+The `v1.8.0` tag resolves directly to the exact release commit. v1.8.0 incorporates the complete architecture governance program OR-GOV-1 through OR-GOV-10, Scribe Specialist Upgrade (SSU), runtime architecture refoundation milestones AR-0 through AR-2, Registry O7 query optimization, and Cloak CUIR reference intelligence. Publication did not graduate scaffold-only hosts or publish those scaffold surfaces to marketplaces.
 
 Scaffold-only hosts are not full support claims. Promotion requirements and graduation order live in `docs/project/SCAFFOLD_ADAPTER_GRADUATION_CRITERIA.md`.
 

--- a/docs/setup/INSTALLATION.md
+++ b/docs/setup/INSTALLATION.md
@@ -4,9 +4,9 @@ Orchestra can be installed in several ways depending on your AI host or IDE.
 
 ## Release Status
 
-The current public GitHub Release is `v1.7.0: Adaptive Intelligence, Portable Memory & Design Fidelity`, published from lightweight tag `v1.7.0` at exact GitHub-verified signed release commit `e5305ef3e160209a0345bd2c7843c923940e62c5`. The release is non-draft, non-prerelease, immutable, and independently verified as latest.
+The current public GitHub Release is `v1.8.0: Governance Hardening, Runtime Refoundation & Traceability`, published from lightweight tag `v1.8.0` at exact GitHub-verified signed release commit `dad1f153f1be6522a8a7964258a2122a8d057596`. The release is non-draft, non-prerelease, immutable, and independently verified as latest.
 
-The `v1.7.0` tag is a lightweight `commit` ref resolving directly to the release commit; there is no separate tag object. Package/version surfaces are normalized to `1.7.0`. Installing directly from later `main` commits may include post-release maintenance, so use tag `v1.7.0` when exact released content is required.
+The `v1.8.0` tag is a lightweight `commit` ref resolving directly to the release commit; there is no separate tag object. Package/version surfaces are normalized to `1.8.0`. Installing directly from later `main` commits may include post-release maintenance, so use tag `v1.7.0` when exact released content is required.
 
 | Host | Install Surface | Current Status |
 |---|---|---|

--- a/docs/validation/V1_8_0_PUBLICATION_CLOSEOUT.md
+++ b/docs/validation/V1_8_0_PUBLICATION_CLOSEOUT.md
@@ -1,0 +1,55 @@
+# Orchestra v1.8.0 Publication Closeout
+
+Status: `PUBLISHED_VERIFIED_COMPLETE`
+
+## Canonical release identity
+
+- Tag / release: `v1.8.0`
+- GitHub Release id: `RE_kwDOS_4UtM4WyusI`
+- Canonical release commit: `dad1f153f1be6522a8a7964258a2122a8d057596`
+- Canonical release tree: `4effcd97e15f843c8c0d9d45217870ee9d6480ff`
+- Sole parent: `b601c2d853ad0dcdc68b8dc652578f19ef663c79`
+- Canonical commit signature: GitHub verified / valid (RSA key B5690EEEBB952194)
+- Tag type: lightweight `commit` ref
+- Draft: `false`
+- Prerelease: `false`
+- Immutable: `true`
+- Latest release at closeout: `true`
+
+## Canonical exact-head validation
+
+- Source Qualification PR: #770 (`release/v1.8.0-governance-runtime-traceability-20260904`)
+  - Governance Check `33818301776`: PASS
+  - validate / runtime `33818301771`: PASS
+  - Required Analysis Compatibility / CodeQL `33818301794` / `33818355067`: PASS
+  - Cross-platform Validation `33818301751`: PASS on Windows, Ubuntu, and macOS
+  - bounded-pilot `33818301782`: PASS
+  - Unresolved review threads: `0`
+- Canonical Integration PR: #772 (`materialize/v1.8.0-release-20260904`)
+  - Governance Check `33819113908`: PASS
+  - validate / runtime `33819113935`: PASS
+  - Required Analysis Compatibility / CodeQL `33819113974` / `33819112138`: PASS
+  - Cross-platform Validation `33819114267`: PASS on Windows, Ubuntu, and macOS
+  - bounded-pilot `33819113940`: PASS
+  - Unresolved review threads: `0`
+  - Expected-head Squash: PASS
+
+## Signed materialization
+
+- Signed materialized candidate: `0ccde647ae41e078b7ec7c3453fc67d7f7703f31`
+- Signed-materialization PR: #771: PASS
+- Reviewed tree = signed materialized tree = canonical release tree: `4effcd97e15f843c8c0d9d45217870ee9d6480ff` (exact match)
+
+## Post-publication verification
+
+- Lightweight tag `v1.8.0` target: exact canonical release commit `dad1f153f1be6522a8a7964258a2122a8d057596`
+- Immutable release identity: `true`
+- Exact release body match: verified identical to `docs/releases/v1.8.0-governance-hardening-runtime-refoundation-traceability-release-candidate.md`
+- Latest release identity: `true` (`v1.8.0`)
+- Previous release preservation: `v1.7.0` preserved at `e5305ef3e160209a0345bd2c7843c923940e62c5`, `v1.6.0` preserved at `ba35764a14111518c7da729b5a4c69c6af485a9b`
+
+## Release boundaries
+
+v1.8.0 does not authorize AR-3 or AR-4 implementation, runtime redesign, new OR-GOV phases, provider promotion, policy activation, deployment, production mutation, marketplace publication beyond repository distribution, scaffold-host promotion, destructive testing, force push, or history rewrite. The MigrationRiskContract unknown-production gap remains explicitly documented.
+
+The published release remains authoritative for v1.8.0 even as `main` receives later post-release maintenance.

--- a/machine/developer-portal/catalog.v1.json
+++ b/machine/developer-portal/catalog.v1.json
@@ -15,8 +15,8 @@
     "refreshes_installed_integrations": false
   },
   "public_release_boundary": {
-    "release": "v1.7.0",
-    "target_commit": "e5305ef3e160209a0345bd2c7843c923940e62c5",
+    "release": "v1.8.0",
+    "target_commit": "dad1f153f1be6522a8a7964258a2122a8d057596",
     "moved_by_portal": false
   },
   "surfaces": [

--- a/machine/schemas/developer-portal-catalog.schema.json
+++ b/machine/schemas/developer-portal-catalog.schema.json
@@ -83,10 +83,10 @@
       ],
       "properties": {
         "release": {
-          "const": "v1.7.0"
+          "const": "v1.8.0"
         },
         "target_commit": {
-          "const": "e5305ef3e160209a0345bd2c7843c923940e62c5"
+          "const": "dad1f153f1be6522a8a7964258a2122a8d057596"
         },
         "moved_by_portal": {
           "const": false

--- a/profile-pio.json
+++ b/profile-pio.json
@@ -3,7 +3,7 @@
   "project": "Orchestra",
   "featured": true,
   "summary": "Coordinates AI-assisted development as a governed system of specialist routing, validation, evidence, and human approval rather than an unbounded agent loop.",
-  "status": "Latest release: v1.7.0",
+  "status": "Latest release: v1.8.0",
   "next": "Next release: not announced",
   "url": "https://github.com/Baelfyre/Orchestra"
 }

--- a/tests/runtime/test_developer_portal.py
+++ b/tests/runtime/test_developer_portal.py
@@ -71,8 +71,8 @@ def test_portal_preserves_authority_boundaries_and_current_mcp_release_projectio
         "mcp_server": "PUBLISHED_V1_6_STABLE_RETAINED_V1_7",
     }
     assert catalog["public_release_boundary"] == {
-        "release": "v1.7.0",
-        "target_commit": "e5305ef3e160209a0345bd2c7843c923940e62c5",
+        "release": "v1.8.0",
+        "target_commit": "dad1f153f1be6522a8a7964258a2122a8d057596",
         "moved_by_portal": False,
     }
 


### PR DESCRIPTION
## Summary

Close out Orchestra v1.8.0 publication:
- Reconcile current public release surfaces from v1.7.0 to v1.8.0 across \PROJECT_STATE.md\, \PROJECT_CONTEXT.md\, \SESSION_HANDOFF.md\, \README.json\, \profile-pio.json\, \docs/README.md\, \docs/setup/INSTALLATION.md\, \docs/setup/COMPATIBILITY.md\, and \docs/developer/README.md\.
- Synchronize Developer Portal catalog, schema, and tests with published canonical release commit \dad1f153f1be6522a8a7964258a2122a8d057596\.
- Add \docs/validation/V1_8_0_PUBLICATION_CLOSEOUT.md\ recording verified lightweight tag \1.8.0\, immutable GitHub Release \RE_kwDOS_4UtM4WyusI\, and exact release boundaries.
- Preserves tag \1.8.0\ on release commit \dad1f153f1be6522a8a7964258a2122a8d057596\.