### PR TITLE
feat(uief): implement cloak visible layer fidelity handoff contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Post-v1.8.0 UIEF-4 Cloak implementation-bound fidelity handoff
+
+- Introduces library-neutral UI fidelity handoff machine contract schema `machine/schemas/ui-fidelity-handoff.v1.schema.json` under JSON Schema Draft 2020-12.
+- Establishes canonical reference machine contract in `machine/ui/ui-fidelity-handoff.v1.json` binding design intent, macro composition, information hierarchy, CUIR normalized pattern references, provider-observed references, required regions, responsive transformations, component roles, visual/typography/spacing relationships, and explicit preserve/adapt/avoid/unresolved rules.
+- Adds progressive-disclosure handoff guide at `skills/cloak/UI_FIDELITY_HANDOFF_GUIDE.md` and byte-identical Codex mirror at `adapters/codex/skills/cloak/UI_FIDELITY_HANDOFF_GUIDE.md` without modifying the historical frozen Cloak core skill (`skills/cloak/SKILL.md`).
+- Adds `UI_FIDELITY_HANDOFF` output format to `skills/cloak/OUTPUT_FORMATS.md` and `adapters/codex/skills/cloak/OUTPUT_FORMATS.md`.
+- Formalizes `UIFidelityHandoff` domain model and `validate_ui_fidelity_handoff` parser/validator in `orchestra_runtime/domain/orchestration/ui_fidelity.py` and machine contract validation in `orchestra_runtime/machine_contracts.py`.
+- Enforces strict authority invariants: Cloak cannot grant implementation, architecture translation, or release authority; Ponytail consumes the handoff via `to_ponytail_context()` but cannot create or own handoff contracts.
+- Enforces strict prohibitions against generic `execution_mode` contamination and premature UIEF-5 Clockwork engineering translation.
+- Provides deterministic test fixtures in `tests/fixtures/ui/uief4-*.json` and comprehensive runtime validation in `tests/runtime/test_uief4_cloak_fidelity_handoff.py`.
+
 ## Post-v1.8.0 UIEF-3 Ponytail frontend fidelity execution layer
 
 - Establishes Ponytail frontend fidelity execution progressive-disclosure guide at `skills/ponytail/FRONTEND_FIDELITY_EXECUTION_GUIDE.md` and byte-identical Codex mirror at `adapters/codex/skills/ponytail/FRONTEND_FIDELITY_EXECUTION_GUIDE.md`.

--- a/README.json
+++ b/README.json
@@ -594,6 +594,27 @@
       "authority_expansion": false,
       "authority_note": "UIEF-3 implements accepted frontend fidelity contracts only. It does not transfer design authority to Ponytail, allow profile self-selection or downgrade, authorize UIEF-4 UIFidelityHandoff creation, release, deployment, or policy activation."
     },
