### PR TITLE
feat(uai): clarify canonical command surface and separate native custom-agent probe

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,7 +5,7 @@ When assisting in the Orchestra repository or working with Orchestra-integrated 
 ## 1. Governance and Routing Architecture
 
 1. **Governance Layer**: `The Steward` (business alignment, scope, SDLC) and `The Governor` (legal, compliance, privacy, IP, licensing) sit above the Conductor. The Conductor cannot override governance decisions.
-2. **Routing Layer**: `Conductor` is the exclusive router and workflow orchestrator. Do not invent custom subagent chains or bypass the Conductor for complex tasks.
+2. **Routing Layer**: `Conductor` is the exclusive router and workflow orchestrator. Do not invent custom subagent chains or bypass the Conductor for complex tasks. Canonical command `/conductor` invokes Conductor for task classification, routing, and specialist orchestration.
 3. **Specialist Ownership**: Domain specialists exclusively own their respective domains:
    - `clockwork`: Architecture, OOP, layering, refactoring.
    - `cloak`: UI/UX, accessibility, design patterns.
@@ -17,11 +17,14 @@ When assisting in the Orchestra repository or working with Orchestra-integrated 
    - `dagger`: Chaos, adversarial, and resilience testing (destructive execution strictly blocked).
    - `arbiter`: Workflow continuity, validation, and transition governance.
    - `the-tuner`: Cross-specialist coordination.
-4. **Implementation Layer**: `Ponytail` handles focused implementation, strictly keeping code minimal, reversible, and free of over-engineering.
+4. **Implementation Layer**: `Ponytail` handles focused implementation, strictly keeping code minimal, reversible, and free of over-engineering. Canonical command `/ponytail` invokes Ponytail for bounded code edits within established architecture.
 5. **Simplicity Filter**: `Caveman` ensures the smallest safe change set, avoiding broad refactors during bug fixes.
 
 ## 2. Core Invariants
 
+- `CONDUCTOR != PONYTAIL`
+- `ROUTING_AUTHORITY != IMPLEMENTATION_AUTHORITY`
+- `CUSTOM_AGENT_CAPABILITY != ORCHESTRA_ROUTING_AUTHORITY`
 - `HOST != PROVIDER`
 - `PROVIDER != SPECIALIST`
 - `HOST_IDENTITY != AUTHORITY`

