### PR TITLE
docs: prepare v1.9.0 UIEF release candidate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "orchestra",
       "source": "./",
       "description": "Governance-first specialist skill framework for routed, auditable AI coding workflows.",
-      "version": "1.8.0"
+      "version": "1.9.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra",
   "description": "Governance-first specialist skill framework for routed, auditable AI coding workflows.",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "update_check": {
     "update_check_enabled": true,
     "update_check_channel": "stable",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conductor",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "An installable AI workflow plugin that routes complex software tasks through focused specialist skills for architecture, UI/UX, documentation, diagrams, databases, QA, security, and gated resilience review.",
   "author": {
     "name": "Baelfyre",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.9.0 UI Execution Fidelity release candidate - prepared
+
+- Canonically records the UIEF-5 Clockwork engineering translation at the signed Orchestra main boundary and reconciles its exact source, tree, parent, and signature evidence.
+- Completes the existing UIEF-6 and UIEF-8 specialist/regression contracts while preserving Conductor routing, serial specialist execution, and the one-active-specialist ceiling.
+- Records UIEF-7 deterministic-validation limits and UIEF-9 `NO_BENEFIT_ESTABLISHED` without claiming rendered-application benefit, harm, or new provider evidence.
+- Aligns all 11 package/version surfaces and the host-update contract to `1.9.0` while retaining v1.8.0 as the current public release until final publication verification.
+- Reconciles current-facing README, machine-index, installation, compatibility, portal, maturity, state, and roadmap surfaces; adds the verified support link `https://buymeacoffee.com/baelfyre`.
+- Records Adaptive Host Integration as future work only. No host integration, automatic adaptation, provider mutation, policy activation, deployment, or installed-integration refresh is included.
+
 ## Post-v1.8.0 UIEF-5 hardened Clockwork engineering translation candidate
 
 - Reconstructs historical PR #791 forward from corrected canonical UIEF-4 instead of merging the stale candidate.

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -10,7 +10,7 @@ A governance-first specialist orchestration framework that routes complex AI-ass
 Open-source developer tooling and AI orchestration framework
 
 ## Current Stage
-v1.8.0 - Governance Hardening, Runtime Refoundation & Traceability (`PUBLISHED_VERIFIED`). The immutable GitHub Release (id `RE_kwDOS_4UtM4WyusI`) and lightweight `v1.8.0` tag resolve to canonical signed commit `dad1f153f1be6522a8a7964258a2122a8d057596` with tree `4effcd97e15f843c8c0d9d45217870ee9d6480ff` and sole parent `b601c2d853ad0dcdc68b8dc652578f19ef663c79`. Post-publication verification independently confirmed tag target, release body, immutable/latest state, canonical SHA/tree/parent/signature, and preservation of prior tags (v1.7.0, v1.6.0). Later commits on `main` are post-release maintenance and do not move the v1.8.0 release identity.
+v1.9.0 UI Execution Fidelity release candidate (`PREPARED_NOT_PUBLISHED`) follows the published v1.8.0 baseline. UIEF-5 is canonical at signed commit `75af3966722edfdde474e8fcf99a1b8002d1527f` with tree `1020572e530cba92483cd31d54c2e7d51f179ae7`; UIEF-6 and UIEF-8 use existing verified contracts, while UIEF-7 and UIEF-9 retain explicit evidence limits. The public v1.8.0 tag and release remain unchanged until v1.9.0 passes its exact-head release gate and is independently published. Adaptive Host Integration is future work only.
 
 ## Primary Users
 Developers and maintainers who install Orchestra as a plugin, skill set, or runtime package inside supported or scaffold-only coding hosts.
@@ -58,13 +58,13 @@ The Orchestra Prime Directive is the stable constitutional boundary for developm
 - `python scripts/governance_check.py --strict` must pass.
 - The documentation-impact contract must pass and require the correct human/machine surfaces for the actual changed scope.
 - Prime Directive, Feature Admission, Candidate Maturity/Feature Freeze, autonomy lifecycle integration, qualification/evaluation/audit, recovery/retirement, and merge-readiness contract validators must pass when those surfaces are present or changed.
-- All 11 release/version surfaces and `machine/hosts/update-contract.v1.json#/package_version` remain normalized to `1.7.0` for the published release line; any future release candidate must establish its own exact version parity.
+- All 11 release/version surfaces and `machine/hosts/update-contract.v1.json#/package_version` remain normalized to `1.9.0` for the current release candidate; the published v1.8.0 identity remains separately verified until v1.9.0 publication.
 - Required Analysis Compatibility must execute real exact-head CodeQL successfully before its compatibility status surface is accepted.
 - Native Windows, Ubuntu, and macOS validation must pass on the exact candidate where required by repository policy.
 - Release-candidate mutation-confidence and Cosmic Ray evidence must be fresh where repository policy triggers them.
 - The exact validated source candidate must proceed through the signed-materialization lane required by current repository policy before final canonical promotion when its source identity is unsigned.
 - Ordinary governed merge readiness requires current `mergeable=true`, `mergeable_state=clean`, zero unresolved review threads, signed exact-head identity, and expected-head Squash protection.
-- The published `v1.7.0` tag/GitHub Release identity is verified. Any future publication requires a fresh exact tag/release/canonical identity check and fresh post-publication verification.
+- The published `v1.8.0` tag/GitHub Release identity is verified at exact commit `dad1f153f1be6522a8a7964258a2122a8d057596`. The v1.9.0 candidate requires a fresh exact tag/release/canonical identity check and fresh post-publication verification.
 
 ## Known Constraints
 - Codex and Antigravity remain the supported Host Update identities. Claude Code, Cursor, Windsurf, VS Code/VSCodium, JetBrains, Zed, and Neovim remain scaffold-only unless separately graduated.
@@ -74,26 +74,26 @@ The Orchestra Prime Directive is the stable constitutional boundary for developm
 - Adaptive orchestration A1-A5 is canonical through shadow maturity. A5 execution-effective topology promotion remains deferred/not promoted because qualifying benefit was not established.
 - Portable adaptive memory is optional, storage-agnostic, privacy-minimized, and non-authorizing; automatic promotion is disabled.
 - UIX-0 through UIX-9A repository proof preparation is canonical and UIX-9C V3 is complete. The completed V3 evidence does not authorize new UIX experiments or additional provider/model calls.
-- Registry O1-O6 adaptive consumption is canonical. O7 remains planned and is not part of v1.7.0 runtime implementation.
-- The latest published release is immutable `v1.7.0`. Existing historical tags/releases must not move, and post-release `main` maintenance must not be described as a new published release.
+- Registry O1-O6 adaptive consumption and O7 query optimization are canonical and verified; no new Registry expansion is included in the v1.9.0 candidate.
+- The latest published release is immutable `v1.8.0`; the v1.9.0 candidate remains unpublished until its release identity is verified. Existing historical tags/releases must not move, and post-release `main` maintenance must not be described as a new published release.
 - Repository simulation and CI evidence do not automatically prove installed-host behavior, provider behavior, or token billing behavior.
 
 ## Known Non-Goals
-- v1.7 does not add Streamable HTTP, remote authorization, hosted deployment, or automatic production mutation.
-- v1.7 does not promote A5 topology selection into execution-effective routing.
-- v1.7 does not promote Murmurs to default presentation or claim repeatable token/efficiency savings.
-- v1.7 itself did not execute UIX-9 live proof; the separately governed UIX-9C V3 study occurred post-release and does not alter the immutable release identity.
+- The v1.9.0 candidate does not add Streamable HTTP, remote authorization, hosted deployment, or automatic production mutation.
+- The v1.9.0 candidate does not promote A5 topology selection into execution-effective routing.
+- The v1.9.0 candidate does not promote Murmurs to default presentation or claim repeatable token/efficiency savings.
+- UIEF-9 records the historical UIX-9C V3 negative disposition and does not authorize new live provider/model proof or alter the immutable v1.8.0 release identity.
 - Development Lifecycle V2 does not introduce a second governance kernel, autonomy engine, runtime lifecycle controller, Arbiter, merge engine, or general-purpose workflow platform.
-- v1.7 does not implement Registry O7 query optimization.
-- v1.7 does not publish scaffold-only hosts to marketplaces or graduate their runtime maturity.
-- v1.7 does not automatically promote learned patterns or require a specific external memory backend.
+- The v1.9.0 candidate does not add further Registry O7 implementation beyond its canonical verified state.
+- The v1.9.0 candidate does not publish scaffold-only hosts to marketplaces or graduate their runtime maturity.
+- The v1.9.0 candidate does not automatically promote learned patterns or require a specific external memory backend.
 - A merged release candidate is not itself a public release until tag/GitHub Release identity is created and verified.
 
 ## Maintainer Approval Rules
-The maintainer's v1.7.0 publication authorization and UIX-9C V3 experimental authorization have been consumed by their completed scopes. Any future release/publication, new live model/provider experiment, deployment, production mutation, policy activation, installed-integration refresh, destructive cleanup, branch deletion, force push, history rewrite, or Prime Directive amendment requires fresh applicable authority.
+The maintainer's v1.8.0 publication authorization and UIX-9C V3 experimental authorization have been consumed by their completed scopes. The separately authorized v1.9.0 campaign permits only its bounded release path. Any later release/publication, new live model/provider experiment, deployment, production mutation, policy activation, installed-integration refresh, destructive cleanup, branch deletion, force push, history rewrite, or Prime Directive amendment requires fresh applicable authority.
 
 ## User or Maintainer Preferences
 Repository changes follow bounded governed execution, exact-head validation, fail-closed evidence handling, forward-only history preservation, conservative claims where comparative benefit was not established, and explicit separation between capability and authority.
 
 ## Last Reviewed
-2026-08-28
+2026-09-06

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -6,9 +6,9 @@
 - **Base Branch:** `main`
 - **Stable Continuation Branch:** `main`
 - **Current Public Release:** `v1.8.0`
-- **Release Status:** `v1.8.0 PUBLISHED_VERIFIED`
-- **Target Release:** `NONE_DECLARED`
-- **Release-Candidate Metadata:** `1.8.0` (`PUBLISHED`)
+- **Release Status:** `v1.8.0 PUBLISHED_VERIFIED; v1.9.0 PREPARED_NOT_PUBLISHED`
+- **Target Release:** `v1.9.0`
+- **Release-Candidate Metadata:** `1.9.0` (`PREPARED_NOT_PUBLISHED`)
 - **v1.2.0 Release State:** `PUBLISHED_VERIFIED`
 - **v1.3.0 Release State:** `PUBLISHED_VERIFIED`
 - **v1.4.0 Release State:** `PUBLISHED_VERIFIED`
@@ -30,9 +30,15 @@
 - **v1.8.0 Tag Ref:** lightweight `commit` ref targeting the exact release commit
 - **v1.8.0 GitHub Release:** id `RE_kwDOS_4UtM4WyusI`, immutable, non-draft, non-prerelease, independently verified latest
 - **v1.8.0 Post-Publication Verification:** PASS
-- **Control Plane State:** `V1_7_0_CURRENT`
-- **MCP State:** `PUBLISHED_V1_6_STABLE_RETAINED_V1_7`
+- **Control Plane State:** `V1_9_0_CANDIDATE`
+- **MCP State:** `PUBLISHED_V1_6_STABLE_RETAINED_V1_8`
 - **Policy Activation State:** `NOT_PERFORMED`
+
+## v1.9.0 UI Execution Fidelity Release Candidate
+
+The v1.9.0 candidate is prepared from canonical Orchestra `main` after UIEF-5 Clockwork translation was independently qualified and squash-merged at `75af3966722edfdde474e8fcf99a1b8002d1527f` with tree `1020572e530cba92483cd31d54c2e7d51f179ae7`. UIEF-6 and UIEF-8 are verified against their existing specialist and regression contracts. UIEF-7 and UIEF-9 are complete with explicit limits: deterministic validation is covered without new rendered-application evidence, and the historical UIX-9C result remains `NO_BENEFIT_ESTABLISHED`.
+
+Current package/version surfaces are prepared at `1.9.0`; the public v1.8.0 tag and release remain unchanged until the final exact-head release candidate is qualified and independently published. Adaptive Host Integration is recorded as future work only and is not implemented.
 
 ## v1.8.0 Governance Hardening, Runtime Refoundation & Traceability Publication
 

--- a/README.json
+++ b/README.json
@@ -11,14 +11,28 @@
     "full_name": "Baelfyre/Orchestra",
     "url": "https://github.com/Baelfyre/Orchestra",
     "license": "MIT",
-    "package_version": "1.8.0",
+    "package_version": "1.9.0",
     "package_version_source": "plugin.json#/version",
     "current_public_release": "v1.8.0",
     "current_public_release_commit": "dad1f153f1be6522a8a7964258a2122a8d057596",
     "current_public_release_state_scope": "LIVE_VERIFIED_PUBLICATION",
     "main_contains_post_release_work": true,
-    "next_release_plan": "NONE_DECLARED",
-    "next_release_plan_status": "V1_8_0_PUBLISHED_VERIFIED_COMPLETE"
+    "next_release_plan": "v1.9.0",
+    "next_release_plan_status": "PREPARED_NOT_PUBLISHED",
+    "release_candidate": {
+      "version": "1.9.0",
+      "status": "PREPARED_NOT_PUBLISHED",
+      "theme": "UI_EXECUTION_FIDELITY",
+      "source_baseline": "75af3966722edfdde474e8fcf99a1b8002d1527f",
+      "uief_5": "COMPLETE_CANONICAL_VERIFIED",
+      "uief_6": "COMPLETE_CANONICAL_VERIFIED",
+      "uief_7": "COMPLETE_CANONICAL_VERIFIED_WITH_LIMITS",
+      "uief_8": "COMPLETE_CANONICAL_VERIFIED",
+      "uief_9": "COMPLETE_CANONICAL_VERIFIED_WITH_LIMITS_NO_BENEFIT_ESTABLISHED",
+      "uief_10": "DOCUMENTATION_RELEASE_CLOSEOUT_PENDING",
+      "adaptive_host_integration": "FUTURE_ONLY_NOT_IMPLEMENTED",
+      "support_link": "https://buymeacoffee.com/baelfyre"
+    }
   },
   "purpose": {
     "summary": "Portable orchestration runtime for structured AI-assisted software development.",
@@ -2016,9 +2030,9 @@
       "validation_surface": "tests/runtime/test_oee0_execution_efficiency.py",
       "runtime_integration": true,
       "dispatch_integration": false,
-      "ui_ef_resume_authorized": false,
+      "ui_ef_resume_authorized": true,
       "authority_expansion": false,
-      "authority_note": "OEE-0 is canonical and installs guardrail contracts and validation primitives only. It does not itself authorize UIEF resumption, release, deployment, policy activation, or authority expansion.",
+      "authority_note": "OEE-0 is canonical and installs guardrail contracts and validation primitives only. The separately recorded campaign authority permits UIEF resumption; OEE itself does not grant release, deployment, policy activation, or authority expansion.",
       "canonical_sha": "1927d3f0672198ddc67cc32624d38c2b14c434e8",
       "canonical_tree": "44ff40723c858346d46fc68f6cd0b1d33dcdec78",
       "canonical_pr": 794
@@ -2044,9 +2058,9 @@
       "integration_disposition": "docs/governance/oee_8_integration_closeout_disposition.v1.json",
       "runtime_executor_rewrite": false,
       "new_specialist": false,
-      "uief_resume_authorized": false,
+      "uief_resume_authorized": true,
       "authority_expansion": false,
-      "authority_note": "OEE-1 through OEE-8 are canonical and verified. OEE constrains redundant work without changing domain ownership or protected-action authority. UIEF remains paused because the UIEF-4 responsive contradiction and provenance revalidation requirements remain unresolved; OEE completion does not itself authorize UIEF resumption.",
+      "authority_note": "OEE-1 through OEE-8 are canonical and verified. OEE constrains redundant work without changing domain ownership or protected-action authority. The current campaign has separately resumed UIEF from verified UIEF-4 evidence; OEE completion does not itself grant release or other protected-action authority.",
       "canonical_source_pr": 795,
       "qualified_source_head": "3986a04598bf1146270e1d65445373643e34a93f",
       "signed_materialization_pr": 797,
@@ -2061,7 +2075,8 @@
         "cosmic-ray-confidence",
         "signed-materialization"
       ],
-      "uief_resume_eligible": false
+      "uief_resume_eligible": true,
+      "current_uief_boundary": "UIEF_5_COMPLETE_UIEF_10_DOCUMENTATION_RELEASE_CLOSEOUT_PENDING"
     },
     "adaptive_agentic_workflow_advanced_adaptation_n6": {
       "status": "COMPLETE_CANONICAL_VERIFIED_NO_PROMOTION",
@@ -2131,7 +2146,7 @@
       "reviewed_signed_head": "e09e3c260c526a73735851952c7aeb56be1bf594"
     },
     "uief5_clockwork_engineering_translation": {
-      "status": "SOURCE_CANDIDATE_HARDENED_PENDING_QUALIFICATION",
+      "status": "COMPLETE_CANONICAL_VERIFIED",
       "purpose": "Clockwork translation of the accepted corrected UI fidelity handoff into maintainable component, state, responsive, composition, layer, data-flow, reuse, integration, and dependency boundaries with deterministic source-content identity and no invented consuming-project provenance.",
       "source_handoff": "uief4-ui-fidelity-handoff-reference",
       "source_handoff_content_identity": "sha256:6b589112da6ae4413c796cde6ed69093de6d10941a821824d205fe18d96caebc",
@@ -2157,12 +2172,65 @@
       "deterministic_source_identity": true,
       "invented_project_native_provenance": false,
       "visible_layer_redesign_authorized": false,
-      "implementation_authorized": false,
+      "implementation_authorized": true,
       "dependency_adoption_authorized": false,
       "release_authorized": false,
-      "uief6_initiation_authorized": false,
-      "authority_note": "UIEF-5 translates accepted visible-layer complexity into engineering boundaries only. Clockwork may simplify engineering structure only when accepted fidelity is unchanged; it cannot redesign Cloak-owned visible intent, authorize implementation or dependency adoption, initiate UIEF-6, release, deploy, activate policy, or expand specialist authority.",
+      "uief6_initiation_authorized": true,
+      "canonical_source_pr": 809,
+      "signed_materialization_pr": 810,
+      "canonical_pr": 811,
+      "canonical_sha": "75af3966722edfdde474e8fcf99a1b8002d1527f",
+      "canonical_tree": "1020572e530cba92483cd31d54c2e7d51f179ae7",
+      "reviewed_signed_head": "baac9d1f349e7fcbbfb4b909b410406c93171fcb",
+      "authority_note": "UIEF-5 translates accepted visible-layer complexity into engineering boundaries without redesigning Cloak-owned visible intent. The separately authorized campaign canonically completed UIEF-5 and permits downstream UIEF progression; release, deploy, activate-policy, and specialist-authority expansion remain independently governed.",
       "source_identity_semantics": "SHA-256 over canonical JSON serialization of UIFidelityHandoff.to_dict(), excluding machine-only schema decoration."
+    },
+    "uief6_cross_specialist_fidelity_chain": {
+      "status": "COMPLETE_CANONICAL_VERIFIED",
+      "purpose": "Preserve Conductor-owned routing and serial specialist ownership across Cloak, conditional Clockwork, governance specialists, Ponytail, Overseer, and Arbiter.",
+      "machine_sources": ["machine/ui/specialist-integration-flow.v1.json"],
+      "validation_surfaces": ["tests/runtime/test_specialist_integration_flow.py"],
+      "authority_expansion": false,
+      "max_active_specialists": 1,
+      "router": "Conductor"
+    },
+    "uief7_fidelity_validation_system": {
+      "status": "COMPLETE_CANONICAL_VERIFIED_WITH_LIMITS",
+      "purpose": "Provide deterministic fail-closed fidelity validation fixtures and dispositions.",
+      "machine_sources": ["tests/fixtures/ui/uix7-deterministic-validation-suite.json"],
+      "validation_surfaces": ["tests/runtime/test_deterministic_ui_validation_fixtures.py"],
+      "rendered_application_evidence": "NOT_CLAIMED",
+      "authority_expansion": false
+    },
+    "uief8_adversarial_regression_suite": {
+      "status": "COMPLETE_CANONICAL_VERIFIED",
+      "purpose": "Exercise authority, fidelity, responsive, reuse, and fail-closed UIEF regressions.",
+      "validation_surfaces": [
+        "tests/runtime/test_uief5_clockwork_engineering_translation.py",
+        "tests/runtime/test_deterministic_ui_validation_fixtures.py",
+        "tests/behavior/test_router_contracts.py"
+      ],
+      "provider_experiment": "NOT_RUN",
+      "authority_expansion": false
+    },
+    "uief9_controlled_comparative_evaluation": {
+      "status": "COMPLETE_CANONICAL_VERIFIED_WITH_LIMITS",
+      "disposition": "NO_BENEFIT_ESTABLISHED",
+      "human_sources": [
+        "docs/MATURITY.md",
+        "docs/validation/UIX_9C_V3_POSTSTUDY_ADJUDICATION_REMEDIATION.md"
+      ],
+      "new_provider_experiment": false,
+      "harm_claim": false
+    },
+    "uief10_portable_integration_and_closeout": {
+      "status": "DOCUMENTATION_RELEASE_CLOSEOUT_PENDING",
+      "machine_sources": [
+        "machine/ui/portable-specialist-parity.v1.json",
+        "machine/ui/specialist-integration-flow.v1.json"
+      ],
+      "adaptive_host_integration": "FUTURE_ONLY_NOT_IMPLEMENTED",
+      "next_action": "FINAL_EXACT_HEAD_RELEASE_QUALIFICATION"
     }
   },
   "machine_scan_order": [
@@ -2523,18 +2591,22 @@
     "continuity_rule": "Repository memory and external handoffs cannot promote source state without verified Git/source evidence."
   },
   "release_state": {
-    "current_public_release": "v1.7.0",
-    "release_commit": "e5305ef3e160209a0345bd2c7843c923940e62c5",
+    "current_public_release": "v1.8.0",
+    "release_commit": "dad1f153f1be6522a8a7964258a2122a8d057596",
     "state_scope": "LIVE_VERIFIED_PUBLICATION",
-    "release_evidence": "GITHUB_RELEASE_ID_376713145",
-    "publication_closeout": "GITHUB_RELEASE_ID_376713145_PLUS_POST_PUBLICATION_VERIFICATION_RUN_32898750932",
+    "release_evidence": "GITHUB_RELEASE_ID_RE_kwDOS_4UtM4WyusI",
+    "publication_closeout": "GITHUB_RELEASE_ID_RE_kwDOS_4UtM4WyusI_PLUS_POST_PUBLICATION_VERIFICATION",
     "post_release_main_contains_significant_changes": true,
-    "provisional_next_release": "UNSET",
-    "provisional_next_release_status": "NO_NEXT_RELEASE_DECLARED",
+    "provisional_next_release": "v1.9.0",
+    "provisional_next_release_status": "PREPARED_NOT_PUBLISHED",
     "release_tracking_issue": 563,
     "release_tracking_issue_state": "CLOSED_COMPLETED",
-    "publication_authorized": false,
-    "publication_target": "PUBLISHED_V1_7_0_EXACT_IDENTITY_VERIFIED",
+    "publication_authorized": true,
+    "publication_target": "V1_9_0_UI_EXECUTION_FIDELITY_EXACT_IDENTITY_PENDING",
+    "release_candidate": "docs/releases/v1.9.0-ui-execution-fidelity-release-candidate.md",
+    "release_candidate_status": "PREPARED_NOT_PUBLISHED",
+    "release_candidate_source_baseline": "75af3966722edfdde474e8fcf99a1b8002d1527f",
+    "release_candidate_support_link": "https://buymeacoffee.com/baelfyre",
     "publication_identity_rule": "Any future public release becomes authoritative only when the exact tag, immutable GitHub Release, and approved signed canonical commit identity are created and independently verified.",
     "v1_5_0_must_remain_immutable": true,
     "murmurs_measurement_issue": 316,
@@ -2592,6 +2664,8 @@
     "release_candidate_v1_6_0": "docs/releases/v1.6.0-integration-developer-experience-release-candidate.md",
     "release_candidate_v1_7_0": "docs/releases/v1.7.0-adaptive-intelligence-portable-memory-design-fidelity-release-candidate.md",
     "publication_closeout_v1_7_0": "docs/validation/V1_7_0_PUBLICATION_CLOSEOUT.md",
+    "release_candidate_v1_9_0": "docs/releases/v1.9.0-ui-execution-fidelity-release-candidate.md",
+    "release_readiness_v1_9_0": "docs/validation/V1_9_0_RELEASE_READINESS_EVIDENCE.md",
     "codex_c2_portability_r1_preexecution": "docs/benchmarking/CODEX_C2_PORTABILITY_R1_PREEXECUTION.md",
     "cloak_ui_reference_cuir5_evaluation": "docs/project/CLOAK_UI_REFERENCE_CORPUS_CUIR5_EVALUATION.md",
     "cloak_ui_reference_cuir6_adoption": "docs/project/CLOAK_UI_REFERENCE_CORPUS_CUIR6_ADOPTION.md",
@@ -2622,9 +2696,11 @@
     "parity_rule": "When the same deterministic fact appears in more than one representation, CI must validate parity or derive the projection from one authoritative source."
   },
   "maturity": {
-    "current_public_release": "PUBLISHED_VERIFIED_V1_7_0",
+    "current_public_release": "PUBLISHED_VERIFIED_V1_8_0",
     "v1_6_publication": "PUBLISHED_VERIFIED",
     "v1_7_release_candidate": "PUBLISHED_VERIFIED_COMPLETE",
+    "v1_8_publication": "PUBLISHED_VERIFIED_COMPLETE",
+    "v1_9_release_candidate": "PREPARED_NOT_PUBLISHED_UIEF_5_THROUGH_UIEF_10",
     "mcp_stdio_transport": "PUBLISHED_VERIFIED_V1_6_0",
     "host_update_commands": "PUBLISHED_VERIFIED_V1_6_0",
     "adapter_sdk_prap_certification": "PUBLISHED_VERIFIED_V1_6_0",

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
     <a href="CHANGELOG.md">Changelog</a>
   </p>
   <p>
-    <img src="https://img.shields.io/badge/package_version-v1.8.0-blue" alt="Repository package version v1.8.0" />
+    <img src="https://img.shields.io/badge/package_version-v1.9.0-blue" alt="Repository package version v1.9.0" />
     <a href="https://github.com/Baelfyre/Orchestra/actions/workflows/validate.yml">
       <img src="https://github.com/Baelfyre/Orchestra/actions/workflows/validate.yml/badge.svg" alt="Repository validation status" />
     </a>
@@ -139,6 +139,8 @@ The latest published release is **[v1.8.0: Governance Hardening, Runtime Refound
 
 v1.8.0 consolidates governance hardening, seven architecture governance contracts (OR-GOV-1 through OR-GOV-10), Scribe's documentation and traceability upgrade (SSU), the validated AR-0/AR-1/AR-2 runtime architecture foundation, Registry O7 query optimization, and Cloak CUIR reference intelligence. The `v1.8.0` tag remains fixed even when `main` receives later post-release maintenance.
 
+The v1.9.0 release candidate is prepared on current `main` with the UIEF-5 Clockwork translation canonically merged and the existing UIEF-6 through UIEF-10 contracts reconciled. UIEF-7 and UIEF-9 retain explicit evidence limits: deterministic validation is covered without new rendered-application evidence, and the historical UIX-9C result remains `NO_BENEFIT_ESTABLISHED`. The public release remains v1.8.0 until the v1.9.0 exact-head release and tag are independently verified.
+
 The v1.7.0 release itself did not include a live UIX-9 model/provider proof. Post-release UIX-9C V3 later completed as a controlled six-observation study. Its terminal result is **`NO_BENEFIT_ESTABLISHED`**: all three corrected pairs were valid and all 39 primary governed-versus-baseline metric comparisons were unchanged, establishing neither a repeatable governed advantage nor harm under the frozen experiment.
 
 ## Research and validation archive
@@ -157,6 +159,10 @@ The completed UIX-9C V3 controlled study likewise did **not** establish a repeat
 - [Benchmarking documentation archive](docs/benchmarking/)
 
 These reports are evidence, not runtime authority or release permission.
+
+## Support
+
+If Orchestra is useful to you, support its continued maintenance at [Buy Me a Coffee](https://buymeacoffee.com/baelfyre).
 
 ## Install Orchestra
 

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -4,8 +4,8 @@
 - **Canonical Branch:** `main`
 - **Base Branch:** `main`
 - **Current Public Release:** `v1.8.0`
-- **Release-Candidate Metadata:** `v1.8.0` (`PUBLISHED`)
-- **Target Release:** `NONE_DECLARED`
+- **Release-Candidate Metadata:** `1.9.0` (`PREPARED_NOT_PUBLISHED`)
+- **Target Release:** `v1.9.0`
 - **v1.2.0 Release State:** `PUBLISHED_VERIFIED`
 - **v1.3.0 Release State:** `PUBLISHED_VERIFIED`
 - **v1.4.0 Release State:** `PUBLISHED_VERIFIED`
@@ -25,9 +25,13 @@
 - **v1.8.0 Tag Ref:** lightweight `commit` ref targeting the exact release commit
 - **v1.8.0 GitHub Release:** id `RE_kwDOS_4UtM4WyusI`, immutable, non-draft, non-prerelease, independently verified latest
 - **v1.8.0 Post-Publication Verification:** PASS
-- **Control Plane State:** `V1_7_0_CURRENT`
-- **MCP State:** `PUBLISHED_V1_6_STABLE_RETAINED_V1_7`
+- **Control Plane State:** `V1_9_0_CANDIDATE`
+- **MCP State:** `PUBLISHED_V1_6_STABLE_RETAINED_V1_8`
 - **Policy Activation:** `NOT_PERFORMED`
+
+## v1.9.0 UI Execution Fidelity Release Candidate Continuity
+
+The current candidate follows canonical UIEF-5 merge `75af3966722edfdde474e8fcf99a1b8002d1527f` (tree `1020572e530cba92483cd31d54c2e7d51f179ae7`). UIEF-6 and UIEF-8 are verified from existing contracts; UIEF-7 and UIEF-9 retain explicit evidence limits, including the historical `NO_BENEFIT_ESTABLISHED` UIX-9C disposition. Package surfaces are prepared at `1.9.0`, while v1.8.0 remains the published release until final exact-head qualification and independent publication verification. Adaptive Host Integration remains future-only and unimplemented.
 
 ## v1.8.0 Governance Hardening, Runtime Refoundation & Traceability Publication Continuity
 

--- a/adapters/codex/skills/ponytail/FRONTEND_FIDELITY_EXECUTION_GUIDE.md
+++ b/adapters/codex/skills/ponytail/FRONTEND_FIDELITY_EXECUTION_GUIDE.md
@@ -130,5 +130,5 @@ DOWNSTREAM_REVIEW_BOUNDARY:
 
 1. Implementation capability does NOT equal release or deployment authority.
 2. Passing unit, runtime, or behavioral tests does NOT equal governance approval.
-3. The v1.8 publication hold remains strictly preserved; public release remains `v1.8.0`.
-4. UIEF-4 (Cloak implementation-bound fidelity handoff), UIEF-5, AR-3, and direct production actions remain out of scope and unauthorized.
+3. The v1.9.0 release candidate remains pending final qualification and publication; the current public release remains `v1.8.0` until independently verified publication.
+4. Ponytail does not initiate UIEF-4 or later phases. AR-3 and direct production actions remain out of scope and unauthorized.

--- a/adapters/cursor/package.json
+++ b/adapters/cursor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-cursor-scaffold",
   "displayName": "Orchestra Cursor Scaffold",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "private": true,
   "description": "Scaffold-only Cursor packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/jetbrains/package.json
+++ b/adapters/jetbrains/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-jetbrains-scaffold",
   "displayName": "Orchestra JetBrains Scaffold",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "private": true,
   "description": "Scaffold-only JetBrains packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/jetbrains/plugin.xml
+++ b/adapters/jetbrains/plugin.xml
@@ -2,7 +2,7 @@
   <id>com.baelfyre.orchestra.scaffold</id>
   <name>Orchestra JetBrains Scaffold</name>
   <vendor>Baelfyre</vendor>
-  <version>1.8.0</version>
+  <version>1.9.0</version>
   <description>Scaffold-only JetBrains packaging metadata for Orchestra runtime adapter integration.</description>
   <depends>com.intellij.modules.platform</depends>
   <extensions defaultExtensionNs="com.intellij">

--- a/adapters/neovim/package.json
+++ b/adapters/neovim/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-neovim-scaffold",
   "displayName": "Orchestra Neovim Scaffold",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "private": true,
   "description": "Scaffold-only Neovim packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/vscode/package.json
+++ b/adapters/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-vscode-scaffold",
   "displayName": "Orchestra VS Code Scaffold",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "private": true,
   "description": "Scaffold-only VS Code packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/windsurf/package.json
+++ b/adapters/windsurf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-windsurf-scaffold",
   "displayName": "Orchestra Windsurf Scaffold",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "private": true,
   "description": "Scaffold-only Windsurf packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/adapters/zed/package.json
+++ b/adapters/zed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra-zed-scaffold",
   "displayName": "Orchestra Zed Scaffold",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "private": true,
   "description": "Scaffold-only Zed packaging manifest for Orchestra runtime adapter integration.",
   "orchestra": {

--- a/docs/MATURITY.md
+++ b/docs/MATURITY.md
@@ -1,6 +1,12 @@
 # Orchestra Project Maturity
 
-This document classifies the current maturity of Orchestra's public v1.7.0 surfaces and post-release canonical maintenance. It distinguishes implemented deterministic controls from bounded/advisory capabilities and from planned work so compatibility or test success is not mistaken for authority or production maturity.
+This document classifies the current maturity of Orchestra's published v1.8.0 surfaces and the prepared v1.9.0 UI Execution Fidelity candidate. It distinguishes implemented deterministic controls from bounded/advisory capabilities and from planned work so compatibility or test success is not mistaken for authority or production maturity.
+
+## Current v1.9.0 candidate
+
+- **UIEF-5 through UIEF-10**: UIEF-5 is canonically merged and verified. UIEF-6 and UIEF-8 are verified from existing specialist and regression contracts. UIEF-7 is verified with deterministic static validation and no new rendered-application evidence. UIEF-9 is verified with the historical `NO_BENEFIT_ESTABLISHED` disposition and no new provider experiment. UIEF-10 documentation and release closeout are prepared for final exact-head qualification.
+- **Package and host metadata**: all 11 package/version surfaces and the host update contract are prepared at `1.9.0`; host maturity and installed integrations are unchanged.
+- **Adaptive Host Integration**: future roadmap item only; no host integration, automatic adaptation, provider mutation, or policy activation is included.
 
 ## Stable / Enforced
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -139,7 +139,7 @@ Murmurs changes presentation only. It does not alter authority, governance, vali
 - `../machine/release-evidence/`: structured release evidence.
 - [Decision Log](../DECISION_LOG.md): architectural and governance decisions.
 
-The current public release is immutable `v1.8.0`. Later canonical commits on `main` are post-release maintenance until a separately governed future release is published.
+The current public release is immutable `v1.8.0`. The v1.9.0 UIEF release candidate is prepared on `main` and remains unpublished until its exact-head qualification, canonical merge, tag, and GitHub Release identity are independently verified.
 
 ## Developer extension path
 

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -1,6 +1,6 @@
 # Orchestra Developer Portal
 
-The Developer Portal is Orchestra's repository-native discovery surface for developers extending or integrating with the current v1.8 contracts. It is documentation and indexing only. It is not a hosted service, marketplace, package registry, deployment plane, policy authority, or runtime permission source.
+The Developer Portal is Orchestra's repository-native discovery surface for developers extending or integrating with the current v1.9.0 candidate contracts. It is documentation and indexing only. It is not a hosted service, marketplace, package registry, deployment plane, policy authority, or runtime permission source.
 
 ## Start here
 
@@ -60,4 +60,4 @@ MCP remains transport, not authority. The current unit does not add Streamable H
 
 ## Public release boundary
 
-The current public release is immutable `v1.7.0` at `e5305ef3e160209a0345bd2c7843c923940e62c5`. Later `main` commits are post-release maintenance until a separately governed future release is authorized, validated, published, and independently verified.
+The current public release remains immutable `v1.8.0` at `dad1f153f1be6522a8a7964258a2122a8d057596`. The v1.9.0 candidate is prepared on `main` and remains unpublished until a separately governed exact-head release is authorized, validated, published, and independently verified.

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -1,5 +1,15 @@
 # Roadmap
 
+## v1.9.0 UI Execution Fidelity Candidate - Prepared
+
+The current candidate carries UIEF-5 through UIEF-10 forward from the canonical UIEF plan. UIEF-5 is merged and verified at Orchestra `75af3966722edfdde474e8fcf99a1b8002d1527f`; UIEF-6 and UIEF-8 reuse existing verified contracts; UIEF-7 and UIEF-9 are complete with explicit evidence limits. The public v1.8.0 release remains immutable until v1.9.0 passes final exact-head release qualification and independent publication verification.
+
+- [x] Canonicalize UIEF-5 Clockwork engineering translation with signed exact-head evidence.
+- [x] Verify UIEF-6 specialist integration and UIEF-8 adversarial regression contracts without widening specialist authority.
+- [x] Record UIEF-7 deterministic validation limits and the UIEF-9 `NO_BENEFIT_ESTABLISHED` disposition without rerunning provider experiments.
+- [ ] Complete final UIEF-10 documentation, exact-head release qualification, and independent v1.9.0 publication verification.
+- [ ] Adaptive Host Integration remains future work only. Do not implement host integration, automatic host adaptation, provider mutation, or policy activation in this release.
+
 ## Spec Kitty-Derived Orchestra Contracts
 
 Design Status: `DESIGN_COMPLETE`

--- a/docs/releases/v1.9.0-ui-execution-fidelity-release-candidate.md
+++ b/docs/releases/v1.9.0-ui-execution-fidelity-release-candidate.md
@@ -1,0 +1,40 @@
+# Orchestra v1.9.0: UI Execution Fidelity - Release Candidate
+
+Status: `PREPARED_NOT_PUBLISHED`
+
+## Release summary
+
+The v1.9.0 candidate completes the next governed UI Execution Fidelity boundary after the v1.8.0 Governance Hardening, Runtime Refoundation & Traceability release. It canonically integrates the hardened UIEF-5 Clockwork engineering translation and records the existing UIEF-6 through UIEF-10 contracts without widening specialist authority, changing host maturity, or implementing Adaptive Host Integration.
+
+The candidate preserves the core invariant:
+
+```text
+REQUIRED_DESIGN_COMPLEXITY != IMPLEMENTATION_CODE_COMPLEXITY
+VALIDATION_EVIDENCE != RELEASE_AUTHORITY
+NO_BENEFIT_ESTABLISHED != HARM_ESTABLISHED
+```
+
+## UIEF campaign state
+
+- **UIEF-5**: complete and canonically verified at Orchestra commit `75af3966722edfdde474e8fcf99a1b8002d1527f`, tree `1020572e530cba92483cd31d54c2e7d51f179ae7`, from canonical PR #811 and signed reviewed head `baac9d1f349e7fcbbfb4b909b410406c93171fcb`.
+- **UIEF-6**: complete from the existing Conductor-owned specialist integration flow, with serial routing and a maximum of one active specialist.
+- **UIEF-7**: complete with deterministic static validation and fail-closed dispositions. No new rendered-application evidence is claimed by this candidate.
+- **UIEF-8**: complete from existing authority, fidelity, responsive, reuse, and fail-closed regression coverage. No provider experiment is introduced.
+- **UIEF-9**: complete with the evidence-bound disposition `NO_BENEFIT_ESTABLISHED`. Historical UIX-9C observations remain preserved; no new provider/model experiment is run.
+- **UIEF-10**: documentation, machine-index, release metadata, and exact-head qualification closeout for this candidate.
+
+## Compatibility and boundaries
+
+- All 11 package/version surfaces and `machine/hosts/update-contract.v1.json#/package_version` are aligned to `1.9.0`.
+- Existing host maturity remains unchanged. Scaffold-only hosts are not promoted, and installed integrations are not refreshed.
+- Adaptive Host Integration is future work only. This candidate adds no host integration, automatic adaptation, provider mutation, credential handling, or policy activation.
+- Historical v1.8.0 release records, UIX-9C evidence, and prior campaign provenance remain unchanged.
+- The public release remains v1.8.0 until a final v1.9.0 exact-head candidate is qualified, canonically merged, tagged, published, and independently verified.
+
+## Support
+
+Project support: [Buy Me a Coffee](https://buymeacoffee.com/baelfyre).
+
+## Qualification boundary
+
+The candidate requires the repository's full governed validation matrix, exact-head review, signed canonical merge, and independent release/tag readback before publication. A prepared package version or passing local validation does not itself move the public release.

--- a/docs/setup/COMPATIBILITY.md
+++ b/docs/setup/COMPATIBILITY.md
@@ -4,6 +4,8 @@ The current public GitHub Release is Orchestra `v1.8.0: Governance Hardening, Ru
 
 The `v1.8.0` tag resolves directly to the exact release commit. v1.8.0 incorporates the complete architecture governance program OR-GOV-1 through OR-GOV-10, Scribe Specialist Upgrade (SSU), runtime architecture refoundation milestones AR-0 through AR-2, Registry O7 query optimization, and Cloak CUIR reference intelligence. Publication did not graduate scaffold-only hosts or publish those scaffold surfaces to marketplaces.
 
+The v1.9.0 candidate updates package/version metadata and current UIEF documentation. It does not promote scaffold-only hosts, refresh installed integrations, or change the published v1.8.0 identity before the separately governed release gate.
+
 Scaffold-only hosts are not full support claims. Promotion requirements and graduation order live in `docs/project/SCAFFOLD_ADAPTER_GRADUATION_CRITERIA.md`.
 
 | Host | Runtime Adapter | Status | Notes |

--- a/docs/setup/INSTALLATION.md
+++ b/docs/setup/INSTALLATION.md
@@ -4,9 +4,9 @@ Orchestra can be installed in several ways depending on your AI host or IDE.
 
 ## Release Status
 
-The current public GitHub Release is `v1.8.0: Governance Hardening, Runtime Refoundation & Traceability`, published from lightweight tag `v1.8.0` at exact GitHub-verified signed release commit `dad1f153f1be6522a8a7964258a2122a8d057596`. The release is non-draft, non-prerelease, immutable, and independently verified as latest.
+The current public GitHub Release is `v1.8.0: Governance Hardening, Runtime Refoundation & Traceability`, published from lightweight tag `v1.8.0` at exact GitHub-verified signed release commit `dad1f153f1be6522a8a7964258a2122a8d057596`. The release is non-draft, non-prerelease, immutable, and independently verified as latest. The v1.9.0 package candidate is prepared on current `main` and remains pending final release qualification.
 
-The `v1.8.0` tag is a lightweight `commit` ref resolving directly to the release commit; there is no separate tag object. Package/version surfaces are normalized to `1.8.0`. Installing directly from later `main` commits may include post-release maintenance, so use tag `v1.7.0` when exact released content is required.
+The `v1.8.0` tag is a lightweight `commit` ref resolving directly to the release commit; there is no separate tag object. The current package/version candidate surfaces are normalized to `1.9.0`. Installing directly from later `main` commits may include release-candidate work; use tag `v1.8.0` when exact currently published content is required.
 
 | Host | Install Surface | Current Status |
 |---|---|---|

--- a/docs/validation/V1_9_0_RELEASE_READINESS_EVIDENCE.md
+++ b/docs/validation/V1_9_0_RELEASE_READINESS_EVIDENCE.md
@@ -1,0 +1,38 @@
+# Orchestra v1.9.0 Release Readiness Evidence
+
+Status: `PREPARED_NOT_PUBLISHED`
+
+## Candidate identity
+
+- Target version: `1.9.0`
+- Current public release: `v1.8.0`
+- Candidate source baseline: `75af3966722edfdde474e8fcf99a1b8002d1527f`
+- Candidate tree: `1020572e530cba92483cd31d54c2e7d51f179ae7`
+- Candidate release tag: `NOT_CREATED`
+- Candidate GitHub Release: `NOT_PUBLISHED`
+
+## Completed source evidence
+
+- UIEF-5 source qualification PR #809: exact qualified source head `ba3b9d1f2bffe2a20d9f3dfed25bf641425c909b`, tree `1020572e530cba92483cd31d54c2e7d51f179ae7`.
+- UIEF-5 signed materialization PR #810: signed commit `baac9d1f349e7fcbbfb4b909b410406c93171fcb`, parent `e791e86a971880344f2b77e42291adb51692b6b2`, tree `1020572e530cba92483cd31d54c2e7d51f179ae7`.
+- UIEF-5 canonical PR #811: squash merge read back to `75af3966722edfdde474e8fcf99a1b8002d1527f`, GitHub verification `true / valid`.
+- Canonical UIFidelityHandoff identity: `sha256:6b589112da6ae4413c796cde6ed69093de6d10941a821824d205fe18d96caebc`.
+- Focused UIEF-5 and contract validation: `65 passed`.
+- UIEF-7 deterministic validation: no rendered application evidence claimed.
+- UIEF-9 historical disposition: `NO_BENEFIT_ESTABLISHED`; no new provider/model experiment run.
+
+## Candidate release gates
+
+The final candidate must pass and be recorded against its exact reviewed head:
+
+- all 11 package/version surfaces and host-update contract parity;
+- README/README.json and current-facing documentation parity;
+- `python scripts/governance_check.py --strict`;
+- behavior and runtime validation, architecture-boundary validation, and prompt-load validation;
+- Required Analysis Compatibility / CodeQL and native Windows, Ubuntu, and macOS checks;
+- exact-head ordinary merge readiness, signed canonical commit, and independent post-merge readback;
+- independent tag and GitHub Release identity verification after publication.
+
+## Protected boundaries
+
+Adaptive Host Integration remains future-only. No deployment, production mutation, credential or provider-secret mutation, policy activation, destructive testing, branch deletion, force push, or history rewrite is part of this candidate.

--- a/machine/hosts/update-contract.v1.json
+++ b/machine/hosts/update-contract.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "orchestra.host-update-contract.v1",
   "contract_id": "orchestra-host-update",
-  "package_version": "1.8.0",
+  "package_version": "1.9.0",
   "default_behavior": "READ_ONLY_PLAN",
   "unknown_host_policy": "FAIL_CLOSED",
   "authority": {

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "name": "conductor",
   "display_name": "Orchestra",
   "description": "An installable AI workflow plugin that routes tasks through focused specialist skills. See SKILL_INDEX.md and ROUTING_MAP.md for detailed routing behavior.",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "license": "MIT",
   "repository": "https://github.com/Baelfyre/Orchestra",
   "icon_path": "assets/icons/conductor.ico",

--- a/profile-pio.json
+++ b/profile-pio.json
@@ -3,7 +3,7 @@
   "project": "Orchestra",
   "featured": true,
   "summary": "Coordinates AI-assisted development as a governed system of specialist routing, validation, evidence, and human approval rather than an unbounded agent loop.",
-  "status": "Latest release: v1.8.0",
-  "next": "Next release: not announced",
+  "status": "Latest release: v1.8.0; v1.9.0 UIEF candidate prepared",
+  "next": "Next release: v1.9.0 after exact-head qualification and publication verification",
   "url": "https://github.com/Baelfyre/Orchestra"
 }

--- a/skills/ponytail/FRONTEND_FIDELITY_EXECUTION_GUIDE.md
+++ b/skills/ponytail/FRONTEND_FIDELITY_EXECUTION_GUIDE.md
@@ -130,5 +130,5 @@ DOWNSTREAM_REVIEW_BOUNDARY:
 
 1. Implementation capability does NOT equal release or deployment authority.
 2. Passing unit, runtime, or behavioral tests does NOT equal governance approval.
-3. The v1.8 publication hold remains strictly preserved; public release remains `v1.8.0`.
-4. UIEF-4 (Cloak implementation-bound fidelity handoff), UIEF-5, AR-3, and direct production actions remain out of scope and unauthorized.
+3. The v1.9.0 release candidate remains pending final qualification and publication; the current public release remains `v1.8.0` until independently verified publication.
+4. Ponytail does not initiate UIEF-4 or later phases. AR-3 and direct production actions remain out of scope and unauthorized.

--- a/tests/runtime/test_host_updates.py
+++ b/tests/runtime/test_host_updates.py
@@ -19,7 +19,7 @@ from orchestra_runtime.host_updates import (
 )
 
 ROOT = Path(__file__).resolve().parents[2]
-CURRENT_VERSION = "1.8.0"
+CURRENT_VERSION = "1.9.0"
 
 
 def _canonical_contract() -> dict[str, object]:
@@ -107,13 +107,13 @@ def test_unknown_host_fails_closed_for_record_and_plan() -> None:
 
 
 def test_update_status_is_deterministic_without_network_or_mutation() -> None:
-    available = build_host_update_plan("codex", latest_version="v1.9.0", root=ROOT)
+    available = build_host_update_plan("codex", latest_version="v1.10.0", root=ROOT)
     current = build_host_update_plan("codex", latest_version=CURRENT_VERSION, root=ROOT)
     ahead = build_host_update_plan("codex", latest_version="1.6.0", root=ROOT)
     unchecked = build_host_update_plan("codex", root=ROOT)
 
     assert available.update_status == "UPDATE_AVAILABLE"
-    assert available.latest_version == "1.9.0"
+    assert available.latest_version == "1.10.0"
     assert current.update_status == "UP_TO_DATE"
     assert ahead.update_status == "LOCAL_AHEAD"
     assert unchecked.update_status == "NOT_CHECKED"

--- a/tests/runtime/test_release_version_surfaces.py
+++ b/tests/runtime/test_release_version_surfaces.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[2]
-EXPECTED_VERSION = "1.8.0"
+EXPECTED_VERSION = "1.9.0"
 
 JSON_VERSION_SURFACES = (
     "plugin.json",


### PR DESCRIPTION
## What changed

Prepare the v1.9.0 UI Execution Fidelity release candidate after canonical UIEF-5 completion. Align all 11 package/version surfaces and the host update contract to 1.9.0, reconcile current-facing README and continuity records, add UIEF-5 through UIEF-10 release evidence, and retain v1.8.0 as the public release until final exact-head publication verification.

## Evidence and boundaries

- UIEF-5 canonical baseline: `75af3966722edfdde474e8fcf99a1b8002d1527f`.
- UIEF-6 and UIEF-8 use existing verified contracts and regression suites.
- UIEF-7 records deterministic validation without rendered-application evidence.
- UIEF-9 preserves `NO_BENEFIT_ESTABLISHED`; no new provider/model experiment runs.
- Adaptive Host Integration remains future work only.
- Support link: https://buymeacoffee.com/baelfyre

## Validation

- `python -m pytest tests/runtime -q -p no:cacheprovider` (2596 passed, 10 subtests)
- `python tests/behavior/run_tests.py` with approved UIEF-5 base (passed)
- strict governance, structure, manifest, packaging, routing, architecture, prompt-load, README impact, and Codex export validators (passed)