+    "uief4_cloak_fidelity_handoff": {
+      "status": "IMPLEMENTED_CANONICAL",
+      "purpose": "Cloak implementation-bound fidelity handoff contract binding design intent, macro composition, information hierarchy, CUIR normalized pattern references, provider-observed references, required regions, responsive transformations, component roles, visual/typography/spacing relationships, and explicit preserve/adapt/avoid/unresolved rules into an implementation-consumable contract.",
+      "machine_sources": [
+        "machine/schemas/ui-fidelity-handoff.v1.schema.json",
+        "machine/ui/ui-fidelity-handoff.v1.json",
+        "orchestra_runtime/domain/orchestration/ui_fidelity.py",
+        "skills/cloak/OUTPUT_FORMATS.md",
+        "adapters/codex/skills/cloak/OUTPUT_FORMATS.md"
+      ],
+      "human_sources": [
+        "skills/cloak/UI_FIDELITY_HANDOFF_GUIDE.md",
+        "adapters/codex/skills/cloak/UI_FIDELITY_HANDOFF_GUIDE.md",
+        "docs/project/UI_EXECUTION_FIDELITY_PLAN.md"
+      ],
+      "validation_surface": "tests/runtime/test_uief4_cloak_fidelity_handoff.py",
+      "runtime_integration": true,
+      "frozen_core_preserved": true,
+      "authority_expansion": false,
+      "authority_note": "UIEF-4 binds accepted visible design intent and fidelity requirements into an implementation-consumable handoff. It does not transfer design authority to Ponytail, authorize implementation, architecture translation, release, deployment, or policy activation."
+    },
     "governed_ui_optional_adapter_boundaries_uix6": {
       "status": "IMPLEMENTED_CANONICAL_NO_ADOPTION",
       "purpose": "Library-neutral UIX-6 audit and boundary contract for optional Figma, Code Connect, Storybook, Playwright, axe, and project-native design-token evidence capabilities.",
@@ -2405,6 +2426,7 @@
     "conductor_routing_evaluation_guide": "skills/conductor/ROUTING_EVALUATION_GUIDE.md",
     "conductor_architecture_governance_intake_guide": "skills/conductor/ARCHITECTURE_GOVERNANCE_INTAKE_GUIDE.md",
     "ponytail_frontend_fidelity_execution_guide": "skills/ponytail/FRONTEND_FIDELITY_EXECUTION_GUIDE.md",
+    "cloak_ui_fidelity_handoff_guide": "skills/cloak/UI_FIDELITY_HANDOFF_GUIDE.md",
     "ui_execution_fidelity_plan": "docs/project/UI_EXECUTION_FIDELITY_PLAN.md"
   },
   "representation_policy": {

--- a/adapters/codex/skills/cloak/OUTPUT_FORMATS.md
+++ b/adapters/codex/skills/cloak/OUTPUT_FORMATS.md
@@ -134,3 +134,32 @@ Reason:
 ```
 
 Write `None confirmed` for empty issue sections. State whether the interface is ready, needs revision, or needs major restructuring.
+---
+
+## UI_FIDELITY_HANDOFF
+
+Use when performing UIEF visible-layer fidelity handoffs to Ponytail for execution.
+
+\\	ext
+HANDOFF ID:
+DESIGN INTENT:
+UI IMPLEMENTATION PROFILE:
+DESIGN CONTRACT REF:
+INFORMATION HIERARCHY:
+MACRO COMPOSITION:
+REQUIRED REGIONS:
+SELECTED PATTERNS:
+PROVENANCE IDENTIFIERS:
+COMPONENT ROLES:
+VISUAL RELATIONSHIPS:
+TYPOGRAPHY ROLES:
+SPACING RELATIONSHIPS:
+RESPONSIVE TRANSFORMATIONS:
+INTERACTION STATES:
+ASSET REQUIREMENTS:
+PRESERVE:
+ADAPT:
+AVOID:
+UNRESOLVED:
+HANDOFF TO: Ponytail (Implementation)
+\

--- a/adapters/codex/skills/cloak/UI_FIDELITY_HANDOFF_GUIDE.md
+++ b/adapters/codex/skills/cloak/UI_FIDELITY_HANDOFF_GUIDE.md
@@ -1,0 +1,38 @@
+# Cloak UI Fidelity Handoff Guide (UIEF-4)
+
+This guide governs the Cloak implementation-bound visible-layer fidelity handoff contract (UIFidelityHandoff) under the UI Execution Fidelity (UIEF) architecture.
+
+## 1. Specialist Authority and Separation of Concerns
+
+- **Cloak (Design Authority)**: Owns the visible-layer design intent, information hierarchy, macro-composition specification, pattern selection, and the UIFidelityHandoff contract. Cloak never authors code implementations or modifies persistence/infrastructure.
+- **Conductor (Routing Authority)**: Retains upstream authority over UIImplementationProfile selection (MINIMAL_SAFE vs UI_CONTRACT_FIDELITY). Cloak binds to the selected profile and does not self-assign or re-route profiles.
+- **Ponytail (Implementation Consumer)**: Downstream implementation specialist that strictly consumes the UIFidelityHandoff without authoring, inventing, or altering design decisions.
+- **Clockwork Boundary**: UIEF-5 Clockwork engineering translation remains strictly outside UIEF-4. Cloak does not generate architectural refactoring or engineering translations.
+
+## 2. Provenance and Reference Discipline
+
+- **CUIR References**: Selected CUIR-3/CUIR-4 normalized patterns must carry explicit provenance IDs (source_kind: CUIR_NORMALIZED). They provide structural pattern guidance without copying external assets.
+- **Project-Native Primacy**: Native components, design tokens, and existing layouts (source_kind: PROJECT_NATIVE) outrank external references unless explicitly deprecated.
+- **Provider References**: Public provider guidance (PUBLIC_PROVIDER_GUIDANCE) and observed provider outputs (OBSERVED_PROVIDER_OUTPUT) are marked dvisory_only: true and serve solely as comparative evidence. Never claim proprietary provider internal algorithms or copy third-party source code.
+
+## 3. Required Semantic Structure
+
+The UIFidelityHandoff machine contract must bind:
+1. **Design Intent**: Concise, actionable specification of accepted user-facing intent.
+2. **Information Hierarchy**: Ordered levels from topmost landmarks to granular elements with target component mapping.
+3. **Macro Composition**: Uncompromised structural compositions (layouts, split panes, action bars) that Ponytail is prohibited from simplifying solely to reduce code size.
+4. **Selected Pattern References**: Curated patterns with source kind, reference link, and provenance identifier.
+5. **Pattern Application Reason**: Transparent rationale for each chosen pattern.
+6. **Required Regions**: Explicit landmarks (BANNER, NAVIGATION, MAIN, COMPLEMENTARY) and placement rules.
+7. **Component, Typography, Spacing, and Visual Roles**: Explicit definitions preventing implementation-level guesswork.
+8. **Responsive Transformations**: Concrete breakpoint transitions preserving core utility across desktop, tablet, and mobile viewports.
+9. **Interaction States**: Comprehensive state coverage (DEFAULT, HOVER, FOCUS_VISIBLE, ACTIVE, DISABLED, LOADING, EMPTY, ERROR).
+10. **Preserve / Adapt / Avoid Constraints**: Unambiguous guardrails defining non-negotiable elements (preserve), flexible margins (dapt), and forbidden anti-patterns (void).
+11. **Explicit Unresolved Items**: Unresolved requirements or missing design tokens must be explicitly enumerated in unresolved. Never invent missing facts or silently drop unresolved requirements.
+
+## 4. Handoff Consumption by Ponytail
+
+Ponytail consumes the handoff via 	o_ponytail_context():
+- Ponytail executes the defined composition using project-native code and components.
+- Any deviation required by technical constraints must be recorded as an authorized UIDeviationRecord in Ponytail execution payload.
+- Omission of required compositions without an authorized deviation fails closed.

--- a/docs/project/UI_EXECUTION_FIDELITY_PLAN.md
+++ b/docs/project/UI_EXECUTION_FIDELITY_PLAN.md
@@ -438,6 +438,31 @@ CUIR and provider-observed patterns remain guidance evidence. UIEF binds selecte
 Exit:
 UIEF_4_CLOAK_IMPLEMENTATION_BINDING_READY
 
+The canonical UIEF-4 implementation is the versioned machine contract at
+`machine/ui/ui-fidelity-handoff.v1.json` with its schema at
+`machine/schemas/ui-fidelity-handoff.v1.schema.json`. Cloak binds accepted design
+intelligence, macro composition, information hierarchy, CUIR normalized pattern
+references, provider-observed pattern references, required regions, responsive
+transformations, component roles, visual/typography/spacing relationships, and
+explicit preserve/adapt/avoid/unresolved rules into an implementation-consumable
+handoff without modifying the historical frozen Cloak core skill (`skills/cloak/SKILL.md`).
+
+The progressive-disclosure implementation guidance lives in
+`skills/cloak/UI_FIDELITY_HANDOFF_GUIDE.md` with byte-identical Codex mirror at
+`adapters/codex/skills/cloak/UI_FIDELITY_HANDOFF_GUIDE.md` and the
+`UI_FIDELITY_HANDOFF` output format in `skills/cloak/OUTPUT_FORMATS.md`.
+Cloak remains the exclusive owner of visible design intent and fidelity handoff;
+Ponytail consumes the handoff via `to_ponytail_context()` but cannot create or own
+handoff contracts. Authority invariants strictly ensure the handoff conveys no
+implementation, architecture translation, or release authority. Generic `execution_mode`
+contamination and premature UIEF-5 Clockwork translation initiation are strictly
+prohibited and fail closed.
+
+The runtime enforcement contracts, schema validation, and semantic test coverage
+live in `orchestra_runtime/domain/orchestration/ui_fidelity.py`,
+`orchestra_runtime/machine_contracts.py`, and
+`tests/runtime/test_uief4_cloak_fidelity_handoff.py`.
+
 ### UIEF-5 - Clockwork UI engineering translation
 
 Goal:

--- a/machine/schemas/ui-fidelity-handoff.v1.schema.json
+++ b/machine/schemas/ui-fidelity-handoff.v1.schema.json
@@ -1,0 +1,386 @@
+{
+  "": {
+    "provenanceRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_id",
+        "source_kind",
+        "reference_ref",
+        "provenance_id"
+      ],
+      "properties": {
+        "source_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_kind": {
+          "enum": [
+            "CUIR_NORMALIZED",
+            "PROJECT_NATIVE",
+            "PUBLIC_PROVIDER_GUIDANCE",
+            "OBSERVED_PROVIDER_OUTPUT"
+          ]
+        },
+        "reference_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "provenance_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "advisory_only": {
+          "type": "boolean"
+        }
+      }
+    },
+    "patternRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "pattern_id",
+        "source_kind",
+        "reference_ref",
+        "provenance_id"
+      ],
+      "properties": {
+        "pattern_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_kind": {
+          "enum": [
+            "CUIR_NORMALIZED",
+            "PROJECT_NATIVE",
+            "PUBLIC_PROVIDER_GUIDANCE",
+            "OBSERVED_PROVIDER_OUTPUT"
+          ]
+        },
+        "reference_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "provenance_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "advisory_only": {
+          "type": "boolean"
+        }
+      }
+    },
+    "hierarchyItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "level",
+        "description"
+      ],
+      "properties": {
+        "level": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_components": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "compositionItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "composition_id",
+        "structural_role",
+        "description"
+      ],
+      "properties": {
+        "composition_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "structural_role": {
+          "enum": [
+            "MACRO_LAYOUT",
+            "VISUAL_HIERARCHY",
+            "RESPONSIVE_TRANSFORMATION",
+            "CONTAINER_FLOW",
+            "FOCUSED_REGION"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reference_ref": {
+          "type": "string"
+        }
+      }
+    },
+    "regionItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "region_id",
+        "role",
+        "placement"
+      ],
+      "properties": {
+        "region_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "role": {
+          "type": "string",
+          "minLength": 1
+        },
+        "placement": {
+          "type": "string",
+          "minLength": 1
+        },
+        "collapsible": {
+          "type": "boolean"
+        }
+      }
+    },
+    "responsiveItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "breakpoint",
+        "transformation"
+      ],
+      "properties": {
+        "breakpoint": {
+          "type": "string",
+          "minLength": 1
+        },
+        "transformation": {
+          "type": "string",
+          "minLength": 1
+        },
+        "affected_regions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "assetItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "asset_id",
+        "kind",
+        "usage"
+      ],
+      "properties": {
+        "asset_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "kind": {
+          "enum": [
+            "DESIGN_TOKEN",
+            "ICON",
+            "ILLUSTRATION",
+            "TYPOGRAPHY_SPEC",
+            "NATIVE_COMPONENT"
+          ]
+        },
+        "usage": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reference_ref": {
+          "type": "string"
+        }
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "implementation_authorized",
+        "architecture_translation_authorized",
+        "release_authorized"
+      ],
+      "properties": {
+        "implementation_authorized": {
+          "const": false
+        },
+        "architecture_translation_authorized": {
+          "const": false
+        },
+        "release_authorized": {
+          "const": false
+        }
+      }
+    }
+  },
+  "title": "Orchestra UI Fidelity Handoff Contract v1",
+  "description": "Cloak implementation-bound visible-layer fidelity handoff contract binding design intent, macro-composition, information hierarchy, pattern intelligence, and execution constraints for Ponytail consumption without transferring design authority or implementation ownership.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "contract_id",
+    "owned_by",
+    "design_contract_ref",
+    "ui_implementation_profile_ref",
+    "source_revision_or_contract_identity",
+    "provenance_refs",
+    "design_intent",
+    "information_hierarchy",
+    "macro_composition",
+    "selected_pattern_refs",
+    "pattern_application_reason",
+    "required_regions",
+    "component_roles",
+    "visual_relationships",
+    "typography_roles",
+    "spacing_relationships",
+    "responsive_transformations",
+    "interaction_states",
+    "asset_requirements",
+    "preserve",
+    "adapt",
+    "avoid",
+    "unresolved",
+    "authority"
+  ],
+  "properties": {
+    "": {
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "orchestra.ui-fidelity-handoff.v1"
+    },
+    "contract_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "owned_by": {
+      "const": "cloak"
+    },
+    "design_contract_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "ui_implementation_profile_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_revision_or_contract_identity": {
+      "type": "string",
+      "minLength": 1
+    },
+    "provenance_refs": {
+      "type": "array",
+      "items": {
+        "": "#//provenanceRef"
+      }
+    },
+    "design_intent": {
+      "type": "string",
+      "minLength": 1
+    },
+    "information_hierarchy": {
+      "type": "array",
+      "items": {
+        "": "#//hierarchyItem"
+      }
+    },
+    "macro_composition": {
+      "type": "array",
+      "items": {
+        "": "#//compositionItem"
+      }
+    },
+    "selected_pattern_refs": {
+      "type": "array",
+      "items": {
+        "": "#//patternRef"
+      }
+    },
+    "pattern_application_reason": {
+      "type": "string",
+      "minLength": 1
+    },
+    "required_regions": {
+      "type": "array",
+      "items": {
+        "": "#//regionItem"
+      }
+    },
+    "component_roles": {
+      "type": "object"
+    },
+    "visual_relationships": {
+      "type": "object"
+    },
+    "typography_roles": {
+      "type": "object"
+    },
+    "spacing_relationships": {
+      "type": "object"
+    },
+    "responsive_transformations": {
+      "type": "array",
+      "items": {
+        "": "#//responsiveItem"
+      }
+    },
+    "interaction_states": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "asset_requirements": {
+      "type": "array",
+      "items": {
+        "": "#//assetItem"
+      }
+    },
+    "preserve": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "adapt": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "avoid": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "unresolved": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "authority": {
+      "": "#//authority"
+    }
+  }
+}

--- a/machine/ui/ui-fidelity-handoff.v1.json
+++ b/machine/ui/ui-fidelity-handoff.v1.json
@@ -1,0 +1,253 @@
+{
+  "": "../schemas/ui-fidelity-handoff.v1.schema.json",
+  "schema_version": "orchestra.ui-fidelity-handoff.v1",
+  "contract_id": "uief4-ui-fidelity-handoff-reference",
+  "owned_by": "cloak",
+  "design_contract_ref": "machine/schemas/ui-design-contract.schema.json",
+  "ui_implementation_profile_ref": "machine/ui/ui-implementation-profile.v1.json",
+  "source_revision_or_contract_identity": "uief1-ui-implementation-profile-reference",
+  "provenance_refs": [
+    {
+      "source_id": "cuir-workspace-split-pane-prov",
+      "source_kind": "CUIR_NORMALIZED",
+      "reference_ref": "docs/specs/cuir/CUIR_NORMALIZED_PATTERNS.md#workspace-split-pane",
+      "provenance_id": "CUIR-3-WORKSPACE-SPLIT-PANE-001",
+      "advisory_only": false
+    },
+    {
+      "source_id": "native-command-palette-prov",
+      "source_kind": "PROJECT_NATIVE",
+      "reference_ref": "components/palette/CommandPalette.tsx",
+      "provenance_id": "PROJECT-NATIVE-PALETTE-001",
+      "advisory_only": false
+    },
+    {
+      "source_id": "public-anthropic-artifact-canvas-prov",
+      "source_kind": "PUBLIC_PROVIDER_GUIDANCE",
+      "reference_ref": "docs/specs/ui/PUBLIC_PROVIDER_UI_REFERENCE_INTELLIGENCE.md#anthropic-artifact-canvas",
+      "provenance_id": "PUBLIC-PROVIDER-ANTHROPIC-CANVAS-001",
+      "advisory_only": true
+    },
+    {
+      "source_id": "observed-sidecar-drawer-layout-prov",
+      "source_kind": "OBSERVED_PROVIDER_OUTPUT",
+      "reference_ref": "docs/specs/ui/OBSERVED_PROVIDER_PATTERNS.md#sidecar-drawer-layout",
+      "provenance_id": "OBSERVED-PROVIDER-SIDECAR-DRAWER-001",
+      "advisory_only": true
+    }
+  ],
+  "design_intent": "Deliver a high-density, multi-pane developer workspace interface maintaining macro composition and visual hierarchy without code-size-induced composition simplification.",
+  "information_hierarchy": [
+    {
+      "level": 1,
+      "title": "Workspace Header and Navigation",
+      "description": "Topmost operational bar exposing repository context, status indicator, and global command trigger.",
+      "target_components": [
+        "WorkspaceHeader",
+        "StatusIndicator",
+        "GlobalCommandTrigger"
+      ]
+    },
+    {
+      "level": 2,
+      "title": "Dual-Pane Operational Canvas",
+      "description": "Primary content region divided into collateral navigator (left) and active document viewer (right).",
+      "target_components": [
+        "SplitPaneContainer",
+        "CollateralNavigator",
+        "DocumentViewer"
+      ]
+    },
+    {
+      "level": 3,
+      "title": "Docked Secondary Inspector",
+      "description": "Bottom contextual inspector displaying diagnostics, metadata, and execution telemetry.",
+      "target_components": [
+        "ContextualInspector",
+        "TelemetryPanel"
+      ]
+    }
+  ],
+  "macro_composition": [
+    {
+      "composition_id": "desktop-macro-grid",
+      "structural_role": "MACRO_LAYOUT",
+      "description": "3-region vertical grid with fixed header (48px), flex primary workspace (1fr), and docked bottom tray (auto/collapsible).",
+      "reference_ref": "docs/specs/ui/COMPOSITIONS.md#desktop-macro-grid"
+    },
+    {
+      "composition_id": "action-bar-visual-hierarchy",
+      "structural_role": "VISUAL_HIERARCHY",
+      "description": "Prominent left-aligned breadcrumb title with right-aligned action group maintaining high-contrast primary CTA.",
+      "reference_ref": "docs/specs/ui/COMPOSITIONS.md#action-bar-visual-hierarchy"
+    },
+    {
+      "composition_id": "split-pane-responsive-collapse",
+      "structural_role": "RESPONSIVE_TRANSFORMATION",
+      "description": "Horizontal split-pane on viewports >= 1024px; vertical accordion-stack collapse on viewports < 1024px.",
+      "reference_ref": "docs/specs/ui/COMPOSITIONS.md#split-pane-responsive-collapse"
+    }
+  ],
+  "selected_pattern_refs": [
+    {
+      "pattern_id": "cuir-workspace-split-pane",
+      "source_kind": "CUIR_NORMALIZED",
+      "reference_ref": "docs/specs/cuir/CUIR_NORMALIZED_PATTERNS.md#workspace-split-pane",
+      "provenance_id": "CUIR-3-WORKSPACE-SPLIT-PANE-001",
+      "advisory_only": false
+    },
+    {
+      "pattern_id": "native-command-palette",
+      "source_kind": "PROJECT_NATIVE",
+      "reference_ref": "components/palette/CommandPalette.tsx",
+      "provenance_id": "PROJECT-NATIVE-PALETTE-001",
+      "advisory_only": false
+    },
+    {
+      "pattern_id": "public-anthropic-artifact-canvas-flow",
+      "source_kind": "PUBLIC_PROVIDER_GUIDANCE",
+      "reference_ref": "docs/specs/ui/PUBLIC_PROVIDER_UI_REFERENCE_INTELLIGENCE.md#anthropic-artifact-canvas",
+      "provenance_id": "PUBLIC-PROVIDER-ANTHROPIC-CANVAS-001",
+      "advisory_only": true
+    },
+    {
+      "pattern_id": "observed-sidecar-drawer-layout",
+      "source_kind": "OBSERVED_PROVIDER_OUTPUT",
+      "reference_ref": "docs/specs/ui/OBSERVED_PROVIDER_PATTERNS.md#sidecar-drawer-layout",
+      "provenance_id": "OBSERVED-PROVIDER-SIDECAR-DRAWER-001",
+      "advisory_only": true
+    }
+  ],
+  "pattern_application_reason": "Normalized CUIR split-pane provides deterministic layout stability; native command palette preserves existing user muscle memory; provider references serve as advisory-only pattern evidence.",
+  "required_regions": [
+    {
+      "region_id": "region-header",
+      "role": "BANNER",
+      "placement": "TOP_FIXED",
+      "collapsible": false
+    },
+    {
+      "region_id": "region-nav-sidebar",
+      "role": "NAVIGATION",
+      "placement": "LEFT_FLEXIBLE",
+      "collapsible": true
+    },
+    {
+      "region_id": "region-main-content",
+      "role": "MAIN",
+      "placement": "CENTER_EXPANDING",
+      "collapsible": false
+    },
+    {
+      "region_id": "region-bottom-dock",
+      "role": "COMPLEMENTARY",
+      "placement": "BOTTOM_DOCKED",
+      "collapsible": true
+    }
+  ],
+  "component_roles": {
+    "primary_container": "LayoutShell",
+    "navigator": "CollateralTree",
+    "viewer": "ActiveDocumentViewer",
+    "status_indicator": "SystemStateBadge",
+    "action_palette": "CommandPalette"
+  },
+  "visual_relationships": {
+    "grid_gap": "12px",
+    "sidebar_width_range": "240px-360px",
+    "content_min_width": "480px",
+    "elevation_hierarchy": {
+      "base_surface": "0px",
+      "docked_surface": "2px",
+      "floating_palette": "8px"
+    }
+  },
+  "typography_roles": {
+    "page_title": "font-size: 1.125rem; font-weight: 600; line-height: 1.5rem;",
+    "section_header": "font-size: 0.875rem; font-weight: 600; text-transform: uppercase;",
+    "body_text": "font-size: 0.875rem; font-weight: 400; line-height: 1.25rem;",
+    "code_snippet": "font-family: monospace; font-size: 0.8125rem;"
+  },
+  "spacing_relationships": {
+    "layout_padding": "16px",
+    "component_padding": "8px 12px",
+    "compact_padding": "4px 8px",
+    "element_gap": "8px"
+  },
+  "responsive_transformations": [
+    {
+      "breakpoint": "desktop (>= 1024px)",
+      "transformation": "Multi-column split view with visible sidebar and expanded document canvas.",
+      "affected_regions": [
+        "region-nav-sidebar",
+        "region-main-content"
+      ]
+    },
+    {
+      "breakpoint": "tablet (768px - 1023px)",
+      "transformation": "Sidebar collapsed to drawer toggle; main content occupies full viewport width.",
+      "affected_regions": [
+        "region-nav-sidebar",
+        "region-main-content"
+      ]
+    },
+    {
+      "breakpoint": "mobile (< 768px)",
+      "transformation": "Single-column vertical stack with drawer overlay navigation.",
+      "affected_regions": [
+        "region-header",
+        "region-nav-sidebar",
+        "region-main-content",
+        "region-bottom-dock"
+      ]
+    }
+  ],
+  "interaction_states": [
+    "DEFAULT",
+    "HOVER",
+    "FOCUS_VISIBLE",
+    "ACTIVE",
+    "DISABLED",
+    "LOADING",
+    "EMPTY",
+    "ERROR"
+  ],
+  "asset_requirements": [
+    {
+      "asset_id": "icon-command-palette",
+      "kind": "ICON",
+      "usage": "Trigger button icon for command palette in header bar.",
+      "reference_ref": "assets/icons/command.svg"
+    },
+    {
+      "asset_id": "token-color-surface-base",
+      "kind": "DESIGN_TOKEN",
+      "usage": "Background color variable for primary shell.",
+      "reference_ref": "tokens/color.json#surface-base"
+    }
+  ],
+  "preserve": [
+    "Preserve desktop-macro-grid layout structure across all desktop viewports.",
+    "Preserve action-bar-visual-hierarchy with unambiguous primary action salience.",
+    "Preserve split-pane-responsive-collapse behavior without dropping sidecar accessibility.",
+    "Preserve keyboard navigability (Tab, Shift+Tab, Escape, Enter) across all interactive elements."
+  ],
+  "adapt": [
+    "Adapt column widths fluidly between minimum and maximum constraints.",
+    "Adapt bottom dock height according to inspector content volume."
+  ],
+  "avoid": [
+    "Do not replace required multi-region composition with flat single-pane layout to reduce code size.",
+    "Do not remove split-pane divider to avoid implementing drag/collapse interactions.",
+    "Do not invent unrequested modal dialogs or floating overlays.",
+    "Do not downgrade UI_CONTRACT_FIDELITY profile."
+  ],
+  "unresolved": [
+    "Exact custom accent color token pending design system token finalization (fallback: project native brand blue)."
+  ],
+  "authority": {
+    "implementation_authorized": false,
+    "architecture_translation_authorized": false,
+    "release_authorized": false
+  }
+}

--- a/orchestra_runtime/domain/orchestration/__init__.py
+++ b/orchestra_runtime/domain/orchestration/__init__.py
@@ -3,22 +3,30 @@
 from .ui_fidelity import (
     MINIMAL_SAFE,
     UI_CONTRACT_FIDELITY,
+    UI_FIDELITY_HANDOFF_SCHEMA,
+    VALID_SOURCE_KINDS,
     PonytailFidelityExecution,
     UIDeviationRecord,
+    UIFidelityHandoff,
     UIFidelityRouting,
     classify_ui_fidelity,
     enforce_ponytail_fidelity_execution,
+    validate_ui_fidelity_handoff,
 )
 from .workflow import WORKFLOW_SANITY_SCHEMA_VERSION, WorkflowSanityReceipt
 
 __all__ = [
     "MINIMAL_SAFE",
     "UI_CONTRACT_FIDELITY",
+    "UI_FIDELITY_HANDOFF_SCHEMA",
+    "VALID_SOURCE_KINDS",
     "PonytailFidelityExecution",
     "UIDeviationRecord",
+    "UIFidelityHandoff",
     "UIFidelityRouting",
     "WORKFLOW_SANITY_SCHEMA_VERSION",
     "WorkflowSanityReceipt",
     "classify_ui_fidelity",
     "enforce_ponytail_fidelity_execution",
+    "validate_ui_fidelity_handoff",
 ]

--- a/orchestra_runtime/domain/orchestration/ui_fidelity.py
+++ b/orchestra_runtime/domain/orchestration/ui_fidelity.py
@@ -394,12 +394,261 @@ def enforce_ponytail_fidelity_execution(
     )
 
 
+VALID_SOURCE_KINDS = frozenset(
+    (
+        "CUIR_NORMALIZED",
+        "PROJECT_NATIVE",
+        "PUBLIC_PROVIDER_GUIDANCE",
+        "OBSERVED_PROVIDER_OUTPUT",
+    )
+)
+
+UI_FIDELITY_HANDOFF_SCHEMA = "orchestra.ui-fidelity-handoff.v1"
+
+
+@dataclass(frozen=True)
+class UIFidelityHandoff:
+    schema_version: str
+    contract_id: str
+    owned_by: str
+    design_contract_ref: str
+    ui_implementation_profile_ref: str
+    source_revision_or_contract_identity: str
+    provenance_refs: tuple[dict[str, Any], ...]
+    design_intent: str
+    information_hierarchy: tuple[dict[str, Any] | str, ...]
+    macro_composition: tuple[dict[str, Any], ...]
+    selected_pattern_refs: tuple[dict[str, Any], ...]
+    pattern_application_reason: str
+    required_regions: tuple[dict[str, Any] | str, ...]
+    component_roles: dict[str, Any]
+    visual_relationships: dict[str, Any]
+    typography_roles: dict[str, Any]
+    spacing_relationships: dict[str, Any]
+    responsive_transformations: tuple[dict[str, Any] | str, ...]
+    interaction_states: tuple[str, ...]
+    asset_requirements: tuple[dict[str, Any] | str, ...]
+    preserve: tuple[str, ...]
+    adapt: tuple[str, ...]
+    avoid: tuple[str, ...]
+    unresolved: tuple[str, ...]
+    authority: dict[str, Any]
+
+    def validate(self) -> None:
+        if self.schema_version != UI_FIDELITY_HANDOFF_SCHEMA:
+            raise ValueError(f"unsupported UIFidelityHandoff schema_version: {self.schema_version}")
+        if self.owned_by != "cloak":
+            raise ValueError("UIFidelityHandoff must be owned by cloak")
+
+        # Authority invariant: handoff does NOT authorize implementation or architecture translation
+        if not isinstance(self.authority, Mapping):
+            raise ValueError("UIFidelityHandoff requires mapping authority")
+        if (
+            self.authority.get("implementation_authorized") is not False
+            or self.authority.get("architecture_translation_authorized") is not False
+            or self.authority.get("release_authorized") is not False
+        ):
+            raise ValueError("UIFidelityHandoff cannot authorize implementation, architecture translation, or release")
+
+        # UIEF-5 Clockwork boundary invariant
+        if hasattr(self, "clockwork_translation") or hasattr(self, "engineering_translation_authorized"):
+            raise ValueError("UIFidelityHandoff cannot embed or initiate UIEF-5 engineering translation")
+
+        # Non-empty string validations
+        for field_name in (
+            "contract_id",
+            "design_contract_ref",
+            "ui_implementation_profile_ref",
+            "source_revision_or_contract_identity",
+            "design_intent",
+            "pattern_application_reason",
+        ):
+            val = getattr(self, field_name)
+            if not isinstance(val, str) or not val.strip():
+                raise ValueError(f"UIFidelityHandoff requires non-empty string {field_name}")
+
+        # Required collections validations
+        for field_name in (
+            "provenance_refs",
+            "information_hierarchy",
+            "macro_composition",
+            "selected_pattern_refs",
+            "required_regions",
+            "preserve",
+            "avoid",
+        ):
+            val = getattr(self, field_name)
+            if not isinstance(val, (tuple, list)) or not val:
+                raise ValueError(f"UIFidelityHandoff requires non-empty collection {field_name}")
+
+        # Check selected_pattern_refs provenance
+        for pat in self.selected_pattern_refs:
+            if not isinstance(pat, Mapping):
+                raise ValueError("selected_pattern_refs items must be mappings")
+            pat_id = str(pat.get("pattern_id", "")).strip()
+            source_kind = str(pat.get("source_kind", "")).strip()
+            prov_id = str(pat.get("provenance_id", "")).strip()
+            if not pat_id:
+                raise ValueError("selected_pattern_refs items require pattern_id")
+            if source_kind not in VALID_SOURCE_KINDS:
+                raise ValueError(f"unrecognized source_kind in pattern_ref: {source_kind}")
+            if not prov_id:
+                raise ValueError("selected_pattern_refs items require provenance_id")
+
+        # Check macro_composition structural roles
+        for comp in self.macro_composition:
+            if not isinstance(comp, Mapping):
+                raise ValueError("macro_composition items must be mappings")
+            if not str(comp.get("composition_id", "")).strip():
+                raise ValueError("macro_composition items require composition_id")
+
+        # Check unresolved must be a tuple/list (can be empty, but must be present)
+        if not isinstance(self.unresolved, (tuple, list)):
+            raise ValueError("UIFidelityHandoff requires unresolved list")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "contract_id": self.contract_id,
+            "owned_by": self.owned_by,
+            "design_contract_ref": self.design_contract_ref,
+            "ui_implementation_profile_ref": self.ui_implementation_profile_ref,
+            "source_revision_or_contract_identity": self.source_revision_or_contract_identity,
+            "provenance_refs": list(self.provenance_refs),
+            "design_intent": self.design_intent,
+            "information_hierarchy": list(self.information_hierarchy),
+            "macro_composition": list(self.macro_composition),
+            "selected_pattern_refs": list(self.selected_pattern_refs),
+            "pattern_application_reason": self.pattern_application_reason,
+            "required_regions": list(self.required_regions),
+            "component_roles": dict(self.component_roles),
+            "visual_relationships": dict(self.visual_relationships),
+            "typography_roles": dict(self.typography_roles),
+            "spacing_relationships": dict(self.spacing_relationships),
+            "responsive_transformations": list(self.responsive_transformations),
+            "interaction_states": list(self.interaction_states),
+            "asset_requirements": list(self.asset_requirements),
+            "preserve": list(self.preserve),
+            "adapt": list(self.adapt),
+            "avoid": list(self.avoid),
+            "unresolved": list(self.unresolved),
+            "authority": dict(self.authority),
+        }
+
+    def to_ponytail_context(self) -> dict[str, Any]:
+        """Convert handoff into context format required by Ponytail UIEF-3 execution."""
+        return {
+            "ui_implementation_profile": UI_CONTRACT_FIDELITY,
+            "ui_fidelity_context": {
+                "design_contract_ref": self.design_contract_ref,
+                "cloak_handoff_ref": self.contract_id,
+                "clockwork_boundary_ref": "docs/architecture/UIEF_CLOCKWORK_ENGINEERING_BOUNDARY.md",
+                "pattern_refs": list(self.selected_pattern_refs),
+                "composition_refs": list(self.macro_composition),
+                "required_fidelity": {
+                    "preserve_macro_composition": True,
+                    "preserve_visual_hierarchy": True,
+                    "preserve_interaction_states": True,
+                    "preserve_responsive_transformation": True,
+                    "min_accessibility_level": "WCAG_AA",
+                },
+                "required_regions": list(self.required_regions),
+                "preserve": list(self.preserve),
+                "adapt": list(self.adapt),
+                "avoid": list(self.avoid),
+                "unresolved": list(self.unresolved),
+            },
+        }
+
+
+def validate_ui_fidelity_handoff(data: Mapping[str, Any]) -> UIFidelityHandoff:
+    if not isinstance(data, Mapping):
+        raise ValueError("UIFidelityHandoff data must be a mapping")
+
+    # Contamination check
+    exec_mode = data.get("execution_mode")
+    if isinstance(exec_mode, str) and exec_mode in (MINIMAL_SAFE, UI_CONTRACT_FIDELITY):
+        raise ValueError("Generic execution_mode cannot be contaminated with UI fidelity profile values")
+
+    # Prohibited initiation / boundary checks
+    if "clockwork_translation" in data or data.get("engineering_translation_authorized") is True:
+        raise ValueError("UIFidelityHandoff cannot embed or initiate UIEF-5 engineering translation")
+
+    owned_by = str(data.get("owned_by", "")).strip()
+    if owned_by != "cloak":
+        raise ValueError("UIFidelityHandoff must be owned by cloak")
+
+    authority = data.get("authority", {})
+    if not isinstance(authority, Mapping):
+        raise ValueError("UIFidelityHandoff requires mapping authority")
+
+    for seq_field in (
+        "provenance_refs",
+        "information_hierarchy",
+        "macro_composition",
+        "selected_pattern_refs",
+        "required_regions",
+        "responsive_transformations",
+        "interaction_states",
+        "asset_requirements",
+        "preserve",
+        "adapt",
+        "avoid",
+        "unresolved",
+    ):
+        if seq_field in data and not isinstance(data[seq_field], (list, tuple)):
+            raise ValueError(f"UIFidelityHandoff requires list or tuple for {seq_field}")
+
+    for map_field in (
+        "component_roles",
+        "visual_relationships",
+        "typography_roles",
+        "spacing_relationships",
+    ):
+        if map_field in data and not isinstance(data[map_field], Mapping):
+            raise ValueError(f"UIFidelityHandoff requires mapping for {map_field}")
+
+    handoff = UIFidelityHandoff(
+        schema_version=str(data.get("schema_version", UI_FIDELITY_HANDOFF_SCHEMA)),
+        contract_id=str(data.get("contract_id", "")),
+        owned_by=owned_by,
+        design_contract_ref=str(data.get("design_contract_ref", "")),
+        ui_implementation_profile_ref=str(data.get("ui_implementation_profile_ref", "")),
+        source_revision_or_contract_identity=str(data.get("source_revision_or_contract_identity", "")),
+        provenance_refs=tuple(dict(x) if isinstance(x, Mapping) else x for x in data.get("provenance_refs", ())),
+        design_intent=str(data.get("design_intent", "")),
+        information_hierarchy=tuple(data.get("information_hierarchy", ())),
+        macro_composition=tuple(dict(x) if isinstance(x, Mapping) else x for x in data.get("macro_composition", ())),
+        selected_pattern_refs=tuple(dict(x) if isinstance(x, Mapping) else x for x in data.get("selected_pattern_refs", ())),
+        pattern_application_reason=str(data.get("pattern_application_reason", "")),
+        required_regions=tuple(data.get("required_regions", ())),
+        component_roles=dict(data.get("component_roles", {})),
+        visual_relationships=dict(data.get("visual_relationships", {})),
+        typography_roles=dict(data.get("typography_roles", {})),
+        spacing_relationships=dict(data.get("spacing_relationships", {})),
+        responsive_transformations=tuple(data.get("responsive_transformations", ())),
+        interaction_states=tuple(str(x) for x in data.get("interaction_states", ())),
+        asset_requirements=tuple(data.get("asset_requirements", ())),
+        preserve=tuple(str(x) for x in data.get("preserve", ())),
+        adapt=tuple(str(x) for x in data.get("adapt", ())),
+        avoid=tuple(str(x) for x in data.get("avoid", ())),
+        unresolved=tuple(str(x) for x in data.get("unresolved", ())),
+        authority=dict(authority),
+    )
+    handoff.validate()
+    return handoff
+
+
 __all__ = [
     "MINIMAL_SAFE",
     "UI_CONTRACT_FIDELITY",
     "UIFidelityRouting",
     "UIDeviationRecord",
     "PonytailFidelityExecution",
+    "UIFidelityHandoff",
+    "VALID_SOURCE_KINDS",
+    "UI_FIDELITY_HANDOFF_SCHEMA",
     "classify_ui_fidelity",
     "enforce_ponytail_fidelity_execution",
+    "validate_ui_fidelity_handoff",
 ]

--- a/orchestra_runtime/machine_contracts.py
+++ b/orchestra_runtime/machine_contracts.py
@@ -10,11 +10,13 @@ SPECIALIST_REGISTRY_SCHEMA_VERSION = "orchestra.specialist-registry.v1"
 ROUTING_CONTRACT_SCHEMA_VERSION = "orchestra.routing-contract.v1"
 GOVERNANCE_POLICY_SCHEMA_VERSION = "orchestra.governance-policy.v1"
 UI_FIDELITY_ROUTING_CONTRACT_SCHEMA_VERSION = "orchestra.ui-fidelity-routing.v1"
+UI_FIDELITY_HANDOFF_SCHEMA_VERSION = "orchestra.ui-fidelity-handoff.v1"
 
 _MACHINE_ROOT = Path("machine")
 _SPECIALIST_REGISTRY = _MACHINE_ROOT / "specialists" / "registry.v1.json"
 _ROUTING_CONTRACT = _MACHINE_ROOT / "routing" / "routes.v1.json"
 _UI_FIDELITY_ROUTING_CONTRACT = _MACHINE_ROOT / "routing" / "ui-fidelity-routing.v1.json"
+_UI_FIDELITY_HANDOFF_CONTRACT = _MACHINE_ROOT / "ui" / "ui-fidelity-handoff.v1.json"
 _GOVERNANCE_POLICY = _MACHINE_ROOT / "governance" / "policy.v1.json"
 
 FRONTMATTER_FIELDS = (
@@ -131,6 +133,13 @@ def load_ui_fidelity_routing_contract(root: Path | str | None = None) -> dict[st
     contract = _load_json(_root(root) / _UI_FIDELITY_ROUTING_CONTRACT)
     if contract.get("schema_version") != UI_FIDELITY_ROUTING_CONTRACT_SCHEMA_VERSION:
         raise ValueError("unsupported UI fidelity routing contract schema_version")
+    return contract
+
+
+def load_ui_fidelity_handoff_contract(root: Path | str | None = None) -> dict[str, Any]:
+    contract = _load_json(_root(root) / _UI_FIDELITY_HANDOFF_CONTRACT)
+    if contract.get("schema_version") != UI_FIDELITY_HANDOFF_SCHEMA_VERSION:
+        raise ValueError("unsupported UI fidelity handoff contract schema_version")
     return contract
 
 
@@ -322,6 +331,41 @@ def machine_contract_errors(root: Path | str | None = None) -> tuple[str, ...]:
             errors.append("UI_FIDELITY_ROUTING_AUTHORITY_EXPANSION")
     except (ValueError, OSError) as exc:
         errors.append(f"UI_FIDELITY_ROUTING_CONTRACT_INVALID:{exc}")
+
+    try:
+        handoff = load_ui_fidelity_handoff_contract(repo_root)
+        if handoff.get("owned_by") != "cloak":
+            errors.append("UI_FIDELITY_HANDOFF_OWNER_INVALID")
+        authority = handoff.get("authority")
+        if not isinstance(authority, dict) or any(value is not False for value in authority.values()):
+            errors.append("UI_FIDELITY_HANDOFF_AUTHORITY_EXPANSION")
+        for req_field in (
+            "design_contract_ref",
+            "ui_implementation_profile_ref",
+            "source_revision_or_contract_identity",
+            "provenance_refs",
+            "design_intent",
+            "information_hierarchy",
+            "macro_composition",
+            "selected_pattern_refs",
+            "pattern_application_reason",
+            "required_regions",
+            "component_roles",
+            "visual_relationships",
+            "typography_roles",
+            "spacing_relationships",
+            "responsive_transformations",
+            "interaction_states",
+            "asset_requirements",
+            "preserve",
+            "adapt",
+            "avoid",
+            "unresolved",
+        ):
+            if req_field not in handoff:
+                errors.append(f"UI_FIDELITY_HANDOFF_MISSING_FIELD:{req_field}")
+    except (ValueError, OSError) as exc:
+        errors.append(f"UI_FIDELITY_HANDOFF_CONTRACT_INVALID:{exc}")
 
     try:
         policy = load_governance_policy(repo_root)

--- a/skills/cloak/OUTPUT_FORMATS.md
+++ b/skills/cloak/OUTPUT_FORMATS.md
@@ -134,3 +134,32 @@ Reason:
 ```
 
 Write `None confirmed` for empty issue sections. State whether the interface is ready, needs revision, or needs major restructuring.
+---
+
+## UI_FIDELITY_HANDOFF
+
+Use when performing UIEF visible-layer fidelity handoffs to Ponytail for execution.
+
+\\	ext
+HANDOFF ID:
+DESIGN INTENT:
+UI IMPLEMENTATION PROFILE:
+DESIGN CONTRACT REF:
+INFORMATION HIERARCHY:
+MACRO COMPOSITION:
+REQUIRED REGIONS:
+SELECTED PATTERNS:
+PROVENANCE IDENTIFIERS:
+COMPONENT ROLES:
+VISUAL RELATIONSHIPS:
+TYPOGRAPHY ROLES:
+SPACING RELATIONSHIPS:
+RESPONSIVE TRANSFORMATIONS:
+INTERACTION STATES:
+ASSET REQUIREMENTS:
+PRESERVE:
+ADAPT:
+AVOID:
+UNRESOLVED:
+HANDOFF TO: Ponytail (Implementation)
+\

--- a/skills/cloak/UI_FIDELITY_HANDOFF_GUIDE.md
+++ b/skills/cloak/UI_FIDELITY_HANDOFF_GUIDE.md
@@ -1,0 +1,38 @@
+# Cloak UI Fidelity Handoff Guide (UIEF-4)
+
+This guide governs the Cloak implementation-bound visible-layer fidelity handoff contract (UIFidelityHandoff) under the UI Execution Fidelity (UIEF) architecture.
+
+## 1. Specialist Authority and Separation of Concerns
+
+- **Cloak (Design Authority)**: Owns the visible-layer design intent, information hierarchy, macro-composition specification, pattern selection, and the UIFidelityHandoff contract. Cloak never authors code implementations or modifies persistence/infrastructure.
+- **Conductor (Routing Authority)**: Retains upstream authority over UIImplementationProfile selection (MINIMAL_SAFE vs UI_CONTRACT_FIDELITY). Cloak binds to the selected profile and does not self-assign or re-route profiles.
+- **Ponytail (Implementation Consumer)**: Downstream implementation specialist that strictly consumes the UIFidelityHandoff without authoring, inventing, or altering design decisions.
+- **Clockwork Boundary**: UIEF-5 Clockwork engineering translation remains strictly outside UIEF-4. Cloak does not generate architectural refactoring or engineering translations.
+
+## 2. Provenance and Reference Discipline
+
+- **CUIR References**: Selected CUIR-3/CUIR-4 normalized patterns must carry explicit provenance IDs (source_kind: CUIR_NORMALIZED). They provide structural pattern guidance without copying external assets.
+- **Project-Native Primacy**: Native components, design tokens, and existing layouts (source_kind: PROJECT_NATIVE) outrank external references unless explicitly deprecated.
+- **Provider References**: Public provider guidance (PUBLIC_PROVIDER_GUIDANCE) and observed provider outputs (OBSERVED_PROVIDER_OUTPUT) are marked dvisory_only: true and serve solely as comparative evidence. Never claim proprietary provider internal algorithms or copy third-party source code.
+
+## 3. Required Semantic Structure
+
+The UIFidelityHandoff machine contract must bind:
+1. **Design Intent**: Concise, actionable specification of accepted user-facing intent.
+2. **Information Hierarchy**: Ordered levels from topmost landmarks to granular elements with target component mapping.
+3. **Macro Composition**: Uncompromised structural compositions (layouts, split panes, action bars) that Ponytail is prohibited from simplifying solely to reduce code size.
+4. **Selected Pattern References**: Curated patterns with source kind, reference link, and provenance identifier.
+5. **Pattern Application Reason**: Transparent rationale for each chosen pattern.
+6. **Required Regions**: Explicit landmarks (BANNER, NAVIGATION, MAIN, COMPLEMENTARY) and placement rules.
+7. **Component, Typography, Spacing, and Visual Roles**: Explicit definitions preventing implementation-level guesswork.
+8. **Responsive Transformations**: Concrete breakpoint transitions preserving core utility across desktop, tablet, and mobile viewports.
+9. **Interaction States**: Comprehensive state coverage (DEFAULT, HOVER, FOCUS_VISIBLE, ACTIVE, DISABLED, LOADING, EMPTY, ERROR).
+10. **Preserve / Adapt / Avoid Constraints**: Unambiguous guardrails defining non-negotiable elements (preserve), flexible margins (dapt), and forbidden anti-patterns (void).
+11. **Explicit Unresolved Items**: Unresolved requirements or missing design tokens must be explicitly enumerated in unresolved. Never invent missing facts or silently drop unresolved requirements.
+
+## 4. Handoff Consumption by Ponytail
+
+Ponytail consumes the handoff via 	o_ponytail_context():
+- Ponytail executes the defined composition using project-native code and components.
+- Any deviation required by technical constraints must be recorded as an authorized UIDeviationRecord in Ponytail execution payload.
+- Omission of required compositions without an authorized deviation fails closed.

--- a/tests/fixtures/ui/uief4-invalid-clockwork-translation.json
+++ b/tests/fixtures/ui/uief4-invalid-clockwork-translation.json
@@ -1,0 +1,258 @@
+{
+  "": "../schemas/ui-fidelity-handoff.v1.schema.json",
+  "schema_version": "orchestra.ui-fidelity-handoff.v1",
+  "contract_id": "uief4-ui-fidelity-handoff-reference",
+  "owned_by": "cloak",
+  "design_contract_ref": "machine/schemas/ui-design-contract.schema.json",
+  "ui_implementation_profile_ref": "machine/ui/ui-implementation-profile.v1.json",
+  "source_revision_or_contract_identity": "uief1-ui-implementation-profile-reference",
+  "provenance_refs": [
+    {
+      "source_id": "cuir-workspace-split-pane-prov",
+      "source_kind": "CUIR_NORMALIZED",
+      "reference_ref": "docs/specs/cuir/CUIR_NORMALIZED_PATTERNS.md#workspace-split-pane",
+      "provenance_id": "CUIR-3-WORKSPACE-SPLIT-PANE-001",
+      "advisory_only": false
+    },
+    {
+      "source_id": "native-command-palette-prov",
+      "source_kind": "PROJECT_NATIVE",
+      "reference_ref": "components/palette/CommandPalette.tsx",
+      "provenance_id": "PROJECT-NATIVE-PALETTE-001",
+      "advisory_only": false
+    },
+    {
+      "source_id": "public-anthropic-artifact-canvas-prov",
+      "source_kind": "PUBLIC_PROVIDER_GUIDANCE",
+      "reference_ref": "docs/specs/ui/PUBLIC_PROVIDER_UI_REFERENCE_INTELLIGENCE.md#anthropic-artifact-canvas",
+      "provenance_id": "PUBLIC-PROVIDER-ANTHROPIC-CANVAS-001",
+      "advisory_only": true
+    },
+    {
+      "source_id": "observed-sidecar-drawer-layout-prov",
+      "source_kind": "OBSERVED_PROVIDER_OUTPUT",
+      "reference_ref": "docs/specs/ui/OBSERVED_PROVIDER_PATTERNS.md#sidecar-drawer-layout",
+      "provenance_id": "OBSERVED-PROVIDER-SIDECAR-DRAWER-001",
+      "advisory_only": true
+    }
+  ],
+  "design_intent": "Deliver a high-density, multi-pane developer workspace interface maintaining macro composition and visual hierarchy without code-size-induced composition simplification.",
+  "information_hierarchy": [
+    {
+      "level": 1,
+      "title": "Workspace Header and Navigation",
+      "description": "Topmost operational bar exposing repository context, status indicator, and global command trigger.",
+      "target_components": [
+        "WorkspaceHeader",
+        "StatusIndicator",
+        "GlobalCommandTrigger"
+      ]
+    },
+    {
+      "level": 2,
+      "title": "Dual-Pane Operational Canvas",
+      "description": "Primary content region divided into collateral navigator (left) and active document viewer (right).",
+      "target_components": [
+        "SplitPaneContainer",
+        "CollateralNavigator",
+        "DocumentViewer"
+      ]
+    },
+    {
+      "level": 3,
+      "title": "Docked Secondary Inspector",
+      "description": "Bottom contextual inspector displaying diagnostics, metadata, and execution telemetry.",
+      "target_components": [
+        "ContextualInspector",
+        "TelemetryPanel"
+      ]
+    }
+  ],
+  "macro_composition": [
+    {
+      "composition_id": "desktop-macro-grid",
+      "structural_role": "MACRO_LAYOUT",
+      "description": "3-region vertical grid with fixed header (48px), flex primary workspace (1fr), and docked bottom tray (auto/collapsible).",
+      "reference_ref": "docs/specs/ui/COMPOSITIONS.md#desktop-macro-grid"
+    },
+    {
+      "composition_id": "action-bar-visual-hierarchy",
+      "structural_role": "VISUAL_HIERARCHY",
+      "description": "Prominent left-aligned breadcrumb title with right-aligned action group maintaining high-contrast primary CTA.",
+      "reference_ref": "docs/specs/ui/COMPOSITIONS.md#action-bar-visual-hierarchy"
+    },
+    {
+      "composition_id": "split-pane-responsive-collapse",
+      "structural_role": "RESPONSIVE_TRANSFORMATION",
+      "description": "Horizontal split-pane on viewports >= 1024px; vertical accordion-stack collapse on viewports < 1024px.",
+      "reference_ref": "docs/specs/ui/COMPOSITIONS.md#split-pane-responsive-collapse"
+    }
+  ],
+  "selected_pattern_refs": [
+    {
+      "pattern_id": "cuir-workspace-split-pane",
+      "source_kind": "CUIR_NORMALIZED",
+      "reference_ref": "docs/specs/cuir/CUIR_NORMALIZED_PATTERNS.md#workspace-split-pane",
+      "provenance_id": "CUIR-3-WORKSPACE-SPLIT-PANE-001",
+      "advisory_only": false
+    },
+    {
+      "pattern_id": "native-command-palette",
+      "source_kind": "PROJECT_NATIVE",
+      "reference_ref": "components/palette/CommandPalette.tsx",
+      "provenance_id": "PROJECT-NATIVE-PALETTE-001",
+      "advisory_only": false
+    },
+    {
+      "pattern_id": "public-anthropic-artifact-canvas-flow",
+      "source_kind": "PUBLIC_PROVIDER_GUIDANCE",
+      "reference_ref": "docs/specs/ui/PUBLIC_PROVIDER_UI_REFERENCE_INTELLIGENCE.md#anthropic-artifact-canvas",
+      "provenance_id": "PUBLIC-PROVIDER-ANTHROPIC-CANVAS-001",
+      "advisory_only": true
+    },
+    {
+      "pattern_id": "observed-sidecar-drawer-layout",
+      "source_kind": "OBSERVED_PROVIDER_OUTPUT",
+      "reference_ref": "docs/specs/ui/OBSERVED_PROVIDER_PATTERNS.md#sidecar-drawer-layout",
+      "provenance_id": "OBSERVED-PROVIDER-SIDECAR-DRAWER-001",
+      "advisory_only": true
+    }
+  ],
+  "pattern_application_reason": "Normalized CUIR split-pane provides deterministic layout stability; native command palette preserves existing user muscle memory; provider references serve as advisory-only pattern evidence.",
+  "required_regions": [
+    {
+      "region_id": "region-header",
+      "role": "BANNER",
+      "placement": "TOP_FIXED",
+      "collapsible": false
+    },
+    {
+      "region_id": "region-nav-sidebar",
+      "role": "NAVIGATION",
+      "placement": "LEFT_FLEXIBLE",
+      "collapsible": true
+    },
+    {
+      "region_id": "region-main-content",
+      "role": "MAIN",
+      "placement": "CENTER_EXPANDING",
+      "collapsible": false
+    },
+    {
+      "region_id": "region-bottom-dock",
+      "role": "COMPLEMENTARY",
+      "placement": "BOTTOM_DOCKED",
+      "collapsible": true
+    }
+  ],
+  "component_roles": {
+    "primary_container": "LayoutShell",
+    "navigator": "CollateralTree",
+    "viewer": "ActiveDocumentViewer",
+    "status_indicator": "SystemStateBadge",
+    "action_palette": "CommandPalette"
+  },
+  "visual_relationships": {
+    "grid_gap": "12px",
+    "sidebar_width_range": "240px-360px",
+    "content_min_width": "480px",
+    "elevation_hierarchy": {
+      "base_surface": "0px",
+      "docked_surface": "2px",
+      "floating_palette": "8px"
+    }
+  },
+  "typography_roles": {
+    "page_title": "font-size: 1.125rem; font-weight: 600; line-height: 1.5rem;",
+    "section_header": "font-size: 0.875rem; font-weight: 600; text-transform: uppercase;",
+    "body_text": "font-size: 0.875rem; font-weight: 400; line-height: 1.25rem;",
+    "code_snippet": "font-family: monospace; font-size: 0.8125rem;"
+  },
+  "spacing_relationships": {
+    "layout_padding": "16px",
+    "component_padding": "8px 12px",
+    "compact_padding": "4px 8px",
+    "element_gap": "8px"
+  },
+  "responsive_transformations": [
+    {
+      "breakpoint": "desktop (>= 1024px)",
+      "transformation": "Multi-column split view with visible sidebar and expanded document canvas.",
+      "affected_regions": [
+        "region-nav-sidebar",
+        "region-main-content"
+      ]
+    },
+    {
+      "breakpoint": "tablet (768px - 1023px)",
+      "transformation": "Sidebar collapsed to drawer toggle; main content occupies full viewport width.",
+      "affected_regions": [
+        "region-nav-sidebar",
+        "region-main-content"
+      ]
+    },
+    {
+      "breakpoint": "mobile (< 768px)",
+      "transformation": "Single-column vertical stack with drawer overlay navigation.",
+      "affected_regions": [
+        "region-header",
+        "region-nav-sidebar",
+        "region-main-content",
+        "region-bottom-dock"
+      ]
+    }
+  ],
+  "interaction_states": [
+    "DEFAULT",
+    "HOVER",
+    "FOCUS_VISIBLE",
+    "ACTIVE",
+    "DISABLED",
+    "LOADING",
+    "EMPTY",
+    "ERROR"
+  ],
+  "asset_requirements": [
+    {
+      "asset_id": "icon-command-palette",
+      "kind": "ICON",
+      "usage": "Trigger button icon for command palette in header bar.",
+      "reference_ref": "assets/icons/command.svg"
+    },
+    {
+      "asset_id": "token-color-surface-base",
+      "kind": "DESIGN_TOKEN",
+      "usage": "Background color variable for primary shell.",
+      "reference_ref": "tokens/color.json#surface-base"
+    }
+  ],
+  "preserve": [
+    "Preserve desktop-macro-grid layout structure across all desktop viewports.",
+    "Preserve action-bar-visual-hierarchy with unambiguous primary action salience.",
+    "Preserve split-pane-responsive-collapse behavior without dropping sidecar accessibility.",
+    "Preserve keyboard navigability (Tab, Shift+Tab, Escape, Enter) across all interactive elements."
+  ],
+  "adapt": [
+    "Adapt column widths fluidly between minimum and maximum constraints.",
+    "Adapt bottom dock height according to inspector content volume."
+  ],
+  "avoid": [
+    "Do not replace required multi-region composition with flat single-pane layout to reduce code size.",
+    "Do not remove split-pane divider to avoid implementing drag/collapse interactions.",
+    "Do not invent unrequested modal dialogs or floating overlays.",
+    "Do not downgrade UI_CONTRACT_FIDELITY profile."
+  ],
+  "unresolved": [
+    "Exact custom accent color token pending design system token finalization (fallback: project native brand blue)."
+  ],
+  "authority": {
+    "implementation_authorized": false,
+    "architecture_translation_authorized": false,
+    "release_authorized": false
+  },
+  "clockwork_translation": {
+    "refactor_modules": [
+      "services.py"
+    ]
+  }
+}

--- a/tests/fixtures/ui/uief4-invalid-contaminated-execution-mode.json
+++ b/tests/fixtures/ui/uief4-invalid-contaminated-execution-mode.json
@@ -1,0 +1,254 @@
+{
+  "": "../schemas/ui-fidelity-handoff.v1.schema.json",
+  "schema_version": "orchestra.ui-fidelity-handoff.v1",
+  "contract_id": "uief4-ui-fidelity-handoff-reference",
+  "owned_by": "cloak",
+  "design_contract_ref": "machine/schemas/ui-design-contract.schema.json",
+  "ui_implementation_profile_ref": "machine/ui/ui-implementation-profile.v1.json",
+  "source_revision_or_contract_identity": "uief1-ui-implementation-profile-reference",
+  "provenance_refs": [
+    {
+      "source_id": "cuir-workspace-split-pane-prov",
+      "source_kind": "CUIR_NORMALIZED",
+      "reference_ref": "docs/specs/cuir/CUIR_NORMALIZED_PATTERNS.md#workspace-split-pane",
+      "provenance_id": "CUIR-3-WORKSPACE-SPLIT-PANE-001",
+      "advisory_only": false
+    },
+    {
+      "source_id": "native-command-palette-prov",
+      "source_kind": "PROJECT_NATIVE",
+      "reference_ref": "components/palette/CommandPalette.tsx",
+      "provenance_id": "PROJECT-NATIVE-PALETTE-001",
+      "advisory_only": false
+    },
+    {
+      "source_id": "public-anthropic-artifact-canvas-prov",
+      "source_kind": "PUBLIC_PROVIDER_GUIDANCE",
+      "reference_ref": "docs/specs/ui/PUBLIC_PROVIDER_UI_REFERENCE_INTELLIGENCE.md#anthropic-artifact-canvas",
+      "provenance_id": "PUBLIC-PROVIDER-ANTHROPIC-CANVAS-001",
+      "advisory_only": true
+    },
+    {
+      "source_id": "observed-sidecar-drawer-layout-prov",
+      "source_kind": "OBSERVED_PROVIDER_OUTPUT",
+      "reference_ref": "docs/specs/ui/OBSERVED_PROVIDER_PATTERNS.md#sidecar-drawer-layout",
+      "provenance_id": "OBSERVED-PROVIDER-SIDECAR-DRAWER-001",
+      "advisory_only": true
+    }
+  ],
+  "design_intent": "Deliver a high-density, multi-pane developer workspace interface maintaining macro composition and visual hierarchy without code-size-induced composition simplification.",
+  "information_hierarchy": [
+    {
+      "level": 1,
+      "title": "Workspace Header and Navigation",
+      "description": "Topmost operational bar exposing repository context, status indicator, and global command trigger.",
+      "target_components": [
+        "WorkspaceHeader",
+        "StatusIndicator",
+        "GlobalCommandTrigger"
+      ]
+    },
+    {
+      "level": 2,
+      "title": "Dual-Pane Operational Canvas",
+      "description": "Primary content region divided into collateral navigator (left) and active document viewer (right).",
+      "target_components": [
+        "SplitPaneContainer",
+        "CollateralNavigator",
+        "DocumentViewer"
+      ]
+    },
+    {
+      "level": 3,
+      "title": "Docked Secondary Inspector",
+      "description": "Bottom contextual inspector displaying diagnostics, metadata, and execution telemetry.",
+      "target_components": [
+        "ContextualInspector",
+        "TelemetryPanel"
+      ]
+    }
+  ],
+  "macro_composition": [
+    {
+      "composition_id": "desktop-macro-grid",
+      "structural_role": "MACRO_LAYOUT",
+      "description": "3-region vertical grid with fixed header (48px), flex primary workspace (1fr), and docked bottom tray (auto/collapsible).",
+      "reference_ref": "docs/specs/ui/COMPOSITIONS.md#desktop-macro-grid"
+    },
+    {
+      "composition_id": "action-bar-visual-hierarchy",
+      "structural_role": "VISUAL_HIERARCHY",
+      "description": "Prominent left-aligned breadcrumb title with right-aligned action group maintaining high-contrast primary CTA.",
+      "reference_ref": "docs/specs/ui/COMPOSITIONS.md#action-bar-visual-hierarchy"
+    },
+    {
+      "composition_id": "split-pane-responsive-collapse",
+      "structural_role": "RESPONSIVE_TRANSFORMATION",
+      "description": "Horizontal split-pane on viewports >= 1024px; vertical accordion-stack collapse on viewports < 1024px.",
+      "reference_ref": "docs/specs/ui/COMPOSITIONS.md#split-pane-responsive-collapse"
+    }
+  ],
+  "selected_pattern_refs": [
+    {
+      "pattern_id": "cuir-workspace-split-pane",
+      "source_kind": "CUIR_NORMALIZED",
+      "reference_ref": "docs/specs/cuir/CUIR_NORMALIZED_PATTERNS.md#workspace-split-pane",
+      "provenance_id": "CUIR-3-WORKSPACE-SPLIT-PANE-001",
+      "advisory_only": false
+    },
+    {
+      "pattern_id": "native-command-palette",
+      "source_kind": "PROJECT_NATIVE",
+      "reference_ref": "components/palette/CommandPalette.tsx",
+      "provenance_id": "PROJECT-NATIVE-PALETTE-001",
+      "advisory_only": false
+    },
+    {
+      "pattern_id": "public-anthropic-artifact-canvas-flow",
+      "source_kind": "PUBLIC_PROVIDER_GUIDANCE",
+      "reference_ref": "docs/specs/ui/PUBLIC_PROVIDER_UI_REFERENCE_INTELLIGENCE.md#anthropic-artifact-canvas",
+      "provenance_id": "PUBLIC-PROVIDER-ANTHROPIC-CANVAS-001",
+      "advisory_only": true
+    },
+    {
+      "pattern_id": "observed-sidecar-drawer-layout",
+      "source_kind": "OBSERVED_PROVIDER_OUTPUT",
+      "reference_ref": "docs/specs/ui/OBSERVED_PROVIDER_PATTERNS.md#sidecar-drawer-layout",
+      "provenance_id": "OBSERVED-PROVIDER-SIDECAR-DRAWER-001",
+      "advisory_only": true
+    }
+  ],
+  "pattern_application_reason": "Normalized CUIR split-pane provides deterministic layout stability; native command palette preserves existing user muscle memory; provider references serve as advisory-only pattern evidence.",
+  "required_regions": [
+    {
+      "region_id": "region-header",
+      "role": "BANNER",
+      "placement": "TOP_FIXED",
+      "collapsible": false
+    },
+    {
+      "region_id": "region-nav-sidebar",
+      "role": "NAVIGATION",
+      "placement": "LEFT_FLEXIBLE",
+      "collapsible": true
+    },
+    {
+      "region_id": "region-main-content",
+      "role": "MAIN",
+      "placement": "CENTER_EXPANDING",
+      "collapsible": false
+    },
+    {
+      "region_id": "region-bottom-dock",
+      "role": "COMPLEMENTARY",
+      "placement": "BOTTOM_DOCKED",
+      "collapsible": true
+    }
+  ],
+  "component_roles": {
+    "primary_container": "LayoutShell",
+    "navigator": "CollateralTree",
+    "viewer": "ActiveDocumentViewer",
+    "status_indicator": "SystemStateBadge",
+    "action_palette": "CommandPalette"
+  },
+  "visual_relationships": {
+    "grid_gap": "12px",
+    "sidebar_width_range": "240px-360px",
+    "content_min_width": "480px",
+    "elevation_hierarchy": {
+      "base_surface": "0px",
+      "docked_surface": "2px",
+      "floating_palette": "8px"
+    }
+  },
+  "typography_roles": {
+    "page_title": "font-size: 1.125rem; font-weight: 600; line-height: 1.5rem;",
+    "section_header": "font-size: 0.875rem; font-weight: 600; text-transform: uppercase;",
+    "body_text": "font-size: 0.875rem; font-weight: 400; line-height: 1.25rem;",
+    "code_snippet": "font-family: monospace; font-size: 0.8125rem;"
+  },
+  "spacing_relationships": {
+    "layout_padding": "16px",
+    "component_padding": "8px 12px",
+    "compact_padding": "4px 8px",
+    "element_gap": "8px"
+  },
+  "responsive_transformations": [
+    {
+      "breakpoint": "desktop (>= 1024px)",
+      "transformation": "Multi-column split view with visible sidebar and expanded document canvas.",
+      "affected_regions": [
+        "region-nav-sidebar",
+        "region-main-content"
+      ]
+    },
+    {
+      "breakpoint": "tablet (768px - 1023px)",
+      "transformation": "Sidebar collapsed to drawer toggle; main content occupies full viewport width.",
+      "affected_regions": [
+        "region-nav-sidebar",
+        "region-main-content"
+      ]
+    },
+    {
+      "breakpoint": "mobile (< 768px)",
+      "transformation": "Single-column vertical stack with drawer overlay navigation.",
+      "affected_regions": [
+        "region-header",
+        "region-nav-sidebar",
+        "region-main-content",
+        "region-bottom-dock"
+      ]
+    }
+  ],
+  "interaction_states": [
+    "DEFAULT",
+    "HOVER",
+    "FOCUS_VISIBLE",
+    "ACTIVE",
+    "DISABLED",
+    "LOADING",
+    "EMPTY",
+    "ERROR"
+  ],
+  "asset_requirements": [
+    {
+      "asset_id": "icon-command-palette",
+      "kind": "ICON",
+      "usage": "Trigger button icon for command palette in header bar.",
+      "reference_ref": "assets/icons/command.svg"
+    },
+    {
+      "asset_id": "token-color-surface-base",
+      "kind": "DESIGN_TOKEN",
+      "usage": "Background color variable for primary shell.",
+      "reference_ref": "tokens/color.json#surface-base"
+    }
+  ],
+  "preserve": [
+    "Preserve desktop-macro-grid layout structure across all desktop viewports.",
+    "Preserve action-bar-visual-hierarchy with unambiguous primary action salience.",
+    "Preserve split-pane-responsive-collapse behavior without dropping sidecar accessibility.",
+    "Preserve keyboard navigability (Tab, Shift+Tab, Escape, Enter) across all interactive elements."
+  ],
+  "adapt": [
+    "Adapt column widths fluidly between minimum and maximum constraints.",
+    "Adapt bottom dock height according to inspector content volume."
+  ],
+  "avoid": [
+    "Do not replace required multi-region composition with flat single-pane layout to reduce code size.",
+    "Do not remove split-pane divider to avoid implementing drag/collapse interactions.",
+    "Do not invent unrequested modal dialogs or floating overlays.",
+    "Do not downgrade UI_CONTRACT_FIDELITY profile."
+  ],
+  "unresolved": [
+    "Exact custom accent color token pending design system token finalization (fallback: project native brand blue)."
+  ],
+  "authority": {
+    "implementation_authorized": false,
+    "architecture_translation_authorized": false,
+    "release_authorized": false
+  },
+  "execution_mode": "UI_CONTRACT_FIDELITY"
+}

--- a/tests/fixtures/ui/uief4-invalid-missing-binding.json
+++ b/tests/fixtures/ui/uief4-invalid-missing-binding.json
@@ -1,0 +1,252 @@
+{
+  "": "../schemas/ui-fidelity-handoff.v1.schema.json",
+  "schema_version": "orchestra.ui-fidelity-handoff.v1",
+  "contract_id": "uief4-ui-fidelity-handoff-reference",
+  "owned_by": "cloak",
+  "ui_implementation_profile_ref": "machine/ui/ui-implementation-profile.v1.json",
+  "source_revision_or_contract_identity": "uief1-ui-implementation-profile-reference",
+  "provenance_refs": [
+    {
+      "source_id": "cuir-workspace-split-pane-prov",
+      "source_kind": "CUIR_NORMALIZED",
+      "reference_ref": "docs/specs/cuir/CUIR_NORMALIZED_PATTERNS.md#workspace-split-pane",
+      "provenance_id": "CUIR-3-WORKSPACE-SPLIT-PANE-001",
+      "advisory_only": false
+    },
+    {
+      "source_id": "native-command-palette-prov",
+      "source_kind": "PROJECT_NATIVE",
+      "reference_ref": "components/palette/CommandPalette.tsx",
+      "provenance_id": "PROJECT-NATIVE-PALETTE-001",
+      "advisory_only": false
+    },
+    {
+      "source_id": "public-anthropic-artifact-canvas-prov",
+      "source_kind": "PUBLIC_PROVIDER_GUIDANCE",
+      "reference_ref": "docs/specs/ui/PUBLIC_PROVIDER_UI_REFERENCE_INTELLIGENCE.md#anthropic-artifact-canvas",
+      "provenance_id": "PUBLIC-PROVIDER-ANTHROPIC-CANVAS-001",
+      "advisory_only": true
+    },
+    {
+      "source_id": "observed-sidecar-drawer-layout-prov",
+      "source_kind": "OBSERVED_PROVIDER_OUTPUT",
+      "reference_ref": "docs/specs/ui/OBSERVED_PROVIDER_PATTERNS.md#sidecar-drawer-layout",
+      "provenance_id": "OBSERVED-PROVIDER-SIDECAR-DRAWER-001",
+      "advisory_only": true
+    }
+  ],
+  "design_intent": "Deliver a high-density, multi-pane developer workspace interface maintaining macro composition and visual hierarchy without code-size-induced composition simplification.",
+  "information_hierarchy": [
+    {
+      "level": 1,
+      "title": "Workspace Header and Navigation",
+      "description": "Topmost operational bar exposing repository context, status indicator, and global command trigger.",
+      "target_components": [
+        "WorkspaceHeader",
+        "StatusIndicator",
+        "GlobalCommandTrigger"
+      ]
+    },
+    {
+      "level": 2,
+      "title": "Dual-Pane Operational Canvas",
+      "description": "Primary content region divided into collateral navigator (left) and active document viewer (right).",
+      "target_components": [
+        "SplitPaneContainer",
+        "CollateralNavigator",
+        "DocumentViewer"
+      ]
+    },
+    {
+      "level": 3,
+      "title": "Docked Secondary Inspector",
+      "description": "Bottom contextual inspector displaying diagnostics, metadata, and execution telemetry.",
+      "target_components": [
+        "ContextualInspector",
+        "TelemetryPanel"
+      ]
+    }
+  ],
+  "macro_composition": [
+    {
+      "composition_id": "desktop-macro-grid",
+      "structural_role": "MACRO_LAYOUT",
+      "description": "3-region vertical grid with fixed header (48px), flex primary workspace (1fr), and docked bottom tray (auto/collapsible).",
+      "reference_ref": "docs/specs/ui/COMPOSITIONS.md#desktop-macro-grid"
+    },
+    {
+      "composition_id": "action-bar-visual-hierarchy",
+      "structural_role": "VISUAL_HIERARCHY",
+      "description": "Prominent left-aligned breadcrumb title with right-aligned action group maintaining high-contrast primary CTA.",
+      "reference_ref": "docs/specs/ui/COMPOSITIONS.md#action-bar-visual-hierarchy"
+    },
+    {
+      "composition_id": "split-pane-responsive-collapse",
+      "structural_role": "RESPONSIVE_TRANSFORMATION",
+      "description": "Horizontal split-pane on viewports >= 1024px; vertical accordion-stack collapse on viewports < 1024px.",
+      "reference_ref": "docs/specs/ui/COMPOSITIONS.md#split-pane-responsive-collapse"
+    }
+  ],
+  "selected_pattern_refs": [
+    {
+      "pattern_id": "cuir-workspace-split-pane",
+      "source_kind": "CUIR_NORMALIZED",
+      "reference_ref": "docs/specs/cuir/CUIR_NORMALIZED_PATTERNS.md#workspace-split-pane",
+      "provenance_id": "CUIR-3-WORKSPACE-SPLIT-PANE-001",
+      "advisory_only": false
+    },
+    {
+      "pattern_id": "native-command-palette",
+      "source_kind": "PROJECT_NATIVE",
+      "reference_ref": "components/palette/CommandPalette.tsx",
+      "provenance_id": "PROJECT-NATIVE-PALETTE-001",
+      "advisory_only": false
+    },
+    {
+      "pattern_id": "public-anthropic-artifact-canvas-flow",
+      "source_kind": "PUBLIC_PROVIDER_GUIDANCE",
+      "reference_ref": "docs/specs/ui/PUBLIC_PROVIDER_UI_REFERENCE_INTELLIGENCE.md#anthropic-artifact-canvas",
+      "provenance_id": "PUBLIC-PROVIDER-ANTHROPIC-CANVAS-001",
+      "advisory_only": true
+    },
+    {
+      "pattern_id": "observed-sidecar-drawer-layout",
+      "source_kind": "OBSERVED_PROVIDER_OUTPUT",
+      "reference_ref": "docs/specs/ui/OBSERVED_PROVIDER_PATTERNS.md#sidecar-drawer-layout",
+      "provenance_id": "OBSERVED-PROVIDER-SIDECAR-DRAWER-001",
+      "advisory_only": true
+    }
+  ],
+  "pattern_application_reason": "Normalized CUIR split-pane provides deterministic layout stability; native command palette preserves existing user muscle memory; provider references serve as advisory-only pattern evidence.",
+  "required_regions": [
+    {
+      "region_id": "region-header",
+      "role": "BANNER",
+      "placement": "TOP_FIXED",
+      "collapsible": false
+    },
+    {
+      "region_id": "region-nav-sidebar",
+      "role": "NAVIGATION",
+      "placement": "LEFT_FLEXIBLE",
+      "collapsible": true
+    },
+    {
+      "region_id": "region-main-content",
+      "role": "MAIN",
+      "placement": "CENTER_EXPANDING",
+      "collapsible": false
+    },
+    {
+      "region_id": "region-bottom-dock",
+      "role": "COMPLEMENTARY",
+      "placement": "BOTTOM_DOCKED",
+      "collapsible": true
+    }
+  ],
+  "component_roles": {
+    "primary_container": "LayoutShell",
+    "navigator": "CollateralTree",
+    "viewer": "ActiveDocumentViewer",
+    "status_indicator": "SystemStateBadge",
+    "action_palette": "CommandPalette"
+  },
+  "visual_relationships": {
+    "grid_gap": "12px",
+    "sidebar_width_range": "240px-360px",
+    "content_min_width": "480px",
+    "elevation_hierarchy": {
+      "base_surface": "0px",
+      "docked_surface": "2px",
+      "floating_palette": "8px"
+    }
+  },
+  "typography_roles": {
+    "page_title": "font-size: 1.125rem; font-weight: 600; line-height: 1.5rem;",
+    "section_header": "font-size: 0.875rem; font-weight: 600; text-transform: uppercase;",
+    "body_text": "font-size: 0.875rem; font-weight: 400; line-height: 1.25rem;",
+    "code_snippet": "font-family: monospace; font-size: 0.8125rem;"
+  },
+  "spacing_relationships": {
+    "layout_padding": "16px",
+    "component_padding": "8px 12px",
+    "compact_padding": "4px 8px",
+    "element_gap": "8px"
+  },
+  "responsive_transformations": [
+    {
+      "breakpoint": "desktop (>= 1024px)",
+      "transformation": "Multi-column split view with visible sidebar and expanded document canvas.",
+      "affected_regions": [
+        "region-nav-sidebar",
+        "region-main-content"
+      ]
+    },
+    {
+      "breakpoint": "tablet (768px - 1023px)",
+      "transformation": "Sidebar collapsed to drawer toggle; main content occupies full viewport width.",
+      "affected_regions": [
+        "region-nav-sidebar",
+        "region-main-content"
+      ]
+    },
+    {
+      "breakpoint": "mobile (< 768px)",
+      "transformation": "Single-column vertical stack with drawer overlay navigation.",
+      "affected_regions": [
+        "region-header",
+        "region-nav-sidebar",
+        "region-main-content",
+        "region-bottom-dock"
+      ]
+    }
+  ],
+  "interaction_states": [
+    "DEFAULT",
+    "HOVER",
+    "FOCUS_VISIBLE",
+    "ACTIVE",
+    "DISABLED",
+    "LOADING",
+    "EMPTY",
+    "ERROR"
+  ],
+  "asset_requirements": [
+    {
+      "asset_id": "icon-command-palette",
+      "kind": "ICON",
+      "usage": "Trigger button icon for command palette in header bar.",
+      "reference_ref": "assets/icons/command.svg"
+    },
+    {
+      "asset_id": "token-color-surface-base",
+      "kind": "DESIGN_TOKEN",
+      "usage": "Background color variable for primary shell.",
+      "reference_ref": "tokens/color.json#surface-base"
+    }
+  ],
+  "preserve": [
+    "Preserve desktop-macro-grid layout structure across all desktop viewports.",
+    "Preserve action-bar-visual-hierarchy with unambiguous primary action salience.",
+    "Preserve split-pane-responsive-collapse behavior without dropping sidecar accessibility.",
+    "Preserve keyboard navigability (Tab, Shift+Tab, Escape, Enter) across all interactive elements."
+  ],
+  "adapt": [
+    "Adapt column widths fluidly between minimum and maximum constraints.",
+    "Adapt bottom dock height according to inspector content volume."
+  ],
+  "avoid": [
+    "Do not replace required multi-region composition with flat single-pane layout to reduce code size.",
+    "Do not remove split-pane divider to avoid implementing drag/collapse interactions.",
+    "Do not invent unrequested modal dialogs or floating overlays.",
+    "Do not downgrade UI_CONTRACT_FIDELITY profile."
+  ],
+  "unresolved": [
+    "Exact custom accent color token pending design system token finalization (fallback: project native brand blue)."
+  ],
+  "authority": {
+    "implementation_authorized": false,
+    "architecture_translation_authorized": false,
+    "release_authorized": false
+  }
+}

--- a/tests/fixtures/ui/uief4-invalid-ponytail-owner.json
+++ b/tests/fixtures/ui/uief4-invalid-ponytail-owner.json
@@ -1,0 +1,253 @@
+{
+  "": "../schemas/ui-fidelity-handoff.v1.schema.json",
+  "schema_version": "orchestra.ui-fidelity-handoff.v1",
+  "contract_id": "uief4-ui-fidelity-handoff-reference",
+  "owned_by": "ponytail",
+  "design_contract_ref": "machine/schemas/ui-design-contract.schema.json",
+  "ui_implementation_profile_ref": "machine/ui/ui-implementation-profile.v1.json",
+  "source_revision_or_contract_identity": "uief1-ui-implementation-profile-reference",
+  "provenance_refs": [
+    {
+      "source_id": "cuir-workspace-split-pane-prov",
+      "source_kind": "CUIR_NORMALIZED",
+      "reference_ref": "docs/specs/cuir/CUIR_NORMALIZED_PATTERNS.md#workspace-split-pane",
+      "provenance_id": "CUIR-3-WORKSPACE-SPLIT-PANE-001",
+      "advisory_only": false
+    },
+    {
+      "source_id": "native-command-palette-prov",
+      "source_kind": "PROJECT_NATIVE",
+      "reference_ref": "components/palette/CommandPalette.tsx",
+      "provenance_id": "PROJECT-NATIVE-PALETTE-001",
+      "advisory_only": false
+    },
+    {
+      "source_id": "public-anthropic-artifact-canvas-prov",
+      "source_kind": "PUBLIC_PROVIDER_GUIDANCE",
+      "reference_ref": "docs/specs/ui/PUBLIC_PROVIDER_UI_REFERENCE_INTELLIGENCE.md#anthropic-artifact-canvas",
+      "provenance_id": "PUBLIC-PROVIDER-ANTHROPIC-CANVAS-001",
+      "advisory_only": true
+    },
+    {
+      "source_id": "observed-sidecar-drawer-layout-prov",
+      "source_kind": "OBSERVED_PROVIDER_OUTPUT",
+      "reference_ref": "docs/specs/ui/OBSERVED_PROVIDER_PATTERNS.md#sidecar-drawer-layout",
+      "provenance_id": "OBSERVED-PROVIDER-SIDECAR-DRAWER-001",
+      "advisory_only": true
+    }
+  ],
+  "design_intent": "Deliver a high-density, multi-pane developer workspace interface maintaining macro composition and visual hierarchy without code-size-induced composition simplification.",
+  "information_hierarchy": [
+    {
+      "level": 1,
+      "title": "Workspace Header and Navigation",
+      "description": "Topmost operational bar exposing repository context, status indicator, and global command trigger.",
+      "target_components": [
+        "WorkspaceHeader",
+        "StatusIndicator",
+        "GlobalCommandTrigger"
+      ]
+    },
+    {
+      "level": 2,
+      "title": "Dual-Pane Operational Canvas",
+      "description": "Primary content region divided into collateral navigator (left) and active document viewer (right).",
+      "target_components": [
+        "SplitPaneContainer",
+        "CollateralNavigator",
+        "DocumentViewer"
+      ]
+    },
+    {
+      "level": 3,
+      "title": "Docked Secondary Inspector",
+      "description": "Bottom contextual inspector displaying diagnostics, metadata, and execution telemetry.",
+      "target_components": [
+        "ContextualInspector",
+        "TelemetryPanel"
+      ]
+    }
+  ],
+  "macro_composition": [
+    {
+      "composition_id": "desktop-macro-grid",
+      "structural_role": "MACRO_LAYOUT",
+      "description": "3-region vertical grid with fixed header (48px), flex primary workspace (1fr), and docked bottom tray (auto/collapsible).",
+      "reference_ref": "docs/specs/ui/COMPOSITIONS.md#desktop-macro-grid"
+    },
+    {
+      "composition_id": "action-bar-visual-hierarchy",
+      "structural_role": "VISUAL_HIERARCHY",
+      "description": "Prominent left-aligned breadcrumb title with right-aligned action group maintaining high-contrast primary CTA.",
+      "reference_ref": "docs/specs/ui/COMPOSITIONS.md#action-bar-visual-hierarchy"
+    },
+    {
+      "composition_id": "split-pane-responsive-collapse",
+      "structural_role": "RESPONSIVE_TRANSFORMATION",
+      "description": "Horizontal split-pane on viewports >= 1024px; vertical accordion-stack collapse on viewports < 1024px.",
+      "reference_ref": "docs/specs/ui/COMPOSITIONS.md#split-pane-responsive-collapse"
+    }
+  ],
+  "selected_pattern_refs": [
+    {
+      "pattern_id": "cuir-workspace-split-pane",
+      "source_kind": "CUIR_NORMALIZED",
+      "reference_ref": "docs/specs/cuir/CUIR_NORMALIZED_PATTERNS.md#workspace-split-pane",
+      "provenance_id": "CUIR-3-WORKSPACE-SPLIT-PANE-001",
+      "advisory_only": false
+    },
+    {
+      "pattern_id": "native-command-palette",
+      "source_kind": "PROJECT_NATIVE",
+      "reference_ref": "components/palette/CommandPalette.tsx",
+      "provenance_id": "PROJECT-NATIVE-PALETTE-001",
+      "advisory_only": false
+    },
+    {
+      "pattern_id": "public-anthropic-artifact-canvas-flow",
+      "source_kind": "PUBLIC_PROVIDER_GUIDANCE",
+      "reference_ref": "docs/specs/ui/PUBLIC_PROVIDER_UI_REFERENCE_INTELLIGENCE.md#anthropic-artifact-canvas",
+      "provenance_id": "PUBLIC-PROVIDER-ANTHROPIC-CANVAS-001",
+      "advisory_only": true
+    },
+    {
+      "pattern_id": "observed-sidecar-drawer-layout",
+      "source_kind": "OBSERVED_PROVIDER_OUTPUT",
+      "reference_ref": "docs/specs/ui/OBSERVED_PROVIDER_PATTERNS.md#sidecar-drawer-layout",
+      "provenance_id": "OBSERVED-PROVIDER-SIDECAR-DRAWER-001",
+      "advisory_only": true
+    }
+  ],
+  "pattern_application_reason": "Normalized CUIR split-pane provides deterministic layout stability; native command palette preserves existing user muscle memory; provider references serve as advisory-only pattern evidence.",
+  "required_regions": [
+    {
+      "region_id": "region-header",
+      "role": "BANNER",
+      "placement": "TOP_FIXED",
+      "collapsible": false
+    },
+    {
+      "region_id": "region-nav-sidebar",
+      "role": "NAVIGATION",
+      "placement": "LEFT_FLEXIBLE",
+      "collapsible": true
+    },
+    {
+      "region_id": "region-main-content",
+      "role": "MAIN",
+      "placement": "CENTER_EXPANDING",
+      "collapsible": false
+    },
+    {
+      "region_id": "region-bottom-dock",
+      "role": "COMPLEMENTARY",
+      "placement": "BOTTOM_DOCKED",
+      "collapsible": true
+    }
+  ],
+  "component_roles": {
+    "primary_container": "LayoutShell",
+    "navigator": "CollateralTree",
+    "viewer": "ActiveDocumentViewer",
+    "status_indicator": "SystemStateBadge",
+    "action_palette": "CommandPalette"
+  },
+  "visual_relationships": {
+    "grid_gap": "12px",
+    "sidebar_width_range": "240px-360px",
+    "content_min_width": "480px",
+    "elevation_hierarchy": {
+      "base_surface": "0px",
+      "docked_surface": "2px",
+      "floating_palette": "8px"
+    }
+  },
+  "typography_roles": {
+    "page_title": "font-size: 1.125rem; font-weight: 600; line-height: 1.5rem;",
+    "section_header": "font-size: 0.875rem; font-weight: 600; text-transform: uppercase;",
+    "body_text": "font-size: 0.875rem; font-weight: 400; line-height: 1.25rem;",
+    "code_snippet": "font-family: monospace; font-size: 0.8125rem;"
+  },
+  "spacing_relationships": {
+    "layout_padding": "16px",
+    "component_padding": "8px 12px",
+    "compact_padding": "4px 8px",
+    "element_gap": "8px"
+  },
+  "responsive_transformations": [
+    {
+      "breakpoint": "desktop (>= 1024px)",
+      "transformation": "Multi-column split view with visible sidebar and expanded document canvas.",
+      "affected_regions": [
+        "region-nav-sidebar",
+        "region-main-content"
+      ]
+    },
+    {
+      "breakpoint": "tablet (768px - 1023px)",
+      "transformation": "Sidebar collapsed to drawer toggle; main content occupies full viewport width.",
+      "affected_regions": [
+        "region-nav-sidebar",
+        "region-main-content"
+      ]
+    },
+    {
+      "breakpoint": "mobile (< 768px)",
+      "transformation": "Single-column vertical stack with drawer overlay navigation.",
+      "affected_regions": [
+        "region-header",
+        "region-nav-sidebar",
+        "region-main-content",
+        "region-bottom-dock"
+      ]
+    }
+  ],
+  "interaction_states": [
+    "DEFAULT",
+    "HOVER",
+    "FOCUS_VISIBLE",
+    "ACTIVE",
+    "DISABLED",
+    "LOADING",
+    "EMPTY",
+    "ERROR"
+  ],
+  "asset_requirements": [
+    {
+      "asset_id": "icon-command-palette",
+      "kind": "ICON",
+      "usage": "Trigger button icon for command palette in header bar.",
+      "reference_ref": "assets/icons/command.svg"
+    },
+    {
+      "asset_id": "token-color-surface-base",
+      "kind": "DESIGN_TOKEN",
+      "usage": "Background color variable for primary shell.",
+      "reference_ref": "tokens/color.json#surface-base"
+    }
+  ],
+  "preserve": [
+    "Preserve desktop-macro-grid layout structure across all desktop viewports.",
+    "Preserve action-bar-visual-hierarchy with unambiguous primary action salience.",
+    "Preserve split-pane-responsive-collapse behavior without dropping sidecar accessibility.",
+    "Preserve keyboard navigability (Tab, Shift+Tab, Escape, Enter) across all interactive elements."
+  ],
+  "adapt": [
+    "Adapt column widths fluidly between minimum and maximum constraints.",
+    "Adapt bottom dock height according to inspector content volume."
+  ],
+  "avoid": [
+    "Do not replace required multi-region composition with flat single-pane layout to reduce code size.",
+    "Do not remove split-pane divider to avoid implementing drag/collapse interactions.",
+    "Do not invent unrequested modal dialogs or floating overlays.",
+    "Do not downgrade UI_CONTRACT_FIDELITY profile."
+  ],
+  "unresolved": [
+    "Exact custom accent color token pending design system token finalization (fallback: project native brand blue)."
+  ],
+  "authority": {
+    "implementation_authorized": false,
+    "architecture_translation_authorized": false,
+    "release_authorized": false
+  }
+}

--- a/tests/fixtures/ui/uief4-valid-fidelity-handoff.json
+++ b/tests/fixtures/ui/uief4-valid-fidelity-handoff.json
@@ -1,0 +1,253 @@
+{
+  "": "../schemas/ui-fidelity-handoff.v1.schema.json",
+  "schema_version": "orchestra.ui-fidelity-handoff.v1",
+  "contract_id": "uief4-ui-fidelity-handoff-reference",
+  "owned_by": "cloak",
+  "design_contract_ref": "machine/schemas/ui-design-contract.schema.json",
+  "ui_implementation_profile_ref": "machine/ui/ui-implementation-profile.v1.json",
+  "source_revision_or_contract_identity": "uief1-ui-implementation-profile-reference",
+  "provenance_refs": [
+    {
+      "source_id": "cuir-workspace-split-pane-prov",
+      "source_kind": "CUIR_NORMALIZED",
+      "reference_ref": "docs/specs/cuir/CUIR_NORMALIZED_PATTERNS.md#workspace-split-pane",
+      "provenance_id": "CUIR-3-WORKSPACE-SPLIT-PANE-001",
+      "advisory_only": false
+    },
+    {
+      "source_id": "native-command-palette-prov",
+      "source_kind": "PROJECT_NATIVE",
+      "reference_ref": "components/palette/CommandPalette.tsx",
+      "provenance_id": "PROJECT-NATIVE-PALETTE-001",
+      "advisory_only": false
+    },
+    {
+      "source_id": "public-anthropic-artifact-canvas-prov",
+      "source_kind": "PUBLIC_PROVIDER_GUIDANCE",
+      "reference_ref": "docs/specs/ui/PUBLIC_PROVIDER_UI_REFERENCE_INTELLIGENCE.md#anthropic-artifact-canvas",
+      "provenance_id": "PUBLIC-PROVIDER-ANTHROPIC-CANVAS-001",
+      "advisory_only": true
+    },
+    {
+      "source_id": "observed-sidecar-drawer-layout-prov",
+      "source_kind": "OBSERVED_PROVIDER_OUTPUT",
+      "reference_ref": "docs/specs/ui/OBSERVED_PROVIDER_PATTERNS.md#sidecar-drawer-layout",
+      "provenance_id": "OBSERVED-PROVIDER-SIDECAR-DRAWER-001",
+      "advisory_only": true
+    }
+  ],
+  "design_intent": "Deliver a high-density, multi-pane developer workspace interface maintaining macro composition and visual hierarchy without code-size-induced composition simplification.",
+  "information_hierarchy": [
+    {
+      "level": 1,
+      "title": "Workspace Header and Navigation",
+      "description": "Topmost operational bar exposing repository context, status indicator, and global command trigger.",
+      "target_components": [
+        "WorkspaceHeader",
+        "StatusIndicator",
+        "GlobalCommandTrigger"
+      ]
+    },
+    {
+      "level": 2,
+      "title": "Dual-Pane Operational Canvas",
+      "description": "Primary content region divided into collateral navigator (left) and active document viewer (right).",
+      "target_components": [
+        "SplitPaneContainer",
+        "CollateralNavigator",
+        "DocumentViewer"
+      ]
+    },
+    {
+      "level": 3,
+      "title": "Docked Secondary Inspector",
+      "description": "Bottom contextual inspector displaying diagnostics, metadata, and execution telemetry.",
+      "target_components": [
+        "ContextualInspector",
+        "TelemetryPanel"
+      ]
+    }
+  ],
+  "macro_composition": [
+    {
+      "composition_id": "desktop-macro-grid",
+      "structural_role": "MACRO_LAYOUT",
+      "description": "3-region vertical grid with fixed header (48px), flex primary workspace (1fr), and docked bottom tray (auto/collapsible).",
+      "reference_ref": "docs/specs/ui/COMPOSITIONS.md#desktop-macro-grid"
+    },
+    {
+      "composition_id": "action-bar-visual-hierarchy",
+      "structural_role": "VISUAL_HIERARCHY",
+      "description": "Prominent left-aligned breadcrumb title with right-aligned action group maintaining high-contrast primary CTA.",
+      "reference_ref": "docs/specs/ui/COMPOSITIONS.md#action-bar-visual-hierarchy"
+    },
+    {
+      "composition_id": "split-pane-responsive-collapse",
+      "structural_role": "RESPONSIVE_TRANSFORMATION",
+      "description": "Horizontal split-pane on viewports >= 1024px; vertical accordion-stack collapse on viewports < 1024px.",
+      "reference_ref": "docs/specs/ui/COMPOSITIONS.md#split-pane-responsive-collapse"
+    }
+  ],
+  "selected_pattern_refs": [
+    {
+      "pattern_id": "cuir-workspace-split-pane",
+      "source_kind": "CUIR_NORMALIZED",
+      "reference_ref": "docs/specs/cuir/CUIR_NORMALIZED_PATTERNS.md#workspace-split-pane",
+      "provenance_id": "CUIR-3-WORKSPACE-SPLIT-PANE-001",
+      "advisory_only": false
+    },
+    {
+      "pattern_id": "native-command-palette",
+      "source_kind": "PROJECT_NATIVE",
+      "reference_ref": "components/palette/CommandPalette.tsx",
+      "provenance_id": "PROJECT-NATIVE-PALETTE-001",
+      "advisory_only": false
+    },
+    {
+      "pattern_id": "public-anthropic-artifact-canvas-flow",
+      "source_kind": "PUBLIC_PROVIDER_GUIDANCE",
+      "reference_ref": "docs/specs/ui/PUBLIC_PROVIDER_UI_REFERENCE_INTELLIGENCE.md#anthropic-artifact-canvas",
+      "provenance_id": "PUBLIC-PROVIDER-ANTHROPIC-CANVAS-001",
+      "advisory_only": true
+    },
+    {
+      "pattern_id": "observed-sidecar-drawer-layout",
+      "source_kind": "OBSERVED_PROVIDER_OUTPUT",
+      "reference_ref": "docs/specs/ui/OBSERVED_PROVIDER_PATTERNS.md#sidecar-drawer-layout",
+      "provenance_id": "OBSERVED-PROVIDER-SIDECAR-DRAWER-001",
+      "advisory_only": true
+    }
+  ],
+  "pattern_application_reason": "Normalized CUIR split-pane provides deterministic layout stability; native command palette preserves existing user muscle memory; provider references serve as advisory-only pattern evidence.",
+  "required_regions": [
+    {
+      "region_id": "region-header",
+      "role": "BANNER",
+      "placement": "TOP_FIXED",
+      "collapsible": false
+    },
+    {
+      "region_id": "region-nav-sidebar",
+      "role": "NAVIGATION",
+      "placement": "LEFT_FLEXIBLE",
+      "collapsible": true
+    },
+    {
+      "region_id": "region-main-content",
+      "role": "MAIN",
+      "placement": "CENTER_EXPANDING",
+      "collapsible": false
+    },
+    {
+      "region_id": "region-bottom-dock",
+      "role": "COMPLEMENTARY",
+      "placement": "BOTTOM_DOCKED",
+      "collapsible": true
+    }
+  ],
+  "component_roles": {
+    "primary_container": "LayoutShell",
+    "navigator": "CollateralTree",
+    "viewer": "ActiveDocumentViewer",
+    "status_indicator": "SystemStateBadge",
+    "action_palette": "CommandPalette"
+  },
+  "visual_relationships": {
+    "grid_gap": "12px",
+    "sidebar_width_range": "240px-360px",
+    "content_min_width": "480px",
+    "elevation_hierarchy": {
+      "base_surface": "0px",
+      "docked_surface": "2px",
+      "floating_palette": "8px"
+    }
+  },
+  "typography_roles": {
+    "page_title": "font-size: 1.125rem; font-weight: 600; line-height: 1.5rem;",
+    "section_header": "font-size: 0.875rem; font-weight: 600; text-transform: uppercase;",
+    "body_text": "font-size: 0.875rem; font-weight: 400; line-height: 1.25rem;",
+    "code_snippet": "font-family: monospace; font-size: 0.8125rem;"
+  },
+  "spacing_relationships": {
+    "layout_padding": "16px",
+    "component_padding": "8px 12px",
+    "compact_padding": "4px 8px",
+    "element_gap": "8px"
+  },
+  "responsive_transformations": [
+    {
+      "breakpoint": "desktop (>= 1024px)",
+      "transformation": "Multi-column split view with visible sidebar and expanded document canvas.",
+      "affected_regions": [
+        "region-nav-sidebar",
+        "region-main-content"
+      ]
+    },
+    {
+      "breakpoint": "tablet (768px - 1023px)",
+      "transformation": "Sidebar collapsed to drawer toggle; main content occupies full viewport width.",
+      "affected_regions": [
+        "region-nav-sidebar",
+        "region-main-content"
+      ]
+    },
+    {
+      "breakpoint": "mobile (< 768px)",
+      "transformation": "Single-column vertical stack with drawer overlay navigation.",
+      "affected_regions": [
+        "region-header",
+        "region-nav-sidebar",
+        "region-main-content",
+        "region-bottom-dock"
+      ]
+    }
+  ],
+  "interaction_states": [
+    "DEFAULT",
+    "HOVER",
+    "FOCUS_VISIBLE",
+    "ACTIVE",
+    "DISABLED",
+    "LOADING",
+    "EMPTY",
+    "ERROR"
+  ],
+  "asset_requirements": [
+    {
+      "asset_id": "icon-command-palette",
+      "kind": "ICON",
+      "usage": "Trigger button icon for command palette in header bar.",
+      "reference_ref": "assets/icons/command.svg"
+    },
+    {
+      "asset_id": "token-color-surface-base",
+      "kind": "DESIGN_TOKEN",
+      "usage": "Background color variable for primary shell.",
+      "reference_ref": "tokens/color.json#surface-base"
+    }
+  ],
+  "preserve": [
+    "Preserve desktop-macro-grid layout structure across all desktop viewports.",
+    "Preserve action-bar-visual-hierarchy with unambiguous primary action salience.",
+    "Preserve split-pane-responsive-collapse behavior without dropping sidecar accessibility.",
+    "Preserve keyboard navigability (Tab, Shift+Tab, Escape, Enter) across all interactive elements."
+  ],
+  "adapt": [
+    "Adapt column widths fluidly between minimum and maximum constraints.",
+    "Adapt bottom dock height according to inspector content volume."
+  ],
+  "avoid": [
+    "Do not replace required multi-region composition with flat single-pane layout to reduce code size.",
+    "Do not remove split-pane divider to avoid implementing drag/collapse interactions.",
+    "Do not invent unrequested modal dialogs or floating overlays.",
+    "Do not downgrade UI_CONTRACT_FIDELITY profile."
+  ],
+  "unresolved": [
+    "Exact custom accent color token pending design system token finalization (fallback: project native brand blue)."
+  ],
+  "authority": {
+    "implementation_authorized": false,
+    "architecture_translation_authorized": false,
+    "release_authorized": false
+  }
+}

--- a/tests/runtime/test_machine_contracts.py
+++ b/tests/runtime/test_machine_contracts.py
@@ -131,6 +131,12 @@ def test_load_contract_rejects_wrong_schema(tmp_path):
     with pytest.raises(ValueError, match="unsupported UI fidelity routing"):
         contracts.load_ui_fidelity_routing_contract(tmp_path)
 
+    handoff_path = tmp_path / "machine" / "ui"
+    handoff_path.mkdir(parents=True)
+    (handoff_path / "ui-fidelity-handoff.v1.json").write_text('{"schema_version":"wrong"}', encoding="utf-8")
+    with pytest.raises(ValueError, match="unsupported UI fidelity handoff"):
+        contracts.load_ui_fidelity_handoff_contract(tmp_path)
+
 
 @pytest.mark.parametrize(
     ("field", "value", "message"),
@@ -146,3 +152,31 @@ def test_machine_contract_errors_reject_ui_fidelity_contract_drift(monkeypatch, 
     fidelity[field] = value
     monkeypatch.setattr(contracts, "load_ui_fidelity_routing_contract", lambda root=None: fidelity)
     assert message in contracts.machine_contract_errors(ROOT)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("owned_by", "ponytail", "UI_FIDELITY_HANDOFF_OWNER_INVALID"),
+        ("authority", {"implementation_authorized": True}, "UI_FIDELITY_HANDOFF_AUTHORITY_EXPANSION"),
+    ],
+)
+def test_machine_contract_errors_reject_ui_fidelity_handoff_contract_drift(monkeypatch, field, value, message):
+    handoff = deepcopy(contracts.load_ui_fidelity_handoff_contract(ROOT))
+    handoff[field] = value
+    monkeypatch.setattr(contracts, "load_ui_fidelity_handoff_contract", lambda root=None: handoff)
+    assert message in contracts.machine_contract_errors(ROOT)
+
+
+def test_machine_contract_errors_reject_ui_fidelity_handoff_missing_required_field(monkeypatch):
+    handoff = deepcopy(contracts.load_ui_fidelity_handoff_contract(ROOT))
+    del handoff["preserve"]
+    monkeypatch.setattr(contracts, "load_ui_fidelity_handoff_contract", lambda root=None: handoff)
+    assert "UI_FIDELITY_HANDOFF_MISSING_FIELD:preserve" in contracts.machine_contract_errors(ROOT)
+
+
+def test_machine_contract_errors_reject_ui_fidelity_handoff_contract_exception(monkeypatch):
+    def _failing_loader(root=None):
+        raise ValueError("corrupted handoff")
+    monkeypatch.setattr(contracts, "load_ui_fidelity_handoff_contract", _failing_loader)
+    assert "UI_FIDELITY_HANDOFF_CONTRACT_INVALID:corrupted handoff" in contracts.machine_contract_errors(ROOT)

--- a/tests/runtime/test_refoundation_contract_failures.py
+++ b/tests/runtime/test_refoundation_contract_failures.py
@@ -121,6 +121,10 @@ def _machine_repo(tmp_path: Path):
         tmp_path / "machine/routing/ui-fidelity-routing.v1.json",
         json.loads((Path(__file__).resolve().parents[2] / "machine/routing/ui-fidelity-routing.v1.json").read_text(encoding="utf-8")),
     )
