### PR TITLE
docs(readme): simplify Orchestra landing page and restore support link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 <div align="center">
   <img src="./assets/readme/orchestra-governance-banner.svg" alt="Orchestra banner showing coordinated software responsibilities" width="100%" />
 
-  <p><strong>A portable governance and orchestration runtime for structured AI-assisted development.</strong></p>
+  <p><strong>Governed orchestration for AI-assisted software development.</strong></p>
 
   <p>
-    <a href="docs/setup/INSTALLATION.md">Installation</a> |
+    <a href="docs/setup/INSTALLATION.md">Install</a> |
     <a href="docs/README.md">Documentation</a> |
     <a href="docs/developer/README.md">Developer Portal</a> |
-    <a href="docs/README.md#governance-and-authority">Governance</a> |
-    <a href="docs/setup/VALIDATION.md">Validation</a> |
-    <a href="docs/THIRD_PARTY_PROVENANCE.md">Acknowledgements</a> |
-    <a href="CHANGELOG.md">Changelog</a>
+    <a href="docs/governance/README.md">Governance</a> |
+    <a href="CHANGELOG.md">Changelog</a> |
+    <a href="https://buymeacoffee.com/baelfyre">Support</a>
   </p>
+
   <p>
-    <img src="https://img.shields.io/badge/package_version-v1.9.0-blue" alt="Repository package version v1.9.0" />
+    <img src="https://img.shields.io/badge/release-v1.9.0-blue" alt="Latest release v1.9.0" />
     <a href="https://github.com/Baelfyre/Orchestra/actions/workflows/validate.yml">
       <img src="https://github.com/Baelfyre/Orchestra/actions/workflows/validate.yml/badge.svg" alt="Repository validation status" />
     </a>
@@ -23,223 +23,134 @@
 
 ---
 
-## Purpose
+## What is Orchestra?
 
-AI can generate quickly. Reliable software development still needs ownership, constraints, evidence, and explicit authority.
+Orchestra is a governance and orchestration framework for AI-assisted software development.
 
-**Orchestra coordinates AI-assisted development across specialist responsibilities, governance, validation, evidence, host integrations, and human approval boundaries.**
+It helps an AI coding workflow behave more like a coordinated engineering process by routing work to focused specialists, keeping authority boundaries explicit, validating important transitions, and preserving enough evidence to continue safely across handoffs.
 
-It is **not an AI model**. Models generate and review work. Orchestra determines how permitted work is routed, sequenced, constrained, validated, recorded, and handed to the next responsible boundary.
+Orchestra is **not an AI model** and it does not replace your IDE, coding agent, or engineering judgment. It sits around those tools and helps coordinate how work moves from intent to implementation to validation.
 
-> **Core rule:** routing, tool access, compatibility, validation success, and mergeability are not authority.
+## Why use it?
 
-## Mission and vision
+AI can generate code quickly, but larger projects can still suffer from:
 
-**Mission:** make AI-assisted software engineering more reliable through explicit specialist ownership, bounded authority, deterministic safeguards, validation, evidence, and auditable state transitions.
+- context drift between tasks or sessions;
+- architecture, security, UI, database, and implementation decisions conflicting with each other;
+- agents doing work outside the authority actually granted by the user;
+- successful tests being mistaken for permission to merge, deploy, or change policy;
+- repeated re-analysis because earlier evidence was not carried forward clearly.
 
-**Vision:** enable the highest useful level of AI-assisted autonomy consistent with explicit human authority, deterministic safeguards, auditable evidence, and recoverable engineering state.
+Orchestra is designed to reduce those problems without turning every task into a large multi-agent workflow.
 
-## Prime Directive
-
-> Orchestra shall permit an AI-assisted action or lifecycle transition only within explicit, reduction-only authority and current applicable evidence. It shall never infer permission from capability, routing, confidence, learned state, validation success, mergeability, or prior success. A permanent capability shall be promoted only when proportional evidence shows that it solves an Orchestra-owned problem whose benefit justifies its complexity and risk without weakening these boundaries.
-
-The practical trust boundary is intentionally strict:
+## How it works
 
 ```text
-CAN_EDIT != MAY_EDIT
-CAN_PUSH != MAY_PUSH
+User request
+    ↓
+Authority and project context
+    ↓
+Conductor chooses the smallest useful route
+    ↓
+Specialist work
+    ↓
+Validation and evidence
+    ↓
+Arbiter / human boundary when required
+    ↓
+Next bounded action
+```
+
+The key distinction is simple:
+
+```text
+CAN_DO != MAY_DO
 TESTS_PASS != MERGE_AUTHORITY
-VALIDATION_SUCCESS != AUTHORITY
-MCP_EXPOSURE != AUTHORITY
-SELECTED_SPECIALIST != UNLIMITED_AUTHORITY
-MERGEABLE != MERGE_READY
-MERGE_READY != MERGE_AUTHORITY
+MERGEABLE != APPROVED
+TOOL_ACCESS != PERMISSION
 ```
 
