### PR TITLE
feat(uief): add deterministic conductor fidelity routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Post-v1.8.0 UIEF-2 Conductor fidelity routing and context gate
+
+- Adds a versioned machine contract for deterministic design-fidelity triggers and `FAST_MODE_PROHIBITED` semantics.
+- Routes material UI fidelity work through `UI_CONTRACT_FIDELITY` while preserving `MINIMAL_SAFE` eligibility for genuinely trivial UI changes.
+- Forwards only the selected profile's required design/reference context and preserves generic runtime `execution_mode` semantics.
+- Adds fail-closed runtime behavior tests for trigger determinism, bounded context, missing evidence, and Ponytail self-selection or downgrade attempts.
+
 ## Post-v1.8.0 UIEF-1 UI implementation profile contract candidate
 
 - Introduces library-neutral UI implementation profile contract schema `machine/schemas/ui-implementation-profile.v1.schema.json` under JSON Schema Draft 2020-12.

--- a/README.json
+++ b/README.json
@@ -555,6 +555,26 @@
       "runtime_integration": false,
       "authority_note": "UIX-5 sequences existing specialists and binds evidence to handoffs; it does not create a specialist, expand authority, make UI or rendered evidence approval, activate adoption, or authorize Figma mutation."
     },
+    "uief2_conductor_fidelity_routing": {
+      "status": "IMPLEMENTED_CANONICAL",
+      "purpose": "Deterministic Conductor selection of MINIMAL_SAFE or UI_CONTRACT_FIDELITY from accepted design-fidelity evidence, with FAST prohibition and bounded downstream context.",
+      "machine_sources": [
+        "machine/routing/ui-fidelity-routing.v1.json",
+        "machine/schemas/ui-fidelity-routing.v1.schema.json",
+        "orchestra_runtime/domain/orchestration/ui_fidelity.py",
+        "orchestra_runtime/machine_contracts.py",
+        "orchestra_runtime/services.py"
+      ],
+      "human_sources": [
+        "docs/project/UI_EXECUTION_FIDELITY_PLAN.md"
+      ],
+      "validation_surface": "tests/runtime/test_uief2_conductor_fidelity_routing.py",
+      "runtime_integration": true,
+      "fast_mode_prohibited_on_material_trigger": true,
+      "generic_execution_mode_preserved": true,
+      "authority_expansion": false,
+      "authority_note": "UIEF-2 routes and bounds fidelity context only. It does not transfer UI design authority to Ponytail, allow profile self-selection or downgrade, expand authority, authorize external tools, release, deployment, policy activation, or other protected actions."
+    },
     "governed_ui_optional_adapter_boundaries_uix6": {
       "status": "IMPLEMENTED_CANONICAL_NO_ADOPTION",
       "purpose": "Library-neutral UIX-6 audit and boundary contract for optional Figma, Code Connect, Storybook, Playwright, axe, and project-native design-token evidence capabilities.",
@@ -2022,6 +2042,8 @@
   "machine_contracts": {
     "specialist_registry": "machine/specialists/registry.v1.json",
     "routing_contract": "machine/routing/routes.v1.json",
+    "ui_fidelity_routing_contract": "machine/routing/ui-fidelity-routing.v1.json",
+    "ui_fidelity_routing_schema": "machine/schemas/ui-fidelity-routing.v1.schema.json",
     "governance_policy": "machine/governance/policy.v1.json",
     "feature_decision_record_schema": "machine/schemas/feature-decision-record.v1.schema.json",
     "control_plane_migration": "machine/migration/control-plane.v1.json",
@@ -2362,7 +2384,8 @@
     "scribe_documentation_reconciliation_guide": "skills/scribe/DOCUMENTATION_SYSTEM_RECONCILIATION_GUIDE.md",
     "scribe_output_templates": "skills/scribe/OUTPUT_TEMPLATES.md",
     "conductor_routing_evaluation_guide": "skills/conductor/ROUTING_EVALUATION_GUIDE.md",
-    "conductor_architecture_governance_intake_guide": "skills/conductor/ARCHITECTURE_GOVERNANCE_INTAKE_GUIDE.md"
+    "conductor_architecture_governance_intake_guide": "skills/conductor/ARCHITECTURE_GOVERNANCE_INTAKE_GUIDE.md",
+    "ui_execution_fidelity_plan": "docs/project/UI_EXECUTION_FIDELITY_PLAN.md"
   },
   "representation_policy": {
     "markdown": "Human-readable explanation, rationale, examples, and nuanced specialist guidance",

--- a/docs/project/UI_EXECUTION_FIDELITY_PLAN.md
+++ b/docs/project/UI_EXECUTION_FIDELITY_PLAN.md
@@ -324,6 +324,32 @@ Required work:
 Exit:
 UIEF_2_ROUTING_AND_CONTEXT_GATE_READY
 
+The canonical UIEF-2 implementation is the versioned machine contract at
+`machine/routing/ui-fidelity-routing.v1.json` with its schema at
+`machine/schemas/ui-fidelity-routing.v1.schema.json`. Conductor classifies
+accepted design-fidelity evidence in deterministic contract order and selects
+`UI_CONTRACT_FIDELITY` for material triggers such as an accepted design
+contract, explicit reference fidelity, normalized pattern references,
+non-trivial composition, visual hierarchy or density, responsive
+transformation, or interaction-state and motion requirements. A material
+trigger makes `FAST` invalid; genuinely trivial UI work without a trigger
+remains eligible for `MINIMAL_SAFE` and `FAST`.
+
+Only the selected profile and traceable, allowlisted fidelity references are
+forwarded downstream. `UI_CONTRACT_FIDELITY` requires the design contract,
+Cloak, pattern, composition, and Clockwork boundary references together with
+the required fidelity disposition fields. `MINIMAL_SAFE` removes stale
+fidelity-only context. Generic `execution_mode` remains reserved for
+`HOST_NATIVE` and `DETERMINISTIC_TEST_ENGINE` semantics. Conductor owns
+selection, and Ponytail cannot self-select, downgrade, or add fidelity-only
+context. Missing profile evidence, conflicting explicit minimal selection,
+invalid authority flags, and missing required references fail closed.
+
+The runtime contract and focused semantic coverage live in
+`orchestra_runtime/domain/orchestration/ui_fidelity.py`,
+`orchestra_runtime/services.py`, and
+`tests/runtime/test_uief2_conductor_fidelity_routing.py`.
+
 ### UIEF-3 - Ponytail frontend fidelity execution layer
 
 Goal:

--- a/machine/routing/ui-fidelity-routing.v1.json
+++ b/machine/routing/ui-fidelity-routing.v1.json
@@ -1,0 +1,184 @@
+{
+  "$schema": "../schemas/ui-fidelity-routing.v1.schema.json",
+  "schema_version": "orchestra.ui-fidelity-routing.v1",
+  "contract_id": "uief2-conductor-fidelity-routing",
+  "source_reference": "docs/project/UI_EXECUTION_FIDELITY_PLAN.md#uief-2-conductor-fidelity-routing-and-context-gate",
+  "selected_by": "conductor",
+  "profiles": [
+    "MINIMAL_SAFE",
+    "UI_CONTRACT_FIDELITY"
+  ],
+  "metadata_keys": {
+    "profile": "ui_implementation_profile",
+    "fidelity_evidence": "ui_fidelity_evidence",
+    "fidelity_context": "ui_fidelity_context",
+    "trigger_ids": "ui_fidelity_trigger_ids",
+    "fast_mode_prohibited": "fast_mode_prohibited",
+    "risk_mode": "risk_mode",
+    "generic_execution_mode": "execution_mode"
+  },
+  "fast_mode": {
+    "value": "FAST",
+    "prohibited_when": "DESIGN_FIDELITY_TRIGGER",
+    "allowed_when": "NO_MATERIAL_FIDELITY_TRIGGER"
+  },
+  "triggers": [
+    {
+      "id": "accepted_frozen_ui_design_contract",
+      "prompt_terms": [
+        "accepted ui design contract",
+        "frozen ui design contract",
+        "ui design contract"
+      ],
+      "evidence_keys": [
+        "design_contract_ref",
+        "ui_design_contract_ref"
+      ]
+    },
+    {
+      "id": "cloak_fidelity_handoff",
+      "prompt_terms": [
+        "cloak fidelity handoff",
+        "cloak handoff",
+        "ui fidelity handoff"
+      ],
+      "evidence_keys": [
+        "cloak_handoff_ref",
+        "cloak_fidelity_handoff_ref"
+      ]
+    },
+    {
+      "id": "reference_or_figma_fidelity",
+      "prompt_terms": [
+        "figma fidelity",
+        "accepted figma design",
+        "reference fidelity",
+        "match the reference",
+        "preserve the reference"
+      ],
+      "evidence_keys": [
+        "reference_ref",
+        "figma_ref"
+      ]
+    },
+    {
+      "id": "normalized_ui_reference_patterns",
+      "prompt_terms": [
+        "cuiR pattern",
+        "cuir pattern",
+        "normalized reference pattern",
+        "reference pattern"
+      ],
+      "evidence_keys": [
+        "pattern_refs"
+      ]
+    },
+    {
+      "id": "non_trivial_macro_composition",
+      "prompt_terms": [
+        "macro composition",
+        "non-trivial composition",
+        "multi-region composition"
+      ],
+      "evidence_keys": [
+        "composition_refs"
+      ]
+    },
+    {
+      "id": "visual_hierarchy_or_density",
+      "prompt_terms": [
+        "visual hierarchy",
+        "visual density",
+        "optical balance"
+      ],
+      "evidence_keys": [
+        "visual_hierarchy",
+        "optical_balance"
+      ]
+    },
+    {
+      "id": "responsive_transformation",
+      "prompt_terms": [
+        "responsive reordering",
+        "responsive transformation",
+        "responsive collapse"
+      ],
+      "evidence_keys": [
+        "responsive_reordering",
+        "responsive_transformation"
+      ]
+    },
+    {
+      "id": "interaction_state_or_layering",
+      "prompt_terms": [
+        "interaction states",
+        "motion and layering",
+        "interaction behavior and layering"
+      ],
+      "evidence_keys": [
+        "interaction_states",
+        "motion",
+        "layering"
+      ]
+    },
+    {
+      "id": "greenfield_or_aesthetic_heavy_ui",
+      "prompt_terms": [
+        "greenfield ui",
+        "aesthetic-heavy ui",
+        "aesthetic heavy ui"
+      ],
+      "evidence_keys": [
+        "greenfield_ui",
+        "aesthetic_heavy_ui"
+      ]
+    }
+  ],
+  "documented_non_triggers": [
+    "copy-only correction with no visual-contract impact",
+    "simple label or typo with no fidelity evidence",
+    "isolated mechanical UI fix that does not alter accepted composition, hierarchy, state, responsive, motion, or reference binding"
+  ],
+  "fidelity_profile_required_fields": [
+    "selection_reason",
+    "selected_by",
+    "design_contract_ref",
+    "cloak_handoff_ref",
+    "pattern_refs",
+    "composition_refs",
+    "clockwork_boundary_ref",
+    "required_fidelity",
+    "allowed_deviations"
+  ],
+  "fidelity_required_true_fields": [
+    "preserve_macro_composition",
+    "preserve_visual_hierarchy",
+    "preserve_interaction_states",
+    "preserve_responsive_transformation"
+  ],
+  "context_forward_fields": [
+    "profile",
+    "design_contract_ref",
+    "cloak_handoff_ref",
+    "pattern_refs",
+    "composition_refs",
+    "clockwork_boundary_ref",
+    "required_fidelity",
+    "allowed_deviations",
+    "selection_reason",
+    "selected_by",
+    "authority"
+  ],
+  "authority_false_fields": [
+    "grants_specialist_authority",
+    "grants_implementation_authority",
+    "ponytail_can_self_select",
+    "ponytail_can_downgrade"
+  ],
+  "authority": {
+    "grants_specialist_authority": false,
+    "grants_implementation_authority": false,
+    "ponytail_can_self_select": false,
+    "ponytail_can_downgrade": false
+  }
+}

--- a/machine/schemas/ui-fidelity-routing.v1.schema.json
+++ b/machine/schemas/ui-fidelity-routing.v1.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Baelfyre/Orchestra/blob/main/machine/schemas/ui-fidelity-routing.v1.schema.json",
+  "title": "Orchestra UI Fidelity Routing Contract v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schema_version",
+    "contract_id",
+    "source_reference",
+    "selected_by",
+    "profiles",
+    "metadata_keys",
+    "fast_mode",
+    "triggers",
+    "documented_non_triggers",
+    "fidelity_profile_required_fields",
+    "fidelity_required_true_fields",
+    "context_forward_fields",
+    "authority_false_fields",
+    "authority"
+  ],
+  "properties": {
+    "$schema": {"type": "string"},
+    "schema_version": {"const": "orchestra.ui-fidelity-routing.v1"},
+    "contract_id": {"type": "string", "minLength": 1},
+    "source_reference": {"type": "string", "minLength": 1},
+    "selected_by": {"const": "conductor"},
+    "profiles": {
+      "type": "array",
+      "const": ["MINIMAL_SAFE", "UI_CONTRACT_FIDELITY"]
+    },
+    "metadata_keys": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["profile", "fidelity_evidence", "fidelity_context", "trigger_ids", "fast_mode_prohibited", "risk_mode", "generic_execution_mode"],
+      "properties": {
+        "profile": {"const": "ui_implementation_profile"},
+        "fidelity_evidence": {"const": "ui_fidelity_evidence"},
+        "fidelity_context": {"const": "ui_fidelity_context"},
+        "trigger_ids": {"const": "ui_fidelity_trigger_ids"},
+        "fast_mode_prohibited": {"const": "fast_mode_prohibited"},
+        "risk_mode": {"const": "risk_mode"},
+        "generic_execution_mode": {"const": "execution_mode"}
+      }
+    },
+    "fast_mode": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value", "prohibited_when", "allowed_when"],
+      "properties": {
+        "value": {"const": "FAST"},
+        "prohibited_when": {"const": "DESIGN_FIDELITY_TRIGGER"},
+        "allowed_when": {"const": "NO_MATERIAL_FIDELITY_TRIGGER"}
+      }
+    },
+    "triggers": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "prompt_terms", "evidence_keys"],
+        "properties": {
+          "id": {"type": "string", "minLength": 1},
+          "prompt_terms": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+          "evidence_keys": {"type": "array", "items": {"type": "string", "minLength": 1}}
+        }
+      }
+    },
+    "documented_non_triggers": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+    "fidelity_profile_required_fields": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+    "fidelity_required_true_fields": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+    "context_forward_fields": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+    "authority_false_fields": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["grants_specialist_authority", "grants_implementation_authority", "ponytail_can_self_select", "ponytail_can_downgrade"],
+      "properties": {
+        "grants_specialist_authority": {"const": false},
+        "grants_implementation_authority": {"const": false},
+        "ponytail_can_self_select": {"const": false},
+        "ponytail_can_downgrade": {"const": false}
+      }
+    }
+  }
+}

