### PR TITLE
feat(uai): add canonical host capability contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased UAI-2 host capability contract
+
+- Adds a versioned UAI host capability contract, schema, evidence freshness fields, host-neutral transport compatibility, fail-closed validation, and Copilot capability profile evidence.
+- Preserves Conductor as the sole internal specialist router and keeps host capability, transport selection, provider advisory, and AWF workflow topology separate.
+- Does not promote the Copilot Conductor capability beyond `SUPPORTED_WITH_LIMITS` before the required focused live retest, and does not add automatic provider routing, fallback, concurrency widening, AR-3, AR-4, release, or deployment behavior.
+
 ## v1.9.0 UI Execution Fidelity - published and verified
 
 - Canonically records the UIEF-5 Clockwork engineering translation at the signed Orchestra main boundary and reconciles its exact source, tree, parent, and signature evidence.

--- a/README.json
+++ b/README.json
@@ -2233,20 +2233,30 @@
       "next_action": "FINAL_EXACT_HEAD_RELEASE_QUALIFICATION"
     },
     "universal_adaptive_integration_uai": {
-      "status": "UAI_0_BASELINE_AND_PROBE_PREPARED",
-      "purpose": "Decoupled host adapter templates and empirical capability probe suite distinguishing canonical command invocation from native custom-agent capabilities without authority expansion.",
+      "status": "UAI_2_CANONICAL_HOST_CAPABILITY_CONTRACT_VERIFIED_WITH_CONDUCTOR_LIMITS",
+      "purpose": "Versioned host capability evidence and host-neutral transport compatibility that preserve Conductor specialist routing and AWF workflow topology without authority expansion.",
       "human_sources": [
         "adapters/github-copilot/README.md",
-        "adapters/github-copilot/probe-guide.md"
+        "adapters/github-copilot/probe-guide.md",
+        "docs/setup/HOST_CAPABILITY_CONTRACT.md"
       ],
       "machine_sources": [
         "adapters/github-copilot/copilot-instructions.template.md",
-        "adapters/github-copilot/custom-agent.template.md"
+        "adapters/github-copilot/custom-agent.template.md",
+        "machine/hosts/capability-contract.v1.json",
+        "machine/schemas/host-capability-contract.v1.schema.json",
+        "scripts/validate_host_capability_contract.py",
+        "tests/runtime/test_host_capability_contract.py"
       ],
       "probed_hosts": [
         "github-copilot"
       ],
-      "authority_expansion": false
+      "copilot_conductor_status": "SUPPORTED_WITH_LIMITS",
+      "copilot_ponytail_status": "SUPPORTED_VERIFIED",
+      "unverified_dimensions": "AVAILABLE_NOT_YET_VERIFIED_OR_UNKNOWN",
+      "authority_expansion": false,
+      "automatic_provider_routing": false,
+      "automatic_provider_fallback": false
     }
   },
   "machine_scan_order": [
@@ -2282,51 +2292,56 @@
     },
     {
       "order": 7,
+      "path": "machine/hosts/capability-contract.v1.json",
+      "purpose": "UAI host capability evidence, freshness, dispositions, and transport compatibility without authority expansion"
+    },
+    {
+      "order": 8,
       "path": "machine/protocol/prap-certification-contract.v1.json",
       "purpose": "Adapter SDK / PRAP compatibility certification contract"
     },
     {
-      "order": 8,
+      "order": 9,
       "path": "machine/developer-portal/catalog.v1.json",
       "purpose": "Machine Developer Portal discovery catalog"
     },
     {
-      "order": 9,
+      "order": 10,
       "path": "machine/knowledge/",
       "purpose": "Machine-readable specialist knowledge references and provenance-bound catalogs"
     },
     {
-      "order": 10,
+      "order": 11,
       "path": "machine/presentation/murmurs-policy.v1.json",
       "purpose": "Deterministic Murmurs presentation dispositions and required-explanation safety boundaries"
     },
     {
-      "order": 11,
+      "order": 12,
       "path": "machine/provenance/third-party.v1.json",
       "purpose": "Canonical semantic record of third-party dependencies, references, protocol sources, historical research, planned research, reviewed revisions, license state, learned patterns, affected surfaces, evidence, and incorporation boundaries"
     },
     {
-      "order": 12,
+      "order": 13,
       "path": "machine/release-evidence/",
       "purpose": "Structured release and confidence evidence"
     },
     {
-      "order": 13,
+      "order": 14,
       "path": "machine/schemas/",
       "purpose": "JSON Schema contracts for machine-readable records"
     },
     {
-      "order": 14,
+      "order": 15,
       "path": "docs/README.md",
       "purpose": "Human documentation map and current entry-point classification"
     },
     {
-      "order": 15,
+      "order": 16,
       "path": "PROJECT_STATE.md",
       "purpose": "Human project continuity and implementation chronology"
     },
     {
-      "order": 16,
+      "order": 17,
       "path": "README.md",
       "purpose": "Concise human landing page"
     }
@@ -2340,6 +2355,8 @@
     "feature_decision_record_schema": "machine/schemas/feature-decision-record.v1.schema.json",
     "control_plane_migration": "machine/migration/control-plane.v1.json",
     "host_update_contract": "machine/hosts/update-contract.v1.json",
+    "host_capability_contract": "machine/hosts/capability-contract.v1.json",
+    "host_capability_contract_schema": "machine/schemas/host-capability-contract.v1.schema.json",
     "prap_certification_contract": "machine/protocol/prap-certification-contract.v1.json",
     "developer_portal_catalog": "machine/developer-portal/catalog.v1.json",
     "murmurs_presentation_policy": "machine/presentation/murmurs-policy.v1.json",
@@ -2416,6 +2433,8 @@
     "presentation_policy_schema": "machine/schemas/presentation-policy.schema.json",
     "murmurs_vocabulary_schema": "machine/schemas/murmurs-vocabulary.schema.json",
     "communication_measurement_schema": "machine/schemas/communication-measurement.schema.json",
+    "host_capability_contract_validator": "scripts/validate_host_capability_contract.py",
+    "host_capability_contract_tests": "tests/runtime/test_host_capability_contract.py",
     "prap_certification_evidence_schema": "machine/schemas/prap-certification-evidence.schema.json",
     "developer_portal_catalog_schema": "machine/schemas/developer-portal-catalog.schema.json",
     "readme_machine_index_schema": "machine/schemas/readme-machine-index.schema.json",