-See the full [Orchestra Prime Directive](docs/governance/ORCHESTRA_PRIME_DIRECTIVE.md) and [Governance Overview](docs/governance/README.md).
+Capability is not authority.
 
-## Core capabilities
+## What Orchestra provides
 
-| Capability | What it does | Go deeper |
-| --- | --- | --- |
-| **Specialist orchestration** | Routes work to focused architecture, implementation, security, UI/UX, database, QA, documentation, governance, and coordination roles. | [Skills & Routing](docs/README.md#specialists-routing-and-coordination) |
-| **Governed execution** | Keeps authority, capabilities, governance, human gates, and repository policy separate and explicit. | [Governance & Authority](docs/README.md#governance-and-authority) |
-| **Cross-domain coordination** | Sequences specialist work, detects contradictions, and re-enters the correct owner when assumptions become stale. | [Coordination](docs/README.md#specialists-routing-and-coordination) |
-| **Adaptive context and shadow learning** | Maintains bounded local evidence, advisory specialist context, and non-authorizing adaptive evaluation without allowing learned state to silently create authority. | [Adaptive Architecture](docs/README.md#adaptive-intelligence) |
-| **Portable adaptive memory** | Keeps adaptive state local by default while allowing explicitly reviewed learned candidates to use a storage-agnostic user-selected backend. | [Portable Adaptive Memory](docs/architecture/PORTABLE_ADAPTIVE_MEMORY.md) |
-| **UI design fidelity** | Preserves design-source evidence, project-native components, tokens, assets, accessibility requirements, specialist ownership, and deterministic validation. | [UI Design Fidelity Plan](docs/project/UI_DESIGN_FIDELITY_SYSTEM_PLAN.md) |
-| **Adaptive documentation and traceability** | Extends Scribe with domain narrative, bidirectional evidence traceability, system-to-documentation reconstruction, and documentation/implementation reconciliation while preserving specialist ownership. | [Scribe Specialist Upgrade](docs/project/SCRIBE_SPECIALIST_UPGRADE_SSU.md) |
-| **Product intent and capacity governance** | Extends The Steward with product intent contracts, capacity envelopes, workload assumptions, and adaptive parameter elicitation without overengineering or architecture overreach. | [Steward Intent & Capacity](skills/the-steward/PRODUCT_INTENT_AND_CAPACITY_ENVELOPE_GUIDE.md) |
-| **Architecture complexity and scale posture governance** | Extends Clockwork with architecture complexity decisions, scale-ready versus scale-provisioned posture, and simpler-alternative justification without premature infrastructure expansion. | [Clockwork Complexity & Scale](skills/clockwork/ARCHITECTURE_COMPLEXITY_AND_SCALE_POSTURE_GUIDE.md) |
-| **Architecture governance intake and adaptive routing** | Extends Conductor with evidence-bound architecture intake, decision-specific capacity routing, and minimum specialist route composition without transferring domain authority. | [Conductor Architecture Governance Intake](skills/conductor/ARCHITECTURE_GOVERNANCE_INTAKE_GUIDE.md) |
-| **Governance contract invalidation and minimal re-entry** | Extends The Tuner with declared governance-contract dependencies, clause-sensitive invalidation, finite cycle handling, and smallest-owner re-entry recommendations without direct routing or authority expansion. | [Cross-Specialist Coordination Protocol](docs/routing/CROSS_SPECIALIST_COORDINATION_PROTOCOL.md) |
-| **Validation and evidence** | Uses deterministic checks, exact-head evidence, cross-platform validation, and fail-closed transition rules. | [Validation & Evidence](docs/README.md#validation-evidence-and-continuity) |
-| **Portable host integration** | Supports governed adapter surfaces, PRAP compatibility, host maturity contracts, and bounded MCP transport. | [Hosts & Integrations](docs/README.md#hosts-adapters-and-integrations) |
-| **Machine-readable knowledge** | Exposes structured contracts, schemas, provenance, release evidence, and an AI-first repository index. | [`README.json`](README.json) |
+| Area | What Orchestra adds |
+| --- | --- |
+| **Specialist routing** | Focused ownership for architecture, implementation, security, UI/UX, persistence, QA, documentation, governance, and coordination. |
+| **Governed execution** | Clear separation between what a tool can do and what the user has actually authorized. |
+| **Cross-specialist coordination** | Re-entry and handoff rules when a decision in one domain invalidates another. |
+| **UI fidelity** | Preserves accepted design complexity, reusable project-native components, responsive intent, and validation boundaries. |
+| **Validation and evidence** | Deterministic checks, exact-head evidence, cross-platform validation, and fail-closed transitions where appropriate. |
+| **Continuity** | Machine-readable state, receipts, contracts, and bounded adaptive memory to reduce repeated reconstruction. |
+| **Portable integration** | Adapter and MCP surfaces that allow Orchestra to work across supported AI coding hosts without transferring authority to the host. |
 
-## How Orchestra works
+For the full capability map, see the [Documentation Map](docs/README.md).
+
+## Quick start
+
+### Codex
+
+Add this repository as a Marketplace source, install Orchestra, then invoke:
 
 ```text
-Request / Project Context
-        ↓
-Governance + Authority Boundaries
-        ↓
-Conductor Routing
-        ↓
-Specialist Execution / Tuner Coordination
-        ↓
-Validation + Evidence
-        ↓
-Arbiter Transition
-        ↓
-Next bounded action or human gate
+@Orchestra
 ```
 
-The deterministic control plane defines what is allowed. Specialists decide how to perform their owned work inside those boundaries. Validation proves outcomes; it does not grant permission.
-
-## Development Lifecycle V2
-
-Development-candidate maturity is kept separate from Orchestra's runtime execution lifecycle. The high-level promotion path is:
-
-```text
-Feature Admission
-    ↓
-Baseline + Implementation
-    ↓
-Candidate Declaration / Feature Freeze
-    ↓
-Qualification Gate Set
-    ↓
-Promotion Adjudication
-    ↓
-Merge Preparation
-    ↓
-Merge + Independent Verification
-    ↓
-Closeout + Retirement
-```
-
-This preserves an important distinction: **implemented != validated != evidence-supported != worth adopting != merge-ready != released or activated**. Greater autonomy may remove unnecessary pauses after a gate is satisfied; it does not remove the gate or create protected-action authority.
-
-See [Feature Admission](docs/governance/FEATURE_ADMISSION_POLICY.md), [Candidate Maturity and Feature Freeze](docs/governance/CANDIDATE_MATURITY_FEATURE_FREEZE.md), and [Qualification Gates, Evaluation, and Independent Audit](docs/governance/QUALIFICATION_GATES_EVALUATION_AUDIT.md).
-
-## Portable adaptive memory
-
-Orchestra adaptive learning remains machine-local by default. An optional portable-memory contract can stage explicitly reviewed learned candidates for a user-selected backend without coupling the runtime to a specific repository or storage service.
-
-Supported backend classes are generic: local JSON, Git-backed JSON, HTTP/API storage, or a custom adapter. Backend configuration and credentials remain outside portable learned-pattern payloads.
-
-Portable memory remains advisory and non-authorizing. It cannot grant execution or policy authority, override explicit instructions, relax governance, transfer local identity, or automatically promote learned state.
-
-See [Portable Adaptive Memory](docs/architecture/PORTABLE_ADAPTIVE_MEMORY.md).
-
-## Current release state
-
-The latest published release is **[v1.9.0: UI Execution Fidelity](https://github.com/Baelfyre/Orchestra/releases/tag/v1.9.0)**. The immutable release resolves to canonical commit `7129a690b041bddbf8b58f41db0c4a680317fda1` with tree `babf0a0c61d4a073144891b295b1989c256513eb` and a GitHub verified/valid signature.
-
-v1.8.0 consolidated governance hardening, seven architecture governance contracts (OR-GOV-1 through OR-GOV-10), Scribe's documentation and traceability upgrade (SSU), the validated AR-0/AR-1/AR-2 runtime architecture foundation, Registry O7 query optimization, and Cloak CUIR reference intelligence. Its tag remains fixed after v1.9.0 publication.
-
-v1.9.0 carries the canonically merged UIEF-5 Clockwork translation and reconciles the existing UIEF-6 through UIEF-10 contracts. UIEF-7 and UIEF-9 retain explicit evidence limits: deterministic validation is covered without new rendered-application evidence, and the historical UIX-9C result remains `NO_BENEFIT_ESTABLISHED`. The v1.9.0 tag and GitHub Release were independently verified at the exact signed commit above.
-
-The v1.7.0 release itself did not include a live UIX-9 model/provider proof. Post-release UIX-9C V3 later completed as a controlled six-observation study. Its terminal result is **`NO_BENEFIT_ESTABLISHED`**: all three corrected pairs were valid and all 39 primary governed-versus-baseline metric comparisons were unchanged, establishing neither a repeatable governed advantage nor harm under the frozen experiment.
-
-## Research and validation archive
-
-Detailed comparative benchmark reports are retained as research and validation evidence rather than expanded in this landing page.
-
-The completed confirmatory program did **not** establish a repeatable efficiency benefit for Murmurs, so Murmurs is not promoted to the default execution path and is not required by specialists. Historical experiments remain preserved so the negative result is not lost or repeatedly re-tested until positive.
-
-The completed UIX-9C V3 controlled study likewise did **not** establish a repeatable governed UIX advantage on its frozen fixture. The null result is retained as valid negative evidence and does not establish harm.
-
-- [UIX-9C V3 post-study result](docs/validation/uix9b-live-evidence-v2/v3-poststudy-result.v2.json)
-- [B-Phase Terminal Closeout Decision](docs/benchmarking/B_PHASE_CLOSEOUT_DECISION.md)
-- [B-Phase Final Evidence Synthesis](docs/benchmarking/B_PHASE_FINAL_EVIDENCE_SYNTHESIS.md)
-- [Codex C1 Cross-Provider Reconciliation](docs/benchmarking/CODEX_C1_CROSS_PROVIDER_RECONCILIATION.md)
-- [Codex C2R1 Machine-JSON Reconciliation](docs/benchmarking/CODEX_C2R1_MACHINE_JSON_RECONCILIATION.md)
-- [Benchmarking documentation archive](docs/benchmarking/)
-
-These reports are evidence, not runtime authority or release permission.
-
-## Support
-
-If Orchestra is useful to you, support its continued maintenance at [Buy Me a Coffee](https://buymeacoffee.com/baelfyre).
-
-## Install Orchestra
-
-**Codex:** add this repository as a Marketplace source, install Orchestra, then invoke `@Orchestra`.
-
-**Antigravity:**
+### Antigravity
 
 ```sh
 agy plugin install https://github.com/Baelfyre/Orchestra
 ```
 
-**Other hosts and local setups:** use the [Installation Guide](docs/setup/INSTALLATION.md) and [Compatibility Guide](docs/setup/COMPATIBILITY.md).
+### Other hosts
 
-## Use Orchestra through MCP
+See the [Installation Guide](docs/setup/INSTALLATION.md) and [Compatibility Guide](docs/setup/COMPATIBILITY.md).
 
-Orchestra can expose a bounded tool surface to an MCP-compatible client while preserving the same PRAP adapter, runtime, governance, and authority boundaries.
+## MCP
 
-Launch the stdio server with an existing adapter identity:
+Orchestra can expose a bounded tool surface to an MCP-compatible client while preserving the same runtime and governance boundaries.
 
 ```sh
 python scripts/mcp_server.py --adapter codex
 ```
 
-The bounded MCP transport, introduced in v1.6.0 and retained in v1.7.0, targets protocol revision `2026-07-28` and exposes only `server/discover`, `tools/list`, and `tools/call`.
+MCP is transport, not authority. Discovery or tool access does not grant permission to perform protected actions.
 
-**MCP is transport, not authority.** Client metadata, tool arguments, discovery, or compatibility cannot grant Orchestra runtime authority.
+See [MCP stdio governed tool transport](docs/developer/MCP_STDIO_TRANSPORT.md).
 
-See [MCP stdio governed tool transport](docs/developer/MCP_STDIO_TRANSPORT.md) for protocol handling, safety boundaries, and non-goals.
+## Current release
 
-## Build or certify an adapter with the SDK / PRAP
+The latest published release is **[v1.9.0: UI Execution Fidelity](https://github.com/Baelfyre/Orchestra/releases/tag/v1.9.0)**.
 
-Integration authors can use Orchestra's stable SDK import surface and read-only PRAP v1 compatibility certification.
+v1.9.0 completes the current UI execution fidelity program while preserving explicit evidence limits where the project did not establish stronger claims. Detailed release evidence, maturity records, and historical validation remain in the documentation instead of being duplicated here.
 
-```text
-orchestra_runtime.protocol.sdk
-```
+See:
 
-Certify one adapter:
+- [Changelog](CHANGELOG.md)
+- [Maturity](docs/MATURITY.md)
+- [Validation documentation](docs/setup/VALIDATION.md)
 
-```sh
-python scripts/certify_adapter.py --adapter codex --json
-```
+## Documentation
 
-Or certify every contract-declared adapter:
+Use the README as the entry point, then go deeper only when needed:
 
-```sh
-python scripts/certify_adapter.py --all --json
-```
+- [Documentation Map](docs/README.md)
+- [Installation](docs/setup/INSTALLATION.md)
+- [Governance](docs/governance/README.md)
+- [Developer Portal](docs/developer/README.md)
+- [Architecture](docs/architecture/)
+- [Routing and coordination](docs/routing/)
+- [Validation](docs/setup/VALIDATION.md)
+- [Third-party provenance](docs/THIRD_PARTY_PROVENANCE.md)
 
-Certification validates compatibility. It does not install integrations, promote host maturity, deploy, activate policy, or grant runtime authority.
+For AI systems and exact structured project state, start with [`README.json`](README.json).
 
-See [Adapter SDK and PRAP v1 Compatibility Certification](docs/setup/ADAPTER_SDK_PRAP.md) for the full contract and authority boundary.
+## Support
 
-## Documentation and provenance
+If Orchestra is useful to you and you want to support its continued development:
 
-Start with the [Documentation Map](docs/README.md) for architecture, specialists, governance, adaptive intelligence, UI design fidelity, validation, hosts, MCP, knowledge, provenance, releases, and historical design records.
-
-Developers extending Orchestra should use the [Developer Portal](docs/developer/README.md), which indexes the Adapter SDK, PRAP certification, host, specialist, governance, and validation contracts.
-
-Orchestra records third-party relationships without treating a reference as automatic source adoption, runtime dependency, affiliation, or authority transfer.
-
-- [Third-Party Provenance and Acknowledgements](docs/THIRD_PARTY_PROVENANCE.md)
-- [`machine/provenance/third-party.v1.json`](machine/provenance/third-party.v1.json)
-
-## Machine-readable reference
-
-AI systems should start with [`README.json`](README.json), then follow its ordered references into `machine/` contracts and JSON Schemas.
-
-Orchestra uses a hybrid representation policy:
-
-- **Markdown** for human explanation, rationale, examples, and specialist guidance.
-- **JSON** for canonical structured machine state, contracts, indexes, receipts, provenance, and evidence.
-- **JSON Schema** for deterministic validation.
-- **TOON** only as a derived, validated, non-authoritative model-context projection when it provides measured context benefit.
-
-When prose and a machine contract disagree on an exact deterministic fact, use the machine contract and treat the mismatch as documentation drift.
+**[Buy me a coffee](https://buymeacoffee.com/baelfyre)**
 
 ---
 
-**License:** [MIT](LICENSE) | **Changelog:** [CHANGELOG.md](CHANGELOG.md) | **Security:** [SECURITY.md](SECURITY.md)
+**License:** [MIT](LICENSE) | **Security:** [SECURITY.md](SECURITY.md) | **Changelog:** [CHANGELOG.md](CHANGELOG.md)


### PR DESCRIPTION
## Summary

Refine README.md into a human-readable project landing page instead of duplicating the full documentation archive.

- remove the Mission & Vision section
- simplify the project explanation and trust model
- reduce the capability list to the core areas a new reader needs
- keep quick-start instructions for Codex, Antigravity, other hosts, and MCP
- condense current-release information and move detailed evidence to the docs
- add the missing Buy Me a Coffee link in the top navigation and Support section
- preserve README.json as the machine-readable source for exact structured state

No runtime, governance, release, adapter, or policy behavior is changed.