### PR TITLE
feat(awf): derive adaptive topology from ordinary Conductor intake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Adds automatic Conductor TaskProfile derivation when no explicit structured profile is supplied; explicit valid structured profiles remain supported.
 - Adds machine-readable selection traces containing matched signals, derived reason codes, selected/rejected patterns, selected specialists, and underlying human-gate reasons without exposing private model reasoning.
 - Keeps unknown domains fail-closed at Conductor, keeps protected-action authorization explicit, and preserves OEE `max_parallel_specialists = 1`.
-- Adds three controlled runtime scenarios for single-owner UI review, multi-domain implementation, and protected production deployment.
+- Expands controlled calibration to 18 positive RouterService scenarios and adds a 20-case adversarial negative-routing corpus covering negation, quoted/example content, hypothetical actions, representation-only work, and protected-action false-positive suppression.
 - Does not widen specialist authority, change OEE concurrency, promote A5, resume UIEF, release, deploy, or activate policy.
 
 ## Post-v1.8.0 Adaptive Agentic Workflow AWF-I0 through AWF-I10 candidate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Post-v1.8.0 AWF-N1 through AWF-N3 adaptive intake candidate
+
+- Reconciles AWF-I0 through AWF-I10 as complete canonical at merge commit `7f1e1962817b1b363fbcb1629902d69d50f1daa6`, sourced from fully qualified PR #800.
+- Adds a machine-configured deterministic Conductor intake policy that derives TaskProfile fields from ordinary prompt and host context signals without granting authority.
+- Adds automatic Conductor TaskProfile derivation when no explicit structured profile is supplied; explicit valid structured profiles remain supported.
+- Adds machine-readable selection traces containing matched signals, derived reason codes, selected/rejected patterns, selected specialists, and underlying human-gate reasons without exposing private model reasoning.
+- Keeps unknown domains fail-closed at Conductor, keeps protected-action authorization explicit, and preserves OEE `max_parallel_specialists = 1`.
+- Adds three controlled runtime scenarios for single-owner UI review, multi-domain implementation, and protected production deployment.
+- Does not widen specialist authority, change OEE concurrency, promote A5, resume UIEF, release, deploy, or activate policy.
+
 ## Post-v1.8.0 Adaptive Agentic Workflow AWF-I0 through AWF-I10 candidate
 
 - Adds execution-effective, authority-aware adaptive workflow topology selection under the invariant `WORKFLOW_TOPOLOGY_CHANGE != AUTHORITY_EXPANSION`.

--- a/README.json
+++ b/README.json
@@ -2265,7 +2265,10 @@
     "agentic_workflow_profile_schema": "machine/schemas/agentic-workflow-profile.v1.schema.json",
     "agentic_patterns": "machine/workflows/patterns.v1.json",
     "agentic_composition_invariants": "machine/workflows/composition-invariants.v1.json",
-    "agentic_workflow_implementation": "machine/adaptive/awf-agentic-workflow-implementation.v1.json"
+    "agentic_workflow_implementation": "machine/adaptive/awf-agentic-workflow-implementation.v1.json",
+    "task_profile_derivation_schema": "machine/schemas/task-profile-derivation.v1.schema.json",
+    "task_profile_derivation_policy": "machine/workflows/task-profile-derivation.v1.json",
+    "agentic_selection_trace_schema": "machine/schemas/agentic-selection-trace.v1.schema.json"
   },
   "specialists": {
     "count": 14,
@@ -2535,7 +2538,8 @@
     "cloak_ui_reference_corpus_cuir4": "CUIR_4_CANONICAL_MERGED_VERIFIED",
     "cloak_ui_reference_corpus_cuir5": "CUIR_5_CANONICAL_CONTROLLED_EVALUATION_VERIFIED",
     "cloak_ui_reference_corpus_cuir6": "CUIR_6_CANONICAL_ADOPT_OPTIONAL_CLOSEOUT_VERIFIED",
-    "adaptive_agentic_workflow_awf": "IMPLEMENTED_EXECUTION_EFFECTIVE_AUTHORITY_PRESERVING"
+    "adaptive_agentic_workflow_awf": "AWF_I0_I10_COMPLETE_CANONICAL_VERIFIED",
+    "adaptive_agentic_workflow_intake_n1_n3": "IMPLEMENTATION_CANDIDATE"
   },
   "ai_review_guidance": {
     "preferred_entrypoint": "README.json",
@@ -2645,6 +2649,9 @@
     "treat_awf_topology_change_as_non_authority_expanding_when_within_granted_authority": true,
     "treat_awf_as_deterministic_authority_aware_execution_topology_not_a5_shadow_ranker_promotion": true,
     "do_not_use_a5_shadow_ranking_as_awf_execution_selection_without_separate_evidence_contract": true,
-    "preserve_oee_max_parallel_specialists_default_during_awf_selection": true
+    "preserve_oee_max_parallel_specialists_default_during_awf_selection": true,
+    "treat_awf_intake_derivation_as_deterministic_calibratable_routing_evidence": true,
+    "do_not_infer_protected_action_authority_from_awf_prompt_signals": true,
+    "unknown_awf_intake_domain_fails_to_conductor_instead_of_guessing_owner": true
   }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ Older phase documents may retain the status language of the phase in which they 
 - [Adaptive Behavioral Pattern Learning A3](architecture/ADAPTIVE_SHADOW_LEARNING_A3.md): A3.0 shadow-learning contract and non-authorizing signal/candidate/comparison model.
 - [Portable Adaptive Memory](architecture/PORTABLE_ADAPTIVE_MEMORY.md): optional storage-agnostic export contract for user-selected memory backends.
 - [Adaptive Agentic Workflow AWF](architecture/ADAPTIVE_AGENTIC_WORKFLOW_AWF.md): execution-effective authority-aware topology selection inside existing user/project authority, with topology changes separated from authority expansion.
+- [Adaptive Agentic Workflow Intake N1-N3](architecture/ADAPTIVE_AGENTIC_WORKFLOW_INTAKE_N1.md): deterministic ordinary-prompt TaskProfile derivation, explainable selection traces, and controlled calibration scenarios.
 - `../machine/adaptive/a1-memory-contract.v1.json`: A1 machine contract.
 - `../machine/adaptive/a2-context-contract.v1.json`: A2 machine contract.
 - `../machine/adaptive/a3-shadow-learning-contract.v1.json`: A3.0 machine contract.

--- a/docs/architecture/ADAPTIVE_AGENTIC_WORKFLOW_AWF.md
+++ b/docs/architecture/ADAPTIVE_AGENTIC_WORKFLOW_AWF.md
@@ -1,6 +1,6 @@
 # Adaptive Agentic Workflow Architecture (AWF)
 
-Status: IMPLEMENTATION CANDIDATE, EXECUTION-EFFECTIVE WITHIN GRANTED AUTHORITY
+Status: AWF-I0 THROUGH AWF-I10 COMPLETE_CANONICAL_VERIFIED
 
 Architecture baseline: Padayon PR #382, squash merge `b4b59d04ea37c4f23bb6a54e7d217bd3037eb6ab`
 Orchestra source baseline: `75100c3ad0fd9a11c69f2b9b7c5172edd8841cd2`
@@ -216,7 +216,14 @@ Validation:
 - `tests/runtime/test_agentic_workflow_scenarios.py`
 - `tests/fixtures/agentic-workflow/awf-scenarios.v1.json`
 
+## Post-canonical adaptive intake
+
+The canonical AWF selector can consume an explicit TaskProfile. The next bounded increment, AWF-N1 through AWF-N3, adds deterministic ordinary-prompt TaskProfile derivation, machine-readable selection traces, and controlled operational scenarios without changing specialist authority or OEE concurrency.
+
+See [Adaptive Agentic Workflow Intake N1-N3](ADAPTIVE_AGENTIC_WORKFLOW_INTAKE_N1.md).
+
 ## Non-goals
+
 
 This implementation does not:
 

--- a/docs/architecture/ADAPTIVE_AGENTIC_WORKFLOW_INTAKE_N1.md
+++ b/docs/architecture/ADAPTIVE_AGENTIC_WORKFLOW_INTAKE_N1.md
@@ -154,3 +154,56 @@ TERMINAL_EXECUTION_ROLE != DISTINCT_DOMAIN_DECISION_AUTHORITY
 Ponytail, Overseer, and Arbiter can be required in a topology without causing The Tuner or Multi-Agent activation by themselves. The Tuner and Multi-Agent semantics are justified by multiple distinct domain-decision owners, explicit re-entry, or independent subtask evidence.
 
 This prevents a simple single-domain implementation from being over-routed merely because implementation and validation stages exist.
+
+
+## Negative routing calibration
+
+The positive calibration corpus verifies what Orchestra should select. A separate negative-routing corpus verifies what Orchestra must avoid selecting when dangerous or cross-domain terminology is only mentioned, negated, quoted, hypothetical, or scoped to representation work.
+
+The negative corpus contains 20 RouterService-level scenarios covering:
+
+- explicit negation of deploy and merge actions;
+- documentation explaining prohibited force-push and history-rewrite operations;
+- hypothetical production deployment questions;
+- removing the literal word `deploy` from README text;
+- documentation-only use of authorization/security terminology;
+- quoted security marketing language;
+- database terminology inside documentation-only work;
+- documentation of frontend architecture without UI redesign or code mutation;
+- quoted chaos-test examples that must not activate Dagger;
+- quoted `drop table` text that must not activate persistence/destructive execution;
+- release notes that must not become release execution;
+- deployment-documentation review without deployment;
+- security-incident summarization without a Cipher review;
+- authentication terminology in documentation-only typo fixes;
+- architecture terminology in changelog-only work;
+- generic `production` terminology without production mutation;
+- negated test execution;
+- permission terminology used only as a documentation label;
+- screenshot-caption references to database/UI terminology;
+- future deployment planning with execution actions explicitly negated.
+
+### Suppression model
+
+The deterministic intake policy now separates active execution intent from four classes of non-executable mention:
+
+1. **Negated spans** such as `do not deploy`, `without changing the database`, or `never force push`.
+2. **Quoted/example spans** where dangerous strings are content to discuss rather than commands to execute.
+3. **Hypothetical actions** such as `What would happen if we deploy this to production?`.
+4. **Representation-only contexts** such as README, documentation, changelog, summary, caption, sentence, label, or term editing.
+
+Representation-only work suppresses unrelated domain-execution signals and routes to Scribe when appropriate. Audit intent may still be preserved for read-only representation review, while documentation edits retain mutation semantics for the documentation artifact itself.
+
+The policy is machine-configured in `machine/workflows/task-profile-derivation.v1.json`. Suppression behavior is therefore calibratable without changing frozen specialist prompts.
+
+### Negative-routing invariants
+
+```text
+MENTION != INTENT
+NEGATED_ACTION != AUTHORIZED_ACTION
+QUOTED_DANGEROUS_TEXT != PROTECTED_ACTION
+HYPOTHETICAL_ACTION != EXECUTION_REQUEST
+REPRESENTATION_CONTEXT != REFERENCED_DOMAIN_AUTHORITY
+```
+
+A false-negative protected-action detection remains a blocking safety defect. A false-positive protected-action or specialist activation is a routing-calibration defect.

--- a/docs/architecture/ADAPTIVE_AGENTIC_WORKFLOW_INTAKE_N1.md
+++ b/docs/architecture/ADAPTIVE_AGENTIC_WORKFLOW_INTAKE_N1.md
@@ -23,7 +23,7 @@ WORKFLOW_TOPOLOGY_CHANGE != AUTHORITY_EXPANSION
 When Conductor receives an ordinary request and no explicit `agentic_task_profile` is supplied, RouterService derives a TaskProfile from:
 
 - the user request text;
-- existing execution-mode and risk constraints;
+- existing canonical `risk_mode` constraints and namespaced `agentic_execution_mode` / `agentic_risk_level` constraints;
 - explicit host-provided authority-domain hints;
 - explicit protected-action authorization state;
 - current source identity;
@@ -36,7 +36,7 @@ The policy is deliberately calibratable. It stores domain and operation signals 
 ### Safety rules
 
 - Prompt keywords may identify potential work domains, but never grant authority.
-- Explicit host execution mode and risk hints may escalate the derived result but cannot downgrade it.
+- Host `execution_mode` values used by execution engines, such as `HOST_NATIVE`, are not interpreted as AWF risk modes. Canonical `risk_mode` and namespaced AWF mode/risk hints may escalate the derived result but cannot downgrade it.
 - Protected-action authorization is never inferred from text.
 - Unknown domains fail to `ROUTING` with Conductor as owner instead of guessing.
 - Explicit valid structured TaskProfiles remain supported.
@@ -109,6 +109,7 @@ Expected:
 - transition ownership resolves to Arbiter
 - destructive/critical classification
 - protected action required
+- `deploy` plus production context is classified as destructive without making the generic word `production` a universal destructive trigger
 - authorization remains false unless explicitly supplied by trusted context
 - human gate required
 

--- a/docs/architecture/ADAPTIVE_AGENTIC_WORKFLOW_INTAKE_N1.md
+++ b/docs/architecture/ADAPTIVE_AGENTIC_WORKFLOW_INTAKE_N1.md
@@ -1,0 +1,121 @@
+# Adaptive Agentic Workflow Intake N1-N3
+
+Status: IMPLEMENTATION CANDIDATE
+
+Canonical AWF baseline:
+- Orchestra main: `7f1e1962817b1b363fbcb1629902d69d50f1daa6`
+- AWF source PR: #800
+- Qualified source head: `7040618b4faf6998fd88d6bc984677fc42764da4`
+- Padayon architecture baseline: `b4b59d04ea37c4f23bb6a54e7d217bd3037eb6ab`
+
+## Objective
+
+Move AWF from structured TaskProfile execution to ordinary-prompt adaptive orchestration without turning natural-language classification into authority.
+
+The invariant remains:
+
+```text
+WORKFLOW_TOPOLOGY_CHANGE != AUTHORITY_EXPANSION
+```
+
+## N1: Automatic TaskProfile derivation
+
+When Conductor receives an ordinary request and no explicit `agentic_task_profile` is supplied, RouterService derives a TaskProfile from:
+
+- the user request text;
+- existing execution-mode and risk constraints;
+- explicit host-provided authority-domain hints;
+- explicit protected-action authorization state;
+- current source identity;
+- re-entry and critic metadata when supplied.
+
+The deterministic machine policy is `machine/workflows/task-profile-derivation.v1.json`.
+
+The policy is deliberately calibratable. It stores domain and operation signals outside the frozen Conductor skill so routing changes do not increase default prompt load or alter specialist source authority.
+
+### Safety rules
+
+- Prompt keywords may identify potential work domains, but never grant authority.
+- Explicit host execution mode and risk hints may escalate the derived result but cannot downgrade it.
+- Protected-action authorization is never inferred from text.
+- Unknown domains fail to `ROUTING` with Conductor as owner instead of guessing.
+- Explicit valid structured TaskProfiles remain supported.
+- Automatic derivation can be disabled with exact boolean `agentic_workflow_auto = false`.
+
+## N2: Selection trace
+
+Every AWF plan now emits `orchestra.agentic-selection-trace.v1`.
+
+The trace contains:
+
+- deterministic matched signals;
+- derived TaskProfile reason codes;
+- selected specialists;
+- selected patterns;
+- rejected patterns and deterministic rejection reasons;
+- human-gate state and underlying escalation reasons;
+- the authority invariant.
+
+It does not expose private model reasoning.
+
+## N3: Controlled scenarios
+
+### N3-T1: Single-owner UI review
+
+Prompt:
+
+```text
+Review this responsive checkout screen for accessibility and layout issues.
+```
+
+Expected:
+
+- authority domain: UI_UX
+- primary owner: Cloak
+- read-only AUDIT mode
+- one specialist
+- no Multi-Agent topology
+- no human gate
+
+### N3-T2: Multi-domain implementation
+
+Prompt:
+
+```text
+Implement a responsive checkout flow with secure payment authorization and validate the change.
+```
+
+Expected:
+
+- UI_UX + SECURITY + IMPLEMENTATION + VALIDATION
+- Cloak and Cipher domain ownership preserved
+- Ponytail implementation after domain owners
+- Overseer validation
+- The Tuner coordinates cross-domain dependencies
+- Multi-Agent semantics allowed
+- active OEE parallel ceiling remains one
+- no topology-only human gate
+
+### N3-T3: Protected production action
+
+Prompt:
+
+```text
+Deploy the checkout change to production.
+```
+
+Expected:
+
+- transition ownership resolves to Arbiter
+- destructive/critical classification
+- protected action required
+- authorization remains false unless explicitly supplied by trusted context
+- human gate required
+
+## Calibration boundary
+
+N1-N3 are deterministic and evidence-generating.
+
+N4 may adjust signal rules only after controlled or real workflow evidence demonstrates over-routing, under-routing, unnecessary specialist activation, false protected-action escalation, or missed authority domains.
+
+N5 may consider A5 ranking signals, learned recommendations, or concurrency changes only after separate empirical benefit evidence. No such promotion is part of N1-N3.

--- a/docs/architecture/ADAPTIVE_AGENTIC_WORKFLOW_INTAKE_N1.md
+++ b/docs/architecture/ADAPTIVE_AGENTIC_WORKFLOW_INTAKE_N1.md
@@ -120,3 +120,37 @@ N1-N3 are deterministic and evidence-generating.
 N4 may adjust signal rules only after controlled or real workflow evidence demonstrates over-routing, under-routing, unnecessary specialist activation, false protected-action escalation, or missed authority domains.
 
 N5 may consider A5 ranking signals, learned recommendations, or concurrency changes only after separate empirical benefit evidence. No such promotion is part of N1-N3.
+
+
+## Higher calibration corpus
+
+The N3/N4 calibration corpus now contains 18 RouterService-level scenarios covering:
+
+- single-owner UI review;
+- security audit;
+- persistence implementation and validation;
+- architecture refactor;
+- documentation mutation;
+- diagram creation;
+- business-scope review;
+- legal/compliance review;
+- ambiguous fallback;
+- parallel UI/security analysis;
+- protected merge;
+- production deployment;
+- force-push/history rewrite;
+- gated Dagger chaos work;
+- single-domain UI implementation;
+- persistence/security cross-domain implementation;
+- false-positive protection for the generic word `production`;
+- cross-domain security/UI review.
+
+The calibration invariant is:
+
+```text
+TERMINAL_EXECUTION_ROLE != DISTINCT_DOMAIN_DECISION_AUTHORITY
+```
+
+Ponytail, Overseer, and Arbiter can be required in a topology without causing The Tuner or Multi-Agent activation by themselves. The Tuner and Multi-Agent semantics are justified by multiple distinct domain-decision owners, explicit re-entry, or independent subtask evidence.
+
+This prevents a simple single-domain implementation from being over-routed merely because implementation and validation stages exist.

--- a/machine/adaptive/awf-agentic-workflow-implementation.v1.json
+++ b/machine/adaptive/awf-agentic-workflow-implementation.v1.json
@@ -102,7 +102,9 @@
     "tests/runtime/test_agentic_workflow_intake.py",
     "tests/runtime/test_agentic_workflow_intake_edges.py",
     "tests/fixtures/agentic-workflow/awf-intake-calibration.v1.json",
