### PR TITLE
fix(uai): preserve Conductor routing in Copilot projections

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,7 +5,7 @@ When assisting in the Orchestra repository or working with Orchestra-integrated 
 ## 1. Governance and Routing Architecture
 
 1. **Governance Layer**: `The Steward` (business alignment, scope, SDLC) and `The Governor` (legal, compliance, privacy, IP, licensing) sit above the Conductor. The Conductor cannot override governance decisions.
-2. **Routing Layer**: `Conductor` is the exclusive router and workflow orchestrator. Do not invent custom subagent chains or bypass the Conductor for complex tasks. Canonical command `/conductor` invokes Conductor for task classification, routing, and specialist orchestration.
+2. **Routing Layer**: `Conductor` is the exclusive internal specialist router and workflow orchestrator. Do not invent custom subagent chains or bypass Conductor for complex tasks. For clear single-owner work, Conductor may select a direct single-specialist fast route. That route is still a Conductor routing decision: `CLEAR_OWNERSHIP != CONDUCTOR_BYPASS` and `FAST_ROUTE != ROUTER_BYPASS`. Canonical command `/conductor` invokes Conductor for task classification, routing, and specialist orchestration.
 3. **Specialist Ownership**: Domain specialists exclusively own their respective domains:
    - `clockwork`: Architecture, OOP, layering, refactoring.
    - `cloak`: UI/UX, accessibility, design patterns.
@@ -34,6 +34,10 @@ When assisting in the Orchestra repository or working with Orchestra-integrated 
 - `INSTALL_SUCCESS != SUPPORTED_INTEGRATION`
 - `TRANSPORT != WORKFLOW`
 - `MODEL_SELECTION != GOVERNANCE`
+- `CONDUCTOR_IS_SOLE_INTERNAL_SPECIALIST_ROUTER`
+- `CLEAR_OWNERSHIP MAY_ENABLE DIRECT_SINGLE_SPECIALIST_FAST_ROUTE`
+- `CLEAR_OWNERSHIP != CONDUCTOR_BYPASS`
+- `FAST_ROUTE != ROUTER_BYPASS`
 - `UAI_TRANSPORT_SELECTION != AWF_SPECIALIST_ROUTING`
 
 ## 3. Code Modification Rules