--- a/README.json
+++ b/README.json
@@ -2234,7 +2234,7 @@
     },
     "universal_adaptive_integration_uai": {
       "status": "UAI_0_BASELINE_AND_PROBE_PREPARED",
-      "purpose": "Decoupled host adapter templates and empirical capability probe suite for GitHub Copilot and external hosts without authority expansion.",
+      "purpose": "Decoupled host adapter templates and empirical capability probe suite distinguishing canonical command invocation from native custom-agent capabilities without authority expansion.",
       "human_sources": [
         "adapters/github-copilot/README.md",
         "adapters/github-copilot/probe-guide.md"

--- a/adapters/github-copilot/probe-guide.md
+++ b/adapters/github-copilot/probe-guide.md
@@ -9,9 +9,19 @@ Per UAI governance:
 CAPABILITY_NEVER_CREATES_AUTHORITY
 DO_NOT_FABRICATE_SUPPORT_FROM_DOCUMENTATION
 LIVE_EVIDENCE_OVERRIDES_VENDOR_CLAIMS
+CONDUCTOR_IS_EXCLUSIVE_ROUTER
+ORCHESTRA_COMMAND_INVOCATION != NATIVE_COPILOT_CUSTOM_AGENT_CAPABILITY
 ```
 
 Capabilities not yet proven on the live Copilot surface remain `AVAILABLE_NOT_YET_VERIFIED` or `UNKNOWN`.
+
+---
+
+## Architectural Distinctions
+
+1. **Orchestra Command Surface**: Orchestra canonically routes development tasks through slash commands such as `/conductor` (orchestration / routing) and `/ponytail` (bounded implementation).
+2. **Native Copilot Custom-Agent Capability**: Host-level `@agent` support (e.g. `.github/agents/*.agent.md` or `@conductor`) is evaluated strictly as an optional host transport capability. Native `@agent` support is not a prerequisite for Orchestra routing authority.
+3. **Transport Independence**: The UAI resolver maps Orchestra interactions to whatever transport the host supports (slash commands, repository instructions, agent skills, custom agents, MCP, extensions, or CLI). No single transport represents Orchestra's universal architecture.
 
 ---
 
@@ -20,15 +30,18 @@ Capabilities not yet proven on the live Copilot surface remain `AVAILABLE_NOT_YE
 | # | Probe Dimension | Target Surface | Test Mechanism | Deterministic Status | Maintainer Live Action Required |
 |---|---|---|---|---|---|
 | 1 | Repository & Workspace Instructions | `.github/copilot-instructions.md` | Ask Copilot to state primary Orchestra router | AVAILABLE_NOT_YET_VERIFIED | Prompt in Copilot Chat |
-| 2 | Agent Skills Discovery | `.github/skills/*/SKILL.md` or `skills/*/SKILL.md` | Ask Copilot to list available skills | AVAILABLE_NOT_YET_VERIFIED | Prompt in Copilot Chat |
-| 3 | Custom Agent Support | `.github/agents/*.agent.md` | Invoke `@conductor` or custom agent | AVAILABLE_NOT_YET_VERIFIED | Check agent picker in Chat |
-| 4 | MCP Discovery & Tool Visibility | Workspace MCP configuration | Ask Copilot for available external tools | AVAILABLE_NOT_YET_VERIFIED | Check tool icon / call tools |
-| 5 | Plugin / Extension Surface | GitHub Copilot Extensions | Inspect marketplace / extension menu | UNSUPPORTED / NOT_INSTALLED | Check extension list |
-| 6 | CLI Surface | `gh copilot` or `@github/copilot-cli` | Run `gh copilot --version` | VERIFIED_UNSUPPORTED_LOCALLY | Install if desired, else instruction path |
-| 7 | Workspace & File Permissions | Workspace file read/write | Ask Copilot to inspect `plugin.json` | AVAILABLE_NOT_YET_VERIFIED | Ask Copilot to read a file |
-| 8 | Approval & Permission Controls | Edit acceptance / confirmation | Propose an edit to a test file | AVAILABLE_NOT_YET_VERIFIED | Observe diff acceptance flow |
-| 9 | Model Selection Controls | Model picker in Copilot UI | Inspect available models (Claude, GPT-4o, o1, etc.) | AVAILABLE_NOT_YET_VERIFIED | Record available model options |
-| 10 | Organization / Account Policy | Enterprise / Org policy settings | Observe any disabled features or warnings | AVAILABLE_NOT_YET_VERIFIED | Check for policy notices in Copilot |
+| 2 | Orchestra Command Recognition: Conductor | `/conductor` invocation | Probe A: route without implementing | AVAILABLE_NOT_YET_VERIFIED | Prompt in Copilot Chat |
+| 3 | Orchestra Specialist Recognition: Ponytail | `/ponytail` invocation | Probe B: implementation boundaries | AVAILABLE_NOT_YET_VERIFIED | Prompt in Copilot Chat |
+| 4 | Orchestra Command Separation | `/conductor` vs `/ponytail` | Probe C: contrast roles and authority | AVAILABLE_NOT_YET_VERIFIED | Prompt in Copilot Chat |
+| 5 | Native Custom-Agent Capability | `.github/agents/*.agent.md` / UI picker | Probe D: check `@agent` selector support | AVAILABLE_NOT_YET_VERIFIED | Check agent picker in Chat |
+| 6 | Agent Skills Discovery | `.github/skills/*/SKILL.md` or `skills/*/SKILL.md` | Ask Copilot to list available skills | AVAILABLE_NOT_YET_VERIFIED | Prompt in Copilot Chat |
+| 7 | MCP Discovery & Tool Visibility | Workspace MCP configuration | Ask Copilot for available external tools | AVAILABLE_NOT_YET_VERIFIED | Check tool icon / call tools |
+| 8 | Plugin / Extension Surface | GitHub Copilot Extensions | Inspect marketplace / extension menu | UNSUPPORTED / NOT_INSTALLED | Check extension list |
+| 9 | CLI Surface | `gh copilot` or `@github/copilot-cli` | Run `gh copilot --version` | VERIFIED_UNSUPPORTED_LOCALLY | Local CLI verified missing |
+| 10 | Workspace & File Permissions | Workspace file read/write | Ask Copilot to inspect `plugin.json` | AVAILABLE_NOT_YET_VERIFIED | Ask Copilot to read a file |
+| 11 | Approval & Permission Controls | Edit acceptance / confirmation | Propose an edit to a test file | AVAILABLE_NOT_YET_VERIFIED | Observe diff acceptance flow |
+| 12 | Model Selection Controls | Model picker in Copilot UI | Inspect available models (Claude, GPT-4o, o1, etc.) | AVAILABLE_NOT_YET_VERIFIED | Record available model options |
+| 13 | Organization / Account Policy | Enterprise / Org policy settings | Observe any disabled features or warnings | AVAILABLE_NOT_YET_VERIFIED | Check for policy notices in Copilot |
 
 ---
 
@@ -45,6 +58,93 @@ According to the repository instructions for this project, what is the exclusive
 - Copilot identifies `cloak` as the UI specialist.
 - Copilot cites `.github/copilot-instructions.md`.
 
+---
+
+### Probe A: Conductor Command Recognition
+**Surface**: GitHub Copilot Chat (VS Code, Web, or Cloud Agent)
+**Copy-paste prompt**:
+```text
+/conductor
+
+Classify and route this task without implementing it:
+
+Add a new unit test that validates an existing architecture boundary.
+
+State:
+1. task classification;
+2. selected specialist or route;
+3. why that route is appropriate;
+4. authority boundaries;
+5. whether implementation is authorized.
+```
+**Expected verified evidence**:
+- `/conductor` recognized or correctly interpreted.
+- Conductor acts as router/orchestrator.
+- No direct implementation occurs merely from classification.
+- Routing remains bounded by Orchestra specialist ownership.
+- Capability does not create authority.
+*(Do not hard-code an expected destination specialist if the current Orchestra routing contract legitimately chooses another valid specialist.)*
+
+---
+
+### Probe B: Ponytail Specialist Recognition
+**Surface**: GitHub Copilot Chat (VS Code, Web, or Cloud Agent)
+**Copy-paste prompt**:
+```text
+/ponytail
+
+Without modifying any files, explain how you would approach a small implementation change that simplifies existing code while preserving observable behavior.
+
+Also state:
+1. your specialist role;
+2. what work you own;
+3. what work you must not override;
+4. when the task must return to Conductor or another specialist.
+```
+**Expected verified evidence**:
+- `/ponytail` recognized or correctly interpreted.
+- Ponytail identifies as bounded implementation specialist.
+- Ponytail does not claim Conductor routing authority.
+- Ponytail does not override architecture, UI fidelity, security, persistence, or governance ownership.
+- Complexity reduction must preserve accepted behavior/design requirements.
+- Cross-specialist needs return through Conductor.
+
+---
+
+### Probe C: Command Separation
+**Surface**: GitHub Copilot Chat (VS Code, Web, or Cloud Agent)
+**Copy-paste prompt**:
+```text
+According to this repository's Orchestra instructions, explain the difference between:
+
+/conductor
+/ponytail
+
+Do not modify any files.
+```
+**Expected verified evidence**:
+- `/conductor` = orchestration / routing entry.
+- `/ponytail` = bounded implementation specialist.
+- `CONDUCTOR != PONYTAIL`.
+- `ROUTING_AUTHORITY != IMPLEMENTATION_AUTHORITY`.
+
+---
+
+### Probe D: Native Copilot Custom-Agent Observation
+**Surface**: GitHub Copilot Chat (agent selection menu or `@` mention)
+**Action**:
+- Check whether the Copilot UI exposes custom agents or an `@` agent selector (e.g. typing `@` in Chat).
+- Record the observed state:
+  - `SUPPORTED_VERIFIED`: Custom agent menu lists workspace or user agents.
+  - `SUPPORTED_WITH_LIMITS`: Custom agent recognized only in specific surfaces or with limitations.
+  - `UNSUPPORTED`: No `@` agent mechanism exposed.
+  - `BLOCKED_BY_POLICY`: Disabled by organization or account policy.
+  - `UNKNOWN`: Not determinable from current interface.
+**Boundary Note**:
+- Native `@agent` support is recorded strictly as host capability; it is not a prerequisite for Orchestra.
+
+---
+
 ### Probe 2: Agent Skills Discovery
 **Surface**: GitHub Copilot Chat
 **Copy-paste prompt**:
@@ -54,16 +154,7 @@ List all Orchestra skills available in this workspace and display the primary pu
 **Expected verified evidence**:
 - Copilot recognizes `skills/*/SKILL.md` or reports which skill directories are indexed.
 
-### Probe 3: Custom Agent Dispatch
-**Surface**: GitHub Copilot Chat (agent selection menu or `@` mention)
-**Action**:
-- Type `@` in Copilot Chat to check whether `@conductor` or any custom agent is listed.
-- If available, enter:
-```text
-@conductor Classify this task: Add a new unit test for architecture boundary validation.
-```
-**Expected verified evidence**:
-- Copilot resolves `@conductor` as the custom agent and routes the task to `overseer` or `clockwork`.
+---
 
 ### Probe 4: MCP Tool Visibility
 **Surface**: GitHub Copilot Chat (with MCP enabled)
@@ -74,25 +165,33 @@ What external MCP tools are currently configured and callable in this session?
 **Expected verified evidence**:
 - Copilot lists MCP tools or reports that MCP tool transport is not active/available.
 
+---
+
 ### Probe 5 & 6: Extension & CLI Inspection
 **Local command output already recorded**:
 - `gh copilot --version` -> `! Copilot CLI not installed`
 - `code --list-extensions` -> `github.copilot` not installed in default local profile.
 
+---
+
 ### Probe 7 & 8: File Access and Approval Controls
 **Surface**: GitHub Copilot Chat
 **Copy-paste prompt**:
 ```text
-Read line 1-10 of plugin.json and show the exact version string without modifying the file.
+Read lines 1-10 of plugin.json and show the exact version string without modifying the file.
 ```
 **Expected verified evidence**:
 - Copilot reads `plugin.json` and outputs `"version": "1.9.0"`.
+
+---
 
 ### Probe 9: Model Selection Controls
 **Surface**: GitHub Copilot Chat UI
 **Action**:
 - Check the model dropdown in the Copilot Chat interface.
 - Record the exact list of available models (e.g., `Claude 3.5 Sonnet`, `GPT-4o`, `o1-preview`, `o1-mini`).
+
+---
 
 ### Probe 10: Policy Restrictions
 **Surface**: GitHub Copilot Chat / GitHub.com settings

--- a/docs/README.md
+++ b/docs/README.md
@@ -109,7 +109,7 @@ Cross-repository continuity may be supplied by a user-selected external continui
 - [Developer Portal](developer/README.md): extension and integration discovery surface.
 - [MCP stdio Transport](developer/MCP_STDIO_TRANSPORT.md): first bounded MCP tools transport.
 - [GitHub Copilot Adapter](../adapters/github-copilot/README.md): decoupled integration architecture for GitHub Copilot.
-- [GitHub Copilot Probe Guide](../adapters/github-copilot/probe-guide.md): 10-dimension live capability probe guide.
+- [GitHub Copilot Probe Guide](../adapters/github-copilot/probe-guide.md): live capability probe guide distinguishing canonical command invocation from native custom agents.
 - `../machine/hosts/update-contract.v1.json`: host update/maturity contract.
 - `../machine/protocol/prap-certification-contract.v1.json`: PRAP certification contract.
 - `../machine/developer-portal/catalog.v1.json`: machine Developer Portal catalog.


### PR DESCRIPTION
## Summary
Clarify the UAI-1 GitHub Copilot live capability probe to distinguish native Copilot custom-agent capabilities from canonical Orchestra command invocation (/conductor and /ponytail).

- Add Probe A (/conductor recognition), Probe B (/ponytail recognition), and Probe C (command separation) to adapters/github-copilot/probe-guide.md.
- Separate native custom-agent capability discovery as Probe D.
- Align .github/copilot-instructions.md with canonical command invocations and command separation invariants.
- Update README.json and docs/README.md documentation references.
- All strict governance gates pass cleanly.