@@ -2530,6 +2549,9 @@
   },
   "hosts_integrations": {
     "host_update_contract": "machine/hosts/update-contract.v1.json",
+    "host_capability_contract": "machine/hosts/capability-contract.v1.json",
+    "host_capability_contract_schema": "machine/schemas/host-capability-contract.v1.schema.json",
+    "host_capability_contract_validator": "scripts/validate_host_capability_contract.py",
     "uai_routing_boundaries": "adapters/github-copilot/probe-guide.md",
     "adapter_sdk_reference": "docs/setup/ADAPTER_SDK_PRAP.md",
     "adapter_sdk_stable_import_surface": "orchestra_runtime.protocol.sdk",
@@ -2638,6 +2660,7 @@
     "architecture_overview": "docs/architecture/README.md",
     "installation": "docs/setup/INSTALLATION.md",
     "compatibility": "docs/setup/COMPATIBILITY.md",
+    "host_capability_contract": "docs/setup/HOST_CAPABILITY_CONTRACT.md",
     "validation": "docs/setup/VALIDATION.md",
     "developer_portal": "docs/developer/README.md",
     "mcp_transport": "docs/developer/MCP_STDIO_TRANSPORT.md",

--- a/docs/README.md
+++ b/docs/README.md
@@ -105,12 +105,15 @@ Cross-repository continuity may be supplied by a user-selected external continui
 - [Installation](setup/INSTALLATION.md): supported installation paths.
 - [Compatibility](setup/COMPATIBILITY.md): host compatibility and maturity.
 - [Host Updates](setup/HOST_UPDATES.md): governed read-only host update planning.
+- [UAI Host Capability Contract](setup/HOST_CAPABILITY_CONTRACT.md): versioned host capability evidence and transport compatibility without authority expansion.
 - [Adapter SDK and PRAP v1](setup/ADAPTER_SDK_PRAP.md): stable adapter SDK and deterministic compatibility certification.
 - [Developer Portal](developer/README.md): extension and integration discovery surface.
 - [MCP stdio Transport](developer/MCP_STDIO_TRANSPORT.md): first bounded MCP tools transport.
 - [GitHub Copilot Adapter](../adapters/github-copilot/README.md): decoupled integration architecture for GitHub Copilot.
 - [GitHub Copilot Probe Guide](../adapters/github-copilot/probe-guide.md): live capability probe guide distinguishing canonical command invocation from native custom agents.
 - `../machine/hosts/update-contract.v1.json`: host update/maturity contract.
+- `../machine/hosts/capability-contract.v1.json`: UAI host capability and transport compatibility contract.
+- `../machine/schemas/host-capability-contract.v1.schema.json`: UAI host capability contract schema.
 - `../machine/protocol/prap-certification-contract.v1.json`: PRAP certification contract.
 - `../machine/developer-portal/catalog.v1.json`: machine Developer Portal catalog.
 

--- a/docs/setup/HOST_CAPABILITY_CONTRACT.md
+++ b/docs/setup/HOST_CAPABILITY_CONTRACT.md
@@ -1,0 +1,20 @@
+# UAI Host Capability Contract
+
+The canonical Universal Adaptive Integration host contract is [capability-contract.v1.json](../../machine/hosts/capability-contract.v1.json), validated by [host-capability-contract.v1.schema.json](../../machine/schemas/host-capability-contract.v1.schema.json).
+
+It records host capability evidence without creating a second authority model. Each profile carries:
+
+- a versioned capability taxonomy and host-neutral transport compatibility set;
+- source repository, source commit, observation time, environment, probe, subject commit, and freshness invalidation triggers;
+- explicit `SUPPORTED_VERIFIED`, `SUPPORTED_WITH_LIMITS`, `AVAILABLE_NOT_YET_VERIFIED`, `UNKNOWN`, `BLOCKED_BY_POLICY`, `VERIFIED_UNSUPPORTED_LOCALLY`, and `UNSUPPORTED` dispositions;
+- authority fields fixed to false for execution, routing, specialist selection, workflow topology, provider selection, automatic provider routing, and automatic provider fallback.
+
+Capability evidence never grants execution authority. UAI selects a compatible host transport; Conductor remains the sole internal specialist router and AWF remains the workflow-topology authority. A clear single-owner request may use a Conductor-selected direct fast route, but `CLEAR_OWNERSHIP != CONDUCTOR_BYPASS` and `FAST_ROUTE != ROUTER_BYPASS`.
+
+Validate the canonical record with:
+
+```text
+python scripts/validate_host_capability_contract.py
+```
+
+Stale, malformed, contradictory, or authority-expanding records fail closed. Host, extension, account/organization policy, or Orchestra contract changes invalidate the recorded observation for reverification.

--- a/machine/developer-portal/catalog.v1.json
+++ b/machine/developer-portal/catalog.v1.json
@@ -56,6 +56,27 @@
       "authority_role": "GUIDANCE_OVER_HOST_CONTRACT"
     },
     {
+      "id": "uai-host-capability-contract",
+      "title": "UAI Host Capability Contract",
+      "kind": "machine_contract",
+      "path": "machine/hosts/capability-contract.v1.json",
+      "authority_role": "HOST_CAPABILITY_EVIDENCE_WITHOUT_AUTHORITY"
+    },
+    {
+      "id": "uai-host-capability-schema",
+      "title": "UAI Host Capability Contract schema",
+      "kind": "machine_schema",
+      "path": "machine/schemas/host-capability-contract.v1.schema.json",
+      "authority_role": "EVIDENCE_SCHEMA"
+    },
+    {
+      "id": "uai-host-capability-guide",
+      "title": "UAI Host Capability Contract guide",
+      "kind": "human_guide",
+      "path": "docs/setup/HOST_CAPABILITY_CONTRACT.md",
+      "authority_role": "GUIDANCE_OVER_HOST_CAPABILITY_CONTRACT"
+    },
+    {
       "id": "specialist-registry",
       "title": "Specialist registry",
       "kind": "machine_contract",

--- a/machine/hosts/capability-contract.v1.json
+++ b/machine/hosts/capability-contract.v1.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "./machine/schemas/host-capability-contract.v1.schema.json",
+  "schema_version": "orchestra.host-capability-contract.v1",
+  "contract_id": "orchestra-host-capability",
+  "contract_revision": 1,
+  "contract_role": "canonical_uai_host_capability_contract",
+  "authority": {
+    "capability_grants_execution_authority": false,
+    "capability_grants_routing_authority": false,
+    "capability_grants_specialist_selection_authority": false,
+    "capability_grants_workflow_topology_authority": false,
+    "capability_grants_provider_selection_authority": false,
+    "automatic_provider_routing": false,
+    "automatic_provider_fallback": false,
+    "execution_authorized": false
+  },
+  "dispositions": [
+    "SUPPORTED_VERIFIED",
+    "SUPPORTED_WITH_LIMITS",
+    "AVAILABLE_NOT_YET_VERIFIED",
+    "UNKNOWN",
+    "BLOCKED_BY_POLICY",
+    "VERIFIED_UNSUPPORTED_LOCALLY",
+    "UNSUPPORTED"
+  ],
+  "capability_dimensions": {
+    "instruction_surface": ["REPOSITORY_INSTRUCTIONS", "WORKSPACE_INSTRUCTIONS", "PERSONAL_INSTRUCTIONS"],
+    "agent_skills": ["OPEN_AGENT_SKILLS_V1", "TOOL_INVOCATION", "DYNAMIC_INJECTION"],
+    "custom_agents": ["SUBAGENT_DISPATCH", "CUSTOM_ROLE_PROMPT", "INDEPENDENT_CONTEXT"],
+    "tool_transport": ["MCP_STDIO", "MCP_SSE", "NATIVE_IDE_TOOLS", "LANGUAGE_SERVER_TOOLS"],
+    "execution_environment": ["LOCAL_SHELL_EXECUTE", "SANDBOXED_EXECUTE", "READ_ONLY_WORKSPACE", "FILE_READ", "FILE_WRITE"],
+    "control_surface": ["HUMAN_APPROVAL_PROMPTS", "PERMISSION_GATE", "FAIL_CLOSED_DISPOSITION"],
+    "model_selection": ["EXPLICIT_MODEL_CHOICE", "HOST_MANAGED_MODEL", "REASONING_EFFORT_SELECTOR"],
+    "policy_enforcement": ["ORG_POLICY_RESTRICTION", "ENTERPRISE_DISABLE_MCP", "NETWORK_ISOLATION"]
+  },
+  "transport_strategies": [
+    {"strategy_id": "AGENT_SKILLS", "host_neutral": true, "purpose": "Expose repository-scoped skills when the host indexes them."},
+    {"strategy_id": "CUSTOM_AGENT", "host_neutral": true, "purpose": "Expose a host-native custom agent as an optional integration transport."},
+    {"strategy_id": "MCP_TRANSPORT", "host_neutral": true, "purpose": "Expose bounded tools through a configured MCP transport."},
+    {"strategy_id": "PLUGIN_OR_EXTENSION", "host_neutral": true, "purpose": "Expose a host plugin or extension surface when installed and verified."},
+    {"strategy_id": "CLI_ADAPTER", "host_neutral": true, "purpose": "Expose a host CLI adapter when installed and verified."},
+    {"strategy_id": "REPOSITORY_INSTRUCTIONS", "host_neutral": true, "purpose": "Expose repository-scoped instructions."},
+    {"strategy_id": "WORKSPACE_INSTRUCTIONS", "host_neutral": true, "purpose": "Expose workspace-scoped instructions."},
+    {"strategy_id": "INSTRUCTION_ONLY_FALLBACK", "host_neutral": true, "purpose": "Use a bounded instruction-only integration when richer transports are unavailable."},
+    {"strategy_id": "UNSUPPORTED_FAIL_CLOSED", "host_neutral": true, "purpose": "Stop when a required host capability is absent or policy-blocked."}
+  ],
+  "profiles": [
+    {
+      "host_id": "github-copilot",
+      "host_product": "GitHub Copilot",
+      "adapter_id": "github-copilot",
+      "evidence": {
+        "source_repository": "Baelfyre/Padayon",
+        "source_path": "implementation-phase-prompts/orchestra/reports/orchestra-uai0-uai1-copilot-baseline-and-live-probe-20260906-v1-report.json",
+        "source_commit": "267a3c1b302e8fadc939815b761ff32be5ae1eed",
+        "source_type": "LIVE_MAINTAINER_OBSERVATION",
+        "observation_id": "orchestra-uai0-uai1-copilot-baseline-and-live-probe-20260906-v1-report#uai_1_copilot_probe.live_maintainer_evidence",
+        "observed_at": "2026-09-06T13:55:00+08:00",
+        "environment": "CURRENT_THREAD_MAINTAINER_LIVE_GITHUB_COPILOT_OBSERVATION",
+        "probe": "Padayon report Probe A Conductor and Probe B Ponytail live responses",
+        "subject_repository": "Baelfyre/Orchestra",
+        "subject_commit": "0daa34b33adffc023101f958a9dfa39f9dd4ef0d",
+        "freshness": {
+          "status": "CURRENT_AT_OBSERVATION",
+          "max_age_hours": 24,
+          "invalidation_triggers": ["HOST_BUILD_UPDATE", "HOST_EXTENSION_UPDATE", "HOST_POLICY_UPDATE", "ACCOUNT_OR_ORGANIZATION_POLICY_UPDATE", "ORCHESTRA_CONTRACT_REVISION"]
+        }
+      },
+      "authority": {
+        "capability_grants_execution_authority": false,
+        "capability_grants_routing_authority": false,
+        "capability_grants_specialist_selection_authority": false,
+        "capability_grants_workflow_topology_authority": false,
+        "capability_grants_provider_selection_authority": false,
+        "automatic_provider_routing": false,
+        "automatic_provider_fallback": false,
+        "execution_authorized": false
+      },
+      "capabilities": [
+        {"capability_id": "repository_instructions_observability", "category": "instruction_surface", "disposition": "AVAILABLE_NOT_YET_VERIFIED", "evidence_refs": ["orchestra-uai0-uai1-copilot-baseline-and-live-probe-20260906-v1-report#probe_matrix.1"]},
+        {"capability_id": "orchestra_command_recognition_conductor", "category": "instruction_surface", "disposition": "SUPPORTED_WITH_LIMITS", "evidence_refs": ["orchestra-uai0-uai1-copilot-baseline-and-live-probe-20260906-v1-report#uai_1_copilot_probe.live_maintainer_evidence.PROBE_A_CONDUCTOR"], "limitations": ["CLEAR_OWNERSHIP_WAS_INCORRECTLY_INTERPRETED_AS_CONDUCTOR_BYPASS", "FOCUSED_RETEST_REQUIRED_AFTER_UAI_1_PROJECTION_REMEDIATION"]},
+        {"capability_id": "orchestra_specialist_recognition_ponytail", "category": "instruction_surface", "disposition": "SUPPORTED_VERIFIED", "evidence_refs": ["orchestra-uai0-uai1-copilot-baseline-and-live-probe-20260906-v1-report#uai_1_copilot_probe.live_maintainer_evidence.PROBE_B_PONYTAIL"]},
+        {"capability_id": "orchestra_command_separation", "category": "instruction_surface", "disposition": "AVAILABLE_NOT_YET_VERIFIED", "evidence_refs": ["orchestra-uai0-uai1-copilot-baseline-and-live-probe-20260906-v1-report#probe_matrix.2C"]},
+        {"capability_id": "native_custom_agent_support", "category": "custom_agents", "disposition": "AVAILABLE_NOT_YET_VERIFIED", "evidence_refs": ["orchestra-uai0-uai1-copilot-baseline-and-live-probe-20260906-v1-report#probe_matrix.3"]},
+        {"capability_id": "agent_skills_discovery", "category": "agent_skills", "disposition": "AVAILABLE_NOT_YET_VERIFIED", "evidence_refs": ["orchestra-uai0-uai1-copilot-baseline-and-live-probe-20260906-v1-report#probe_matrix.2"]},
+        {"capability_id": "mcp_discovery_and_read_only_tool_visibility", "category": "tool_transport", "disposition": "AVAILABLE_NOT_YET_VERIFIED", "evidence_refs": ["orchestra-uai0-uai1-copilot-baseline-and-live-probe-20260906-v1-report#probe_matrix.4"]},
+        {"capability_id": "plugin_or_custom_marketplace_surface", "category": "tool_transport", "disposition": "VERIFIED_UNSUPPORTED_LOCALLY", "evidence_refs": ["orchestra-uai0-uai1-copilot-baseline-and-live-probe-20260906-v1-report#probe_matrix.5"], "notes": "No local extension installed in the default profile; this does not claim global Copilot marketplace absence."},
+        {"capability_id": "cli_surface", "category": "execution_environment", "disposition": "VERIFIED_UNSUPPORTED_LOCALLY", "evidence_refs": ["orchestra-uai0-uai1-copilot-baseline-and-live-probe-20260906-v1-report#probe_matrix.6"]},
+        {"capability_id": "file_workspace_terminal_tool_permissions", "category": "execution_environment", "disposition": "AVAILABLE_NOT_YET_VERIFIED", "evidence_refs": ["orchestra-uai0-uai1-copilot-baseline-and-live-probe-20260906-v1-report#probe_matrix.7"]},
+        {"capability_id": "approval_and_permission_controls", "category": "control_surface", "disposition": "AVAILABLE_NOT_YET_VERIFIED", "evidence_refs": ["orchestra-uai0-uai1-copilot-baseline-and-live-probe-20260906-v1-report#probe_matrix.8"]},
+        {"capability_id": "model_selection_controls", "category": "model_selection", "disposition": "AVAILABLE_NOT_YET_VERIFIED", "evidence_refs": ["orchestra-uai0-uai1-copilot-baseline-and-live-probe-20260906-v1-report#probe_matrix.9"]},
+        {"capability_id": "organization_or_account_policy_restrictions", "category": "policy_enforcement", "disposition": "AVAILABLE_NOT_YET_VERIFIED", "evidence_refs": ["orchestra-uai0-uai1-copilot-baseline-and-live-probe-20260906-v1-report#probe_matrix.10"]}
+      ],
+      "transport_compatibility": [
+        {"strategy_id": "AGENT_SKILLS", "disposition": "AVAILABLE_NOT_YET_VERIFIED", "evidence_refs": ["orchestra-uai0-uai1-copilot-baseline-and-live-probe-20260906-v1-report#probe_matrix.2"]},
+        {"strategy_id": "CUSTOM_AGENT", "disposition": "AVAILABLE_NOT_YET_VERIFIED", "evidence_refs": ["orchestra-uai0-uai1-copilot-baseline-and-live-probe-20260906-v1-report#probe_matrix.3"]},
+        {"strategy_id": "MCP_TRANSPORT", "disposition": "AVAILABLE_NOT_YET_VERIFIED", "evidence_refs": ["orchestra-uai0-uai1-copilot-baseline-and-live-probe-20260906-v1-report#probe_matrix.4"]},
+        {"strategy_id": "PLUGIN_OR_EXTENSION", "disposition": "VERIFIED_UNSUPPORTED_LOCALLY", "evidence_refs": ["orchestra-uai0-uai1-copilot-baseline-and-live-probe-20260906-v1-report#probe_matrix.5"]},
+        {"strategy_id": "CLI_ADAPTER", "disposition": "VERIFIED_UNSUPPORTED_LOCALLY", "evidence_refs": ["orchestra-uai0-uai1-copilot-baseline-and-live-probe-20260906-v1-report#probe_matrix.6"]},
+        {"strategy_id": "REPOSITORY_INSTRUCTIONS", "disposition": "AVAILABLE_NOT_YET_VERIFIED", "evidence_refs": ["orchestra-uai0-uai1-copilot-baseline-and-live-probe-20260906-v1-report#probe_matrix.1"]},
+        {"strategy_id": "WORKSPACE_INSTRUCTIONS", "disposition": "AVAILABLE_NOT_YET_VERIFIED", "evidence_refs": ["orchestra-uai0-uai1-copilot-baseline-and-live-probe-20260906-v1-report#probe_matrix.1"]},
+        {"strategy_id": "INSTRUCTION_ONLY_FALLBACK", "disposition": "AVAILABLE_NOT_YET_VERIFIED", "evidence_refs": ["orchestra-uai0-uai1-copilot-baseline-and-live-probe-20260906-v1-report#probe_suite_architecture"]},
+        {"strategy_id": "UNSUPPORTED_FAIL_CLOSED", "disposition": "SUPPORTED_VERIFIED", "evidence_refs": ["orchestra-uai0-uai1-copilot-baseline-and-live-probe-20260906-v1-report#uai_0_taxonomy.degradation_and_fail_closed_rules"]}
+      ]
+    }
+  ]
+}