+    _write_json(
+        tmp_path / "machine/ui/ui-fidelity-handoff.v1.json",
+        json.loads((Path(__file__).resolve().parents[2] / "machine/ui/ui-fidelity-handoff.v1.json").read_text(encoding="utf-8")),
+    )
     _write_json(tmp_path / "machine/governance/policy.v1.json", policy)
     assert mc.machine_contract_errors(tmp_path) == ()
     return routing, policy

--- a/tests/runtime/test_uief4_cloak_fidelity_handoff.py
+++ b/tests/runtime/test_uief4_cloak_fidelity_handoff.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from orchestra_runtime.domain.orchestration.ui_fidelity import (
+    UI_CONTRACT_FIDELITY,
+    UI_FIDELITY_HANDOFF_SCHEMA,
+    VALID_SOURCE_KINDS,
+    UIFidelityHandoff,
+    enforce_ponytail_fidelity_execution,
+    validate_ui_fidelity_handoff,
+)
+from orchestra_runtime.machine_contracts import load_ui_fidelity_handoff_contract
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MACHINE_HANDOFF = ROOT / "machine" / "ui" / "ui-fidelity-handoff.v1.json"
+UIX9_MANIFEST = ROOT / "machine" / "ui" / "uix9-live-guidance-manifest.v1.json"
+CLOAK_SKILL_MD = ROOT / "skills" / "cloak" / "SKILL.md"
+GUIDE_SOURCE = ROOT / "skills" / "cloak" / "UI_FIDELITY_HANDOFF_GUIDE.md"
+GUIDE_CODEX = ROOT / "adapters" / "codex" / "skills" / "cloak" / "UI_FIDELITY_HANDOFF_GUIDE.md"
+OUTPUT_FORMATS_SOURCE = ROOT / "skills" / "cloak" / "OUTPUT_FORMATS.md"
+OUTPUT_FORMATS_CODEX = ROOT / "adapters" / "codex" / "skills" / "cloak" / "OUTPUT_FORMATS.md"
+FIXTURES = ROOT / "tests" / "fixtures" / "ui"
+
+
+def _load_fixture(filename: str) -> dict:
+    return json.loads((FIXTURES / filename).read_text(encoding="utf-8"))
+
+
+def test_valid_fidelity_handoff_fixture_parses_and_validates() -> None:
+    data = _load_fixture("uief4-valid-fidelity-handoff.json")
+    handoff = validate_ui_fidelity_handoff(data)
+
+    assert isinstance(handoff, UIFidelityHandoff)
+    assert handoff.schema_version == UI_FIDELITY_HANDOFF_SCHEMA
+    assert handoff.owned_by == "cloak"
+    assert handoff.contract_id == "uief4-ui-fidelity-handoff-reference"
+    assert len(handoff.macro_composition) == 3
+    assert len(handoff.selected_pattern_refs) == 4
+    assert len(handoff.provenance_refs) == 4
+    assert len(handoff.preserve) == 4
+    assert len(handoff.avoid) == 4
+    assert handoff.authority["implementation_authorized"] is False
+    assert handoff.authority["architecture_translation_authorized"] is False
+    assert handoff.authority["release_authorized"] is False
+
+    # Verify serialization
+    serialized = handoff.to_dict()
+    assert serialized["schema_version"] == UI_FIDELITY_HANDOFF_SCHEMA
+    assert serialized["owned_by"] == "cloak"
+    assert len(serialized["macro_composition"]) == 3
+    assert serialized["authority"] == handoff.authority
+
+
+def test_machine_reference_fixture_loads_and_validates() -> None:
+    data = load_ui_fidelity_handoff_contract()
+    handoff = validate_ui_fidelity_handoff(data)
+    assert handoff.contract_id == "uief4-ui-fidelity-handoff-reference"
+    assert handoff.owned_by == "cloak"
+
+
+def test_handoff_to_ponytail_context_executes_cleanly() -> None:
+    data = _load_fixture("uief4-valid-fidelity-handoff.json")
+    handoff = validate_ui_fidelity_handoff(data)
+    ponytail_ctx = handoff.to_ponytail_context()
+
+    assert ponytail_ctx["ui_implementation_profile"] == UI_CONTRACT_FIDELITY
+    assert "ui_fidelity_context" in ponytail_ctx
+    inner_ctx = ponytail_ctx["ui_fidelity_context"]
+    assert inner_ctx["design_contract_ref"] == handoff.design_contract_ref
+    assert inner_ctx["cloak_handoff_ref"] == handoff.contract_id
+    assert inner_ctx["clockwork_boundary_ref"] == "docs/architecture/UIEF_CLOCKWORK_ENGINEERING_BOUNDARY.md"
+
+    # Enforce through Ponytail execution gate
+    execution = enforce_ponytail_fidelity_execution(
+        ponytail_ctx,
+        {
+            "preserved_compositions": [
+                "desktop-macro-grid",
+                "action-bar-visual-hierarchy",
+                "split-pane-responsive-collapse",
+            ],
+            "project_native_reuse": ["components/palette/CommandPalette.tsx"],
+            "deviations": [],
+        },
+    )
+    assert execution.profile == UI_CONTRACT_FIDELITY
+    assert execution.static_review_ready is True
+    assert execution.requires_upstream_reentry is False
+
+
+def test_invalid_missing_binding_fixture_fails() -> None:
+    data = _load_fixture("uief4-invalid-missing-binding.json")
+    with pytest.raises(ValueError, match="UIFidelityHandoff requires non-empty string design_contract_ref"):
+        validate_ui_fidelity_handoff(data)
+
+
+def test_invalid_ponytail_owner_fixture_fails() -> None:
+    data = _load_fixture("uief4-invalid-ponytail-owner.json")
+    with pytest.raises(ValueError, match="UIFidelityHandoff must be owned by cloak"):
+        validate_ui_fidelity_handoff(data)
+
+
+def test_invalid_clockwork_translation_fixture_fails() -> None:
+    data = _load_fixture("uief4-invalid-clockwork-translation.json")
+    with pytest.raises(ValueError, match="cannot embed or initiate UIEF-5 engineering translation"):
+        validate_ui_fidelity_handoff(data)
+
+    # Test direct dataclass attribute rejection
+    base_data = _load_fixture("uief4-valid-fidelity-handoff.json")
+    handoff = validate_ui_fidelity_handoff(base_data)
+    object.__setattr__(handoff, "clockwork_translation", True)
+    with pytest.raises(ValueError, match="cannot embed or initiate UIEF-5 engineering translation"):
+        handoff.validate()
+
+
+def test_invalid_contaminated_execution_mode_fixture_fails() -> None:
+    data = _load_fixture("uief4-invalid-contaminated-execution-mode.json")
+    with pytest.raises(ValueError, match="Generic execution_mode cannot be contaminated"):
+        validate_ui_fidelity_handoff(data)
+
+
+def test_authority_invariants_strictly_enforced() -> None:
+    base_data = _load_fixture("uief4-valid-fidelity-handoff.json")
+
+    # Implementation authorized attempt
+    bad = copy.deepcopy(base_data)
+    bad["authority"]["implementation_authorized"] = True
+    with pytest.raises(ValueError, match="cannot authorize implementation"):
+        validate_ui_fidelity_handoff(bad)
+
+    # Architecture translation authorized attempt
+    bad = copy.deepcopy(base_data)
+    bad["authority"]["architecture_translation_authorized"] = True
+    with pytest.raises(ValueError, match="cannot authorize implementation"):
+        validate_ui_fidelity_handoff(bad)
+
+    # Release authorized attempt
+    bad = copy.deepcopy(base_data)
+    bad["authority"]["release_authorized"] = True
+    with pytest.raises(ValueError, match="cannot authorize implementation"):
+        validate_ui_fidelity_handoff(bad)
+
+    # Missing or invalid authority
+    bad = copy.deepcopy(base_data)
+    bad["authority"] = "not-a-mapping"
+    with pytest.raises(ValueError, match="requires mapping authority"):
+        validate_ui_fidelity_handoff(bad)
+
+    # Direct dataclass authority tests
+    with pytest.raises(ValueError, match="requires mapping authority"):
+        UIFidelityHandoff(
+            schema_version=UI_FIDELITY_HANDOFF_SCHEMA,
+            contract_id="id",
+            owned_by="cloak",
+            design_contract_ref="ref",
+            ui_implementation_profile_ref="ref",
+            source_revision_or_contract_identity="ref",
+            provenance_refs=(),
+            design_intent="intent",
+            information_hierarchy=(),
+            macro_composition=(),
+            selected_pattern_refs=(),
+            pattern_application_reason="reason",
+            required_regions=(),
+            component_roles={},
+            visual_relationships={},
+            typography_roles={},
+            spacing_relationships={},
+            responsive_transformations=(),
+            interaction_states=(),
+            asset_requirements=(),
+            preserve=(),
+            adapt=(),
+            avoid=(),
+            unresolved=(),
+            authority="not-a-mapping",  # type: ignore[arg-type]
+        ).validate()
+
+    with pytest.raises(ValueError, match="must be owned by cloak"):
+        UIFidelityHandoff(
+            schema_version=UI_FIDELITY_HANDOFF_SCHEMA,
+            contract_id="id",
+            owned_by="ponytail",
+            design_contract_ref="ref",
+            ui_implementation_profile_ref="ref",
+            source_revision_or_contract_identity="ref",
+            provenance_refs=(),
+            design_intent="intent",
+            information_hierarchy=(),
+            macro_composition=(),
+            selected_pattern_refs=(),
+            pattern_application_reason="reason",
+            required_regions=(),
+            component_roles={},
+            visual_relationships={},
+            typography_roles={},
+            spacing_relationships={},
+            responsive_transformations=(),
+            interaction_states=(),
+            asset_requirements=(),
+            preserve=(),
+            adapt=(),
+            avoid=(),
+            unresolved=(),
+            authority={"implementation_authorized": False, "architecture_translation_authorized": False, "release_authorized": False},
+        ).validate()
+
+
+def test_string_field_validations() -> None:
+    base_data = _load_fixture("uief4-valid-fidelity-handoff.json")
+
+    # Invalid schema version
+    bad = copy.deepcopy(base_data)
+    bad["schema_version"] = "wrong.schema.version"
+    with pytest.raises(ValueError, match="unsupported UIFidelityHandoff schema_version"):
+        validate_ui_fidelity_handoff(bad)
+
+    for field in (
+        "contract_id",
+        "design_contract_ref",
+        "ui_implementation_profile_ref",
+        "source_revision_or_contract_identity",
+        "design_intent",
+        "pattern_application_reason",
+    ):
+        bad = copy.deepcopy(base_data)
+        bad[field] = "   "
+        with pytest.raises(ValueError, match=f"requires non-empty string {field}"):
+            validate_ui_fidelity_handoff(bad)
+
+
+def test_required_collections_validation() -> None:
+    base_data = _load_fixture("uief4-valid-fidelity-handoff.json")
+
+    for field in (
+        "provenance_refs",
+        "information_hierarchy",
+        "macro_composition",
+        "selected_pattern_refs",
+        "required_regions",
+        "preserve",
+        "avoid",
+    ):
+        bad = copy.deepcopy(base_data)
+        bad[field] = []
+        with pytest.raises(ValueError, match=f"requires non-empty collection {field}"):
+            validate_ui_fidelity_handoff(bad)
+
+    bad = copy.deepcopy(base_data)
+    bad["unresolved"] = "not-a-list"
+    with pytest.raises(ValueError, match="requires list or tuple for unresolved"):
+        validate_ui_fidelity_handoff(bad)
+
+    # Test mapping type checking
+    for map_field in (
+        "component_roles",
+        "visual_relationships",
+        "typography_roles",
+        "spacing_relationships",
+    ):
+        bad = copy.deepcopy(base_data)
+        bad[map_field] = "not-a-mapping"
+        with pytest.raises(ValueError, match=f"requires mapping for {map_field}"):
+            validate_ui_fidelity_handoff(bad)
+
+    # Direct dataclass test for unresolved
+    with pytest.raises(ValueError, match="requires unresolved list"):
+        handoff = validate_ui_fidelity_handoff(base_data)
+        UIFidelityHandoff(
+            schema_version=handoff.schema_version,
+            contract_id=handoff.contract_id,
+            owned_by=handoff.owned_by,
+            design_contract_ref=handoff.design_contract_ref,
+            ui_implementation_profile_ref=handoff.ui_implementation_profile_ref,
+            source_revision_or_contract_identity=handoff.source_revision_or_contract_identity,
+            provenance_refs=handoff.provenance_refs,
+            design_intent=handoff.design_intent,
+            information_hierarchy=handoff.information_hierarchy,
+            macro_composition=handoff.macro_composition,
+            selected_pattern_refs=handoff.selected_pattern_refs,
+            pattern_application_reason=handoff.pattern_application_reason,
+            required_regions=handoff.required_regions,
+            component_roles=handoff.component_roles,
+            visual_relationships=handoff.visual_relationships,
+            typography_roles=handoff.typography_roles,
+            spacing_relationships=handoff.spacing_relationships,
+            responsive_transformations=handoff.responsive_transformations,
+            interaction_states=handoff.interaction_states,
+            asset_requirements=handoff.asset_requirements,
+            preserve=handoff.preserve,
+            adapt=handoff.adapt,
+            avoid=handoff.avoid,
+            unresolved="not-a-tuple",  # type: ignore[arg-type]
+            authority=handoff.authority,
+        ).validate()
+
+
+def test_pattern_refs_validation() -> None:
+    base_data = _load_fixture("uief4-valid-fidelity-handoff.json")
+
+    bad = copy.deepcopy(base_data)
+    bad["selected_pattern_refs"] = ["not-a-mapping"]
+    with pytest.raises(ValueError, match="selected_pattern_refs items must be mappings"):
+        validate_ui_fidelity_handoff(bad)
+
+    bad = copy.deepcopy(base_data)
+    bad["selected_pattern_refs"] = [{"pattern_id": "", "source_kind": "CUIR_NORMALIZED", "provenance_id": "P1"}]
+    with pytest.raises(ValueError, match="selected_pattern_refs items require pattern_id"):
+        validate_ui_fidelity_handoff(bad)
+
+    bad = copy.deepcopy(base_data)
+    bad["selected_pattern_refs"] = [{"pattern_id": "p1", "source_kind": "INVALID_KIND", "provenance_id": "P1"}]
+    with pytest.raises(ValueError, match="unrecognized source_kind"):
+        validate_ui_fidelity_handoff(bad)
+
+    bad = copy.deepcopy(base_data)
+    bad["selected_pattern_refs"] = [{"pattern_id": "p1", "source_kind": "CUIR_NORMALIZED", "provenance_id": ""}]
+    with pytest.raises(ValueError, match="selected_pattern_refs items require provenance_id"):
+        validate_ui_fidelity_handoff(bad)
+
+
+def test_macro_composition_validation() -> None:
+    base_data = _load_fixture("uief4-valid-fidelity-handoff.json")
+
+    bad = copy.deepcopy(base_data)
+    bad["macro_composition"] = ["not-a-mapping"]
+    with pytest.raises(ValueError, match="macro_composition items must be mappings"):
+        validate_ui_fidelity_handoff(bad)
+
+    bad = copy.deepcopy(base_data)
+    bad["macro_composition"] = [{"structural_role": "MACRO_LAYOUT"}]
+    with pytest.raises(ValueError, match="macro_composition items require composition_id"):
+        validate_ui_fidelity_handoff(bad)
+
+
+def test_validate_ui_fidelity_handoff_requires_mapping() -> None:
+    with pytest.raises(ValueError, match="UIFidelityHandoff data must be a mapping"):
+        validate_ui_fidelity_handoff("not-a-mapping")  # type: ignore[arg-type]
+
+
+def test_frozen_cloak_identity_preserved() -> None:
+    manifest_data = json.loads(UIX9_MANIFEST.read_text(encoding="utf-8"))
+    cloak_entries = [
+        entry for entry in manifest_data.get("materials", [])
+        if entry.get("path") == "skills/cloak/SKILL.md"
+    ]
+    assert len(cloak_entries) == 1, "skills/cloak/SKILL.md must be registered in uix9 manifest"
+    expected_digest = cloak_entries[0]["canonical_blob_digest"]
+    skill_content = CLOAK_SKILL_MD.read_bytes().replace(b"\r\n", b"\n")
+    actual_digest = hashlib.sha256(skill_content).hexdigest()
+    assert actual_digest == expected_digest, (
+        f"skills/cloak/SKILL.md was modified! Expected digest {expected_digest} but found {actual_digest}"
+    )
+
+
+def test_codex_parity_mirrors_exist_and_byte_identical() -> None:
+    assert GUIDE_SOURCE.exists(), "skills/cloak/UI_FIDELITY_HANDOFF_GUIDE.md must exist"
+    assert GUIDE_CODEX.exists(), "adapters/codex/skills/cloak/UI_FIDELITY_HANDOFF_GUIDE.md must exist"
+    guide_source_bytes = GUIDE_SOURCE.read_bytes().replace(b"\r\n", b"\n")
+    guide_codex_bytes = GUIDE_CODEX.read_bytes().replace(b"\r\n", b"\n")
+    assert guide_source_bytes == guide_codex_bytes, "Guide must be byte-identical between skills/ and adapters/"
+
+    assert OUTPUT_FORMATS_SOURCE.exists(), "skills/cloak/OUTPUT_FORMATS.md must exist"
+    assert OUTPUT_FORMATS_CODEX.exists(), "adapters/codex/skills/cloak/OUTPUT_FORMATS.md must exist"
+    out_source_bytes = OUTPUT_FORMATS_SOURCE.read_bytes().replace(b"\r\n", b"\n")
+    out_codex_bytes = OUTPUT_FORMATS_CODEX.read_bytes().replace(b"\r\n", b"\n")
+    assert out_source_bytes == out_codex_bytes, "OUTPUT_FORMATS.md must be byte-identical between skills/ and adapters/"
+    assert "UI_FIDELITY_HANDOFF" in OUTPUT_FORMATS_SOURCE.read_text(encoding="utf-8")