--- a/orchestra_runtime/domain/orchestration/__init__.py
+++ b/orchestra_runtime/domain/orchestration/__init__.py
@@ -1,5 +1,13 @@
 """Pure orchestration-domain contracts."""
 
+from .ui_fidelity import MINIMAL_SAFE, UI_CONTRACT_FIDELITY, UIFidelityRouting, classify_ui_fidelity
 from .workflow import WORKFLOW_SANITY_SCHEMA_VERSION, WorkflowSanityReceipt
 
-__all__ = ["WORKFLOW_SANITY_SCHEMA_VERSION", "WorkflowSanityReceipt"]
+__all__ = [
+    "MINIMAL_SAFE",
+    "UI_CONTRACT_FIDELITY",
+    "UIFidelityRouting",
+    "WORKFLOW_SANITY_SCHEMA_VERSION",
+    "WorkflowSanityReceipt",
+    "classify_ui_fidelity",
+]

--- a/orchestra_runtime/domain/orchestration/ui_fidelity.py
+++ b/orchestra_runtime/domain/orchestration/ui_fidelity.py
@@ -1,0 +1,180 @@
+"""Pure UI execution-fidelity routing and context-gate semantics."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+MINIMAL_SAFE = "MINIMAL_SAFE"
+UI_CONTRACT_FIDELITY = "UI_CONTRACT_FIDELITY"
+
+
+@dataclass(frozen=True)
+class UIFidelityRouting:
+    selected_profile: str
+    trigger_ids: tuple[str, ...]
+    fast_mode_prohibited: bool
+    fidelity_context: dict[str, Any] | None
+
+    def to_metadata(self, contract: Mapping[str, Any]) -> dict[str, Any]:
+        keys = contract["metadata_keys"]
+        result: dict[str, Any] = {
+            keys["profile"]: self.selected_profile,
+            keys["trigger_ids"]: self.trigger_ids,
+            keys["fast_mode_prohibited"]: self.fast_mode_prohibited,
+        }
+        if self.fidelity_context is not None:
+            result[keys["fidelity_context"]] = deepcopy(self.fidelity_context)
+        else:
+            result.pop(keys["fidelity_context"], None)
+        return result
+
+
+def _has_value(value: object) -> bool:
+    if value is None or value is False or value == "":
+        return False
+    if isinstance(value, (list, tuple, dict, set, frozenset)):
+        return bool(value)
+    return True
+
+
+def _evidence_values(metadata: Mapping[str, Any], profile: Mapping[str, Any] | None) -> tuple[Mapping[str, Any], ...]:
+    evidence = metadata.get("ui_fidelity_evidence")
+    values: list[Mapping[str, Any]] = []
+    if isinstance(evidence, Mapping):
+        values.append(evidence)
+    if profile is not None:
+        values.append(profile)
+    values.append(metadata)
+    return tuple(values)
+
+
+def _evidence_present(
+    metadata: Mapping[str, Any],
+    profile: Mapping[str, Any] | None,
+    keys: object,
+) -> bool:
+    if not isinstance(keys, list):
+        raise ValueError("UI fidelity trigger evidence_keys must be a list")
+    sources = _evidence_values(metadata, profile)
+    for key in keys:
+        for source in sources:
+            if _has_value(source.get(str(key))):
+                return True
+    return False
+
+
+def _profile_payload(metadata: Mapping[str, Any], contract: Mapping[str, Any]) -> dict[str, Any] | None:
+    raw = metadata.get(contract["metadata_keys"]["profile"])
+    context = metadata.get(contract["metadata_keys"]["fidelity_context"])
+    if isinstance(raw, Mapping):
+        return deepcopy(dict(raw))
+    if isinstance(raw, str) and raw == UI_CONTRACT_FIDELITY and isinstance(context, Mapping):
+        payload = deepcopy(dict(context))
+        payload.setdefault("profile", raw)
+        return payload
+    if raw is not None and not isinstance(raw, str):
+        raise ValueError("UI fidelity profile must be an object or a canonical profile name")
+    return None
+
+
+def _profile_name(metadata: Mapping[str, Any], contract: Mapping[str, Any]) -> str | None:
+    raw = metadata.get(contract["metadata_keys"]["profile"])
+    if isinstance(raw, Mapping):
+        value = raw.get("profile")
+    else:
+        value = raw
+    if value is None:
+        return None
+    if not isinstance(value, str) or value not in tuple(contract["profiles"]):
+        raise ValueError("UI fidelity profile must be MINIMAL_SAFE or UI_CONTRACT_FIDELITY")
+    return value
+
+
+def _validate_profile(profile: Mapping[str, Any], contract: Mapping[str, Any]) -> None:
+    required = tuple(str(item) for item in contract["fidelity_profile_required_fields"])
+    missing = [field for field in required if field not in profile]
+    if missing:
+        raise ValueError("UI_CONTRACT_FIDELITY missing required evidence: " + ", ".join(missing))
+    if profile.get("selected_by") != contract["selected_by"]:
+        raise ValueError("UI implementation profile can only be selected by conductor")
+    if not isinstance(profile.get("selection_reason"), str) or not profile["selection_reason"].strip():
+        raise ValueError("UI implementation profile requires a selection reason")
+    for field in ("design_contract_ref", "cloak_handoff_ref", "clockwork_boundary_ref"):
+        if not isinstance(profile.get(field), str) or not profile[field].strip():
+            raise ValueError(f"UI_CONTRACT_FIDELITY requires {field}")
+    for field in ("pattern_refs", "composition_refs"):
+        if not isinstance(profile.get(field), list) or not profile[field]:
+            raise ValueError(f"UI_CONTRACT_FIDELITY requires non-empty {field}")
+    required_fidelity = profile.get("required_fidelity")
+    if not isinstance(required_fidelity, Mapping):
+        raise ValueError("UI_CONTRACT_FIDELITY requires required_fidelity evidence")
+    for field in contract["fidelity_required_true_fields"]:
+        if required_fidelity.get(field) is not True:
+            raise ValueError(f"UI_CONTRACT_FIDELITY requires {field}=true")
+    authority = profile.get("authority")
+    if not isinstance(authority, Mapping):
+        raise ValueError("UI implementation profile requires authority boundaries")
+    for field in contract["authority_false_fields"]:
+        if authority.get(field) is not False:
+            raise ValueError(f"UI implementation profile authority boundary {field} must be false")
+
+
+def classify_ui_fidelity(
+    prompt: str,
+    metadata: Mapping[str, Any] | None,
+    contract: Mapping[str, Any],
+) -> UIFidelityRouting:
+    values = dict(metadata or {})
+    profile = _profile_payload(values, contract)
+    profile_name = _profile_name(values, contract)
+    normalized_prompt = str(prompt).casefold()
+    trigger_ids: list[str] = []
+    for trigger in contract["triggers"]:
+        terms = trigger.get("prompt_terms")
+        if not isinstance(terms, list):
+            raise ValueError("UI fidelity trigger prompt_terms must be a list")
+        prompt_match = any(str(term).casefold() in normalized_prompt for term in terms)
+        if prompt_match or _evidence_present(values, profile, trigger.get("evidence_keys", [])):
+            trigger_ids.append(str(trigger["id"]))
+
+    if profile_name == UI_CONTRACT_FIDELITY and "explicit_ui_contract_fidelity_profile" not in trigger_ids:
+        trigger_ids.append("explicit_ui_contract_fidelity_profile")
+    if profile_name == MINIMAL_SAFE and trigger_ids:
+        raise ValueError("MINIMAL_SAFE conflicts with a material DESIGN_FIDELITY_TRIGGER")
+
+    selected_profile = UI_CONTRACT_FIDELITY if trigger_ids else MINIMAL_SAFE
+    if selected_profile == UI_CONTRACT_FIDELITY:
+        if profile is None:
+            raise ValueError("UI_CONTRACT_FIDELITY requires conductor-selected profile evidence")
+        profile["profile"] = UI_CONTRACT_FIDELITY
+        _validate_profile(profile, contract)
+        risk_mode = values.get(contract["metadata_keys"]["risk_mode"])
+        if isinstance(risk_mode, str) and risk_mode.casefold() == contract["fast_mode"]["value"].casefold():
+            raise ValueError("DESIGN_FIDELITY_TRIGGER makes FAST_MODE_PROHIBITED")
+        context = {
+            field: deepcopy(profile[field])
+            for field in contract["context_forward_fields"]
+            if field in profile
+        }
+        context["profile"] = UI_CONTRACT_FIDELITY
+        context["selected_by"] = contract["selected_by"]
+        return UIFidelityRouting(UI_CONTRACT_FIDELITY, tuple(trigger_ids), True, context)
+
+    if profile is not None:
+        minimal_profile = dict(profile)
+        if minimal_profile.get("profile") not in (None, MINIMAL_SAFE):
+            raise ValueError("MINIMAL_SAFE routing received a conflicting UI profile")
+        if "selected_by" in minimal_profile and minimal_profile["selected_by"] != contract["selected_by"]:
+            raise ValueError("UI implementation profile can only be selected by conductor")
+        authority = minimal_profile.get("authority")
+        if authority is not None:
+            for field in contract["authority_false_fields"]:
+                if authority.get(field) is not False:
+                    raise ValueError(f"UI implementation profile authority boundary {field} must be false")
+    return UIFidelityRouting(MINIMAL_SAFE, (), False, None)
+
+
+__all__ = ["MINIMAL_SAFE", "UI_CONTRACT_FIDELITY", "UIFidelityRouting", "classify_ui_fidelity"]

--- a/orchestra_runtime/machine_contracts.py
+++ b/orchestra_runtime/machine_contracts.py
@@ -9,10 +9,12 @@ from .repositories import ManifestRepository, SkillSourceRepository
 SPECIALIST_REGISTRY_SCHEMA_VERSION = "orchestra.specialist-registry.v1"
 ROUTING_CONTRACT_SCHEMA_VERSION = "orchestra.routing-contract.v1"
 GOVERNANCE_POLICY_SCHEMA_VERSION = "orchestra.governance-policy.v1"
+UI_FIDELITY_ROUTING_CONTRACT_SCHEMA_VERSION = "orchestra.ui-fidelity-routing.v1"
 
 _MACHINE_ROOT = Path("machine")
 _SPECIALIST_REGISTRY = _MACHINE_ROOT / "specialists" / "registry.v1.json"
 _ROUTING_CONTRACT = _MACHINE_ROOT / "routing" / "routes.v1.json"
+_UI_FIDELITY_ROUTING_CONTRACT = _MACHINE_ROOT / "routing" / "ui-fidelity-routing.v1.json"
 _GOVERNANCE_POLICY = _MACHINE_ROOT / "governance" / "policy.v1.json"
 
 FRONTMATTER_FIELDS = (
@@ -122,6 +124,13 @@ def load_routing_contract(root: Path | str | None = None) -> dict[str, Any]:
     contract = _load_json(repo_root / _ROUTING_CONTRACT)
     if contract.get("schema_version") != ROUTING_CONTRACT_SCHEMA_VERSION:
         raise ValueError("unsupported routing contract schema_version")
+    return contract
+
+
+def load_ui_fidelity_routing_contract(root: Path | str | None = None) -> dict[str, Any]:
+    contract = _load_json(_root(root) / _UI_FIDELITY_ROUTING_CONTRACT)
+    if contract.get("schema_version") != UI_FIDELITY_ROUTING_CONTRACT_SCHEMA_VERSION:
+        raise ValueError("unsupported UI fidelity routing contract schema_version")
     return contract
 
 
@@ -298,6 +307,21 @@ def machine_contract_errors(root: Path | str | None = None) -> tuple[str, ...]:
             errors.append("AMBIGUITY_FALLBACK_UNKNOWN")
     except (ValueError, OSError) as exc:
         errors.append(f"ROUTING_CONTRACT_INVALID:{exc}")
+
+    try:
+        fidelity = load_ui_fidelity_routing_contract(repo_root)
+        if fidelity.get("selected_by") != "conductor":
+            errors.append("UI_FIDELITY_ROUTING_SELECTOR_INVALID")
+        if fidelity.get("profiles") != ["MINIMAL_SAFE", "UI_CONTRACT_FIDELITY"]:
+            errors.append("UI_FIDELITY_ROUTING_PROFILE_SET_INVALID")
+        trigger_ids = [str(item.get("id", "")).strip() for item in fidelity.get("triggers", [])]
+        if not trigger_ids or any(not item for item in trigger_ids) or len(trigger_ids) != len(set(trigger_ids)):
+            errors.append("UI_FIDELITY_ROUTING_TRIGGER_SET_INVALID")
+        authority = fidelity.get("authority")
+        if not isinstance(authority, dict) or any(value is not False for value in authority.values()):
+            errors.append("UI_FIDELITY_ROUTING_AUTHORITY_EXPANSION")
+    except (ValueError, OSError) as exc:
+        errors.append(f"UI_FIDELITY_ROUTING_CONTRACT_INVALID:{exc}")
 
     try:
         policy = load_governance_policy(repo_root)

--- a/orchestra_runtime/services.py
+++ b/orchestra_runtime/services.py
@@ -45,6 +45,7 @@ from .delegation import (
     delegation_accepted_event,
     delegation_rejected_event,
 )
+from .domain.orchestration.ui_fidelity import classify_ui_fidelity
 from .errors import (
     ConflictingCoordinationSignalError,
     CoordinationReadinessError,
@@ -88,6 +89,7 @@ from .machine_contracts import (
     command_route_map,
     command_route_record,
     governance_required_specialists,
+    load_ui_fidelity_routing_contract,
     runtime_validation_rule_records,
 )
 from .models import (
@@ -339,6 +341,8 @@ class RouterService(IRouterService):
         _assert_runtime_machine_contracts()
         self._skill_registry = skill_registry
         self._command_routes = command_routes or command_route_map()
+        registry_root = getattr(getattr(skill_registry, "_skill_repository", None), "repo_root", None)
+        self._ui_fidelity_contract = load_ui_fidelity_routing_contract(registry_root)
         self._fallback_specialist = str(command_route_record("__orchestra_ambiguity_fallback__")["specialist"])
         self._governance_required_specialists = governance_required_specialists()
 
@@ -349,21 +353,29 @@ class RouterService(IRouterService):
             raise ValueError(f"Unable to resolve skill for command '{command.name}'")
 
         governance_required = skill.slug in self._governance_required_specialists
+        ui_fidelity = classify_ui_fidelity(command.raw_input, context.metadata, self._ui_fidelity_contract)
+        context_profile = context.metadata.get(self._ui_fidelity_contract["metadata_keys"]["profile"])
+        if isinstance(context_profile, str) and context_profile != ui_fidelity.selected_profile:
+            raise ValueError("UI fidelity context and routed profile disagree")
         reason = (
             f"{context.adapter_name} command '{command.name}' maps to skill '{skill.slug}' via runtime router"
+            f" with UI profile '{ui_fidelity.selected_profile}'"
         )
+        route_metadata = {"skill_path": str(skill.skill_path)}
+        route_metadata.update(ui_fidelity.to_metadata(self._ui_fidelity_contract))
         return RouteDecision(
             command_name=command.name,
             skill_slug=skill.slug,
             governance_required=governance_required,
             reason=reason,
-            metadata={"skill_path": str(skill.skill_path)},
+            metadata=route_metadata,
         )
 
 
 class ContextAssembler:
     def __init__(self, manifest_repository: ManifestRepository):
         self._manifest_repository = manifest_repository
+        self._ui_fidelity_contract = load_ui_fidelity_routing_contract(manifest_repository.repo_root)
 
     def assemble(self, adapter: IIDEAdapter, prompt: str, metadata: dict | None = None) -> ContextPackage:
         context = adapter.provide_context(prompt, metadata)
@@ -371,6 +383,10 @@ class ContextAssembler:
         merged_metadata.setdefault("governance_validated", False)
         merged_metadata.setdefault("destructive_validated", False)
         merged_metadata.setdefault("dry_run", False)
+        ui_fidelity = classify_ui_fidelity(prompt, merged_metadata, self._ui_fidelity_contract)
+        merged_metadata.update(ui_fidelity.to_metadata(self._ui_fidelity_contract))
+        if ui_fidelity.fidelity_context is None:
+            merged_metadata.pop(self._ui_fidelity_contract["metadata_keys"]["fidelity_context"], None)
         return ContextPackage(
             adapter_name=context.adapter_name,
             prompt=context.prompt,

--- a/tests/runtime/test_machine_contracts.py
+++ b/tests/runtime/test_machine_contracts.py
@@ -124,3 +124,25 @@ def test_load_contract_rejects_wrong_schema(tmp_path):
     (path / "registry.v1.json").write_text('{"schema_version":"wrong","specialists":[]}', encoding="utf-8")
     with pytest.raises(ValueError, match="unsupported specialist registry"):
         contracts.load_specialist_registry(tmp_path)
+
+    fidelity_path = tmp_path / "machine" / "routing"
+    fidelity_path.mkdir(parents=True)
+    (fidelity_path / "ui-fidelity-routing.v1.json").write_text('{"schema_version":"wrong"}', encoding="utf-8")
+    with pytest.raises(ValueError, match="unsupported UI fidelity routing"):
+        contracts.load_ui_fidelity_routing_contract(tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("selected_by", "ponytail", "UI_FIDELITY_ROUTING_SELECTOR_INVALID"),
+        ("profiles", ["MINIMAL_SAFE"], "UI_FIDELITY_ROUTING_PROFILE_SET_INVALID"),
+        ("triggers", [{"id": ""}], "UI_FIDELITY_ROUTING_TRIGGER_SET_INVALID"),
+        ("authority", {"grants_implementation_authority": True}, "UI_FIDELITY_ROUTING_AUTHORITY_EXPANSION"),
+    ],
+)
+def test_machine_contract_errors_reject_ui_fidelity_contract_drift(monkeypatch, field, value, message):
+    fidelity = deepcopy(contracts.load_ui_fidelity_routing_contract(ROOT))
+    fidelity[field] = value
+    monkeypatch.setattr(contracts, "load_ui_fidelity_routing_contract", lambda root=None: fidelity)
+    assert message in contracts.machine_contract_errors(ROOT)

--- a/tests/runtime/test_refoundation_contract_failures.py
+++ b/tests/runtime/test_refoundation_contract_failures.py
@@ -117,6 +117,10 @@ def _machine_repo(tmp_path: Path):
         },
     }
     _write_json(tmp_path / "machine/routing/routes.v1.json", routing)
+    _write_json(
+        tmp_path / "machine/routing/ui-fidelity-routing.v1.json",
+        json.loads((Path(__file__).resolve().parents[2] / "machine/routing/ui-fidelity-routing.v1.json").read_text(encoding="utf-8")),
+    )
     _write_json(tmp_path / "machine/governance/policy.v1.json", policy)
     assert mc.machine_contract_errors(tmp_path) == ()
     return routing, policy

--- a/tests/runtime/test_uief2_conductor_fidelity_routing.py
+++ b/tests/runtime/test_uief2_conductor_fidelity_routing.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from orchestra_runtime.adapters import CodexAdapter
+from orchestra_runtime.domain.orchestration.ui_fidelity import MINIMAL_SAFE, UI_CONTRACT_FIDELITY
+from orchestra_runtime.machine_contracts import load_ui_fidelity_routing_contract
+from orchestra_runtime.models import Command, ContextPackage
+from orchestra_runtime.repositories import ManifestRepository, SkillSourceRepository
+from orchestra_runtime.services import ContextAssembler, RouterService, SkillRegistry
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PROFILE = json.loads((ROOT / "machine/ui/ui-implementation-profile.v1.json").read_text(encoding="utf-8"))
+
+
+def _context(prompt: str, metadata: dict | None = None) -> ContextPackage:
+    repository = ManifestRepository(ROOT)
+    adapter = CodexAdapter(repository)
+    return ContextAssembler(repository).assemble(adapter, prompt, metadata)
+
+
+def _router() -> RouterService:
+    registry = SkillRegistry(ManifestRepository(ROOT), SkillSourceRepository(ROOT))
+    return RouterService(registry)
+
+
+def test_uief2_machine_contract_is_schema_valid_and_loaded() -> None:
+    schema = json.loads((ROOT / "machine/schemas/ui-fidelity-routing.v1.schema.json").read_text(encoding="utf-8"))
+    contract = load_ui_fidelity_routing_contract(ROOT)
+    jsonschema.Draft202012Validator(schema).validate(contract)
+    assert contract["selected_by"] == "conductor"
+    assert contract["profiles"] == [MINIMAL_SAFE, UI_CONTRACT_FIDELITY]
+
+
+def test_material_trigger_selects_fidelity_and_forbids_fast_with_bounded_context() -> None:
+    prompt = "Implement the accepted Figma design with responsive reordering and interaction states."
+    context = _context(
+        prompt,
+        {
+            "ui_implementation_profile": copy.deepcopy(PROFILE),
+            "execution_mode": "HOST_NATIVE",
+            "unrelated_corpus": ["must not be forwarded"],
+        },
+    )
+
+    assert context.metadata["ui_implementation_profile"] == UI_CONTRACT_FIDELITY
+    assert context.metadata["fast_mode_prohibited"] is True
+    assert context.metadata["execution_mode"] == "HOST_NATIVE"
+    assert set(context.metadata["ui_fidelity_context"]) == {
+        "profile",
+        "design_contract_ref",
+        "cloak_handoff_ref",
+        "pattern_refs",
+        "composition_refs",
+        "clockwork_boundary_ref",
+        "required_fidelity",
+        "allowed_deviations",
+        "selection_reason",
+        "selected_by",
+        "authority",
+    }
+    assert "unrelated_corpus" not in context.metadata["ui_fidelity_context"]
+
+    command = Command("conductor", prompt, "codex")
+    decision = _router().route(command, context)
+    assert decision.metadata["ui_implementation_profile"] == UI_CONTRACT_FIDELITY
+    assert decision.metadata["fast_mode_prohibited"] is True
+
+
+def test_multiple_fidelity_triggers_are_deterministic() -> None:
+    prompt = "Preserve the UI design contract, CUIR pattern references, visual hierarchy, and responsive transformation."
+    first = _context(prompt, {"ui_implementation_profile": copy.deepcopy(PROFILE)})
+    second = _context(prompt, {"ui_implementation_profile": copy.deepcopy(PROFILE)})
+
+    assert first.metadata["ui_fidelity_trigger_ids"] == second.metadata["ui_fidelity_trigger_ids"]
+    assert first.metadata["ui_fidelity_context"] == second.metadata["ui_fidelity_context"]
+
+
+def test_trivial_ui_change_remains_fast_eligible_and_loads_no_fidelity_context() -> None:
+    context = _context(
+        "Fix the typo in the submit button label.",
+        {"risk_mode": "FAST", "ui_fidelity_context": {"unrelated_corpus": ["stale"]}},
+    )
+
+    assert context.metadata["ui_implementation_profile"] == MINIMAL_SAFE
+    assert context.metadata["fast_mode_prohibited"] is False
+    assert "ui_fidelity_context" not in context.metadata
+    assert context.metadata["risk_mode"] == "FAST"
+
+
+def test_material_trigger_cannot_enter_fast_even_for_small_request() -> None:
+    with pytest.raises(ValueError, match="FAST_MODE_PROHIBITED"):
+        _context(
+            "Change one small file to preserve the accepted visual hierarchy.",
+            {"ui_implementation_profile": copy.deepcopy(PROFILE), "risk_mode": "FAST"},
+        )
+
+
+def test_profile_selection_and_downgrade_authority_fail_closed() -> None:
+    ponytail_profile = copy.deepcopy(PROFILE)
+    ponytail_profile["selected_by"] = "ponytail"
+    with pytest.raises(ValueError, match="only be selected by conductor"):
+        _context("Implement the accepted UI design contract.", {"ui_implementation_profile": ponytail_profile})
+
+    downgrade = copy.deepcopy(PROFILE)
+    downgrade["profile"] = MINIMAL_SAFE
+    with pytest.raises(ValueError, match="conflicts with a material"):
+        _context("Preserve the accepted visual hierarchy.", {"ui_implementation_profile": downgrade})
+
+
+def test_missing_required_fidelity_evidence_fails_closed() -> None:
+    with pytest.raises(ValueError, match="requires conductor-selected profile evidence"):
+        _context("Implement the accepted Figma design.")

--- a/tests/runtime/test_uief2_conductor_fidelity_routing.py
+++ b/tests/runtime/test_uief2_conductor_fidelity_routing.py
@@ -8,7 +8,11 @@ import jsonschema
 import pytest
 
 from orchestra_runtime.adapters import CodexAdapter
-from orchestra_runtime.domain.orchestration.ui_fidelity import MINIMAL_SAFE, UI_CONTRACT_FIDELITY
+from orchestra_runtime.domain.orchestration.ui_fidelity import (
+    MINIMAL_SAFE,
+    UI_CONTRACT_FIDELITY,
+    classify_ui_fidelity,
+)
 from orchestra_runtime.machine_contracts import load_ui_fidelity_routing_contract
 from orchestra_runtime.models import Command, ContextPackage
 from orchestra_runtime.repositories import ManifestRepository, SkillSourceRepository
@@ -28,6 +32,10 @@ def _context(prompt: str, metadata: dict | None = None) -> ContextPackage:
 def _router() -> RouterService:
     registry = SkillRegistry(ManifestRepository(ROOT), SkillSourceRepository(ROOT))
     return RouterService(registry)
+
+
+def _classify(prompt: str, metadata: dict | None = None, contract: dict | None = None):
+    return classify_ui_fidelity(prompt, metadata, contract or load_ui_fidelity_routing_contract(ROOT))
 
 
 def test_uief2_machine_contract_is_schema_valid_and_loaded() -> None:
@@ -117,3 +125,81 @@ def test_profile_selection_and_downgrade_authority_fail_closed() -> None:
 def test_missing_required_fidelity_evidence_fails_closed() -> None:
     with pytest.raises(ValueError, match="requires conductor-selected profile evidence"):
         _context("Implement the accepted Figma design.")
+
+
+def test_mapping_evidence_is_considered_without_broadening_forwarded_context() -> None:
+    context = _context(
+        "Implement the accepted UI design contract.",
+        {
+            "ui_implementation_profile": copy.deepcopy(PROFILE),
+            "ui_fidelity_evidence": {"visual_hierarchy": True, "unrelated_corpus": ["drop"]},
+        },
+    )
+    assert context.metadata["ui_implementation_profile"] == UI_CONTRACT_FIDELITY
+    assert "unrelated_corpus" not in context.metadata["ui_fidelity_context"]
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (lambda profile: profile.clear(), "missing required evidence"),
+        (lambda profile: profile.update(selection_reason=""), "requires a selection reason"),
+        (lambda profile: profile.update(design_contract_ref=""), "requires design_contract_ref"),
+        (lambda profile: profile.update(pattern_refs=[]), "requires non-empty pattern_refs"),
+        (lambda profile: profile.update(required_fidelity=None), "requires required_fidelity evidence"),
+        (
+            lambda profile: profile["required_fidelity"].update(preserve_visual_hierarchy=False),
+            "preserve_visual_hierarchy=true",
+        ),
+        (lambda profile: profile.update(authority=None), "requires authority boundaries"),
+        (
+            lambda profile: profile["authority"].update(ponytail_can_downgrade=True),
+            "authority boundary ponytail_can_downgrade must be false",
+        ),
+    ],
+)
+def test_invalid_fidelity_profile_evidence_fails_closed(mutate, message: str) -> None:
+    profile = copy.deepcopy(PROFILE)
+    mutate(profile)
+    with pytest.raises(ValueError, match=message):
+        _classify("Implement the accepted UI design contract.", {"ui_implementation_profile": profile})
+
+
+def test_malformed_profile_payload_and_profile_name_fail_closed() -> None:
+    with pytest.raises(ValueError, match="object or a canonical profile name"):
+        _classify("Fix a button label.", {"ui_implementation_profile": 7})
+    with pytest.raises(ValueError, match="must be MINIMAL_SAFE"):
+        _classify("Fix a button label.", {"ui_implementation_profile": {"profile": "UNSAFE"}})
+
+
+def test_malformed_trigger_contract_fails_closed() -> None:
+    contract = copy.deepcopy(load_ui_fidelity_routing_contract(ROOT))
+    contract["triggers"][0]["prompt_terms"] = "not-a-list"
+    with pytest.raises(ValueError, match="prompt_terms must be a list"):
+        _classify("anything", contract=contract)
+
+
+def test_minimal_profile_boundaries_are_checked_without_selecting_fidelity() -> None:
+    assert _classify("Fix a button label.", {"ui_implementation_profile": {"profile": None}}).selected_profile == MINIMAL_SAFE
+
+    contract = copy.deepcopy(load_ui_fidelity_routing_contract(ROOT))
+    contract["profiles"].append("UNSAFE")
+    with pytest.raises(ValueError, match="conflicting UI profile"):
+        _classify("Fix a button label.", {"ui_implementation_profile": {"profile": "UNSAFE"}}, contract=contract)
+
+    with pytest.raises(ValueError, match="only be selected by conductor"):
+        _classify("Fix a button label.", {"ui_implementation_profile": {"selected_by": "ponytail"}})
+
+    safe_authority = {
+        key: False
+        for key in load_ui_fidelity_routing_contract(ROOT)["authority_false_fields"]
+    }
+    assert _classify(
+        "Fix a button label.",
+        {"ui_implementation_profile": {"authority": safe_authority}},
+    ).selected_profile == MINIMAL_SAFE
+
+    unsafe_authority = dict(safe_authority)
+    unsafe_authority["ponytail_can_self_select"] = True
+    with pytest.raises(ValueError, match="authority boundary ponytail_can_self_select must be false"):
+        _classify("Fix a button label.", {"ui_implementation_profile": {"authority": unsafe_authority}})


### PR DESCRIPTION
Implements the bounded UIEF-2 Conductor fidelity routing and context gate. Adds the versioned machine contract and schema, deterministic material-trigger classification, FAST prohibition semantics, bounded downstream fidelity context, fail-closed router/context validation, and focused tests. Preserves generic execution_mode and leaves Ponytail behavior unchanged. Validation completed locally: full runtime suite, approved-base behavior runner, machine contracts, architecture boundaries, structure, export parity, governance strict, diff check, and guardrail scan.