--- a/machine/schemas/host-capability-contract.v1.schema.json
+++ b/machine/schemas/host-capability-contract.v1.schema.json
@@ -1,0 +1,227 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Baelfyre/Orchestra/blob/main/machine/schemas/host-capability-contract.v1.schema.json",
+  "title": "Orchestra Universal Adaptive Integration Host Capability Contract v1",
+  "description": "Host capability evidence and compatibility declarations. Capability never creates execution, routing, workflow, provider, or policy authority.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schema_version",
+    "contract_id",
+    "contract_revision",
+    "contract_role",
+    "authority",
+    "dispositions",
+    "capability_dimensions",
+    "transport_strategies",
+    "profiles"
+  ],
+  "properties": {
+    "$schema": {"const": "./machine/schemas/host-capability-contract.v1.schema.json"},
+    "schema_version": {"const": "orchestra.host-capability-contract.v1"},
+    "contract_id": {"const": "orchestra-host-capability"},
+    "contract_revision": {"const": 1},
+    "contract_role": {"const": "canonical_uai_host_capability_contract"},
+    "authority": {"$ref": "#/$defs/authority"},
+    "dispositions": {
+      "type": "array",
+      "minItems": 7,
+      "uniqueItems": true,
+      "items": {"$ref": "#/$defs/disposition"}
+    },
+    "capability_dimensions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "instruction_surface",
+        "agent_skills",
+        "custom_agents",
+        "tool_transport",
+        "execution_environment",
+        "control_surface",
+        "model_selection",
+        "policy_enforcement"
+      ],
+      "properties": {
+        "instruction_surface": {"$ref": "#/$defs/string_set"},
+        "agent_skills": {"$ref": "#/$defs/string_set"},
+        "custom_agents": {"$ref": "#/$defs/string_set"},
+        "tool_transport": {"$ref": "#/$defs/string_set"},
+        "execution_environment": {"$ref": "#/$defs/string_set"},
+        "control_surface": {"$ref": "#/$defs/string_set"},
+        "model_selection": {"$ref": "#/$defs/string_set"},
+        "policy_enforcement": {"$ref": "#/$defs/string_set"}
+      }
+    },
+    "transport_strategies": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/transport_strategy"}
+    },
+    "profiles": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/profile"}
+    }
+  },
+  "$defs": {
+    "disposition": {
+      "enum": [
+        "SUPPORTED_VERIFIED",
+        "SUPPORTED_WITH_LIMITS",
+        "AVAILABLE_NOT_YET_VERIFIED",
+        "UNKNOWN",
+        "BLOCKED_BY_POLICY",
+        "VERIFIED_UNSUPPORTED_LOCALLY",
+        "UNSUPPORTED"
+      ]
+    },
+    "string_set": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "capability_grants_execution_authority",
+        "capability_grants_routing_authority",
+        "capability_grants_specialist_selection_authority",
+        "capability_grants_workflow_topology_authority",
+        "capability_grants_provider_selection_authority",
+        "automatic_provider_routing",
+        "automatic_provider_fallback",
+        "execution_authorized"
+      ],
+      "properties": {
+        "capability_grants_execution_authority": {"const": false},
+        "capability_grants_routing_authority": {"const": false},
+        "capability_grants_specialist_selection_authority": {"const": false},
+        "capability_grants_workflow_topology_authority": {"const": false},
+        "capability_grants_provider_selection_authority": {"const": false},
+        "automatic_provider_routing": {"const": false},
+        "automatic_provider_fallback": {"const": false},
+        "execution_authorized": {"const": false}
+      }
+    },
+    "evidence_ref_set": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "freshness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "max_age_hours", "invalidation_triggers"],
+      "properties": {
+        "status": {"enum": ["CURRENT_AT_OBSERVATION", "STALE", "UNKNOWN"]},
+        "max_age_hours": {"type": "integer", "minimum": 1},
+        "invalidation_triggers": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "HOST_BUILD_UPDATE",
+              "HOST_EXTENSION_UPDATE",
+              "HOST_POLICY_UPDATE",
+              "ACCOUNT_OR_ORGANIZATION_POLICY_UPDATE",
+              "ORCHESTRA_CONTRACT_REVISION"
+            ]
+          }
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_repository",
+        "source_path",
+        "source_commit",
+        "source_type",
+        "observation_id",
+        "observed_at",
+        "environment",
+        "probe",
+        "subject_repository",
+        "subject_commit",
+        "freshness"
+      ],
+      "properties": {
+        "source_repository": {"type": "string", "minLength": 1},
+        "source_path": {"type": "string", "minLength": 1},
+        "source_commit": {"$ref": "#/$defs/sha"},
+        "source_type": {"enum": ["LIVE_MAINTAINER_OBSERVATION", "REPOSITORY_CONTRACT", "HOST_SELF_REPORT"]},
+        "observation_id": {"type": "string", "minLength": 1},
+        "observed_at": {"type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:[0-9]{2})$"},
+        "environment": {"type": "string", "minLength": 1},
+        "probe": {"type": "string", "minLength": 1},
+        "subject_repository": {"type": "string", "minLength": 1},
+        "subject_commit": {"$ref": "#/$defs/sha"},
+        "freshness": {"$ref": "#/$defs/freshness"}
+      }
+    },
+    "capability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["capability_id", "category", "disposition", "evidence_refs"],
+      "properties": {
+        "capability_id": {"type": "string", "pattern": "^[a-z][a-z0-9_]+$"},
+        "category": {"enum": ["instruction_surface", "agent_skills", "custom_agents", "tool_transport", "execution_environment", "control_surface", "model_selection", "policy_enforcement"]},
+        "disposition": {"$ref": "#/$defs/disposition"},
+        "evidence_refs": {"$ref": "#/$defs/evidence_ref_set"},
+        "limitations": {"$ref": "#/$defs/string_set"},
+        "notes": {"type": "string", "minLength": 1}
+      }
+    },
+    "transport_strategy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["strategy_id", "host_neutral", "purpose"],
+      "properties": {
+        "strategy_id": {"type": "string", "pattern": "^[A-Z][A-Z0-9_]+$"},
+        "host_neutral": {"const": true},
+        "purpose": {"type": "string", "minLength": 1}
+      }
+    },
+    "transport_compatibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["strategy_id", "disposition", "evidence_refs"],
+      "properties": {
+        "strategy_id": {"type": "string", "pattern": "^[A-Z][A-Z0-9_]+$"},
+        "disposition": {"$ref": "#/$defs/disposition"},
+        "evidence_refs": {"$ref": "#/$defs/evidence_ref_set"},
+        "notes": {"type": "string", "minLength": 1}
+      }
+    },
+    "profile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["host_id", "host_product", "adapter_id", "evidence", "authority", "capabilities", "transport_compatibility"],
+      "properties": {
+        "host_id": {"type": "string", "pattern": "^[a-z][a-z0-9-]+$"},
+        "host_product": {"type": "string", "minLength": 1},
+        "adapter_id": {"type": "string", "minLength": 1},
+        "evidence": {"$ref": "#/$defs/evidence"},
+        "authority": {"$ref": "#/$defs/authority"},
+        "capabilities": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/capability"}
+        },
+        "transport_compatibility": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/transport_compatibility"}
+        }
+      }
+    }
+  }
+}