### PR DESCRIPTION
feat(uief): implement cloak visible layer fidelity handoff contract

Implements the bounded UIEF-4 Cloak implementation-bound fidelity handoff contract.

- Introduces library-neutral UI fidelity handoff machine contract schema machine/schemas/ui-fidelity-handoff.v1.schema.json (Draft 2020-12).
- Establishes canonical reference machine contract in machine/ui/ui-fidelity-handoff.v1.json binding design intent, macro composition, information hierarchy, CUIR normalized pattern references, provider-observed references, required regions, responsive transformations, component roles, visual/typography/spacing relationships, and explicit preserve/adapt/avoid/unresolved rules.
- Adds progressive-disclosure guidance in skills/cloak/UI_FIDELITY_HANDOFF_GUIDE.md and byte-identical Codex parity mirror adapters/codex/skills/cloak/UI_FIDELITY_HANDOFF_GUIDE.md without modifying frozen historical skills/cloak/SKILL.md.
- Adds UI_FIDELITY_HANDOFF output format to skills/cloak/OUTPUT_FORMATS.md and adapters/codex/skills/cloak/OUTPUT_FORMATS.md.
- Formalizes UIFidelityHandoff domain model and validate_ui_fidelity_handoff parser/validator in orchestra_runtime/domain/orchestration/ui_fidelity.py and machine contract validation in orchestra_runtime/machine_contracts.py.
- Enforces strict authority invariants (no implementation, architecture translation, or release authority granted) and strict prohibitions against generic execution_mode contamination and premature UIEF-5 Clockwork translation initiation.
- Provides deterministic test fixtures in tests/fixtures/ui/uief4-*.json and comprehensive runtime validation in tests/runtime/test_uief4_cloak_fidelity_handoff.py.
- Validation completed locally: full runtime suite (2335 passed, 98% coverage), machine contracts, architecture boundaries, structure, export parity, governance strict, and diff check.