-    "tests/runtime/test_agentic_workflow_intake_calibration.py"
+    "tests/runtime/test_agentic_workflow_intake_calibration.py",
+    "tests/fixtures/agentic-workflow/awf-negative-routing.v1.json",
+    "tests/runtime/test_agentic_workflow_negative_routing.py"
   ],
   "historical_replay": {
     "case": "UIEF5_20260905_USAGE_EXHAUSTION",
@@ -147,8 +149,10 @@
     "current_scope": [
       "automatic TaskProfile derivation",
       "selection trace explainability",
-      "18-case controlled operational calibration corpus",
-      "terminal-role over-routing suppression"
+      "18-case positive controlled calibration corpus",
+      "20-case adversarial negative-routing corpus",
+      "terminal-role over-routing suppression",
+      "negation, quotation, hypothetical, and representation-only suppression"
     ],
     "prohibited": [
       "OEE concurrency widening",
@@ -156,6 +160,18 @@
       "specialist authority expansion",
       "release/deploy/policy activation",
       "UIEF resumption"
+    ]
+  },
+  "negative_routing": {
+    "status": "IMPLEMENTED_CANDIDATE",
+    "corpus_cases": 20,
+    "policy": "machine/workflows/task-profile-derivation.v1.json",
+    "invariants": [
+      "MENTION != INTENT",
+      "NEGATED_ACTION != AUTHORIZED_ACTION",
+      "QUOTED_DANGEROUS_TEXT != PROTECTED_ACTION",
+      "HYPOTHETICAL_ACTION != EXECUTION_REQUEST",
+      "REPRESENTATION_CONTEXT != REFERENCED_DOMAIN_AUTHORITY"
     ]
   }
 }

--- a/machine/adaptive/awf-agentic-workflow-implementation.v1.json
+++ b/machine/adaptive/awf-agentic-workflow-implementation.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "orchestra.awf-agentic-workflow-implementation.v1",
   "program": "AWF_ADAPTIVE_AGENTIC_WORKFLOW",
-  "status": "IMPLEMENTATION_CANDIDATE_VALIDATION_PENDING",
+  "status": "COMPLETE_CANONICAL_VERIFIED",
   "architecture_baseline": {
     "padayon_pr": 382,
     "padayon_merge_sha": "b4b59d04ea37c4f23bb6a54e7d217bd3037eb6ab",
@@ -10,57 +10,57 @@
   "phases": [
     {
       "id": "AWF-I0",
-      "status": "IMPLEMENTED_CANDIDATE",
+      "status": "COMPLETE_CANONICAL_VERIFIED",
       "goal": "machine schemas and source-binding rules"
     },
     {
       "id": "AWF-I1",
-      "status": "IMPLEMENTED_CANDIDATE",
+      "status": "COMPLETE_CANONICAL_VERIFIED",
       "goal": "source-bound specialist authority view"
     },
     {
       "id": "AWF-I2",
-      "status": "IMPLEMENTED_CANDIDATE",
+      "status": "COMPLETE_CANONICAL_VERIFIED",
       "goal": "topology authority validator"
     },
     {
       "id": "AWF-I3",
-      "status": "IMPLEMENTED_CANDIDATE",
+      "status": "COMPLETE_CANONICAL_VERIFIED",
       "goal": "TaskProfile and deterministic owner resolution"
     },
     {
       "id": "AWF-I4",
-      "status": "IMPLEMENTED_CANDIDATE",
+      "status": "COMPLETE_CANONICAL_VERIFIED",
       "goal": "Planning and bounded Tool/ReAct selection"
     },
     {
       "id": "AWF-I5",
-      "status": "IMPLEMENTED_CANDIDATE",
+      "status": "COMPLETE_CANONICAL_VERIFIED",
       "goal": "bounded critic contract activation"
     },
     {
       "id": "AWF-I6",
-      "status": "IMPLEMENTED_CANDIDATE",
+      "status": "COMPLETE_CANONICAL_VERIFIED",
       "goal": "conditional multi-agent graph semantics under OEE"
     },
     {
       "id": "AWF-I7",
-      "status": "IMPLEMENTED_CANDIDATE",
+      "status": "COMPLETE_CANONICAL_VERIFIED",
       "goal": "specialist re-entry and transition topology integration"
     },
     {
       "id": "AWF-I8",
-      "status": "IMPLEMENTED_CANDIDATE",
+      "status": "COMPLETE_CANONICAL_VERIFIED",
       "goal": "deterministic topology telemetry"
     },
     {
       "id": "AWF-I9",
-      "status": "IMPLEMENTED_CANDIDATE",
+      "status": "COMPLETE_CANONICAL_VERIFIED",
       "goal": "UIEF-5 and synthetic regression corpus"
     },
     {
       "id": "AWF-I10",
-      "status": "QUALIFICATION_PENDING",
+      "status": "COMPLETE_CANONICAL_VERIFIED",
       "goal": "source PR validation and canonical integration"
     }
   ],
@@ -97,7 +97,8 @@
     "tests/runtime/test_agentic_workflow.py",
     "tests/runtime/test_agentic_workflow_oee_replay.py",
     "tests/runtime/test_agentic_workflow_scenarios.py",
-    "scripts/validate_machine_contracts.py"
+    "scripts/validate_machine_contracts.py",
+    "tests/runtime/test_agentic_workflow_edges.py"
   ],
   "historical_replay": {
     "case": "UIEF5_20260905_USAGE_EXHAUSTION",
@@ -108,14 +109,48 @@
     "evidence_claim_scope": "HISTORICAL_REPLAY_ONLY"
   },
   "qualification": {
-    "local_runtime_tests": "NOT_RUN_CONNECTOR_ONLY_ENVIRONMENT",
-    "github_ci": "PENDING_SOURCE_PR",
-    "structural_readback": "PENDING_FINAL_RECONCILIATION"
+    "source_pr": 800,
+    "qualified_source_head": "7040618b4faf6998fd88d6bc984677fc42764da4",
+    "canonical_merge_commit": "7f1e1962817b1b363fbcb1629902d69d50f1daa6",
+    "github_ci": "ALL_SIX_REQUIRED_WORKFLOWS_SUCCESS_ON_QUALIFIED_SOURCE_HEAD",
+    "workflows": [
+      "Governance Check",
+      "Required Analysis Compatibility",
+      "validate",
+      "mutation-confidence",
+      "Cross-platform Validation",
+      "cosmic-ray-confidence"
+    ],
+    "structural_readback": "CANONICAL_MAIN_CONTAINS_MERGED_AWF_TREE"
   },
   "efficiency": {
     "conductor_prompt_load_strategy": "UNCHANGED_CANONICAL_SKILL_RUNTIME_CONTROL_PLANE_ACTIVATION",
     "conductor_skill_modified": false,
     "codex_portable_reference_modified": false,
     "prompt_load_budget_weakened": false
+  },
+  "next_program": {
+    "id": "AWF_N1_N5_CONTINUOUS_ADAPTIVE_INTAKE_AND_CALIBRATION",
+    "status": "IMPLEMENTATION_CANDIDATE",
+    "authority_expansion": false,
+    "phases": [
+      "AWF-N1",
+      "AWF-N2",
+      "AWF-N3",
+      "AWF-N4",
+      "AWF-N5"
+    ],
+    "current_scope": [
+      "automatic TaskProfile derivation",
+      "selection trace explainability",
+      "three controlled operational scenarios"
+    ],
+    "prohibited": [
+      "OEE concurrency widening",
+      "A5 execution promotion",
+      "specialist authority expansion",
+      "release/deploy/policy activation",
+      "UIEF resumption"
+    ]
   }
 }

--- a/machine/adaptive/awf-agentic-workflow-implementation.v1.json
+++ b/machine/adaptive/awf-agentic-workflow-implementation.v1.json
@@ -100,7 +100,9 @@
     "scripts/validate_machine_contracts.py",
     "tests/runtime/test_agentic_workflow_edges.py",
     "tests/runtime/test_agentic_workflow_intake.py",
-    "tests/runtime/test_agentic_workflow_intake_edges.py"
+    "tests/runtime/test_agentic_workflow_intake_edges.py",
+    "tests/fixtures/agentic-workflow/awf-intake-calibration.v1.json",
+    "tests/runtime/test_agentic_workflow_intake_calibration.py"
   ],
   "historical_replay": {
     "case": "UIEF5_20260905_USAGE_EXHAUSTION",
@@ -145,7 +147,8 @@
     "current_scope": [
       "automatic TaskProfile derivation",
       "selection trace explainability",
-      "three controlled operational scenarios"
+      "18-case controlled operational calibration corpus",
+      "terminal-role over-routing suppression"
     ],
     "prohibited": [
       "OEE concurrency widening",

--- a/machine/adaptive/awf-agentic-workflow-implementation.v1.json
+++ b/machine/adaptive/awf-agentic-workflow-implementation.v1.json
@@ -98,7 +98,9 @@
     "tests/runtime/test_agentic_workflow_oee_replay.py",
     "tests/runtime/test_agentic_workflow_scenarios.py",
     "scripts/validate_machine_contracts.py",
-    "tests/runtime/test_agentic_workflow_edges.py"
+    "tests/runtime/test_agentic_workflow_edges.py",
+    "tests/runtime/test_agentic_workflow_intake.py",
+    "tests/runtime/test_agentic_workflow_intake_edges.py"
   ],
   "historical_replay": {
     "case": "UIEF5_20260905_USAGE_EXHAUSTION",

--- a/machine/schemas/agentic-selection-trace.v1.schema.json
+++ b/machine/schemas/agentic-selection-trace.v1.schema.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Baelfyre/Orchestra/blob/main/machine/schemas/agentic-selection-trace.v1.schema.json",
+  "title": "Orchestra Agentic Selection Trace",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "trace_id",
+    "source",
+    "task_id",
+    "matched_signals",
+    "derivation_reasons",
+    "selected_specialists",
+    "selected_patterns",
+    "rejected_patterns",
+    "selection_reasons",
+    "human_gate_required",
+    "escalation_reasons",
+    "authority_rule"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "orchestra.agentic-selection-trace.v1"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "source": {
+      "enum": [
+        "DERIVED_INTAKE",
+        "STRUCTURED_TASK_PROFILE"
+      ]
+    },
+    "task_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "matched_signals": {
+      "type": "array",
+      "maxItems": 128,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "kind",
+          "value",
+          "signal",
+          "position"
+        ],
+        "properties": {
+          "kind": {
+            "enum": [
+              "DOMAIN",
+              "OPERATION"
+            ]
+          },
+          "value": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64
+          },
+          "signal": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          },
+          "position": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      }
+    },
+    "derivation_reasons": {
+      "type": "array",
+      "maxItems": 128,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 256
+      }
+    },
+    "selected_specialists": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 14,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 128
+      }
+    },
+    "selected_patterns": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 5,
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "ROUTING",
+          "PLANNING",
+          "TOOL_REACT",
+          "REFLECTION_CRITIC",
+          "MULTI_AGENT"
+        ]
+      }
+    },
+    "rejected_patterns": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 256
+      }
+    },
+    "selection_reasons": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 128,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 256
+      }
+    },
+    "human_gate_required": {
+      "type": "boolean"
+    },
+    "escalation_reasons": {
+      "type": "array",
+      "maxItems": 32,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 256
+      }
+    },
+    "authority_rule": {
+      "const": "WORKFLOW_TOPOLOGY_CHANGE != AUTHORITY_EXPANSION"
+    }
+  }
+}

--- a/machine/schemas/task-profile-derivation.v1.schema.json
+++ b/machine/schemas/task-profile-derivation.v1.schema.json
@@ -1,0 +1,187 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Baelfyre/Orchestra/blob/main/machine/schemas/task-profile-derivation.v1.schema.json",
+  "title": "Orchestra TaskProfile Derivation Policy",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "owner",
+    "default_execution_mode",
+    "default_risk_level",
+    "governed_domains",
+    "domain_rules",
+    "operation_signals"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "orchestra.task-profile-derivation.v1"
+    },
+    "owner": {
+      "const": "conductor"
+    },
+    "default_execution_mode": {
+      "enum": [
+        "FAST",
+        "STANDARD",
+        "GOVERNED",
+        "AUDIT",
+        "DESTRUCTIVE"
+      ]
+    },
+    "default_risk_level": {
+      "enum": [
+        "LOW",
+        "MEDIUM",
+        "HIGH",
+        "CRITICAL"
+      ]
+    },
+    "governed_domains": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 14,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 64
+      }
+    },
+    "domain_rules": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 14,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "domain",
+          "signals"
+        ],
+        "properties": {
+          "domain": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64
+          },
+          "signals": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 64,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128
+            }
+          }
+        }
+      }
+    },
+    "operation_signals": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mutation",
+        "implementation",
+        "validation",
+        "transition",
+        "audit",
+        "destructive",
+        "protected_action",
+        "parallel"
+      ],
+      "properties": {
+        "mutation": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          }
+        },
+        "implementation": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          }
+        },
+        "validation": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          }
+        },
+        "transition": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          }
+        },
+        "audit": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          }
+        },
+        "destructive": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          }
+        },
+        "protected_action": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          }
+        },
+        "parallel": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          }
+        }
+      }
+    }
+  }
+}

--- a/machine/schemas/task-profile-derivation.v1.schema.json
+++ b/machine/schemas/task-profile-derivation.v1.schema.json
@@ -11,7 +11,8 @@
     "default_risk_level",
     "governed_domains",
     "domain_rules",
-    "operation_signals"
+    "operation_signals",
+    "suppression_rules"
   ],
   "properties": {
     "schema_version": {
@@ -171,6 +172,86 @@
           }
         },
         "parallel": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          }
+        }
+      }
+    },
+    "suppression_rules": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "negation_phrases",
+        "hypothetical_prefixes",
+        "representation_artifacts",
+        "representation_verbs",
+        "representation_edit_verbs",
+        "representation_scope_phrases"
+      ],
+      "properties": {
+        "negation_phrases": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          }
+        },
+        "hypothetical_prefixes": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          }
+        },
+        "representation_artifacts": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          }
+        },
+        "representation_verbs": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          }
+        },
+        "representation_edit_verbs": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          }
+        },
+        "representation_scope_phrases": {
           "type": "array",
           "minItems": 1,
           "maxItems": 64,

--- a/machine/workflows/task-profile-derivation.v1.json
+++ b/machine/workflows/task-profile-derivation.v1.json
@@ -209,5 +209,74 @@
       "parallelize",
       "parallel execution"
     ]
+  },
+  "suppression_rules": {
+    "negation_phrases": [
+      "do not",
+      "don't",
+      "never",
+      "must not",
+      "should not",
+      "without",
+      "no"
+    ],
+    "hypothetical_prefixes": [
+      "what would happen if",
+      "what if",
+      "hypothetically",
+      "suppose",
+      "imagine if",
+      "if we were to"
+    ],
+    "representation_artifacts": [
+      "documentation",
+      "docs",
+      "readme",
+      "changelog",
+      "release notes",
+      "incident report",
+      "report",
+      "screenshot caption",
+      "caption",
+      "sentence",
+      "label",
+      "term"
+    ],
+    "representation_verbs": [
+      "review",
+      "update",
+      "write",
+      "summarize",
+      "explain",
+      "describe",
+      "document",
+      "rename",
+      "fix",
+      "remove",
+      "change",
+      "add"
+    ],
+    "representation_edit_verbs": [
+      "update",
+      "write",
+      "document",
+      "rename",
+      "fix",
+      "remove",
+      "change",
+      "add"
+    ],
+    "representation_scope_phrases": [
+      "documentation only",
+      "docs only",
+      "readme only",
+      "for wording only",
+      "wording only",
+      "without assessing controls",
+      "without changing anything",
+      "that mentions",
+      "screenshot caption",
+      "release notes"
+    ]
   }
 }

--- a/machine/workflows/task-profile-derivation.v1.json
+++ b/machine/workflows/task-profile-derivation.v1.json
@@ -1,0 +1,203 @@
+{
+  "schema_version": "orchestra.task-profile-derivation.v1",
+  "owner": "conductor",
+  "default_execution_mode": "FAST",
+  "default_risk_level": "LOW",
+  "governed_domains": [
+    "LEGAL_COMPLIANCE",
+    "SECURITY",
+    "PERSISTENCE",
+    "ADVERSARIAL"
+  ],
+  "domain_rules": [
+    {
+      "domain": "LEGAL_COMPLIANCE",
+      "signals": [
+        "legal",
+        "licensing",
+        "license",
+        "copyright",
+        "regulatory",
+        "regulation",
+        "compliance"
+      ]
+    },
+    {
+      "domain": "SECURITY",
+      "signals": [
+        "security",
+        "secure",
+        "authentication",
+        "authorization",
+        "auth",
+        "rbac",
+        "permission",
+        "privacy",
+        "secret",
+        "credential"
+      ]
+    },
+    {
+      "domain": "PERSISTENCE",
+      "signals": [
+        "database",
+        "db",
+        "schema",
+        "migration",
+        "sql",
+        "persistence",
+        "index",
+        "constraint"
+      ]
+    },
+    {
+      "domain": "UI_UX",
+      "signals": [
+        "ui",
+        "ux",
+        "frontend",
+        "screen",
+        "layout",
+        "responsive",
+        "accessibility",
+        "visual",
+        "design",
+        "component"
+      ]
+    },
+    {
+      "domain": "ARCHITECTURE",
+      "signals": [
+        "architecture",
+        "architectural",
+        "service boundary",
+        "dependency direction",
+        "concurrency",
+        "state ownership",
+        "layering"
+      ]
+    },
+    {
+      "domain": "BUSINESS_SCOPE",
+      "signals": [
+        "requirements",
+        "acceptance criteria",
+        "scope",
+        "product intent",
+        "business rule"
+      ]
+    },
+    {
+      "domain": "DIAGRAM",
+      "signals": [
+        "diagram",
+        "uml",
+        "plantuml",
+        "sequence diagram",
+        "class diagram",
+        "object diagram"
+      ]
+    },
+    {
+      "domain": "DOCUMENTATION",
+      "signals": [
+        "documentation",
+        "docs",
+        "readme",
+        "changelog",
+        "write-up"
+      ]
+    },
+    {
+      "domain": "ADVERSARIAL",
+      "signals": [
+        "chaos test",
+        "chaos testing",
+        "fuzz",
+        "fuzzing",
+        "adversarial",
+        "resilience test",
+        "negative live execution"
+      ]
+    }
+  ],
+  "operation_signals": {
+    "mutation": [
+      "edit",
+      "update",
+      "modify",
+      "change",
+      "fix",
+      "implement",
+      "build",
+      "add",
+      "remove",
+      "delete",
+      "merge",
+      "deploy",
+      "release",
+      "publish",
+      "refactor"
+    ],
+    "implementation": [
+      "implement",
+      "code change",
+      "modify code",
+      "edit source",
+      "change source",
+      "fix bug",
+      "build feature",
+      "add feature",
+      "refactor code"
+    ],
+    "validation": [
+      "validate",
+      "validation",
+      "verify",
+      "run tests",
+      "test suite",
+      "quality assurance",
+      "qa"
+    ],
+    "transition": [
+      "merge",
+      "release",
+      "publish",
+      "deploy"
+    ],
+    "audit": [
+      "audit",
+      "review",
+      "assess",
+      "analyze"
+    ],
+    "destructive": [
+      "force push",
+      "rewrite history",
+      "drop table",
+      "truncate",
+      "chaos test",
+      "negative live execution",
+      "production"
+    ],
+    "protected_action": [
+      "merge",
+      "release",
+      "publish",
+      "deploy",
+      "production",
+      "force push",
+      "rewrite history",
+      "delete branch",
+      "drop table",
+      "truncate",
+      "chaos test",
+      "negative live execution"
+    ],
+    "parallel": [
+      "in parallel",
+      "parallelize",
+      "parallel execution"
+    ]
+  }
+}