--- a/README.json
+++ b/README.json
@@ -2530,6 +2530,7 @@
   },
   "hosts_integrations": {
     "host_update_contract": "machine/hosts/update-contract.v1.json",
+    "uai_routing_boundaries": "adapters/github-copilot/probe-guide.md",
     "adapter_sdk_reference": "docs/setup/ADAPTER_SDK_PRAP.md",
     "adapter_sdk_stable_import_surface": "orchestra_runtime.protocol.sdk",
     "adapter_certification_commands": [

--- a/adapters/github-copilot/README.md
+++ b/adapters/github-copilot/README.md
@@ -10,6 +10,8 @@ Under UAI, integration with GitHub Copilot is decoupled into:
 3. **Provider Advisory**: Consulting the Provider Capability Broker in shadow mode to evaluate model fitness without automatic provider mutation.
 4. **Specialist & Workflow Preservation**: Preserving Conductor as the sole internal specialist router and deterministic AWF as the workflow topology authority.
 
+Clear ownership can let Conductor choose a direct single-specialist fast route, but it never authorizes a host, native custom agent, or adapter to bypass Conductor. UAI transport selection remains separate from specialist and workflow routing.
+
 ## Status
 
 - Adapter ID: `github-copilot`

--- a/adapters/github-copilot/copilot-instructions.template.md
+++ b/adapters/github-copilot/copilot-instructions.template.md
@@ -3,9 +3,11 @@
 When working in an Orchestra workspace, adhere to the following routing and execution architecture:
 
 ## 1. Conductor Sole Router
-Always route domain requests through the Conductor:
+Always let Conductor classify and route domain requests:
 - Do not invent custom multi-agent chains.
 - Do not mix domain specialist responsibilities.
+- Clear single-owner work may receive a Conductor-selected direct single-specialist fast route; `CLEAR_OWNERSHIP != CONDUCTOR_BYPASS` and `FAST_ROUTE != ROUTER_BYPASS`.
+- Host transport selection and native custom-agent capability do not select specialists or replace Conductor/AWF routing.
 
 ## 2. Specialist Ownership
 - Architecture / OOP / Refactoring: `clockwork`
@@ -26,6 +28,8 @@ Always route domain requests through the Conductor:
 - The Conductor cannot override governance decisions.
 
 ## 4. Invariants
+- `CONDUCTOR_IS_SOLE_INTERNAL_SPECIALIST_ROUTER`
 - Host capability does not grant execution authority.
+- `UAI_TRANSPORT_SELECTION != AWF_SPECIALIST_ROUTING`
 - Do not make broad refactors during targeted bug fixes.
 - Run project validations after modifications.

--- a/adapters/github-copilot/custom-agent.template.md
+++ b/adapters/github-copilot/custom-agent.template.md
@@ -12,6 +12,8 @@ You are the Conductor for Orchestra.
 ## Role and Purpose
 You are the routing and orchestration layer. You classify execution mode and route work to domain specialists. You never perform direct domain implementation.
 
+Native custom-agent availability is only a host transport capability. It does not replace Conductor's internal routing authority. When ownership is clear, Conductor may choose a direct single-specialist fast route, but `CLEAR_OWNERSHIP != CONDUCTOR_BYPASS` and `FAST_ROUTE != ROUTER_BYPASS`.
+
 ## Boundaries
 1. Governance sits above Conductor: respect `The Steward` and `The Governor` decisions.
 2. Route domain work exclusively to designated specialists:
@@ -24,6 +26,8 @@ You are the routing and orchestration layer. You classify execution mode and rou
    - `overseer` for testing and release readiness.
    - `ponytail` for minimal code edits.
 3. Invariants:
+   - Conductor remains the sole internal specialist router.
    - Capability never equals authority.
+   - UAI transport selection never selects the AWF specialist or workflow topology.
    - Do not invent codebase facts.
    - Stop on unresolved gates.

--- a/adapters/github-copilot/probe-guide.md
+++ b/adapters/github-copilot/probe-guide.md
@@ -11,6 +11,9 @@ DO_NOT_FABRICATE_SUPPORT_FROM_DOCUMENTATION
 LIVE_EVIDENCE_OVERRIDES_VENDOR_CLAIMS
 CONDUCTOR_IS_EXCLUSIVE_ROUTER
 ORCHESTRA_COMMAND_INVOCATION != NATIVE_COPILOT_CUSTOM_AGENT_CAPABILITY
+CLEAR_OWNERSHIP != CONDUCTOR_BYPASS
+FAST_ROUTE != ROUTER_BYPASS
+UAI_TRANSPORT_SELECTION != AWF_SPECIALIST_ROUTING
 ```
 
 Capabilities not yet proven on the live Copilot surface remain `AVAILABLE_NOT_YET_VERIFIED` or `UNKNOWN`.
@@ -82,6 +85,9 @@ State:
 - Conductor acts as router/orchestrator.
 - No direct implementation occurs merely from classification.
 - Routing remains bounded by Orchestra specialist ownership.
+- If the task has one clear owner, Conductor may select a direct single-specialist fast route, but the result must identify that route as Conductor-selected rather than a host or specialist bypass.
+- Native custom-agent or other transport capability must not be presented as specialist routing authority.
+- UAI transport selection must remain separate from AWF specialist/workflow routing.
 - Capability does not create authority.
 *(Do not hard-code an expected destination specialist if the current Orchestra routing contract legitimately chooses another valid specialist.)*
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -74,6 +74,8 @@ Repository and runtime validation produce evidence about structure, behavior, co
 
 Adapters, PRAP, host-update tooling, the Developer Portal, and MCP expose or describe Orchestra capabilities without creating a second authority model.
 
+For UAI integrations, host transport selection is separate from specialist and workflow routing. Clear ownership may enable a Conductor-selected direct single-specialist fast route, but `CLEAR_OWNERSHIP != CONDUCTOR_BYPASS` and `FAST_ROUTE != ROUTER_BYPASS`; host capability never grants routing or execution authority.
+
 - [Adapter SDK and PRAP v1](../setup/ADAPTER_SDK_PRAP.md)
 - [Host Updates](../setup/HOST_UPDATES.md)
 - [Developer Portal](../developer/README.md)


### PR DESCRIPTION
## Summary
- remediate the UAI-1 Copilot projection defect where clear ownership was interpreted as Conductor bypass
- preserve Conductor as the sole internal specialist router and keep direct single-specialist fast routes Conductor-selected
- keep UAI transport selection separate from AWF specialist/workflow routing

## Scope
Projection surfaces only: Copilot instructions, adapter templates/probe guide, and README machine-index parity. No Conductor core or AWF changes.

## Validation
- python scripts/governance_check.py --strict
- python scripts/validate_routing_contract.py
- python scripts/validation/validate_architecture_boundaries.py
- python scripts/validate_machine_contracts.py
- python tests/behavior/test_readme_impact.py
- python tests/behavior/test_readme_machine_index.py
- git diff --check

Base: d61d079b4878c86a97ff0ac0cf00917bdfa04173
Head: a18520610110a9466fcc0fc79173846551ee4a0f