--- a/scripts/governance_check.py
+++ b/scripts/governance_check.py
@@ -44,6 +44,7 @@ REQUIRED_VALIDATION_SCRIPTS = [
     "scripts/validate_routing_contract.py",
     "scripts/validate_cross_layer_synchronicity_contract.py",
     "scripts/validate_governed_autonomy_modes_contract.py",
+    "scripts/validate_host_capability_contract.py",
 ]
 
 REPO_MEMORY_FILES = [
@@ -65,6 +66,7 @@ STRICT_VALIDATOR_SCRIPTS = [
     "scripts/validate_routing_contract.py",
     "scripts/validate_cross_layer_synchronicity_contract.py",
     "scripts/validate_governed_autonomy_modes_contract.py",
+    "scripts/validate_host_capability_contract.py",
 ]
 
 SIGNIFICANT_CHANGE_PATTERNS = [

--- a/scripts/validate_host_capability_contract.py
+++ b/scripts/validate_host_capability_contract.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Validate the canonical UAI host capability contract without granting authority."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+CONTRACT_PATH = Path("machine/hosts/capability-contract.v1.json")
+SCHEMA_PATH = Path("machine/schemas/host-capability-contract.v1.schema.json")
+DISPOSITIONS = {
+    "SUPPORTED_VERIFIED",
+    "SUPPORTED_WITH_LIMITS",
+    "AVAILABLE_NOT_YET_VERIFIED",
+    "UNKNOWN",
+    "BLOCKED_BY_POLICY",
+    "VERIFIED_UNSUPPORTED_LOCALLY",
+    "UNSUPPORTED",
+}
+REQUIRED_DIMENSIONS = {
+    "instruction_surface",
+    "agent_skills",
+    "custom_agents",
+    "tool_transport",
+    "execution_environment",
+    "control_surface",
+    "model_selection",
+    "policy_enforcement",
+}
+AUTHORITY_FIELDS = {
+    "capability_grants_execution_authority",
+    "capability_grants_routing_authority",
+    "capability_grants_specialist_selection_authority",
+    "capability_grants_workflow_topology_authority",
+    "capability_grants_provider_selection_authority",
+    "automatic_provider_routing",
+    "automatic_provider_fallback",
+    "execution_authorized",
+}
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _require_object(value: Any, label: str, errors: list[str]) -> bool:
+    if not isinstance(value, dict):
+        errors.append(f"MALFORMED:{label}:must_be_object")
+        return False
+    return True
+
+
+def _require_non_empty_strings(value: Any, label: str, errors: list[str]) -> None:
+    if not isinstance(value, list) or not value or any(not isinstance(item, str) or not item for item in value):
+        errors.append(f"MALFORMED:{label}:must_be_non_empty_string_list")
+        return
+    if len(value) != len(set(value)):
+        errors.append(f"MALFORMED:{label}:duplicates")
+
+
+def _validate_authority(value: Any, label: str, errors: list[str]) -> None:
+    if not _require_object(value, label, errors):
+        return
+    for field in sorted(AUTHORITY_FIELDS):
+        if value.get(field) is not False:
+            errors.append(f"AUTHORITY_EXPANSION:{label}.{field}")
+    extra = set(value) - AUTHORITY_FIELDS
+    for field in sorted(extra):
+        errors.append(f"AUTHORITY_EXPANSION:{label}.{field}")
+
+
+def _validate_evidence(value: Any, label: str, errors: list[str]) -> None:
+    if not _require_object(value, label, errors):
+        return
+    for field in (
+        "source_repository",
+        "source_path",
+        "source_type",
+        "observation_id",
+        "observed_at",
+        "environment",
+        "probe",
+        "subject_repository",
+    ):
+        if not isinstance(value.get(field), str) or not value[field].strip():
+            errors.append(f"MALFORMED:{label}.{field}")
+    for field in ("source_commit", "subject_commit"):
+        if not isinstance(value.get(field), str) or not SHA_PATTERN.fullmatch(value[field]):
+            errors.append(f"MALFORMED:{label}.{field}:sha")
+    freshness = value.get("freshness")
+    if not _require_object(freshness, f"{label}.freshness", errors):
+        return
+    if freshness.get("status") != "CURRENT_AT_OBSERVATION":
+        errors.append(f"FRESHNESS_INVALID:{label}.freshness.status")
+    if not isinstance(freshness.get("max_age_hours"), int) or freshness["max_age_hours"] < 1:
+        errors.append(f"MALFORMED:{label}.freshness.max_age_hours")
+    _require_non_empty_strings(freshness.get("invalidation_triggers"), f"{label}.freshness.invalidation_triggers", errors)
+
+
+def validate_payload(contract: Any, schema: Any | None = None) -> list[str]:
+    errors: list[str] = []
+    if not _require_object(contract, "contract", errors):
+        return errors
+
+    required = {
+        "$schema",
+        "schema_version",
+        "contract_id",
+        "contract_revision",
+        "contract_role",
+        "authority",
+        "dispositions",
+        "capability_dimensions",
+        "transport_strategies",
+        "profiles",
+    }
+    for field in sorted(required - set(contract)):
+        errors.append(f"MALFORMED:missing:{field}")
+    expected_values = {
+        "$schema": "./machine/schemas/host-capability-contract.v1.schema.json",
+        "schema_version": "orchestra.host-capability-contract.v1",
+        "contract_id": "orchestra-host-capability",
+        "contract_revision": 1,
+        "contract_role": "canonical_uai_host_capability_contract",
+    }
+    for field, expected in expected_values.items():
+        if field in contract and contract[field] != expected:
+            errors.append(f"MALFORMED:{field}:unexpected_value")
+
+    if schema is not None and not isinstance(schema, dict):
+        errors.append("MALFORMED:schema:must_be_object")
+    else:
+        try:
+            import jsonschema
+
+            validator = jsonschema.Draft202012Validator(schema)
+            for item in validator.iter_errors(contract):
+                location = ".".join(str(part) for part in item.absolute_path) or "$"
+                errors.append(f"SCHEMA_VALIDATION:{location}:{item.message}")
+        except ImportError:
+            pass
+        except Exception as exc:  # pragma: no cover - schema tooling failure is environment-specific
+            errors.append(f"SCHEMA_VALIDATION:validator_error:{exc}")
+
+    _validate_authority(contract.get("authority"), "authority", errors)
+
+    dispositions = contract.get("dispositions")
+    if (
+        not isinstance(dispositions, list)
+        or any(not isinstance(item, str) for item in dispositions)
+        or set(dispositions) != DISPOSITIONS
+        or len(dispositions) != len(DISPOSITIONS)
+    ):
+        errors.append("MALFORMED:dispositions:must_list_all_supported_dispositions_once")
+
+    dimensions = contract.get("capability_dimensions")
+    if _require_object(dimensions, "capability_dimensions", errors):
+        if set(dimensions) != REQUIRED_DIMENSIONS:
+            errors.append("MALFORMED:capability_dimensions:taxonomy_set_mismatch")
+        for dimension in sorted(REQUIRED_DIMENSIONS):
+            _require_non_empty_strings(dimensions.get(dimension), f"capability_dimensions.{dimension}", errors)
+
+    strategies = contract.get("transport_strategies")
+    strategy_ids: set[str] = set()
+    if not isinstance(strategies, list) or not strategies:
+        errors.append("MALFORMED:transport_strategies:must_be_non_empty_list")
+    else:
+        for index, strategy in enumerate(strategies):
+            label = f"transport_strategies[{index}]"
+            if not _require_object(strategy, label, errors):
+                continue
+            strategy_id = strategy.get("strategy_id")
+            if not isinstance(strategy_id, str) or not strategy_id:
+                errors.append(f"MALFORMED:{label}.strategy_id")
+            elif strategy_id in strategy_ids:
+                errors.append(f"MALFORMED:DUPLICATE_TRANSPORT_STRATEGY:{strategy_id}")
+            else:
+                strategy_ids.add(strategy_id)
+            if strategy.get("host_neutral") is not True:
+                errors.append(f"AUTHORITY_EXPANSION:{label}.host_neutral")
+
+    profiles = contract.get("profiles")
+    profile_ids: set[str] = set()
+    if not isinstance(profiles, list) or not profiles:
+        errors.append("MALFORMED:profiles:must_be_non_empty_list")
+    else:
+        for index, profile in enumerate(profiles):
+            label = f"profiles[{index}]"
+            if not _require_object(profile, label, errors):
+                continue
+            host_id = profile.get("host_id")
+            if not isinstance(host_id, str) or not host_id:
+                errors.append(f"MALFORMED:{label}.host_id")
+            elif host_id in profile_ids:
+                errors.append(f"MALFORMED:DUPLICATE_PROFILE:{host_id}")
+            else:
+                profile_ids.add(host_id)
+            _validate_evidence(profile.get("evidence"), f"{label}.evidence", errors)
+            _validate_authority(profile.get("authority"), f"{label}.authority", errors)
+
+            capabilities = profile.get("capabilities")
+            seen_capabilities: dict[str, str] = {}
+            if not isinstance(capabilities, list) or not capabilities:
+                errors.append(f"MALFORMED:{label}.capabilities:must_be_non_empty_list")
+            else:
+                for capability_index, capability in enumerate(capabilities):
+                    capability_label = f"{label}.capabilities[{capability_index}]"
+                    if not _require_object(capability, capability_label, errors):
+                        continue
+                    capability_id = capability.get("capability_id")
+                    disposition = capability.get("disposition")
+                    if not isinstance(capability_id, str) or not capability_id:
+                        errors.append(f"MALFORMED:{capability_label}.capability_id")
+                    elif capability_id in seen_capabilities:
+                        errors.append(
+                            f"CONTRADICTORY_CAPABILITY:{host_id}:{capability_id}:"
+                            f"{seen_capabilities[capability_id]}:{disposition}"
+                        )
+                    else:
+                        seen_capabilities[capability_id] = str(disposition)
+                    if disposition not in DISPOSITIONS:
+                        errors.append(f"MALFORMED:{capability_label}.disposition")
+                    _require_non_empty_strings(capability.get("evidence_refs"), f"{capability_label}.evidence_refs", errors)
+
+            compatibility = profile.get("transport_compatibility")
+            seen_strategies: set[str] = set()
+            if not isinstance(compatibility, list) or not compatibility:
+                errors.append(f"MALFORMED:{label}.transport_compatibility:must_be_non_empty_list")
+            else:
+                for compatibility_index, item in enumerate(compatibility):
+                    item_label = f"{label}.transport_compatibility[{compatibility_index}]"
+                    if not _require_object(item, item_label, errors):
+                        continue
+                    strategy_id = item.get("strategy_id")
+                    if not isinstance(strategy_id, str) or not strategy_id:
+                        errors.append(f"MALFORMED:{item_label}.strategy_id")
+                    else:
+                        if strategy_id in seen_strategies:
+                            errors.append(f"CONTRADICTORY_TRANSPORT:{host_id}:{strategy_id}")
+                        seen_strategies.add(strategy_id)
+                        if strategy_id not in strategy_ids:
+                            errors.append(f"TRANSPORT_STRATEGY_UNKNOWN:{host_id}:{strategy_id}")
+                    if item.get("disposition") not in DISPOSITIONS:
+                        errors.append(f"MALFORMED:{item_label}.disposition")
+                    _require_non_empty_strings(item.get("evidence_refs"), f"{item_label}.evidence_refs", errors)
+
+            evidence = profile.get("evidence")
+            freshness_status = evidence.get("freshness", {}).get("status") if isinstance(evidence, dict) else None
+            if freshness_status != "CURRENT_AT_OBSERVATION":
+                for capability_id, disposition in seen_capabilities.items():
+                    if disposition in {"SUPPORTED_VERIFIED", "SUPPORTED_WITH_LIMITS"}:
+                        errors.append(f"CONTRADICTORY_EVIDENCE:{host_id}:{capability_id}:positive_status_with_stale_evidence")
+
+            if host_id == "github-copilot":
+                expected = {
+                    "orchestra_command_recognition_conductor": "SUPPORTED_WITH_LIMITS",
+                    "orchestra_specialist_recognition_ponytail": "SUPPORTED_VERIFIED",
+                }
+                for capability_id, expected_disposition in expected.items():
+                    actual = seen_capabilities.get(capability_id)
+                    if actual != expected_disposition:
+                        errors.append(f"COPILOT_STATUS_DRIFT:{capability_id}:{actual}:{expected_disposition}")
+
+    return errors
+
+
+def validate(root: Path) -> list[str]:
+    contract_path = root / CONTRACT_PATH
+    schema_path = root / SCHEMA_PATH
+    errors: list[str] = []
+    try:
+        contract = _load_json(contract_path)
+    except FileNotFoundError:
+        return [f"MALFORMED:missing:{CONTRACT_PATH.as_posix()}"]
+    except (OSError, json.JSONDecodeError) as exc:
+        return [f"MALFORMED:{CONTRACT_PATH.as_posix()}:{exc}"]
+    try:
+        schema = _load_json(schema_path)
+    except FileNotFoundError:
+        errors.append(f"MALFORMED:missing:{SCHEMA_PATH.as_posix()}")
+        schema = None
+    except (OSError, json.JSONDecodeError) as exc:
+        errors.append(f"MALFORMED:{SCHEMA_PATH.as_posix()}:{exc}")
+        schema = None
+    errors.extend(validate_payload(contract, schema))
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[1])
+    args = parser.parse_args(argv)
+    errors = validate(args.repo_root.resolve())
+    if errors:
+        for error in errors:
+            print(f"[FAIL] {error}")
+        return 1
+    print("[PASS] UAI host capability contract is schema-valid, fresh, and authority-bounded.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/runtime/test_host_capability_contract.py
+++ b/tests/runtime/test_host_capability_contract.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+from scripts.validate_host_capability_contract import validate_payload
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT_PATH = ROOT / "machine" / "hosts" / "capability-contract.v1.json"
+SCHEMA_PATH = ROOT / "machine" / "schemas" / "host-capability-contract.v1.schema.json"
+
+
+def _load(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _canonical() -> tuple[dict[str, object], dict[str, object]]:
+    return deepcopy(_load(CONTRACT_PATH)), _load(SCHEMA_PATH)
+
+
+def _copilot(contract: dict[str, object]) -> dict[str, object]:
+    profiles = contract["profiles"]
+    assert isinstance(profiles, list)
+    profile = profiles[0]
+    assert isinstance(profile, dict)
+    return profile
+
+
+def test_canonical_contract_is_schema_valid_and_semantically_bounded() -> None:
+    contract, schema = _canonical()
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(contract)
+    assert validate_payload(contract, schema) == []
+
+    profile = _copilot(contract)
+    capabilities = {item["capability_id"]: item for item in profile["capabilities"]}
+    assert capabilities["orchestra_command_recognition_conductor"]["disposition"] == "SUPPORTED_WITH_LIMITS"
+    assert capabilities["orchestra_specialist_recognition_ponytail"]["disposition"] == "SUPPORTED_VERIFIED"
+    assert all(item["host_neutral"] is True for item in contract["transport_strategies"])
+
+
+def test_malformed_contract_fails_closed() -> None:
+    contract, schema = _canonical()
+    del contract["profiles"]
+    errors = validate_payload(contract, schema)
+    assert any(error.startswith("MALFORMED:missing:profiles") for error in errors)
+
+
+def test_stale_evidence_fails_closed() -> None:
+    contract, schema = _canonical()
+    profile = _copilot(contract)
+    evidence = profile["evidence"]
+    assert isinstance(evidence, dict)
+    freshness = evidence["freshness"]
+    assert isinstance(freshness, dict)
+    freshness["status"] = "STALE"
+    errors = validate_payload(contract, schema)
+    assert any(error.startswith("FRESHNESS_INVALID:") for error in errors)
+    assert any(error.startswith("CONTRADICTORY_EVIDENCE:") for error in errors)
+
+
+def test_contradictory_capability_and_authority_expansion_fail_closed() -> None:
+    contract, schema = _canonical()
+    profile = _copilot(contract)
+    capabilities = profile["capabilities"]
+    assert isinstance(capabilities, list)
+    contradictory = deepcopy(capabilities[0])
+    contradictory["disposition"] = "UNKNOWN"
+    capabilities.append(contradictory)
+    authority = contract["authority"]
+    assert isinstance(authority, dict)
+    authority["capability_grants_routing_authority"] = True
+    errors = validate_payload(contract, schema)
+    assert any(error.startswith("CONTRADICTORY_CAPABILITY:") for error in errors)
+    assert "AUTHORITY_EXPANSION:authority.capability_grants_routing_authority" in errors
+
+
+def test_unknown_transport_strategy_fails_closed() -> None:
+    contract, schema = _canonical()
+    profile = _copilot(contract)
+    compatibility = profile["transport_compatibility"]
+    assert isinstance(compatibility, list)
+    compatibility[0]["strategy_id"] = "UNDECLARED_TRANSPORT"
+    errors = validate_payload(contract, schema)
+    assert "TRANSPORT_STRATEGY_UNKNOWN:github-copilot:UNDECLARED_TRANSPORT" in errors


### PR DESCRIPTION
## Summary
- add the versioned UAI host capability contract and JSON Schema
- record evidence provenance, freshness invalidation, dispositions, host-neutral transport compatibility, and non-authorizing authority fields
- record the Copilot profile with Conductor SUPPORTED_WITH_LIMITS, Ponytail SUPPORTED_VERIFIED, and unverified dimensions preserved
- add fail-closed validator coverage for malformed, stale, contradictory, unknown-transport, and authority-expanding records
- update README machine discovery, Developer Portal catalog, documentation map, and changelog

## Boundaries
- Conductor remains the sole internal specialist router.
- UAI transport selection remains separate from AWF specialist/workflow routing.
- No automatic provider routing or fallback, learned routing promotion, concurrency widening, AR-3, AR-4, release, deployment, marketplace publication, credential/policy changes, force push, or history rewrite.
- UAI-3 is not started.

## Validation
- python scripts/validate_host_capability_contract.py
- python -m pytest tests/runtime/test_host_capability_contract.py -q
- python tests/behavior/run_tests.py with approved base 0daa34b33adffc023101f958a9dfa39f9dd4ef0d
- python -m pytest tests/runtime -q
- python scripts/governance_check.py --strict
- python scripts/validation/validate_architecture_boundaries.py
- python scripts/validate_routing_contract.py
- python scripts/validate_machine_contracts.py
- python tests/behavior/test_readme_impact.py
- python tests/behavior/test_readme_machine_index.py
- git diff --check

Base: 0daa34b33adffc023101f958a9dfa39f9dd4ef0d
Head: 7a9d193ef073726d25591eb27ccb885d1126b787