--- a/machine/workflows/task-profile-derivation.v1.json
+++ b/machine/workflows/task-profile-derivation.v1.json
@@ -41,13 +41,13 @@
       "domain": "PERSISTENCE",
       "signals": [
         "database",
-        "db",
-        "schema",
+        "database schema",
+        "db schema",
         "migration",
         "sql",
         "persistence",
-        "index",
-        "constraint"
+        "database index",
+        "database constraint"
       ]
     },
     {
@@ -60,9 +60,10 @@
         "layout",
         "responsive",
         "accessibility",
-        "visual",
-        "design",
-        "component"
+        "visual design",
+        "ui design",
+        "ui component",
+        "frontend component"
       ]
     },
     {
@@ -124,9 +125,7 @@
   "operation_signals": {
     "mutation": [
       "edit",
-      "update",
       "modify",
-      "change",
       "fix",
       "implement",
       "build",
@@ -137,7 +136,13 @@
       "deploy",
       "release",
       "publish",
-      "refactor"
+      "refactor",
+      "make changes",
+      "update code",
+      "update docs",
+      "update documentation",
+      "update file",
+      "update files"
     ],
     "implementation": [
       "implement",
@@ -178,21 +183,26 @@
       "truncate",
       "chaos test",
       "negative live execution",
-      "production"
+      "deploy to production",
+      "production data",
+      "production mutation",
+      "production database"
     ],
     "protected_action": [
       "merge",
       "release",
       "publish",
       "deploy",
-      "production",
       "force push",
       "rewrite history",
       "delete branch",
       "drop table",
       "truncate",
       "chaos test",
-      "negative live execution"
+      "negative live execution",
+      "production data",
+      "production mutation",
+      "production database"
     ],
     "parallel": [
       "in parallel",

--- a/orchestra_runtime/application/use_cases/__init__.py
+++ b/orchestra_runtime/application/use_cases/__init__.py
@@ -1,5 +1,5 @@
 """Application use cases for governed Orchestra runtime behavior."""
 
-from .agentic_workflow import plan_agentic_workflow
+from .agentic_workflow import plan_agentic_workflow, plan_agentic_workflow_from_intake
 
-__all__ = ["plan_agentic_workflow"]
+__all__ = ["plan_agentic_workflow", "plan_agentic_workflow_from_intake"]

--- a/orchestra_runtime/application/use_cases/agentic_workflow.py
+++ b/orchestra_runtime/application/use_cases/agentic_workflow.py
@@ -1,9 +1,76 @@
 from __future__ import annotations
 
-from typing import Any, Mapping
+from typing import Any, Iterable, Mapping
 
-from ...domain.adaptive import TaskProfile, parse_authority_view, select_agentic_workflow
+from ...domain.adaptive import (
+    TaskProfile,
+    build_selection_trace,
+    derive_task_profile,
+    parse_authority_view,
+    select_agentic_workflow,
+)
 from ...domain.orchestration.execution_efficiency import validate_execution_budget
+
+
+def _validate_registry(
+    specialist_registry: Mapping[str, Any],
+    authority_slugs: set[str],
+) -> None:
+    raw_specialists = specialist_registry.get("specialists")
+    if not isinstance(raw_specialists, list):
+        raise TypeError("specialist registry specialists must be a list")
+    registry_slugs = {
+        str(item.get("slug", "")).strip().casefold()
+        for item in raw_specialists
+        if isinstance(item, Mapping)
+    }
+    if registry_slugs != authority_slugs:
+        raise ValueError(
+            "authority view and canonical specialist registry must have identical specialist sets"
+        )
+
+
+def _plan(
+    *,
+    task: TaskProfile,
+    specialist_authority_view: Mapping[str, Any],
+    specialist_registry: Mapping[str, Any],
+    execution_budget: Mapping[str, Any],
+    source: str,
+    matched_signals: Iterable[dict[str, object]] = (),
+    derivation_reasons: Iterable[str] = (),
+) -> dict[str, Any]:
+    authorities = parse_authority_view(specialist_authority_view)
+    budget = validate_execution_budget(execution_budget)
+    _validate_registry(specialist_registry, set(authorities))
+
+    profile, critic = select_agentic_workflow(task, authorities, budget)
+    parallel_peak = max((len(group) for group in profile.parallel_groups), default=1)
+    trace = build_selection_trace(
+        task=task,
+        profile=profile,
+        source=source,
+        matched_signals=matched_signals,
+        derivation_reasons=derivation_reasons,
+    )
+    return {
+        "task_profile": task.to_dict(),
+        "task_profile_source": source,
+        "workflow_profile": profile.to_dict(),
+        "critic_contract": None if critic is None else critic.to_dict(),
+        "selection_trace": trace,
+        "telemetry": {
+            "specialist_count": len(profile.required_specialists),
+            "pattern_count": len(profile.selected_patterns),
+            "parallel_specialist_peak": parallel_peak,
+            "max_parallel_specialists": profile.max_parallel_specialists,
+            "human_gate_required": profile.human_gate_required,
+            "topology_effective": profile.topology_effective,
+            "reentry_specialist_count": len(task.reentry_specialists),
+            "task_profile_source": source,
+        },
+        "authority_rule": "WORKFLOW_TOPOLOGY_CHANGE != AUTHORITY_EXPANSION",
+    }
 
 
 def plan_agentic_workflow(
@@ -13,40 +80,49 @@ def plan_agentic_workflow(
     specialist_registry: Mapping[str, Any],
     execution_budget: Mapping[str, Any],
 ) -> dict[str, Any]:
-    """Build an execution-effective Conductor topology without expanding authority."""
+    """Build an execution-effective topology from an explicit structured TaskProfile."""
 
     task = TaskProfile.from_mapping(task_profile)
-    authorities = parse_authority_view(specialist_authority_view)
-    budget = validate_execution_budget(execution_budget)
-
-    raw_specialists = specialist_registry.get("specialists")
-    if not isinstance(raw_specialists, list):
-        raise TypeError("specialist registry specialists must be a list")
-    registry_slugs = {
-        str(item.get("slug", "")).strip().casefold()
-        for item in raw_specialists
-        if isinstance(item, Mapping)
-    }
-    if registry_slugs != set(authorities):
-        raise ValueError("authority view and canonical specialist registry must have identical specialist sets")
-
-    profile, critic = select_agentic_workflow(task, authorities, budget)
-    parallel_peak = max((len(group) for group in profile.parallel_groups), default=1)
-    return {
-        "task_profile": task.to_dict(),
-        "workflow_profile": profile.to_dict(),
-        "critic_contract": None if critic is None else critic.to_dict(),
-        "telemetry": {
-            "specialist_count": len(profile.required_specialists),
-            "pattern_count": len(profile.selected_patterns),
-            "parallel_specialist_peak": parallel_peak,
-            "max_parallel_specialists": profile.max_parallel_specialists,
-            "human_gate_required": profile.human_gate_required,
-            "topology_effective": profile.topology_effective,
-            "reentry_specialist_count": len(task.reentry_specialists),
-        },
-        "authority_rule": "WORKFLOW_TOPOLOGY_CHANGE != AUTHORITY_EXPANSION",
-    }
+    return _plan(
+        task=task,
+        specialist_authority_view=specialist_authority_view,
+        specialist_registry=specialist_registry,
+        execution_budget=execution_budget,
+        source="STRUCTURED_TASK_PROFILE",
+        derivation_reasons=("STRUCTURED_TASK_PROFILE_ACCEPTED",),
+    )
 
 
-__all__ = ["plan_agentic_workflow"]
+def plan_agentic_workflow_from_intake(
+    *,
+    prompt: str,
+    metadata: Mapping[str, Any],
+    current_source_identity: str,
+    derivation_policy: Mapping[str, Any],
+    specialist_authority_view: Mapping[str, Any],
+    specialist_registry: Mapping[str, Any],
+    execution_budget: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Derive a TaskProfile from ordinary intake and build the authority-safe topology."""
+
+    derivation = derive_task_profile(
+        prompt=prompt,
+        metadata=metadata,
+        current_source_identity=current_source_identity,
+        policy=derivation_policy,
+    )
+    return _plan(
+        task=derivation.task_profile,
+        specialist_authority_view=specialist_authority_view,
+        specialist_registry=specialist_registry,
+        execution_budget=execution_budget,
+        source="DERIVED_INTAKE",
+        matched_signals=(item.to_dict() for item in derivation.matched_signals),
+        derivation_reasons=derivation.derivation_reasons,
+    )
+
+
+__all__ = [
+    "plan_agentic_workflow",
+    "plan_agentic_workflow_from_intake",
+]

--- a/orchestra_runtime/domain/adaptive/__init__.py
+++ b/orchestra_runtime/domain/adaptive/__init__.py
@@ -1,6 +1,18 @@
 """Pure authority-aware adaptive workflow domain contracts."""
 
 from .agentic_workflow import STOP_CONDITIONS, select_agentic_workflow
+from .intake import (
+    DERIVATION_POLICY_SCHEMA_VERSION,
+    IntakeSignal,
+    TaskProfileDerivation,
+    derive_task_profile,
+    validate_derivation_policy,
+)
+from .selection_trace import (
+    AUTHORITY_RULE,
+    SELECTION_TRACE_SCHEMA_VERSION,
+    build_selection_trace,
+)
 from .task_profile import (
     AUTHORITY_DOMAINS,
     AUTHORITY_DOMAIN_OWNERS,
@@ -24,6 +36,9 @@ from .topology_validator import (
 )
 
 __all__ = [
+    "AUTHORITY_RULE",
+    "DERIVATION_POLICY_SCHEMA_VERSION",
+    "SELECTION_TRACE_SCHEMA_VERSION",
     "AUTHORITY_DOMAINS",
     "AUTHORITY_DOMAIN_OWNERS",
     "AUTHORITY_VIEW_SCHEMA_VERSION",
@@ -38,6 +53,11 @@ __all__ = [
     "TASK_PROFILE_SCHEMA_VERSION",
     "WORKFLOW_PROFILE_SCHEMA_VERSION",
     "AgenticWorkflowProfile",
+    "IntakeSignal",
+    "TaskProfileDerivation",
+    "build_selection_trace",
+    "derive_task_profile",
+    "validate_derivation_policy",
     "CriticContract",
     "SpecialistAuthority",
     "TaskProfile",

--- a/orchestra_runtime/domain/adaptive/agentic_workflow.py
+++ b/orchestra_runtime/domain/adaptive/agentic_workflow.py
@@ -66,14 +66,15 @@ def select_agentic_workflow(
         raise ValueError(f"primary owner is not in canonical authority view: {primary_owner}")
 
     required: list[str] = []
-    domain_owner_count = len(set(owners))
+    terminal_owners = {"ponytail", "overseer", "arbiter", "the-tuner"}
+    decision_owners = [owner for owner in owners if owner not in terminal_owners]
+    decision_owner_count = len(set(decision_owners))
     tuner_needed = bool(task.reentry_specialists) or (
-        domain_owner_count > 1 and (task.dependency_depth > 0 or task.implementation_required)
+        decision_owner_count > 1 and (task.dependency_depth > 0 or task.implementation_required)
     )
     if tuner_needed or "the-tuner" in owners:
         _append_unique(required, "the-tuner")
 
-    terminal_owners = {"ponytail", "overseer", "arbiter", "the-tuner"}
     for owner in owners:
         if owner not in terminal_owners:
             _append_unique(required, owner)
@@ -106,7 +107,7 @@ def select_agentic_workflow(
         patterns.append("REFLECTION_CRITIC")
 
     multi_agent_value = len(required) > 1 and (
-        task.independent_subtasks >= 2 or domain_owner_count >= 2 or bool(task.reentry_specialists)
+        task.independent_subtasks >= 2 or decision_owner_count >= 2 or bool(task.reentry_specialists)
     )
     if multi_agent_value:
         patterns.append("MULTI_AGENT")

--- a/orchestra_runtime/domain/adaptive/intake.py
+++ b/orchestra_runtime/domain/adaptive/intake.py
@@ -1,0 +1,416 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+import json
+import re
+from typing import Any, Mapping
+
+from .task_profile import (
+    AUTHORITY_DOMAINS,
+    AUTHORITY_DOMAIN_OWNERS,
+    EXECUTION_MODES,
+    RISK_LEVELS,
+    TASK_PROFILE_SCHEMA_VERSION,
+    TaskProfile,
+)
+
+DERIVATION_POLICY_SCHEMA_VERSION = "orchestra.task-profile-derivation.v1"
+MODE_ORDER = ("FAST", "STANDARD", "GOVERNED", "AUDIT", "DESTRUCTIVE")
+RISK_ORDER = ("LOW", "MEDIUM", "HIGH", "CRITICAL")
+TERMINAL_DOMAINS = frozenset({"ROUTING", "COORDINATION", "IMPLEMENTATION", "VALIDATION", "TRANSITION"})
+_OPERATION_KEYS = (
+    "mutation",
+    "implementation",
+    "validation",
+    "transition",
+    "audit",
+    "destructive",
+    "protected_action",
+    "parallel",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class IntakeSignal:
+    kind: str
+    value: str
+    signal: str
+    position: int
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "kind": self.kind,
+            "value": self.value,
+            "signal": self.signal,
+            "position": self.position,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class TaskProfileDerivation:
+    task_profile: TaskProfile
+    matched_signals: tuple[IntakeSignal, ...]
+    derivation_reasons: tuple[str, ...]
+
+
+def _clean_prompt(prompt: object) -> str:
+    if not isinstance(prompt, str):
+        raise TypeError("prompt must be a string")
+    text = " ".join(prompt.split())
+    if not text:
+        raise ValueError("prompt must be non-empty")
+    if len(text) > 4096:
+        raise ValueError("prompt exceeds 4096 characters")
+    return text
+
+
+def _signal_position(text: str, signal: str) -> int | None:
+    signal_text = " ".join(str(signal).casefold().split())
+    if not signal_text:
+        raise ValueError("derivation signals must be non-empty")
+    escaped = re.escape(signal_text).replace(r"\ ", r"\s+")
+    match = re.search(rf"(?<!\w){escaped}(?!\w)", text.casefold())
+    return None if match is None else match.start()
+
+
+def _exact_bool_or_default(value: object, default: bool, field_name: str) -> bool:
+    if value is None:
+        return default
+    if type(value) is not bool:
+        raise TypeError(f"{field_name} must be an exact boolean")
+    return value
+
+
+def _bounded_nonnegative_int(value: object, default: int, field_name: str) -> int:
+    if value is None:
+        return default
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{field_name} must be an integer")
+    if value < 0 or value > 64:
+        raise ValueError(f"{field_name} must be between 0 and 64")
+    return value
+
+
+def _string_list(value: object, field_name: str, *, maximum: int) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, (list, tuple)):
+        raise TypeError(f"{field_name} must be a list or tuple")
+    items = tuple(str(item).strip() for item in value)
+    if len(items) > maximum or any(not item for item in items) or len(items) != len(set(items)):
+        raise ValueError(f"{field_name} must be unique, non-empty, and bounded")
+    return items
+
+
+def _validated_policy(policy: Mapping[str, Any]) -> tuple[list[Mapping[str, Any]], Mapping[str, Any], frozenset[str]]:
+    if not isinstance(policy, Mapping):
+        raise TypeError("TaskProfile derivation policy must be a mapping")
+    if policy.get("schema_version") != DERIVATION_POLICY_SCHEMA_VERSION:
+        raise ValueError("unsupported TaskProfile derivation policy schema")
+    if policy.get("owner") != "conductor":
+        raise ValueError("TaskProfile derivation policy owner must be conductor")
+    if policy.get("default_execution_mode") not in EXECUTION_MODES:
+        raise ValueError("TaskProfile derivation default execution mode is invalid")
+    if policy.get("default_risk_level") not in RISK_LEVELS:
+        raise ValueError("TaskProfile derivation default risk level is invalid")
+
+    raw_rules = policy.get("domain_rules")
+    if not isinstance(raw_rules, list) or not raw_rules:
+        raise TypeError("TaskProfile derivation domain_rules must be a non-empty list")
+    seen_domains: set[str] = set()
+    rules: list[Mapping[str, Any]] = []
+    for rule in raw_rules:
+        if not isinstance(rule, Mapping):
+            raise TypeError("TaskProfile derivation domain rule must be a mapping")
+        domain = str(rule.get("domain", "")).strip().upper()
+        signals = rule.get("signals")
+        if domain not in AUTHORITY_DOMAINS or domain in seen_domains:
+            raise ValueError("TaskProfile derivation domain rule set is invalid")
+        if not isinstance(signals, list) or not signals or any(not str(item).strip() for item in signals):
+            raise ValueError("TaskProfile derivation domain signals must be non-empty")
+        seen_domains.add(domain)
+        rules.append(rule)
+
+    raw_operations = policy.get("operation_signals")
+    if not isinstance(raw_operations, Mapping):
+        raise TypeError("TaskProfile derivation operation_signals must be a mapping")
+    if set(raw_operations) != set(_OPERATION_KEYS):
+        raise ValueError("TaskProfile derivation operation signal set changed")
+    for key in _OPERATION_KEYS:
+        signals = raw_operations[key]
+        if not isinstance(signals, list) or not signals or any(not str(item).strip() for item in signals):
+            raise ValueError(f"TaskProfile derivation operation signals are invalid: {key}")
+
+    governed = frozenset(str(item).strip().upper() for item in policy.get("governed_domains", ()))
+    if not governed or not governed.issubset(AUTHORITY_DOMAINS):
+        raise ValueError("TaskProfile derivation governed_domains are invalid")
+    return rules, raw_operations, governed
+
+
+def _matched_signals(
+    prompt: str,
+    domain_rules: list[Mapping[str, Any]],
+    operation_signals: Mapping[str, Any],
+) -> tuple[IntakeSignal, ...]:
+    matches: list[IntakeSignal] = []
+    for rule in domain_rules:
+        domain = str(rule["domain"]).strip().upper()
+        for raw_signal in rule["signals"]:
+            signal = str(raw_signal).strip()
+            position = _signal_position(prompt, signal)
+            if position is not None:
+                matches.append(IntakeSignal("DOMAIN", domain, signal, position))
+    for operation in _OPERATION_KEYS:
+        for raw_signal in operation_signals[operation]:
+            signal = str(raw_signal).strip()
+            position = _signal_position(prompt, signal)
+            if position is not None:
+                matches.append(IntakeSignal("OPERATION", operation.upper(), signal, position))
+    return tuple(sorted(matches, key=lambda item: (item.position, item.kind, item.value, item.signal)))
+
+
+def _operation_active(matches: tuple[IntakeSignal, ...], operation: str) -> bool:
+    target = operation.upper()
+    return any(item.kind == "OPERATION" and item.value == target for item in matches)
+
+
+def _domain_order(matches: tuple[IntakeSignal, ...]) -> list[str]:
+    first_position: dict[str, int] = {}
+    for item in matches:
+        if item.kind == "DOMAIN":
+            first_position.setdefault(item.value, item.position)
+    return [
+        domain
+        for domain, _ in sorted(first_position.items(), key=lambda pair: (pair[1], pair[0]))
+    ]
+
+
+def _stronger(current: str, explicit: object, ordered: tuple[str, ...], field_name: str) -> str:
+    if explicit is None:
+        return current
+    candidate = str(explicit).strip().upper()
+    if candidate not in ordered:
+        raise ValueError(f"{field_name} is invalid")
+    return ordered[max(ordered.index(current), ordered.index(candidate))]
+
+
+def _stable_task_id(prompt: str, source_identity: str) -> str:
+    payload = json.dumps(
+        {"prompt": prompt, "source_identity": source_identity},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return "task." + sha256(payload).hexdigest()[:24]
+
+
+def derive_task_profile(
+    *,
+    prompt: str,
+    metadata: Mapping[str, Any],
+    current_source_identity: str,
+    policy: Mapping[str, Any],
+) -> TaskProfileDerivation:
+    """Derive a minimum authority-safe TaskProfile from deterministic intake signals."""
+
+    text = _clean_prompt(prompt)
+    if not isinstance(metadata, Mapping):
+        raise TypeError("TaskProfile derivation metadata must be a mapping")
+    source_identity = str(current_source_identity).strip()
+    if not source_identity:
+        raise ValueError("current_source_identity must be non-empty")
+
+    domain_rules, operation_signals, governed_domains = _validated_policy(policy)
+    matches = _matched_signals(text, domain_rules, operation_signals)
+    domains = _domain_order(matches)
+
+    explicit_domains = tuple(item.upper() for item in _string_list(
+        metadata.get("agentic_authority_domains"),
+        "agentic_authority_domains",
+        maximum=14,
+    ))
+    if any(item not in AUTHORITY_DOMAINS for item in explicit_domains):
+        raise ValueError("agentic_authority_domains contains an unknown authority domain")
+    for domain in explicit_domains:
+        if domain not in domains:
+            domains.append(domain)
+
+    mutation_required = _operation_active(matches, "mutation")
+    implementation_required = _operation_active(matches, "implementation")
+    validation_required = _operation_active(matches, "validation")
+    transition_required = _operation_active(matches, "transition")
+    audit_requested = _operation_active(matches, "audit")
+    destructive_requested = _operation_active(matches, "destructive")
+    protected_action_required = _operation_active(matches, "protected_action")
+    parallelizable = _operation_active(matches, "parallel")
+
+    if implementation_required and "IMPLEMENTATION" not in domains:
+        domains.append("IMPLEMENTATION")
+    if validation_required and "VALIDATION" not in domains:
+        domains.append("VALIDATION")
+    if transition_required and "TRANSITION" not in domains:
+        domains.append("TRANSITION")
+    if not domains:
+        domains.append("ROUTING")
+
+    nonterminal_domains = [item for item in domains if item not in TERMINAL_DOMAINS]
+    implementation_dependency = 1 if implementation_required and nonterminal_domains else 0
+    dependency_default = max(0, len(nonterminal_domains) - 1) + implementation_dependency
+    independent_default = len(nonterminal_domains) if len(nonterminal_domains) >= 2 else 0
+
+    if destructive_requested:
+        mode = "DESTRUCTIVE"
+    elif audit_requested and not mutation_required:
+        mode = "AUDIT"
+    elif any(domain in governed_domains for domain in domains):
+        mode = "GOVERNED"
+    elif mutation_required or implementation_required or len(nonterminal_domains) > 1:
+        mode = "STANDARD"
+    else:
+        mode = str(policy["default_execution_mode"]).strip().upper()
+    mode = _stronger(mode, metadata.get("execution_mode"), MODE_ORDER, "execution_mode")
+
+    if destructive_requested:
+        risk = "CRITICAL"
+    elif protected_action_required or any(domain in governed_domains for domain in domains):
+        risk = "HIGH"
+    elif mutation_required or implementation_required or len(nonterminal_domains) > 1 or audit_requested:
+        risk = "MEDIUM"
+    else:
+        risk = str(policy["default_risk_level"]).strip().upper()
+    risk = _stronger(risk, metadata.get("risk_level"), RISK_ORDER, "risk_level")
+
+    explicit_owner = metadata.get("agentic_primary_owner")
+    if explicit_owner is None:
+        owner_domain = nonterminal_domains[0] if nonterminal_domains else domains[0]
+        primary_owner = AUTHORITY_DOMAIN_OWNERS[owner_domain]
+    else:
+        primary_owner = str(explicit_owner).strip().casefold()
+        valid_owners = set(AUTHORITY_DOMAIN_OWNERS.values())
+        if primary_owner not in valid_owners:
+            raise ValueError("agentic_primary_owner is not a canonical specialist owner")
+
+    protected_action_authorized = _exact_bool_or_default(
+        metadata.get("protected_action_authorized"),
+        False,
+        "protected_action_authorized",
+    )
+    if protected_action_authorized and not protected_action_required:
+        raise ValueError("protected_action_authorized requires a protected action signal")
+
+    critic_owner = metadata.get("critic_owner")
+    critic_domain = metadata.get("critic_domain")
+    if (critic_owner is None) != (critic_domain is None):
+        raise ValueError("critic_owner and critic_domain must be supplied together")
+
+    reentry_specialists = _string_list(
+        metadata.get("reentry_specialists"),
+        "reentry_specialists",
+        maximum=14,
+    )
+    human_gate_requirements = _string_list(
+        metadata.get("human_gate_requirements"),
+        "human_gate_requirements",
+        maximum=32,
+    )
+
+    task_id = str(metadata.get("agentic_task_id", "")).strip() or _stable_task_id(text, source_identity)
+    goal = str(metadata.get("agentic_goal", "")).strip() or text
+    profile = TaskProfile(
+        schema_version=TASK_PROFILE_SCHEMA_VERSION,
+        task_id=task_id,
+        goal=goal,
+        execution_mode=mode,
+        risk_level=risk,
+        authority_domains=tuple(domains),
+        primary_owner=primary_owner,
+        dependency_depth=_bounded_nonnegative_int(
+            metadata.get("dependency_depth"),
+            dependency_default,
+            "dependency_depth",
+        ),
+        independent_subtasks=_bounded_nonnegative_int(
+            metadata.get("independent_subtasks"),
+            independent_default,
+            "independent_subtasks",
+        ),
+        parallelizable=_exact_bool_or_default(
+            metadata.get("parallelizable"),
+            parallelizable,
+            "parallelizable",
+        ),
+        mutation_required=_exact_bool_or_default(
+            metadata.get("mutation_required"),
+            mutation_required,
+            "mutation_required",
+        ),
+        implementation_required=_exact_bool_or_default(
+            metadata.get("implementation_required"),
+            implementation_required,
+            "implementation_required",
+        ),
+        validation_required=_exact_bool_or_default(
+            metadata.get("validation_required"),
+            validation_required,
+            "validation_required",
+        ),
+        transition_required=_exact_bool_or_default(
+            metadata.get("transition_required"),
+            transition_required,
+            "transition_required",
+        ),
+        external_state_required=_exact_bool_or_default(
+            metadata.get("external_state_required"),
+            audit_requested or mutation_required or validation_required or transition_required,
+            "external_state_required",
+        ),
+        protected_action_required=protected_action_required,
+        protected_action_authorized=protected_action_authorized,
+        objective_verifier_available=_exact_bool_or_default(
+            metadata.get("objective_verifier_available"),
+            validation_required,
+            "objective_verifier_available",
+        ),
+        critic_owner=critic_owner,
+        critic_domain=critic_domain,
+        reentry_specialists=reentry_specialists,
+        current_source_identity=source_identity,
+        human_gate_requirements=human_gate_requirements,
+    )
+
+    reasons: list[str] = []
+    for domain in domains:
+        reasons.append(f"AUTHORITY_DOMAIN:{domain}")
+    reasons.extend(
+        (
+            f"EXECUTION_MODE:{mode}",
+            f"RISK_LEVEL:{risk}",
+            f"PRIMARY_OWNER:{profile.primary_owner}",
+        )
+    )
+    if protected_action_required and not protected_action_authorized:
+        reasons.append("PROTECTED_ACTION_AUTHORITY_NOT_INFERRED")
+    if domains == ["ROUTING"]:
+        reasons.append("UNKNOWN_DOMAIN_FAILS_TO_CONDUCTOR_ROUTING")
+    if explicit_domains:
+        reasons.append("EXPLICIT_AUTHORITY_DOMAINS_PRESERVED")
+    if metadata.get("execution_mode") is not None:
+        reasons.append("EXPLICIT_EXECUTION_MODE_MAY_ESCALATE_ONLY")
+    if metadata.get("risk_level") is not None:
+        reasons.append("EXPLICIT_RISK_LEVEL_MAY_ESCALATE_ONLY")
+
+    return TaskProfileDerivation(
+        task_profile=profile,
+        matched_signals=matches,
+        derivation_reasons=tuple(dict.fromkeys(reasons)),
+    )
+
+
+__all__ = [
+    "DERIVATION_POLICY_SCHEMA_VERSION",
+    "IntakeSignal",
+    "MODE_ORDER",
+    "RISK_ORDER",
+    "TaskProfileDerivation",
+    "derive_task_profile",
+]

--- a/orchestra_runtime/domain/adaptive/intake.py
+++ b/orchestra_runtime/domain/adaptive/intake.py
@@ -103,7 +103,7 @@ def _string_list(value: object, field_name: str, *, maximum: int) -> tuple[str, 
     return items
 
 
-def _validated_policy(policy: Mapping[str, Any]) -> tuple[list[Mapping[str, Any]], Mapping[str, Any], frozenset[str]]:
+def validate_derivation_policy(policy: Mapping[str, Any]) -> tuple[list[Mapping[str, Any]], Mapping[str, Any], frozenset[str]]:
     if not isinstance(policy, Mapping):
         raise TypeError("TaskProfile derivation policy must be a mapping")
     if policy.get("schema_version") != DERIVATION_POLICY_SCHEMA_VERSION:
@@ -220,7 +220,7 @@ def derive_task_profile(
     if not source_identity:
         raise ValueError("current_source_identity must be non-empty")
 
-    domain_rules, operation_signals, governed_domains = _validated_policy(policy)
+    domain_rules, operation_signals, governed_domains = validate_derivation_policy(policy)
     matches = _matched_signals(text, domain_rules, operation_signals)
     domains = _domain_order(matches)
 
@@ -413,4 +413,5 @@ __all__ = [
     "RISK_ORDER",
     "TaskProfileDerivation",
     "derive_task_profile",
+    "validate_derivation_policy",
 ]

--- a/orchestra_runtime/domain/adaptive/intake.py
+++ b/orchestra_runtime/domain/adaptive/intake.py
@@ -240,7 +240,8 @@ def derive_task_profile(
     validation_required = _operation_active(matches, "validation")
     transition_required = _operation_active(matches, "transition")
     audit_requested = _operation_active(matches, "audit")
-    destructive_requested = _operation_active(matches, "destructive")
+    production_transition = transition_required and _signal_position(text, "production") is not None
+    destructive_requested = _operation_active(matches, "destructive") or production_transition
     protected_action_required = _operation_active(matches, "protected_action")
     parallelizable = _operation_active(matches, "parallel")
 
@@ -268,7 +269,12 @@ def derive_task_profile(
         mode = "STANDARD"
     else:
         mode = str(policy["default_execution_mode"]).strip().upper()
-    mode = _stronger(mode, metadata.get("execution_mode"), MODE_ORDER, "execution_mode")
+    explicit_mode = metadata.get("agentic_execution_mode")
+    if explicit_mode is None:
+        risk_mode = metadata.get("risk_mode")
+        if isinstance(risk_mode, str) and risk_mode.strip().upper() in MODE_ORDER:
+            explicit_mode = risk_mode
+    mode = _stronger(mode, explicit_mode, MODE_ORDER, "agentic_execution_mode")
 
     if destructive_requested:
         risk = "CRITICAL"
@@ -278,7 +284,7 @@ def derive_task_profile(
         risk = "MEDIUM"
     else:
         risk = str(policy["default_risk_level"]).strip().upper()
-    risk = _stronger(risk, metadata.get("risk_level"), RISK_ORDER, "risk_level")
+    risk = _stronger(risk, metadata.get("agentic_risk_level"), RISK_ORDER, "agentic_risk_level")
 
     explicit_owner = metadata.get("agentic_primary_owner")
     if explicit_owner is None:
@@ -394,10 +400,12 @@ def derive_task_profile(
         reasons.append("UNKNOWN_DOMAIN_FAILS_TO_CONDUCTOR_ROUTING")
     if explicit_domains:
         reasons.append("EXPLICIT_AUTHORITY_DOMAINS_PRESERVED")
-    if metadata.get("execution_mode") is not None:
+    if explicit_mode is not None:
         reasons.append("EXPLICIT_EXECUTION_MODE_MAY_ESCALATE_ONLY")
-    if metadata.get("risk_level") is not None:
+    if metadata.get("agentic_risk_level") is not None:
         reasons.append("EXPLICIT_RISK_LEVEL_MAY_ESCALATE_ONLY")
+    if production_transition:
+        reasons.append("PRODUCTION_TRANSITION_CLASSIFIED_DESTRUCTIVE")
 
     return TaskProfileDerivation(
         task_profile=profile,

--- a/orchestra_runtime/domain/adaptive/intake.py
+++ b/orchestra_runtime/domain/adaptive/intake.py
@@ -66,12 +66,130 @@ def _clean_prompt(prompt: object) -> str:
 
 
 def _signal_position(text: str, signal: str) -> int | None:
+    positions = _signal_positions(text, signal)
+    return None if not positions else positions[0]
+
+
+def _signal_positions(text: str, signal: str) -> tuple[int, ...]:
     signal_text = " ".join(str(signal).casefold().split())
     if not signal_text:
         raise ValueError("derivation signals must be non-empty")
     escaped = re.escape(signal_text).replace(r"\ ", r"\s+")
-    match = re.search(rf"(?<!\w){escaped}(?!\w)", text.casefold())
-    return None if match is None else match.start()
+    return tuple(
+        match.start()
+        for match in re.finditer(rf"(?<!\w){escaped}(?!\w)", text.casefold())
+    )
+
+
+def _quoted_ranges(text: str) -> tuple[tuple[int, int], ...]:
+    ranges: list[tuple[int, int]] = []
+    for pattern in (r"`[^`]*`", r'"[^"]*"', r"'[^']*'"):
+        for match in re.finditer(pattern, text):
+            ranges.append((match.start(), match.end()))
+    return tuple(sorted(ranges))
+
+
+def _position_in_ranges(position: int, ranges: tuple[tuple[int, int], ...]) -> bool:
+    return any(start <= position < end for start, end in ranges)
+
+
+def _phrase_present(text: str, phrase: str) -> bool:
+    normalized = " ".join(str(phrase).casefold().split())
+    if not normalized:
+        return False
+    escaped = re.escape(normalized).replace(r"\ ", r"\s+")
+    return re.search(rf"(?<!\w){escaped}(?!\w)", text.casefold()) is not None
+
+
+def _is_negated(
+    text: str,
+    position: int,
+    negation_phrases: tuple[str, ...],
+) -> bool:
+    boundary = max(
+        text.rfind(".", 0, position),
+        text.rfind("!", 0, position),
+        text.rfind("?", 0, position),
+        text.rfind(";", 0, position),
+        text.rfind(":", 0, position),
+    )
+    prefix = text[boundary + 1 : position].casefold()
+    for phrase in negation_phrases:
+        normalized = " ".join(str(phrase).casefold().split())
+        escaped = re.escape(normalized).replace(r"\ ", r"\s+")
+        if re.search(rf"(?<!\w){escaped}(?!\w)", prefix):
+            return True
+    return False
+
+
+def _is_hypothetical(
+    text: str,
+    position: int,
+    hypothetical_prefixes: tuple[str, ...],
+) -> bool:
+    normalized = text.casefold().lstrip()
+    for prefix in hypothetical_prefixes:
+        candidate = " ".join(str(prefix).casefold().split())
+        if normalized.startswith(candidate) and position >= normalized.find(candidate) + len(candidate):
+            return True
+    return False
+
+
+def _representation_context(
+    text: str,
+    suppression_rules: Mapping[str, Any],
+    quoted: tuple[tuple[int, int], ...],
+) -> tuple[bool, int | None]:
+    lower = text.casefold()
+    artifacts = tuple(str(item).casefold() for item in suppression_rules["representation_artifacts"])
+    verbs = tuple(str(item).casefold() for item in suppression_rules["representation_verbs"])
+    edit_verbs = tuple(str(item).casefold() for item in suppression_rules["representation_edit_verbs"])
+    scope_phrases = tuple(str(item).casefold() for item in suppression_rules["representation_scope_phrases"])
+    negations = tuple(str(item).casefold() for item in suppression_rules["negation_phrases"])
+
+    artifact_present = any(_phrase_present(lower, item) for item in artifacts)
+    verb_present = any(_phrase_present(lower, item) for item in verbs)
+    scope_present = any(_phrase_present(lower, item) for item in scope_phrases)
+    representation_only = (
+        (artifact_present and verb_present)
+        or scope_present
+        or lower.startswith("document ")
+        or lower.startswith("summarize ")
+    )
+
+    edit_position: int | None = None
+    if representation_only:
+        candidates: list[int] = []
+        for verb in edit_verbs:
+            for position in _signal_positions(text, verb):
+                if _position_in_ranges(position, quoted):
+                    continue
+                if _is_negated(text, position, negations):
+                    continue
+                candidates.append(position)
+        if candidates:
+            edit_position = min(candidates)
+    return representation_only, edit_position
+
+
+def _first_active_signal_position(
+    text: str,
+    signal: str,
+    *,
+    quoted: tuple[tuple[int, int], ...],
+    negation_phrases: tuple[str, ...],
+    hypothetical_prefixes: tuple[str, ...],
+    suppress_hypothetical: bool,
+) -> int | None:
+    for position in _signal_positions(text, signal):
+        if _position_in_ranges(position, quoted):
+            continue
+        if _is_negated(text, position, negation_phrases):
+            continue
+        if suppress_hypothetical and _is_hypothetical(text, position, hypothetical_prefixes):
+            continue
+        return position
+    return None
 
 
 def _exact_bool_or_default(value: object, default: bool, field_name: str) -> bool:
@@ -103,7 +221,7 @@ def _string_list(value: object, field_name: str, *, maximum: int) -> tuple[str, 
     return items
 
 
-def validate_derivation_policy(policy: Mapping[str, Any]) -> tuple[list[Mapping[str, Any]], Mapping[str, Any], frozenset[str]]:
+def validate_derivation_policy(policy: Mapping[str, Any]) -> tuple[list[Mapping[str, Any]], Mapping[str, Any], frozenset[str], Mapping[str, Any]]:
     if not isinstance(policy, Mapping):
         raise TypeError("TaskProfile derivation policy must be a mapping")
     if policy.get("schema_version") != DERIVATION_POLICY_SCHEMA_VERSION:
@@ -145,30 +263,109 @@ def validate_derivation_policy(policy: Mapping[str, Any]) -> tuple[list[Mapping[
     governed = frozenset(str(item).strip().upper() for item in policy.get("governed_domains", ()))
     if not governed or not governed.issubset(AUTHORITY_DOMAINS):
         raise ValueError("TaskProfile derivation governed_domains are invalid")
-    return rules, raw_operations, governed
+
+    raw_suppression = policy.get("suppression_rules")
+    required_suppression = {
+        "negation_phrases",
+        "hypothetical_prefixes",
+        "representation_artifacts",
+        "representation_verbs",
+        "representation_edit_verbs",
+        "representation_scope_phrases",
+    }
+    if not isinstance(raw_suppression, Mapping):
+        raise TypeError("TaskProfile derivation suppression_rules must be a mapping")
+    if set(raw_suppression) != required_suppression:
+        raise ValueError("TaskProfile derivation suppression rule set changed")
+    for key in sorted(required_suppression):
+        values = raw_suppression[key]
+        if not isinstance(values, list) or not values or any(not str(item).strip() for item in values):
+            raise ValueError(f"TaskProfile derivation suppression rules are invalid: {key}")
+    return rules, raw_operations, governed, raw_suppression
 
 
 def _matched_signals(
     prompt: str,
     domain_rules: list[Mapping[str, Any]],
     operation_signals: Mapping[str, Any],
-) -> tuple[IntakeSignal, ...]:
+    suppression_rules: Mapping[str, Any],
+) -> tuple[tuple[IntakeSignal, ...], int, bool]:
     matches: list[IntakeSignal] = []
+    suppressed = 0
+    quoted = _quoted_ranges(prompt)
+    negations = tuple(str(item).casefold() for item in suppression_rules["negation_phrases"])
+    hypotheticals = tuple(str(item).casefold() for item in suppression_rules["hypothetical_prefixes"])
+    representation_only, representation_edit_position = _representation_context(
+        prompt,
+        suppression_rules,
+        quoted,
+    )
+
     for rule in domain_rules:
         domain = str(rule["domain"]).strip().upper()
         for raw_signal in rule["signals"]:
             signal = str(raw_signal).strip()
-            position = _signal_position(prompt, signal)
-            if position is not None:
-                matches.append(IntakeSignal("DOMAIN", domain, signal, position))
+            active_position = None
+            for position in _signal_positions(prompt, signal):
+                if _position_in_ranges(position, quoted):
+                    suppressed += 1
+                    continue
+                if _is_negated(prompt, position, negations):
+                    suppressed += 1
+                    continue
+                if representation_only and domain != "DOCUMENTATION":
+                    suppressed += 1
+                    continue
+                active_position = position
+                break
+            if active_position is not None:
+                matches.append(IntakeSignal("DOMAIN", domain, signal, active_position))
+
     for operation in _OPERATION_KEYS:
         for raw_signal in operation_signals[operation]:
             signal = str(raw_signal).strip()
-            position = _signal_position(prompt, signal)
-            if position is not None:
-                matches.append(IntakeSignal("OPERATION", operation.upper(), signal, position))
-    return tuple(sorted(matches, key=lambda item: (item.position, item.kind, item.value, item.signal)))
+            active_position = None
+            for position in _signal_positions(prompt, signal):
+                if _position_in_ranges(position, quoted):
+                    suppressed += 1
+                    continue
+                if _is_negated(prompt, position, negations):
+                    suppressed += 1
+                    continue
+                if _is_hypothetical(prompt, position, hypotheticals):
+                    suppressed += 1
+                    continue
+                if representation_only and operation != "audit":
+                    suppressed += 1
+                    continue
+                active_position = position
+                break
+            if active_position is not None:
+                matches.append(
+                    IntakeSignal("OPERATION", operation.upper(), signal, active_position)
+                )
 
+    if representation_only and not any(
+        item.kind == "DOMAIN" and item.value == "DOCUMENTATION"
+        for item in matches
+    ):
+        matches.append(IntakeSignal("DOMAIN", "DOCUMENTATION", "representation_context", 0))
+
+    if representation_only and representation_edit_position is not None:
+        matches.append(
+            IntakeSignal(
+                "OPERATION",
+                "MUTATION",
+                "representation_edit",
+                representation_edit_position,
+            )
+        )
+
+    return (
+        tuple(sorted(matches, key=lambda item: (item.position, item.kind, item.value, item.signal))),
+        suppressed,
+        representation_only,
+    )
 
 def _operation_active(matches: tuple[IntakeSignal, ...], operation: str) -> bool:
     target = operation.upper()
@@ -220,8 +417,13 @@ def derive_task_profile(
     if not source_identity:
         raise ValueError("current_source_identity must be non-empty")
 
-    domain_rules, operation_signals, governed_domains = validate_derivation_policy(policy)
-    matches = _matched_signals(text, domain_rules, operation_signals)
+    domain_rules, operation_signals, governed_domains, suppression_rules = validate_derivation_policy(policy)
+    matches, suppressed_signal_count, representation_only = _matched_signals(
+        text,
+        domain_rules,
+        operation_signals,
+        suppression_rules,
+    )
     domains = _domain_order(matches)
 
     explicit_domains = tuple(item.upper() for item in _string_list(
@@ -240,7 +442,18 @@ def derive_task_profile(
     validation_required = _operation_active(matches, "validation")
     transition_required = _operation_active(matches, "transition")
     audit_requested = _operation_active(matches, "audit")
-    production_transition = transition_required and _signal_position(text, "production") is not None
+    quoted_ranges = _quoted_ranges(text)
+    production_position = _first_active_signal_position(
+        text,
+        "production",
+        quoted=quoted_ranges,
+        negation_phrases=tuple(str(item).casefold() for item in suppression_rules["negation_phrases"]),
+        hypothetical_prefixes=tuple(str(item).casefold() for item in suppression_rules["hypothetical_prefixes"]),
+        suppress_hypothetical=True,
+    )
+    if representation_only:
+        production_position = None
+    production_transition = transition_required and production_position is not None
     destructive_requested = _operation_active(matches, "destructive") or production_transition
     protected_action_required = _operation_active(matches, "protected_action")
     parallelizable = _operation_active(matches, "parallel")
@@ -406,6 +619,10 @@ def derive_task_profile(
         reasons.append("EXPLICIT_RISK_LEVEL_MAY_ESCALATE_ONLY")
     if production_transition:
         reasons.append("PRODUCTION_TRANSITION_CLASSIFIED_DESTRUCTIVE")
+    if suppressed_signal_count:
+        reasons.append(f"NEGATIVE_ROUTING_SIGNALS_SUPPRESSED:{suppressed_signal_count}")
+    if representation_only:
+        reasons.append("REPRESENTATION_ONLY_CONTEXT_SUPPRESSED_DOMAIN_EXECUTION")
 
     return TaskProfileDerivation(
         task_profile=profile,

--- a/orchestra_runtime/domain/adaptive/selection_trace.py
+++ b/orchestra_runtime/domain/adaptive/selection_trace.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from hashlib import sha256
+import json
+from typing import Iterable
+
+from .task_profile import TaskProfile
+from .topology_validator import AgenticWorkflowProfile
+
+SELECTION_TRACE_SCHEMA_VERSION = "orchestra.agentic-selection-trace.v1"
+AUTHORITY_RULE = "WORKFLOW_TOPOLOGY_CHANGE != AUTHORITY_EXPANSION"
+
+_REJECTED_PATTERN_REASONS = {
+    "PLANNING": "NO_DEPENDENCY_DECOMPOSITION_OR_MULTI_SPECIALIST_SEQUENCE",
+    "TOOL_REACT": "NO_EXTERNAL_STATE_MUTATION_IMPLEMENTATION_OR_VALIDATION_REQUIRED",
+    "REFLECTION_CRITIC": "NO_DISTINCT_CRITIC_CONTRACT",
+    "MULTI_AGENT": "INSUFFICIENT_DISTINCT_AUTHORITY_REENTRY_OR_SUBTASK_VALUE",
+}
+
+
+def _trace_id(task_id: str, profile_id: str, source: str) -> str:
+    payload = json.dumps(
+        {"task_id": task_id, "profile_id": profile_id, "source": source},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return "agentic-selection." + sha256(payload).hexdigest()[:24]
+
+
+def build_selection_trace(
+    *,
+    task: TaskProfile,
+    profile: AgenticWorkflowProfile,
+    source: str,
+    matched_signals: Iterable[dict[str, object]] = (),
+    derivation_reasons: Iterable[str] = (),
+) -> dict[str, object]:
+    if source not in {"DERIVED_INTAKE", "STRUCTURED_TASK_PROFILE"}:
+        raise ValueError("selection trace source is invalid")
+
+    selected = set(profile.selected_patterns)
+    rejected = {
+        pattern: reason
+        for pattern, reason in _REJECTED_PATTERN_REASONS.items()
+        if pattern not in selected
+    }
+
+    selection_reasons: list[str] = [
+        f"PRIMARY_OWNER:{profile.primary_owner}",
+        *(f"SPECIALIST_SELECTED:{item}" for item in profile.required_specialists),
+        *(f"PATTERN_SELECTED:{item}" for item in profile.selected_patterns),
+    ]
+    if profile.human_gate_required:
+        selection_reasons.append("HUMAN_GATE_FROM_UNDERLYING_BOUNDARY")
+    else:
+        selection_reasons.append("NO_TOPOLOGY_ONLY_HUMAN_GATE")
+    if profile.concurrency_mode != "SINGLE_OWNER":
+        selection_reasons.append(f"CONCURRENCY_MODE:{profile.concurrency_mode}")
+
+    return {
+        "schema_version": SELECTION_TRACE_SCHEMA_VERSION,
+        "trace_id": _trace_id(task.task_id, profile.profile_id, source),
+        "source": source,
+        "task_id": task.task_id,
+        "matched_signals": list(matched_signals),
+        "derivation_reasons": list(dict.fromkeys(str(item) for item in derivation_reasons)),
+        "selected_specialists": list(profile.required_specialists),
+        "selected_patterns": list(profile.selected_patterns),
+        "rejected_patterns": rejected,
+        "selection_reasons": list(dict.fromkeys(selection_reasons)),
+        "human_gate_required": profile.human_gate_required,
+        "escalation_reasons": list(profile.escalation_reasons),
+        "authority_rule": AUTHORITY_RULE,
+    }
+
+
+__all__ = [
+    "AUTHORITY_RULE",
+    "SELECTION_TRACE_SCHEMA_VERSION",
+    "build_selection_trace",
+]

--- a/orchestra_runtime/infrastructure/machine/agentic_workflow.py
+++ b/orchestra_runtime/infrastructure/machine/agentic_workflow.py
@@ -9,16 +9,20 @@ from ...domain.adaptive import (
     PATTERN_ORDER,
     REQUIRED_COMPOSITION_INVARIANT_IDS,
     parse_authority_view,
+    validate_derivation_policy,
 )
 
 AUTHORITY_VIEW_PATH = Path("machine/specialists/authority-view.v1.json")
 PATTERNS_PATH = Path("machine/workflows/patterns.v1.json")
 INVARIANTS_PATH = Path("machine/workflows/composition-invariants.v1.json")
+DERIVATION_POLICY_PATH = Path("machine/workflows/task-profile-derivation.v1.json")
 SCHEMA_PATHS = (
     Path("machine/schemas/task-profile.v1.schema.json"),
     Path("machine/schemas/critic-contract.v1.schema.json"),
     Path("machine/schemas/specialist-authority-view.v1.schema.json"),
     Path("machine/schemas/agentic-workflow-profile.v1.schema.json"),
+    Path("machine/schemas/task-profile-derivation.v1.schema.json"),
+    Path("machine/schemas/agentic-selection-trace.v1.schema.json"),
 )
 
 
@@ -98,6 +102,14 @@ def load_agentic_composition_invariants(root: Path | str | None = None) -> dict[
     return value
 
 
+
+def load_task_profile_derivation_policy(root: Path | str | None = None) -> dict[str, Any]:
+    repo_root = repository_root() if root is None else Path(root)
+    value = _load_json(repo_root / DERIVATION_POLICY_PATH)
+    validate_derivation_policy(value)
+    return value
+
+
 def load_agentic_workflow_contracts(root: Path | str | None = None) -> dict[str, Any]:
     repo_root = repository_root() if root is None else Path(root)
     for schema_path in SCHEMA_PATHS:
@@ -106,6 +118,7 @@ def load_agentic_workflow_contracts(root: Path | str | None = None) -> dict[str,
         "authority_view": load_agentic_workflow_authority_view(repo_root),
         "patterns": load_agentic_pattern_contract(repo_root),
         "composition_invariants": load_agentic_composition_invariants(repo_root),
+        "derivation_policy": load_task_profile_derivation_policy(repo_root),
     }
 
 
@@ -119,6 +132,7 @@ def agentic_workflow_errors(root: Path | str | None = None) -> tuple[str, ...]:
 
 __all__ = [
     "AUTHORITY_VIEW_PATH",
+    "DERIVATION_POLICY_PATH",
     "INVARIANTS_PATH",
     "PATTERNS_PATH",
     "SCHEMA_PATHS",
@@ -127,4 +141,5 @@ __all__ = [
     "load_agentic_pattern_contract",
     "load_agentic_workflow_authority_view",
     "load_agentic_workflow_contracts",
+    "load_task_profile_derivation_policy",
 ]

--- a/orchestra_runtime/services.py
+++ b/orchestra_runtime/services.py
@@ -45,7 +45,10 @@ from .delegation import (
     delegation_accepted_event,
     delegation_rejected_event,
 )
-from .application.use_cases.agentic_workflow import plan_agentic_workflow
+from .application.use_cases.agentic_workflow import (
+    plan_agentic_workflow,
+    plan_agentic_workflow_from_intake,
+)
 from .domain.orchestration.ui_fidelity import classify_ui_fidelity
 from .infrastructure.machine.agentic_workflow import load_agentic_workflow_contracts
 from .infrastructure.machine.execution_efficiency import load_execution_budget_contract
@@ -349,6 +352,8 @@ class RouterService(IRouterService):
         self._ui_fidelity_contract = load_ui_fidelity_routing_contract(registry_root)
         self._fallback_specialist = str(command_route_record("__orchestra_ambiguity_fallback__")["specialist"])
         self._governance_required_specialists = governance_required_specialists()
+        self._agentic_workflow_contracts: dict[str, object] | None = None
+        self._agentic_execution_budget: dict[str, object] | None = None
 
     def route(self, command: Command, context: ContextPackage) -> RouteDecision:
         skill_slug = self._command_routes.get(command.name, self._fallback_specialist)
@@ -369,27 +374,56 @@ class RouterService(IRouterService):
         route_metadata.update(ui_fidelity.to_metadata(self._ui_fidelity_contract))
 
         raw_task_profile = context.metadata.get("agentic_task_profile")
-        if raw_task_profile is not None:
-            if skill.slug != "conductor":
-                raise ValueError("agentic task profile requires Conductor routing")
-            if not isinstance(raw_task_profile, dict):
-                raise ValueError("agentic_task_profile must be a mapping")
-            contracts = load_agentic_workflow_contracts(self._registry_root)
-            execution_budget = load_execution_budget_contract(self._registry_root)
+        if raw_task_profile is not None and skill.slug != "conductor":
+            raise ValueError("agentic task profile requires Conductor routing")
+
+        auto_agentic = context.metadata.get("agentic_workflow_auto", True)
+        if type(auto_agentic) is not bool:
+            raise ValueError("agentic_workflow_auto must be an exact boolean")
+
+        if skill.slug == "conductor" and (raw_task_profile is not None or auto_agentic):
+            if self._agentic_workflow_contracts is None:
+                self._agentic_workflow_contracts = load_agentic_workflow_contracts(self._registry_root)
+            if self._agentic_execution_budget is None:
+                self._agentic_execution_budget = load_execution_budget_contract(self._registry_root)
+
+            contracts = self._agentic_workflow_contracts
+            execution_budget = self._agentic_execution_budget
             registry = {
                 "specialists": [
                     {"slug": registered.slug}
                     for registered in self._skill_registry.load_skills()
                 ]
             }
-            agentic_plan = plan_agentic_workflow(
-                task_profile=raw_task_profile,
-                specialist_authority_view=contracts["authority_view"],
-                specialist_registry=registry,
-                execution_budget=execution_budget,
-            )
+            if raw_task_profile is not None:
+                if not isinstance(raw_task_profile, dict):
+                    raise ValueError("agentic_task_profile must be a mapping")
+                agentic_plan = plan_agentic_workflow(
+                    task_profile=raw_task_profile,
+                    specialist_authority_view=contracts["authority_view"],
+                    specialist_registry=registry,
+                    execution_budget=execution_budget,
+                )
+            else:
+                source_identity = str(
+                    context.metadata.get("current_source_identity")
+                    or f"{context.project_root}@{context.manifest_version}"
+                ).strip()
+                agentic_plan = plan_agentic_workflow_from_intake(
+                    prompt=command.raw_input,
+                    metadata=context.metadata,
+                    current_source_identity=source_identity,
+                    derivation_policy=contracts["derivation_policy"],
+                    specialist_authority_view=contracts["authority_view"],
+                    specialist_registry=registry,
+                    execution_budget=execution_budget,
+                )
+
+            route_metadata["agentic_task_profile"] = agentic_plan["task_profile"]
+            route_metadata["agentic_task_profile_source"] = agentic_plan["task_profile_source"]
             route_metadata["agentic_workflow_profile"] = agentic_plan["workflow_profile"]
             route_metadata["agentic_critic_contract"] = agentic_plan["critic_contract"]
+            route_metadata["agentic_selection_trace"] = agentic_plan["selection_trace"]
             route_metadata["agentic_workflow_telemetry"] = agentic_plan["telemetry"]
             route_metadata["agentic_authority_rule"] = agentic_plan["authority_rule"]
 

--- a/tests/fixtures/agentic-workflow/awf-intake-calibration.v1.json
+++ b/tests/fixtures/agentic-workflow/awf-intake-calibration.v1.json
@@ -1,0 +1,420 @@
+{
+  "schema_version": "orchestra.awf-intake-calibration.v1",
+  "purpose": "Higher-coverage deterministic calibration corpus for ordinary-prompt AWF intake.",
+  "invariants": {
+    "max_parallel_specialists": 1,
+    "topology_change_requires_human_approval": false,
+    "authority_expansion": false
+  },
+  "cases": [
+    {
+      "id": "C01_UI_REVIEW_SINGLE_OWNER",
+      "prompt": "Review this responsive checkout screen for accessibility and layout issues.",
+      "expected": {
+        "authority_domains": [
+          "UI_UX"
+        ],
+        "primary_owner": "cloak",
+        "execution_mode": "AUDIT",
+        "risk_level": "MEDIUM",
+        "required_specialists": [
+          "cloak"
+        ],
+        "selected_patterns": [
+          "ROUTING",
+          "TOOL_REACT"
+        ],
+        "concurrency_mode": "SINGLE_OWNER",
+        "human_gate_required": false
+      }
+    },
+    {
+      "id": "C02_SECURITY_AUDIT_SINGLE_OWNER",
+      "prompt": "Audit authentication, authorization, and secret handling.",
+      "expected": {
+        "authority_domains": [
+          "SECURITY"
+        ],
+        "primary_owner": "cipher",
+        "execution_mode": "AUDIT",
+        "risk_level": "HIGH",
+        "required_specialists": [
+          "cipher"
+        ],
+        "selected_patterns": [
+          "ROUTING",
+          "TOOL_REACT"
+        ],
+        "concurrency_mode": "SINGLE_OWNER",
+        "human_gate_required": false
+      }
+    },
+    {
+      "id": "C03_PERSISTENCE_IMPLEMENT_VALIDATE",
+      "prompt": "Implement a database schema migration and validate it.",
+      "expected": {
+        "authority_domains": [
+          "PERSISTENCE",
+          "IMPLEMENTATION",
+          "VALIDATION"
+        ],
+        "primary_owner": "chronicler",
+        "execution_mode": "GOVERNED",
+        "risk_level": "HIGH",
+        "required_specialists": [
+          "chronicler",
+          "ponytail",
+          "overseer"
+        ],
+        "selected_patterns": [
+          "ROUTING",
+          "PLANNING",
+          "TOOL_REACT"
+        ],
+        "concurrency_mode": "SEQUENTIAL_MULTI_AGENT",
+        "human_gate_required": false
+      }
+    },
+    {
+      "id": "C04_ARCHITECTURE_REFACTOR_VALIDATE",
+      "prompt": "Refactor code layering and dependency direction, then validate it.",
+      "expected": {
+        "authority_domains": [
+          "ARCHITECTURE",
+          "IMPLEMENTATION",
+          "VALIDATION"
+        ],
+        "primary_owner": "clockwork",
+        "execution_mode": "STANDARD",
+        "risk_level": "MEDIUM",
+        "required_specialists": [
+          "clockwork",
+          "ponytail",
+          "overseer"
+        ],
+        "selected_patterns": [
+          "ROUTING",
+          "PLANNING",
+          "TOOL_REACT"
+        ],
+        "concurrency_mode": "SEQUENTIAL_MULTI_AGENT",
+        "human_gate_required": false
+      }
+    },
+    {
+      "id": "C05_DOCUMENTATION_UPDATE",
+      "prompt": "Update documentation in the README for the new workflow.",
+      "expected": {
+        "authority_domains": [
+          "DOCUMENTATION"
+        ],
+        "primary_owner": "scribe",
+        "execution_mode": "STANDARD",
+        "risk_level": "MEDIUM",
+        "required_specialists": [
+          "scribe"
+        ],
+        "selected_patterns": [
+          "ROUTING",
+          "TOOL_REACT"
+        ],
+        "concurrency_mode": "SINGLE_OWNER",
+        "human_gate_required": false
+      }
+    },
+    {
+      "id": "C06_DIAGRAM_BUILD",
+      "prompt": "Build a PlantUML sequence diagram from verified facts.",
+      "expected": {
+        "authority_domains": [
+          "DIAGRAM"
+        ],
+        "primary_owner": "weaver",
+        "execution_mode": "STANDARD",
+        "risk_level": "MEDIUM",
+        "required_specialists": [
+          "weaver"
+        ],
+        "selected_patterns": [
+          "ROUTING",
+          "TOOL_REACT"
+        ],
+        "concurrency_mode": "SINGLE_OWNER",
+        "human_gate_required": false
+      }
+    },
+    {
+      "id": "C07_BUSINESS_SCOPE_REVIEW",
+      "prompt": "Review requirements and acceptance criteria for the checkout scope.",
+      "expected": {
+        "authority_domains": [
+          "BUSINESS_SCOPE"
+        ],
+        "primary_owner": "the-steward",
+        "execution_mode": "AUDIT",
+        "risk_level": "MEDIUM",
+        "required_specialists": [
+          "the-steward"
+        ],
+        "selected_patterns": [
+          "ROUTING",
+          "TOOL_REACT"
+        ],
+        "concurrency_mode": "SINGLE_OWNER",
+        "human_gate_required": false
+      }
+    },
+    {
+      "id": "C08_LEGAL_COMPLIANCE_REVIEW",
+      "prompt": "Review licensing, copyright, and compliance obligations.",
+      "expected": {
+        "authority_domains": [
+          "LEGAL_COMPLIANCE"
+        ],
+        "primary_owner": "the-governor",
+        "execution_mode": "AUDIT",
+        "risk_level": "HIGH",
+        "required_specialists": [
+          "the-governor"
+        ],
+        "selected_patterns": [
+          "ROUTING",
+          "TOOL_REACT"
+        ],
+        "concurrency_mode": "SINGLE_OWNER",
+        "human_gate_required": false
+      }
+    },
+    {
+      "id": "C09_AMBIGUOUS_FAILS_TO_CONDUCTOR",
+      "prompt": "Consider the options.",
+      "expected": {
+        "authority_domains": [
+          "ROUTING"
+        ],
+        "primary_owner": "conductor",
+        "execution_mode": "FAST",
+        "risk_level": "LOW",
+        "required_specialists": [
+          "conductor"
+        ],
+        "selected_patterns": [
+          "ROUTING"
+        ],
+        "concurrency_mode": "SINGLE_OWNER",
+        "human_gate_required": false
+      }
+    },
+    {
+      "id": "C10_PARALLEL_UI_SECURITY_ANALYSIS",
+      "prompt": "Analyze UI and security in parallel.",
+      "expected": {
+        "authority_domains": [
+          "UI_UX",
+          "SECURITY"
+        ],
+        "primary_owner": "cloak",
+        "execution_mode": "AUDIT",
+        "risk_level": "HIGH",
+        "required_specialists": [
+          "the-tuner",
+          "cloak",
+          "cipher"
+        ],
+        "selected_patterns": [
+          "ROUTING",
+          "PLANNING",
+          "TOOL_REACT",
+          "MULTI_AGENT"
+        ],
+        "concurrency_mode": "SEQUENTIAL_MULTI_AGENT",
+        "human_gate_required": false
+      }
+    },
+    {
+      "id": "C11_PROTECTED_MERGE",
+      "prompt": "Merge the approved pull request.",
+      "expected": {
+        "authority_domains": [
+          "TRANSITION"
+        ],
+        "primary_owner": "arbiter",
+        "execution_mode": "STANDARD",
+        "risk_level": "HIGH",
+        "required_specialists": [
+          "arbiter"
+        ],
+        "selected_patterns": [
+          "ROUTING",
+          "TOOL_REACT"
+        ],
+        "concurrency_mode": "SINGLE_OWNER",
+        "human_gate_required": true
+      }
+    },
+    {
+      "id": "C12_PRODUCTION_DEPLOY",
+      "prompt": "Deploy the checkout change to production.",
+      "expected": {
+        "authority_domains": [
+          "TRANSITION"
+        ],
+        "primary_owner": "arbiter",
+        "execution_mode": "DESTRUCTIVE",
+        "risk_level": "CRITICAL",
+        "required_specialists": [
+          "arbiter"
+        ],
+        "selected_patterns": [
+          "ROUTING",
+          "TOOL_REACT"
+        ],
+        "concurrency_mode": "SINGLE_OWNER",
+        "human_gate_required": true
+      }
+    },
+    {
+      "id": "C13_FORCE_PUSH_FAILS_TO_CONDUCTOR_GATE",
+      "prompt": "Force push the branch and rewrite history.",
+      "expected": {
+        "authority_domains": [
+          "ROUTING"
+        ],
+        "primary_owner": "conductor",
+        "execution_mode": "DESTRUCTIVE",
+        "risk_level": "CRITICAL",
+        "required_specialists": [
+          "conductor"
+        ],
+        "selected_patterns": [
+          "ROUTING"
+        ],
+        "concurrency_mode": "SINGLE_OWNER",
+        "human_gate_required": true
+      }
+    },
+    {
+      "id": "C14_CHAOS_TEST_DAGGER_GATE",
+      "prompt": "Run a chaos test against the service in staging.",
+      "expected": {
+        "authority_domains": [
+          "ADVERSARIAL"
+        ],
+        "primary_owner": "dagger",
+        "execution_mode": "DESTRUCTIVE",
+        "risk_level": "CRITICAL",
+        "required_specialists": [
+          "dagger"
+        ],
+        "selected_patterns": [
+          "ROUTING"
+        ],
+        "concurrency_mode": "SINGLE_OWNER",
+        "human_gate_required": true
+      }
+    },
+    {
+      "id": "C15_UI_IMPLEMENT_VALIDATE_NO_TUNER",
+      "prompt": "Fix bug in responsive UI and validate it.",
+      "expected": {
+        "authority_domains": [
+          "UI_UX",
+          "IMPLEMENTATION",
+          "VALIDATION"
+        ],
+        "primary_owner": "cloak",
+        "execution_mode": "STANDARD",
+        "risk_level": "MEDIUM",
+        "required_specialists": [
+          "cloak",
+          "ponytail",
+          "overseer"
+        ],
+        "selected_patterns": [
+          "ROUTING",
+          "PLANNING",
+          "TOOL_REACT"
+        ],
+        "concurrency_mode": "SEQUENTIAL_MULTI_AGENT",
+        "human_gate_required": false
+      }
+    },
+    {
+      "id": "C16_PERSISTENCE_SECURITY_IMPLEMENT",
+      "prompt": "Implement database authorization constraints and validate them.",
+      "expected": {
+        "authority_domains": [
+          "PERSISTENCE",
+          "SECURITY",
+          "IMPLEMENTATION",
+          "VALIDATION"
+        ],
+        "primary_owner": "chronicler",
+        "execution_mode": "GOVERNED",
+        "risk_level": "HIGH",
+        "required_specialists": [
+          "the-tuner",
+          "chronicler",
+          "cipher",
+          "ponytail",
+          "overseer"
+        ],
+        "selected_patterns": [
+          "ROUTING",
+          "PLANNING",
+          "TOOL_REACT",
+          "MULTI_AGENT"
+        ],
+        "concurrency_mode": "SEQUENTIAL_MULTI_AGENT",
+        "human_gate_required": false
+      }
+    },
+    {
+      "id": "C17_PRODUCTION_WORD_FALSE_POSITIVE_GUARD",
+      "prompt": "Review the production roadmap documentation.",
+      "expected": {
+        "authority_domains": [
+          "DOCUMENTATION"
+        ],
+        "primary_owner": "scribe",
+        "execution_mode": "AUDIT",
+        "risk_level": "MEDIUM",
+        "required_specialists": [
+          "scribe"
+        ],
+        "selected_patterns": [
+          "ROUTING",
+          "TOOL_REACT"
+        ],
+        "concurrency_mode": "SINGLE_OWNER",
+        "human_gate_required": false
+      }
+    },
+    {
+      "id": "C18_SECURITY_UI_REVIEW_CROSS_DOMAIN",
+      "prompt": "Review the secure visual design for the checkout screen.",
+      "expected": {
+        "authority_domains": [
+          "SECURITY",
+          "UI_UX"
+        ],
+        "primary_owner": "cipher",
+        "execution_mode": "AUDIT",
+        "risk_level": "HIGH",
+        "required_specialists": [
+          "the-tuner",
+          "cipher",
+          "cloak"
+        ],
+        "selected_patterns": [
+          "ROUTING",
+          "PLANNING",
+          "TOOL_REACT",
+          "MULTI_AGENT"
+        ],
+        "concurrency_mode": "SEQUENTIAL_MULTI_AGENT",
+        "human_gate_required": false
+      }
+    }
+  ]
+}

--- a/tests/fixtures/agentic-workflow/awf-negative-routing.v1.json
+++ b/tests/fixtures/agentic-workflow/awf-negative-routing.v1.json
@@ -1,0 +1,441 @@
+{
+  "schema_version": "orchestra.awf-negative-routing.v1",
+  "purpose": "Adversarial negative-routing corpus that asserts forbidden specialist, pattern, mutation, validation, transition, and protected-action activations.",
+  "cases": [
+    {
+      "id": "N01_NEGATED_DEPLOY_MERGE_DOC_REVIEW",
+      "prompt": "Do not deploy or merge anything. Just review the README for clarity.",
+      "expect": {
+        "protected_action_required": false,
+        "mutation_required": false,
+        "human_gate_required": false,
+        "primary_owner": "scribe"
+      },
+      "avoid": {
+        "authority_domains": [
+          "TRANSITION"
+        ],
+        "specialists": [
+          "arbiter",
+          "ponytail",
+          "the-tuner"
+        ],
+        "patterns": [
+          "MULTI_AGENT"
+        ]
+      }
+    },
+    {
+      "id": "N02_DOCUMENT_PROHIBITED_FORCE_PUSH",
+      "prompt": "Update documentation to explain why force push and rewrite history are prohibited.",
+      "expect": {
+        "protected_action_required": false,
+        "human_gate_required": false,
+        "primary_owner": "scribe"
+      },
+      "avoid": {
+        "specialists": [
+          "arbiter",
+          "dagger",
+          "the-tuner"
+        ],
+        "patterns": [
+          "MULTI_AGENT"
+        ]
+      }
+    },
+    {
+      "id": "N03_HYPOTHETICAL_PRODUCTION_DEPLOY",
+      "prompt": "What would happen if we deploy this change to production?",
+      "expect": {
+        "protected_action_required": false,
+        "mutation_required": false,
+        "human_gate_required": false,
+        "primary_owner": "conductor"
+      },
+      "avoid": {
+        "authority_domains": [
+          "TRANSITION"
+        ],
+        "specialists": [
+          "arbiter",
+          "ponytail",
+          "dagger"
+        ]
+      }
+    },
+    {
+      "id": "N04_REMOVE_DEPLOY_WORD_FROM_README",
+      "prompt": "Remove the word deploy from the README only.",
+      "expect": {
+        "protected_action_required": false,
+        "human_gate_required": false,
+        "primary_owner": "scribe"
+      },
+      "avoid": {
+        "authority_domains": [
+          "TRANSITION"
+        ],
+        "specialists": [
+          "arbiter",
+          "the-tuner"
+        ],
+        "patterns": [
+          "MULTI_AGENT"
+        ]
+      }
+    },
+    {
+      "id": "N05_DOC_AUTHORIZATION_TERM_ONLY",
+      "prompt": "Update documentation only: rename the term authorization to access control.",
+      "expect": {
+        "protected_action_required": false,
+        "human_gate_required": false,
+        "primary_owner": "scribe"
+      },
+      "avoid": {
+        "authority_domains": [
+          "SECURITY"
+        ],
+        "specialists": [
+          "cipher",
+          "the-tuner"
+        ],
+        "patterns": [
+          "MULTI_AGENT"
+        ]
+      }
+    },
+    {
+      "id": "N06_SECURITY_MARKETING_COPY",
+      "prompt": "Review the README sentence 'secure and private by design' for wording only.",
+      "expect": {
+        "mutation_required": false,
+        "human_gate_required": false,
+        "primary_owner": "scribe"
+      },
+      "avoid": {
+        "authority_domains": [
+          "SECURITY",
+          "UI_UX"
+        ],
+        "specialists": [
+          "cipher",
+          "cloak",
+          "the-tuner"
+        ],
+        "patterns": [
+          "MULTI_AGENT"
+        ]
+      }
+    },
+    {
+      "id": "N07_DATABASE_TERM_IN_DOCUMENTATION_ONLY",
+      "prompt": "Update docs only to describe the database migration history without changing the database.",
+      "expect": {
+        "protected_action_required": false,
+        "human_gate_required": false,
+        "primary_owner": "scribe"
+      },
+      "avoid": {
+        "authority_domains": [
+          "PERSISTENCE"
+        ],
+        "specialists": [
+          "chronicler",
+          "the-tuner",
+          "ponytail"
+        ],
+        "patterns": [
+          "MULTI_AGENT"
+        ]
+      }
+    },
+    {
+      "id": "N08_UI_TERM_IN_ARCHITECTURE_DOC",
+      "prompt": "Document the existing frontend architecture. Do not redesign the UI or change code.",
+      "expect": {
+        "protected_action_required": false,
+        "mutation_required": true,
+        "human_gate_required": false,
+        "primary_owner": "scribe"
+      },
+      "avoid": {
+        "authority_domains": [
+          "UI_UX",
+          "IMPLEMENTATION"
+        ],
+        "specialists": [
+          "cloak",
+          "ponytail",
+          "the-tuner"
+        ],
+        "patterns": [
+          "MULTI_AGENT"
+        ]
+      }
+    },
+    {
+      "id": "N09_EXAMPLE_CHAOS_TEST_TEXT",
+      "prompt": "Add an example sentence to the docs: 'Run a chaos test in staging.' Do not execute it.",
+      "expect": {
+        "protected_action_required": false,
+        "human_gate_required": false,
+        "primary_owner": "scribe"
+      },
+      "avoid": {
+        "authority_domains": [
+          "ADVERSARIAL"
+        ],
+        "specialists": [
+          "dagger",
+          "the-tuner"
+        ],
+        "patterns": [
+          "MULTI_AGENT"
+        ]
+      }
+    },
+    {
+      "id": "N10_QUOTED_DROP_TABLE",
+      "prompt": "Explain in the README why 'drop table' is dangerous.",
+      "expect": {
+        "protected_action_required": false,
+        "human_gate_required": false,
+        "primary_owner": "scribe"
+      },
+      "avoid": {
+        "authority_domains": [
+          "PERSISTENCE"
+        ],
+        "specialists": [
+          "chronicler",
+          "dagger",
+          "arbiter"
+        ],
+        "patterns": [
+          "MULTI_AGENT"
+        ]
+      }
+    },
+    {
+      "id": "N11_RELEASE_NOTES_NOT_RELEASE",
+      "prompt": "Write release notes for the upcoming version. Do not publish or release anything.",
+      "expect": {
+        "protected_action_required": false,
+        "human_gate_required": false,
+        "primary_owner": "scribe"
+      },
+      "avoid": {
+        "authority_domains": [
+          "TRANSITION"
+        ],
+        "specialists": [
+          "arbiter",
+          "the-tuner"
+        ],
+        "patterns": [
+          "MULTI_AGENT"
+        ]
+      }
+    },
+    {
+      "id": "N12_REVIEW_DEPLOYMENT_DOCS_ONLY",
+      "prompt": "Review deployment documentation only. No deployment or production changes.",
+      "expect": {
+        "protected_action_required": false,
+        "mutation_required": false,
+        "human_gate_required": false,
+        "primary_owner": "scribe"
+      },
+      "avoid": {
+        "authority_domains": [
+          "TRANSITION"
+        ],
+        "specialists": [
+          "arbiter",
+          "ponytail",
+          "the-tuner"
+        ],
+        "patterns": [
+          "MULTI_AGENT"
+        ]
+      }
+    },
+    {
+      "id": "N13_SECURITY_INCIDENT_SUMMARY_ONLY",
+      "prompt": "Summarize the security incident report without assessing controls or changing anything.",
+      "expect": {
+        "mutation_required": false,
+        "human_gate_required": false,
+        "primary_owner": "scribe"
+      },
+      "avoid": {
+        "authority_domains": [
+          "SECURITY"
+        ],
+        "specialists": [
+          "cipher",
+          "the-tuner"
+        ],
+        "patterns": [
+          "MULTI_AGENT"
+        ]
+      }
+    },
+    {
+      "id": "N14_CODE_WORD_FIX_IN_DOCS",
+      "prompt": "Fix the typo 'authentication' in the documentation only.",
+      "expect": {
+        "protected_action_required": false,
+        "human_gate_required": false,
+        "primary_owner": "scribe"
+      },
+      "avoid": {
+        "authority_domains": [
+          "SECURITY",
+          "IMPLEMENTATION"
+        ],
+        "specialists": [
+          "cipher",
+          "ponytail",
+          "the-tuner"
+        ],
+        "patterns": [
+          "MULTI_AGENT"
+        ]
+      }
+    },
+    {
+      "id": "N15_ARCHITECTURE_WORD_IN_CHANGELOG",
+      "prompt": "Update the changelog entry that mentions architecture. Do not refactor anything.",
+      "expect": {
+        "protected_action_required": false,
+        "human_gate_required": false,
+        "primary_owner": "scribe"
+      },
+      "avoid": {
+        "authority_domains": [
+          "ARCHITECTURE",
+          "IMPLEMENTATION"
+        ],
+        "specialists": [
+          "clockwork",
+          "ponytail",
+          "the-tuner"
+        ],
+        "patterns": [
+          "MULTI_AGENT"
+        ]
+      }
+    },
+    {
+      "id": "N16_PRODUCTION_ROADMAP_FALSE_POSITIVE",
+      "prompt": "Review the production roadmap documentation.",
+      "expect": {
+        "protected_action_required": false,
+        "human_gate_required": false,
+        "primary_owner": "scribe"
+      },
+      "avoid": {
+        "authority_domains": [
+          "TRANSITION"
+        ],
+        "specialists": [
+          "arbiter",
+          "ponytail",
+          "dagger"
+        ]
+      }
+    },
+    {
+      "id": "N17_DO_NOT_RUN_TESTS",
+      "prompt": "Do not run tests. Review the test suite documentation for clarity.",
+      "expect": {
+        "validation_required": false,
+        "mutation_required": false,
+        "human_gate_required": false,
+        "primary_owner": "scribe"
+      },
+      "avoid": {
+        "authority_domains": [
+          "VALIDATION"
+        ],
+        "specialists": [
+          "overseer",
+          "ponytail",
+          "the-tuner"
+        ]
+      }
+    },
+    {
+      "id": "N18_PERMISSION_TEXT_LABEL",
+      "prompt": "Change the documentation label from permission to access level. Documentation only.",
+      "expect": {
+        "protected_action_required": false,
+        "human_gate_required": false,
+        "primary_owner": "scribe"
+      },
+      "avoid": {
+        "authority_domains": [
+          "SECURITY"
+        ],
+        "specialists": [
+          "cipher",
+          "the-tuner"
+        ],
+        "patterns": [
+          "MULTI_AGENT"
+        ]
+      }
+    },
+    {
+      "id": "N19_DATABASE_SCREENSHOT_CAPTION",
+      "prompt": "Update the screenshot caption that says database schema. Do not change the database or UI.",
+      "expect": {
+        "protected_action_required": false,
+        "human_gate_required": false,
+        "primary_owner": "conductor"
+      },
+      "avoid": {
+        "authority_domains": [
+          "PERSISTENCE",
+          "UI_UX",
+          "IMPLEMENTATION"
+        ],
+        "specialists": [
+          "chronicler",
+          "cloak",
+          "ponytail",
+          "the-tuner"
+        ],
+        "patterns": [
+          "MULTI_AGENT"
+        ]
+      }
+    },
+    {
+      "id": "N20_PLAN_DEPLOYMENT_NOT_EXECUTE",
+      "prompt": "Create a plan for a future deployment, but do not deploy, merge, release, or publish anything.",
+      "expect": {
+        "protected_action_required": false,
+        "mutation_required": false,
+        "human_gate_required": false,
+        "primary_owner": "conductor"
+      },
+      "avoid": {
+        "authority_domains": [
+          "TRANSITION"
+        ],
+        "specialists": [
+          "arbiter",
+          "ponytail",
+          "dagger"
+        ],
+        "patterns": [
+          "MULTI_AGENT"
+        ]
+      }
+    }
+  ]
+}

--- a/tests/fixtures/agentic-workflow/awf-negative-routing.v1.json
+++ b/tests/fixtures/agentic-workflow/awf-negative-routing.v1.json
@@ -395,7 +395,7 @@
       "expect": {
         "protected_action_required": false,
         "human_gate_required": false,
-        "primary_owner": "conductor"
+        "primary_owner": "scribe"
       },
       "avoid": {
         "authority_domains": [

--- a/tests/runtime/test_agentic_workflow_intake.py
+++ b/tests/runtime/test_agentic_workflow_intake.py
@@ -156,7 +156,7 @@ def test_host_constraints_can_escalate_but_not_downgrade_mode_or_risk():
     contracts = load_agentic_workflow_contracts(ROOT)
     base = derive_task_profile(
         prompt="Implement secure authentication.",
-        metadata={"execution_mode": "FAST", "risk_level": "LOW"},
+        metadata={"agentic_execution_mode": "FAST", "agentic_risk_level": "LOW"},
         current_source_identity="main@test",
         policy=contracts["derivation_policy"],
     )
@@ -165,7 +165,7 @@ def test_host_constraints_can_escalate_but_not_downgrade_mode_or_risk():
 
     escalated = derive_task_profile(
         prompt="Review this responsive screen.",
-        metadata={"execution_mode": "GOVERNED", "risk_level": "HIGH"},
+        metadata={"agentic_execution_mode": "GOVERNED", "agentic_risk_level": "HIGH"},
         current_source_identity="main@test",
         policy=contracts["derivation_policy"],
     )

--- a/tests/runtime/test_agentic_workflow_intake.py
+++ b/tests/runtime/test_agentic_workflow_intake.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from orchestra_runtime.application.use_cases.agentic_workflow import (
+    plan_agentic_workflow_from_intake,
+)
+from orchestra_runtime.domain.adaptive import derive_task_profile
+from orchestra_runtime.infrastructure.machine.agentic_workflow import (
+    load_agentic_workflow_contracts,
+)
+from orchestra_runtime.infrastructure.machine.execution_efficiency import (
+    load_execution_budget_contract,
+)
+from orchestra_runtime.machine_contracts import load_specialist_registry
+from orchestra_runtime.models import Command, ContextPackage
+from orchestra_runtime.repositories import ManifestRepository, SkillSourceRepository
+from orchestra_runtime.services import RouterService, SkillRegistry
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMAS = ROOT / "machine" / "schemas"
+
+
+def _router() -> RouterService:
+    registry = SkillRegistry(ManifestRepository(ROOT), SkillSourceRepository(ROOT))
+    return RouterService(registry)
+
+
+def _context(prompt: str, metadata: dict | None = None) -> ContextPackage:
+    return ContextPackage(
+        adapter_name="test",
+        prompt=prompt,
+        project_root=ROOT,
+        available_commands=("conductor", "cloak", "cipher", "ponytail", "overseer", "arbiter"),
+        manifest_version="test",
+        metadata=dict(metadata or {}),
+    )
+
+
+def _route(prompt: str, metadata: dict | None = None):
+    return _router().route(
+        Command("conductor", prompt, "test"),
+        _context(prompt, metadata),
+    )
+
+
+def test_n3_t1_single_owner_ui_review_derives_cloak_without_fanout():
+    prompt = "Review this responsive checkout screen for accessibility and layout issues."
+    decision = _route(prompt)
+
+    task = decision.metadata["agentic_task_profile"]
+    profile = decision.metadata["agentic_workflow_profile"]
+    trace = decision.metadata["agentic_selection_trace"]
+
+    assert decision.metadata["agentic_task_profile_source"] == "DERIVED_INTAKE"
+    assert task["authority_domains"] == ["UI_UX"]
+    assert task["primary_owner"] == "cloak"
+    assert task["execution_mode"] == "AUDIT"
+    assert task["mutation_required"] is False
+    assert task["implementation_required"] is False
+
+    assert profile["required_specialists"] == ["cloak"]
+    assert profile["selected_patterns"] == ["ROUTING", "TOOL_REACT"]
+    assert profile["concurrency_mode"] == "SINGLE_OWNER"
+    assert profile["human_gate_required"] is False
+    assert "MULTI_AGENT" in trace["rejected_patterns"]
+    assert trace["authority_rule"] == "WORKFLOW_TOPOLOGY_CHANGE != AUTHORITY_EXPANSION"
+
+
+def test_n3_t2_multi_domain_implementation_composes_serial_oee_topology():
+    prompt = (
+        "Implement a responsive checkout flow with secure payment authorization "
+        "and validate the change."
+    )
+    decision = _route(prompt)
+
+    task = decision.metadata["agentic_task_profile"]
+    profile = decision.metadata["agentic_workflow_profile"]
+    telemetry = decision.metadata["agentic_workflow_telemetry"]
+    trace = decision.metadata["agentic_selection_trace"]
+
+    assert task["authority_domains"] == [
+        "UI_UX",
+        "SECURITY",
+        "IMPLEMENTATION",
+        "VALIDATION",
+    ]
+    assert task["primary_owner"] == "cloak"
+    assert task["execution_mode"] == "GOVERNED"
+    assert task["risk_level"] == "HIGH"
+    assert task["dependency_depth"] == 2
+    assert task["independent_subtasks"] == 2
+
+    assert profile["required_specialists"] == [
+        "the-tuner",
+        "cloak",
+        "cipher",
+        "ponytail",
+        "overseer",
+    ]
+    assert profile["selected_patterns"] == [
+        "ROUTING",
+        "PLANNING",
+        "TOOL_REACT",
+        "MULTI_AGENT",
+    ]
+    assert profile["concurrency_mode"] == "SEQUENTIAL_MULTI_AGENT"
+    assert profile["parallel_groups"] == []
+    assert telemetry["max_parallel_specialists"] == 1
+    assert telemetry["parallel_specialist_peak"] == 1
+    assert profile["human_gate_required"] is False
+    assert "PATTERN_SELECTED:MULTI_AGENT" in trace["selection_reasons"]
+
+
+def test_n3_t3_protected_production_action_requires_gate_without_inferred_authority():
+    prompt = "Deploy the checkout change to production."
+    decision = _route(prompt)
+
+    task = decision.metadata["agentic_task_profile"]
+    profile = decision.metadata["agentic_workflow_profile"]
+    trace = decision.metadata["agentic_selection_trace"]
+
+    assert task["authority_domains"] == ["TRANSITION"]
+    assert task["primary_owner"] == "arbiter"
+    assert task["execution_mode"] == "DESTRUCTIVE"
+    assert task["risk_level"] == "CRITICAL"
+    assert task["protected_action_required"] is True
+    assert task["protected_action_authorized"] is False
+
+    assert profile["required_specialists"] == ["arbiter"]
+    assert profile["human_gate_required"] is True
+    assert profile["escalation_reasons"] == [
+        "PROTECTED_ACTION_REQUIRES_INDEPENDENT_AUTHORITY"
+    ]
+    assert "PROTECTED_ACTION_AUTHORITY_NOT_INFERRED" in trace["derivation_reasons"]
+    assert "HUMAN_GATE_FROM_UNDERLYING_BOUNDARY" in trace["selection_reasons"]
+
+
+def test_unknown_semantics_fail_to_conductor_instead_of_guessing_domain_owner():
+    prompt = "Consider the options."
+    decision = _route(prompt)
+    task = decision.metadata["agentic_task_profile"]
+    profile = decision.metadata["agentic_workflow_profile"]
+
+    assert task["authority_domains"] == ["ROUTING"]
+    assert task["primary_owner"] == "conductor"
+    assert profile["required_specialists"] == ["conductor"]
+    assert profile["selected_patterns"] == ["ROUTING"]
+
+
+def test_host_constraints_can_escalate_but_not_downgrade_mode_or_risk():
+    contracts = load_agentic_workflow_contracts(ROOT)
+    base = derive_task_profile(
+        prompt="Implement secure authentication.",
+        metadata={"execution_mode": "FAST", "risk_level": "LOW"},
+        current_source_identity="main@test",
+        policy=contracts["derivation_policy"],
+    )
+    assert base.task_profile.execution_mode == "GOVERNED"
+    assert base.task_profile.risk_level == "HIGH"
+
+    escalated = derive_task_profile(
+        prompt="Review this responsive screen.",
+        metadata={"execution_mode": "GOVERNED", "risk_level": "HIGH"},
+        current_source_identity="main@test",
+        policy=contracts["derivation_policy"],
+    )
+    assert escalated.task_profile.execution_mode == "AUDIT"
+    assert escalated.task_profile.risk_level == "HIGH"
+
+
+def test_protected_authorization_must_come_from_explicit_context_not_keyword_inference():
+    contracts = load_agentic_workflow_contracts(ROOT)
+    derived = derive_task_profile(
+        prompt="Merge the approved pull request.",
+        metadata={"protected_action_authorized": True},
+        current_source_identity="main@test",
+        policy=contracts["derivation_policy"],
+    )
+    assert derived.task_profile.protected_action_required is True
+    assert derived.task_profile.protected_action_authorized is True
+
+    with pytest.raises(ValueError, match="requires a protected action signal"):
+        derive_task_profile(
+            prompt="Review this responsive screen.",
+            metadata={"protected_action_authorized": True},
+            current_source_identity="main@test",
+            policy=contracts["derivation_policy"],
+        )
+
+
+def test_router_can_disable_auto_derivation_without_disabling_explicit_structured_profile():
+    prompt = "Review this responsive screen."
+    disabled = _route(prompt, {"agentic_workflow_auto": False})
+    assert "agentic_workflow_profile" not in disabled.metadata
+
+    with pytest.raises(ValueError, match="exact boolean"):
+        _route(prompt, {"agentic_workflow_auto": "false"})
+
+
+def test_intake_plan_and_trace_validate_against_machine_schemas():
+    contracts = load_agentic_workflow_contracts(ROOT)
+    result = plan_agentic_workflow_from_intake(
+        prompt="Implement a responsive checkout flow and validate it.",
+        metadata={},
+        current_source_identity="main@test",
+        derivation_policy=contracts["derivation_policy"],
+        specialist_authority_view=contracts["authority_view"],
+        specialist_registry=load_specialist_registry(ROOT),
+        execution_budget=load_execution_budget_contract(ROOT),
+    )
+
+    policy_schema = json.loads(
+        (SCHEMAS / "task-profile-derivation.v1.schema.json").read_text(encoding="utf-8")
+    )
+    trace_schema = json.loads(
+        (SCHEMAS / "agentic-selection-trace.v1.schema.json").read_text(encoding="utf-8")
+    )
+    task_schema = json.loads(
+        (SCHEMAS / "task-profile.v1.schema.json").read_text(encoding="utf-8")
+    )
+
+    Draft202012Validator(policy_schema).validate(contracts["derivation_policy"])
+    Draft202012Validator(task_schema).validate(result["task_profile"])
+    Draft202012Validator(trace_schema).validate(result["selection_trace"])

--- a/tests/runtime/test_agentic_workflow_intake_calibration.py
+++ b/tests/runtime/test_agentic_workflow_intake_calibration.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from orchestra_runtime.models import Command, ContextPackage
+from orchestra_runtime.repositories import ManifestRepository, SkillSourceRepository
+from orchestra_runtime.services import RouterService, SkillRegistry
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE = ROOT / "tests" / "fixtures" / "agentic-workflow" / "awf-intake-calibration.v1.json"
+
+
+def _router() -> RouterService:
+    registry = SkillRegistry(ManifestRepository(ROOT), SkillSourceRepository(ROOT))
+    return RouterService(registry)
+
+
+def _context(prompt: str) -> ContextPackage:
+    return ContextPackage(
+        adapter_name="calibration",
+        prompt=prompt,
+        project_root=ROOT,
+        available_commands=(
+            "conductor",
+            "the-steward",
+            "the-governor",
+            "arbiter",
+            "overseer",
+            "the-tuner",
+            "cipher",
+            "cloak",
+            "dagger",
+            "chronicler",
+            "weaver",
+            "scribe",
+            "clockwork",
+            "ponytail",
+        ),
+        manifest_version="calibration",
+        metadata={},
+    )
+
+
+def test_awf_higher_calibration_corpus_matches_expected_topology():
+    suite = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    assert suite["schema_version"] == "orchestra.awf-intake-calibration.v1"
+    assert len(suite["cases"]) >= 15
+
+    router = _router()
+    for case in suite["cases"]:
+        prompt = case["prompt"]
+        decision = router.route(
+            Command("conductor", prompt, "calibration"),
+            _context(prompt),
+        )
+        task = decision.metadata["agentic_task_profile"]
+        profile = decision.metadata["agentic_workflow_profile"]
+        trace = decision.metadata["agentic_selection_trace"]
+        telemetry = decision.metadata["agentic_workflow_telemetry"]
+        expected = case["expected"]
+
+        for key in ("authority_domains", "primary_owner", "execution_mode", "risk_level"):
+            assert task[key] == expected[key], f"{case['id']} task mismatch: {key}"
+
+        for key in (
+            "required_specialists",
+            "selected_patterns",
+            "concurrency_mode",
+            "human_gate_required",
+        ):
+            assert profile[key] == expected[key], f"{case['id']} profile mismatch: {key}"
+
+        assert profile["max_parallel_specialists"] == suite["invariants"]["max_parallel_specialists"]
+        assert profile["parallel_groups"] == []
+        assert profile["topology_change_requires_human_approval"] is suite["invariants"]["topology_change_requires_human_approval"]
+        assert profile["authority_expansion"] is suite["invariants"]["authority_expansion"]
+        assert trace["selected_specialists"] == expected["required_specialists"]
+        assert trace["selected_patterns"] == expected["selected_patterns"]
+        assert trace["human_gate_required"] is expected["human_gate_required"]
+        assert telemetry["max_parallel_specialists"] == 1

--- a/tests/runtime/test_agentic_workflow_intake_edges.py
+++ b/tests/runtime/test_agentic_workflow_intake_edges.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from orchestra_runtime.domain.adaptive import build_selection_trace, derive_task_profile
+from orchestra_runtime.domain.adaptive import intake as intake_module
+from orchestra_runtime.domain.adaptive.topology_validator import AgenticWorkflowProfile
+from orchestra_runtime.infrastructure.machine.agentic_workflow import (
+    load_agentic_workflow_contracts,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _policy():
+    return deepcopy(load_agentic_workflow_contracts(ROOT)["derivation_policy"])
+
+
+def test_intake_prompt_and_signal_helpers_fail_closed():
+    with pytest.raises(TypeError, match="prompt must be a string"):
+        intake_module._clean_prompt(None)
+    with pytest.raises(ValueError, match="non-empty"):
+        intake_module._clean_prompt("   ")
+    with pytest.raises(ValueError, match="4096"):
+        intake_module._clean_prompt("x" * 4097)
+    with pytest.raises(ValueError, match="signals must be non-empty"):
+        intake_module._signal_position("prompt", " ")
+
+
+@pytest.mark.parametrize("value", [1, "true", []])
+def test_exact_boolean_hint_rejects_non_boolean(value):
+    with pytest.raises(TypeError, match="exact boolean"):
+        intake_module._exact_bool_or_default(value, False, "flag")
+
+
+@pytest.mark.parametrize("value", [True, "1", -1, 65])
+def test_bounded_int_hint_rejects_invalid_values(value):
+    with pytest.raises((TypeError, ValueError)):
+        intake_module._bounded_nonnegative_int(value, 0, "count")
+
+
+def test_string_list_hint_rejects_wrong_shape_duplicates_empty_and_excess():
+    with pytest.raises(TypeError, match="list or tuple"):
+        intake_module._string_list("x", "items", maximum=2)
+    with pytest.raises(ValueError, match="unique"):
+        intake_module._string_list(["x", "x"], "items", maximum=2)
+    with pytest.raises(ValueError, match="unique"):
+        intake_module._string_list([""], "items", maximum=2)
+    with pytest.raises(ValueError, match="unique"):
+        intake_module._string_list(["a", "b", "c"], "items", maximum=2)
+
+
+@pytest.mark.parametrize(
+    ("mutator", "match"),
+    [
+        (lambda p: "not-a-mapping", "mapping"),
+        (lambda p: {**p, "schema_version": "wrong"}, "schema"),
+        (lambda p: {**p, "owner": "ponytail"}, "owner"),
+        (lambda p: {**p, "default_execution_mode": "UNKNOWN"}, "execution mode"),
+        (lambda p: {**p, "default_risk_level": "UNKNOWN"}, "risk level"),
+        (lambda p: {**p, "domain_rules": []}, "domain_rules"),
+        (lambda p: {**p, "domain_rules": ["bad"]}, "domain rule"),
+        (
+            lambda p: {
+                **p,
+                "domain_rules": [
+                    *p["domain_rules"],
+                    deepcopy(p["domain_rules"][0]),
+                ],
+            },
+            "domain rule set",
+        ),
+        (
+            lambda p: {
+                **p,
+                "domain_rules": [
+                    {**p["domain_rules"][0], "signals": []},
+                    *p["domain_rules"][1:],
+                ],
+            },
+            "domain signals",
+        ),
+        (lambda p: {**p, "operation_signals": []}, "operation_signals"),
+        (
+            lambda p: {
+                **p,
+                "operation_signals": {
+                    key: value
+                    for key, value in p["operation_signals"].items()
+                    if key != "parallel"
+                },
+            },
+            "signal set",
+        ),
+        (
+            lambda p: {
+                **p,
+                "operation_signals": {
+                    **p["operation_signals"],
+                    "parallel": [],
+                },
+            },
+            "operation signals",
+        ),
+        (lambda p: {**p, "governed_domains": []}, "governed_domains"),
+        (lambda p: {**p, "governed_domains": ["UNKNOWN"]}, "governed_domains"),
+    ],
+)
+def test_derivation_policy_rejection_matrix(mutator, match):
+    base = _policy()
+    value = mutator(base)
+    with pytest.raises((TypeError, ValueError), match=match):
+        intake_module.validate_derivation_policy(value)
+
+
+def test_derivation_rejects_invalid_metadata_source_domain_and_owner():
+    policy = _policy()
+    with pytest.raises(TypeError, match="metadata must be a mapping"):
+        derive_task_profile(
+            prompt="Review responsive screen.",
+            metadata=[],
+            current_source_identity="main@test",
+            policy=policy,
+        )
+    with pytest.raises(ValueError, match="source_identity"):
+        derive_task_profile(
+            prompt="Review responsive screen.",
+            metadata={},
+            current_source_identity="",
+            policy=policy,
+        )
+    with pytest.raises(ValueError, match="unknown authority domain"):
+        derive_task_profile(
+            prompt="Review responsive screen.",
+            metadata={"agentic_authority_domains": ["UNKNOWN"]},
+            current_source_identity="main@test",
+            policy=policy,
+        )
+    with pytest.raises(ValueError, match="canonical specialist owner"):
+        derive_task_profile(
+            prompt="Review responsive screen.",
+            metadata={"agentic_primary_owner": "unknown"},
+            current_source_identity="main@test",
+            policy=policy,
+        )
+
+
+def test_explicit_domain_owner_and_overrides_are_preserved_without_authority_creation():
+    policy = _policy()
+    result = derive_task_profile(
+        prompt="Review responsive screen.",
+        metadata={
+            "agentic_authority_domains": ["SECURITY"],
+            "agentic_primary_owner": "cloak",
+            "dependency_depth": 3,
+            "independent_subtasks": 2,
+            "parallelizable": True,
+            "external_state_required": False,
+            "objective_verifier_available": True,
+            "reentry_specialists": ["cipher"],
+            "human_gate_requirements": ["EXISTING_GATE"],
+            "agentic_task_id": "explicit-task",
+            "agentic_goal": "Explicit goal",
+        },
+        current_source_identity="main@test",
+        policy=policy,
+    )
+    task = result.task_profile
+    assert task.authority_domains == ("UI_UX", "SECURITY")
+    assert task.primary_owner == "cloak"
+    assert task.dependency_depth == 3
+    assert task.independent_subtasks == 2
+    assert task.parallelizable is True
+    assert task.external_state_required is False
+    assert task.objective_verifier_available is True
+    assert task.reentry_specialists == ("cipher",)
+    assert task.human_gate_requirements == ("EXISTING_GATE",)
+    assert task.task_id == "explicit-task"
+    assert task.goal == "Explicit goal"
+    assert "EXPLICIT_AUTHORITY_DOMAINS_PRESERVED" in result.derivation_reasons
+
+
+def test_critic_hints_must_be_paired():
+    policy = _policy()
+    with pytest.raises(ValueError, match="supplied together"):
+        derive_task_profile(
+            prompt="Review responsive screen.",
+            metadata={"critic_owner": "overseer"},
+            current_source_identity="main@test",
+            policy=policy,
+        )
+
+
+def test_host_native_execution_mode_is_ignored_while_canonical_risk_mode_can_escalate():
+    policy = _policy()
+    host_native = derive_task_profile(
+        prompt="Implement responsive UI.",
+        metadata={"execution_mode": "HOST_NATIVE"},
+        current_source_identity="main@test",
+        policy=policy,
+    )
+    assert host_native.task_profile.execution_mode == "STANDARD"
+
+    escalated = derive_task_profile(
+        prompt="Fix typo.",
+        metadata={"risk_mode": "GOVERNED"},
+        current_source_identity="main@test",
+        policy=policy,
+    )
+    assert escalated.task_profile.execution_mode == "GOVERNED"
+
+
+def test_invalid_namespaced_mode_and_risk_hints_fail_closed():
+    policy = _policy()
+    with pytest.raises(ValueError, match="agentic_execution_mode"):
+        derive_task_profile(
+            prompt="Fix typo.",
+            metadata={"agentic_execution_mode": "UNKNOWN"},
+            current_source_identity="main@test",
+            policy=policy,
+        )
+    with pytest.raises(ValueError, match="agentic_risk_level"):
+        derive_task_profile(
+            prompt="Fix typo.",
+            metadata={"agentic_risk_level": "UNKNOWN"},
+            current_source_identity="main@test",
+            policy=policy,
+        )
+
+
+def test_parallel_signal_is_recorded_but_does_not_change_oee_authority():
+    result = derive_task_profile(
+        prompt="Analyze UI and security in parallel.",
+        metadata={},
+        current_source_identity="main@test",
+        policy=_policy(),
+    )
+    assert result.task_profile.parallelizable is True
+    assert result.task_profile.authority_domains == ("UI_UX", "SECURITY")
+
+
+def test_selection_trace_rejects_unknown_source():
+    task = derive_task_profile(
+        prompt="Review responsive screen.",
+        metadata={},
+        current_source_identity="main@test",
+        policy=_policy(),
+    ).task_profile
+    profile = AgenticWorkflowProfile(
+        profile_id="profile.trace",
+        source_task_id=task.task_id,
+        primary_owner="cloak",
+        required_specialists=("cloak",),
+        selected_patterns=("ROUTING",),
+        sequence=("cloak",),
+        parallel_groups=(),
+        concurrency_mode="SINGLE_OWNER",
+        max_parallel_specialists=1,
+        human_gate_required=False,
+        escalation_reasons=(),
+        stop_conditions=("OBJECTIVE_PASS",),
+        critic_contract_id=None,
+    )
+    with pytest.raises(ValueError, match="source is invalid"):
+        build_selection_trace(task=task, profile=profile, source="UNKNOWN")

--- a/tests/runtime/test_agentic_workflow_intake_edges.py
+++ b/tests/runtime/test_agentic_workflow_intake_edges.py
@@ -266,3 +266,59 @@ def test_selection_trace_rejects_unknown_source():
     )
     with pytest.raises(ValueError, match="source is invalid"):
         build_selection_trace(task=task, profile=profile, source="UNKNOWN")
+
+
+def test_negative_routing_suppression_primitives():
+    policy = _policy()
+
+    negated = derive_task_profile(
+        prompt="Do not deploy or merge anything. Review the README.",
+        metadata={},
+        current_source_identity="main@test",
+        policy=policy,
+    )
+    assert negated.task_profile.protected_action_required is False
+    assert negated.task_profile.transition_required is False
+    assert negated.task_profile.primary_owner == "scribe"
+    assert any(
+        reason.startswith("NEGATIVE_ROUTING_SIGNALS_SUPPRESSED:")
+        for reason in negated.derivation_reasons
+    )
+
+    hypothetical = derive_task_profile(
+        prompt="What would happen if we deploy this change to production?",
+        metadata={},
+        current_source_identity="main@test",
+        policy=policy,
+    )
+    assert hypothetical.task_profile.authority_domains == ("ROUTING",)
+    assert hypothetical.task_profile.protected_action_required is False
+    assert hypothetical.task_profile.mutation_required is False
+
+    quoted = derive_task_profile(
+        prompt="Explain in the README why 'drop table' is dangerous.",
+        metadata={},
+        current_source_identity="main@test",
+        policy=policy,
+    )
+    assert quoted.task_profile.authority_domains == ("DOCUMENTATION",)
+    assert quoted.task_profile.protected_action_required is False
+    assert "REPRESENTATION_ONLY_CONTEXT_SUPPRESSED_DOMAIN_EXECUTION" in quoted.derivation_reasons
+
+
+def test_derivation_policy_rejects_missing_or_malformed_suppression_rules():
+    policy = _policy()
+    missing = deepcopy(policy)
+    missing.pop("suppression_rules")
+    with pytest.raises(TypeError, match="suppression_rules"):
+        intake_module.validate_derivation_policy(missing)
+
+    changed = deepcopy(policy)
+    changed["suppression_rules"].pop("hypothetical_prefixes")
+    with pytest.raises(ValueError, match="suppression rule set"):
+        intake_module.validate_derivation_policy(changed)
+
+    empty = deepcopy(policy)
+    empty["suppression_rules"]["negation_phrases"] = []
+    with pytest.raises(ValueError, match="suppression rules are invalid"):
+        intake_module.validate_derivation_policy(empty)

--- a/tests/runtime/test_agentic_workflow_negative_routing.py
+++ b/tests/runtime/test_agentic_workflow_negative_routing.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from orchestra_runtime.models import Command, ContextPackage
+from orchestra_runtime.repositories import ManifestRepository, SkillSourceRepository
+from orchestra_runtime.services import RouterService, SkillRegistry
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE = ROOT / "tests" / "fixtures" / "agentic-workflow" / "awf-negative-routing.v1.json"
+
+
+def _router() -> RouterService:
+    registry = SkillRegistry(ManifestRepository(ROOT), SkillSourceRepository(ROOT))
+    return RouterService(registry)
+
+
+def _context(prompt: str) -> ContextPackage:
+    return ContextPackage(
+        adapter_name="negative-calibration",
+        prompt=prompt,
+        project_root=ROOT,
+        available_commands=(
+            "conductor",
+            "the-steward",
+            "the-governor",
+            "arbiter",
+            "overseer",
+            "the-tuner",
+            "cipher",
+            "cloak",
+            "dagger",
+            "chronicler",
+            "weaver",
+            "scribe",
+            "clockwork",
+            "ponytail",
+        ),
+        manifest_version="negative-calibration",
+        metadata={},
+    )
+
+
+def test_awf_negative_routing_corpus_avoids_false_activation():
+    suite = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    assert suite["schema_version"] == "orchestra.awf-negative-routing.v1"
+    assert len(suite["cases"]) >= 20
+
+    router = _router()
+    for case in suite["cases"]:
+        prompt = case["prompt"]
+        decision = router.route(
+            Command("conductor", prompt, "negative-calibration"),
+            _context(prompt),
+        )
+        task = decision.metadata["agentic_task_profile"]
+        profile = decision.metadata["agentic_workflow_profile"]
+        expected = case["expect"]
+        avoid = case["avoid"]
+
+        for key, value in expected.items():
+            actual = profile[key] if key in profile else task[key]
+            assert actual == value, f"{case['id']} expected {key}={value!r}, got {actual!r}"
+
+        for domain in avoid.get("authority_domains", []):
+            assert domain not in task["authority_domains"], (
+                f"{case['id']} falsely activated authority domain {domain}: {task['authority_domains']}"
+            )
+
+        for specialist in avoid.get("specialists", []):
+            assert specialist not in profile["required_specialists"], (
+                f"{case['id']} falsely selected specialist {specialist}: "
+                f"{profile['required_specialists']}"
+            )
+
+        for pattern in avoid.get("patterns", []):
+            assert pattern not in profile["selected_patterns"], (
+                f"{case['id']} falsely selected pattern {pattern}: {profile['selected_patterns']}"
+            )
+
+        assert profile["max_parallel_specialists"] == 1
+        assert profile["authority_expansion"] is False
+        assert profile["topology_change_requires_human_approval"] is False


### PR DESCRIPTION
## Summary

Continue Orchestra AWF after canonical PR #800 with AWF-C0 plus the first bounded N1-N3 increment.

Canonical baseline:
- Orchestra main: `7f1e1962817b1b363fbcb1629902d69d50f1daa6`
- AWF source PR #800
- qualified AWF source head: `7040618b4faf6998fd88d6bc984677fc42764da4`
- Padayon AWF architecture baseline: `b4b59d04ea37c4f23bb6a54e7d217bd3037eb6ab`

## AWF-C0

Reconcile the stale implementation record from candidate/pending state to AWF-I0 through AWF-I10 complete canonical verified after PR #800 merge.

## AWF-N1: automatic TaskProfile derivation

- Add machine-configured deterministic Conductor intake policy.
- Derive TaskProfile from ordinary request text plus explicit host context when no structured profile is supplied.
- Preserve explicit structured TaskProfile support.
- Unknown domains fail to Conductor routing instead of guessing a specialist.
- Explicit mode/risk constraints can preserve or escalate derived constraints, not downgrade them.
- Protected-action authorization is never inferred from prompt text.
- Automatic derivation can be explicitly disabled with exact boolean `agentic_workflow_auto=false`.
- Cache AWF machine contracts lazily at the RouterService boundary to avoid loading them on unrelated direct-specialist routes.

## AWF-N2: explainable selection trace

Add `orchestra.agentic-selection-trace.v1` with:
- deterministic matched signals
- derivation reason codes
- selected specialists
- selected patterns
- rejected patterns with bounded reasons
- underlying human-gate reasons
- authority invariant

The trace is decision evidence, not private model reasoning.

## AWF-N3/N4: higher controlled calibration

The RouterService-level calibration corpus now contains 18 scenarios:

1. single-owner UI review
2. security audit
3. persistence implementation + validation
4. architecture refactor + validation
5. documentation mutation
6. diagram creation
7. business-scope review
8. legal/compliance review
9. ambiguous fallback
10. parallel UI/security analysis
11. protected merge
12. production deployment
13. force-push/history rewrite
14. gated Dagger chaos work
15. single-domain UI implementation + validation
16. persistence/security cross-domain implementation
17. generic `production` false-positive guard
18. cross-domain security/UI review

Calibration also enforces:

`TERMINAL_EXECUTION_ROLE != DISTINCT_DOMAIN_DECISION_AUTHORITY`

Ponytail, Overseer, and Arbiter do not activate The Tuner or Multi-Agent merely because implementation, validation, or transition stages are required. Those patterns require distinct domain-decision owners, re-entry, or independent-subtask evidence.

The expanded runtime suite passes with 95.80% branch coverage and 98.37% statement coverage on source head `cc9bab9003d72770d2c31465d3b4485b7475132d`.

## Negative routing calibration

A separate 20-case adversarial corpus now verifies what Orchestra must **not** activate when dangerous or cross-domain terminology is merely negated, quoted, hypothetical, or scoped to representation work.

Covered negative cases include:

- `do not deploy or merge`
- documentation explaining `force push` / `rewrite history`
- hypothetical production deployment
- removing the literal word `deploy` from README text
- documentation-only authorization/security/database/UI terminology
- quoted chaos-test and `drop table` examples
- release notes without release execution
- deployment-documentation review without deployment
- security-incident summarization without Cipher activation
- changelog architecture mentions without Clockwork
- negated test execution
- screenshot-caption database/UI references
- future deployment planning with execution explicitly negated

The deterministic suppression invariants are:

- `MENTION != INTENT`
- `NEGATED_ACTION != AUTHORIZED_ACTION`
- `QUOTED_DANGEROUS_TEXT != PROTECTED_ACTION`
- `HYPOTHETICAL_ACTION != EXECUTION_REQUEST`
- `REPRESENTATION_CONTEXT != REFERENCED_DOMAIN_AUTHORITY`

The negative corpus initially failed on `Do not deploy or merge anything. Just review the README for clarity.` because protected-action signals were treated as active intent. The intake policy now suppresses negated spans, quoted/example spans, hypothetical operations, and representation-only domain references while preserving active contrast cases such as real production deploy, chaos-test, security, and merge requests.

Final documented source head `186f92cc9ae6acaa55c14418b5199c97b5ba8a0a` passes all six protected workflows.

## Preserved invariants

`WORKFLOW_TOPOLOGY_CHANGE != AUTHORITY_EXPANSION`

- Conductor remains exclusive dispatcher.
- Specialist authority is unchanged.
- OEE `max_parallel_specialists = 1` remains unchanged.
- Prompt signals do not grant protected authority.
- No A5 execution promotion.
- No UIEF resumption.
- No release/deployment/policy activation from this PR.

This source PR requires exact-head protected CI qualification before any canonical merge.