### PR TITLE
feat(uai): add provider model capability contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased UAI-3 provider/model capability contract
+
+- Adds a provider/model-neutral capability vocabulary for tool calling, structured output, context limits, multimodal input, host-exposed execution, sub-agents, concurrency exposure, MCP compatibility, model selection, reasoning/runtime modes, permission semantics, and provider-policy restrictions.
+- Requires provenance and current freshness for positive provider/model capability profiles; the canonical profile set remains empty because no fresh provider/model observation is admitted by current evidence.
+- Keeps provider/model capability descriptive and non-authorizing. No automatic provider switching, fallback, credential changes, learned-routing promotion, specialist-routing change, AWF topology change, release, or deployment is included.
+
 ## Unreleased UAI-2 host capability contract
 
 - Adds a versioned UAI host capability contract, schema, evidence freshness fields, host-neutral transport compatibility, fail-closed validation, and Copilot capability profile evidence.

--- a/README.json
+++ b/README.json
@@ -2233,12 +2233,13 @@
       "next_action": "FINAL_EXACT_HEAD_RELEASE_QUALIFICATION"
     },
     "universal_adaptive_integration_uai": {
-      "status": "UAI_2_CANONICAL_HOST_CAPABILITY_CONTRACT_VERIFIED_WITH_CONDUCTOR_LIMITS",
-      "purpose": "Versioned host capability evidence and host-neutral transport compatibility that preserve Conductor specialist routing and AWF workflow topology without authority expansion.",
+      "status": "UAI_3_PROVIDER_MODEL_CAPABILITY_CONTRACT_COMPLETE_CANONICAL_VERIFIED",
+      "purpose": "Versioned host and provider/model capability evidence with host-neutral transport compatibility that preserve Conductor specialist routing and AWF workflow topology without authority expansion.",
       "human_sources": [
         "adapters/github-copilot/README.md",
         "adapters/github-copilot/probe-guide.md",
-        "docs/setup/HOST_CAPABILITY_CONTRACT.md"
+        "docs/setup/HOST_CAPABILITY_CONTRACT.md",
+        "docs/setup/PROVIDER_MODEL_CAPABILITY_CONTRACT.md"
       ],
       "machine_sources": [
         "adapters/github-copilot/copilot-instructions.template.md",
@@ -2246,7 +2247,11 @@
         "machine/hosts/capability-contract.v1.json",
         "machine/schemas/host-capability-contract.v1.schema.json",
         "scripts/validate_host_capability_contract.py",
-        "tests/runtime/test_host_capability_contract.py"
+        "tests/runtime/test_host_capability_contract.py",
+        "machine/providers/provider-model-capability-contract.v1.json",
+        "machine/schemas/provider-model-capability-contract.v1.schema.json",
+        "scripts/validate_provider_model_capability_contract.py",
+        "tests/runtime/test_provider_model_capability_contract.py"
       ],
       "probed_hosts": [
         "github-copilot"
@@ -2254,9 +2259,11 @@
       "copilot_conductor_status": "SUPPORTED_WITH_LIMITS",
       "copilot_ponytail_status": "SUPPORTED_VERIFIED",
       "unverified_dimensions": "AVAILABLE_NOT_YET_VERIFIED_OR_UNKNOWN",
+      "provider_model_profiles": "NONE_ADMITTED_CURRENT_EVIDENCE_BOUNDARY",
       "authority_expansion": false,
       "automatic_provider_routing": false,
-      "automatic_provider_fallback": false
+      "automatic_provider_fallback": false,
+      "learned_routing_promotion": false
     }
   },
   "machine_scan_order": [
@@ -2297,51 +2304,56 @@
     },
     {
       "order": 8,
+      "path": "machine/providers/provider-model-capability-contract.v1.json",
+      "purpose": "UAI provider/model technical capability vocabulary and provenance-bounded profiles without provider selection or authority expansion"
+    },
+    {
+      "order": 9,
       "path": "machine/protocol/prap-certification-contract.v1.json",
       "purpose": "Adapter SDK / PRAP compatibility certification contract"
     },
     {
-      "order": 9,
+      "order": 10,
       "path": "machine/developer-portal/catalog.v1.json",
       "purpose": "Machine Developer Portal discovery catalog"
     },
     {
-      "order": 10,
+      "order": 11,
       "path": "machine/knowledge/",
       "purpose": "Machine-readable specialist knowledge references and provenance-bound catalogs"
     },
     {
-      "order": 11,
+      "order": 12,
       "path": "machine/presentation/murmurs-policy.v1.json",
       "purpose": "Deterministic Murmurs presentation dispositions and required-explanation safety boundaries"
     },
     {
-      "order": 12,
+      "order": 13,
       "path": "machine/provenance/third-party.v1.json",
       "purpose": "Canonical semantic record of third-party dependencies, references, protocol sources, historical research, planned research, reviewed revisions, license state, learned patterns, affected surfaces, evidence, and incorporation boundaries"
     },
     {
-      "order": 13,
+      "order": 14,
       "path": "machine/release-evidence/",
       "purpose": "Structured release and confidence evidence"
     },
     {
-      "order": 14,
+      "order": 15,
       "path": "machine/schemas/",
       "purpose": "JSON Schema contracts for machine-readable records"
     },
     {
-      "order": 15,
+      "order": 16,
       "path": "docs/README.md",
       "purpose": "Human documentation map and current entry-point classification"
     },
     {
-      "order": 16,
+      "order": 17,
       "path": "PROJECT_STATE.md",
       "purpose": "Human project continuity and implementation chronology"
     },
     {
-      "order": 17,
+      "order": 18,
       "path": "README.md",
       "purpose": "Concise human landing page"
     }
@@ -2357,6 +2369,8 @@
     "host_update_contract": "machine/hosts/update-contract.v1.json",
     "host_capability_contract": "machine/hosts/capability-contract.v1.json",
     "host_capability_contract_schema": "machine/schemas/host-capability-contract.v1.schema.json",
+    "provider_model_capability_contract": "machine/providers/provider-model-capability-contract.v1.json",
+    "provider_model_capability_contract_schema": "machine/schemas/provider-model-capability-contract.v1.schema.json",
     "prap_certification_contract": "machine/protocol/prap-certification-contract.v1.json",
     "developer_portal_catalog": "machine/developer-portal/catalog.v1.json",
     "murmurs_presentation_policy": "machine/presentation/murmurs-policy.v1.json",
@@ -2552,6 +2566,9 @@
     "host_capability_contract": "machine/hosts/capability-contract.v1.json",
     "host_capability_contract_schema": "machine/schemas/host-capability-contract.v1.schema.json",
     "host_capability_contract_validator": "scripts/validate_host_capability_contract.py",
+    "provider_model_capability_contract": "machine/providers/provider-model-capability-contract.v1.json",
+    "provider_model_capability_contract_schema": "machine/schemas/provider-model-capability-contract.v1.schema.json",
+    "provider_model_capability_contract_validator": "scripts/validate_provider_model_capability_contract.py",
     "uai_routing_boundaries": "adapters/github-copilot/probe-guide.md",
     "adapter_sdk_reference": "docs/setup/ADAPTER_SDK_PRAP.md",
     "adapter_sdk_stable_import_surface": "orchestra_runtime.protocol.sdk",
@@ -2661,6 +2678,7 @@
     "installation": "docs/setup/INSTALLATION.md",
     "compatibility": "docs/setup/COMPATIBILITY.md",
     "host_capability_contract": "docs/setup/HOST_CAPABILITY_CONTRACT.md",
+    "provider_model_capability_contract": "docs/setup/PROVIDER_MODEL_CAPABILITY_CONTRACT.md",
     "validation": "docs/setup/VALIDATION.md",
     "developer_portal": "docs/developer/README.md",
     "mcp_transport": "docs/developer/MCP_STDIO_TRANSPORT.md",

--- a/docs/README.md
+++ b/docs/README.md
@@ -106,6 +106,7 @@ Cross-repository continuity may be supplied by a user-selected external continui
 - [Compatibility](setup/COMPATIBILITY.md): host compatibility and maturity.
 - [Host Updates](setup/HOST_UPDATES.md): governed read-only host update planning.
 - [UAI Host Capability Contract](setup/HOST_CAPABILITY_CONTRACT.md): versioned host capability evidence and transport compatibility without authority expansion.
+- [UAI Provider/Model Capability Contract](setup/PROVIDER_MODEL_CAPABILITY_CONTRACT.md): provider/model-neutral technical capability vocabulary and evidence boundaries without provider selection.
 - [Adapter SDK and PRAP v1](setup/ADAPTER_SDK_PRAP.md): stable adapter SDK and deterministic compatibility certification.
 - [Developer Portal](developer/README.md): extension and integration discovery surface.
 - [MCP stdio Transport](developer/MCP_STDIO_TRANSPORT.md): first bounded MCP tools transport.
@@ -114,6 +115,8 @@ Cross-repository continuity may be supplied by a user-selected external continui
 - `../machine/hosts/update-contract.v1.json`: host update/maturity contract.
 - `../machine/hosts/capability-contract.v1.json`: UAI host capability and transport compatibility contract.
 - `../machine/schemas/host-capability-contract.v1.schema.json`: UAI host capability contract schema.
+- `../machine/providers/provider-model-capability-contract.v1.json`: UAI provider/model capability contract.
+- `../machine/schemas/provider-model-capability-contract.v1.schema.json`: UAI provider/model capability contract schema.
 - `../machine/protocol/prap-certification-contract.v1.json`: PRAP certification contract.
 - `../machine/developer-portal/catalog.v1.json`: machine Developer Portal catalog.
 

--- a/docs/setup/PROVIDER_MODEL_CAPABILITY_CONTRACT.md
+++ b/docs/setup/PROVIDER_MODEL_CAPABILITY_CONTRACT.md
@@ -1,0 +1,17 @@
+# UAI Provider/Model Capability Contract
+
+The canonical provider/model capability contract is [provider-model-capability-contract.v1.json](../../machine/providers/provider-model-capability-contract.v1.json), validated by [provider-model-capability-contract.v1.schema.json](../../machine/schemas/provider-model-capability-contract.v1.schema.json) and [validate_provider_model_capability_contract.py](../../scripts/validate_provider_model_capability_contract.py).
+
+It defines the technical capability vocabulary needed by UAI without selecting a provider, model, host, specialist, or workflow topology. The vocabulary covers tool calling, structured output, context limits, multimodal input, host-exposed code/terminal access, sub-agents, concurrency exposure, MCP compatibility, model selection, reasoning/runtime modes, permission semantics, and provider-policy restrictions.
+
+The current contract deliberately contains no provider/model profile. Current repository evidence does not establish a fresh provider/model capability observation that can be promoted into a canonical profile. The empty profile set is therefore an explicit evidence boundary, not an inferred absence of provider capability.
+
+Provider/model profiles, when admitted later, require exact provider/model identity, provenance, freshness, per-capability dispositions, and authority fields fixed to false. `SUPPORTED_VERIFIED` and `SUPPORTED_WITH_LIMITS` require current evidence. Static declarations remain `AVAILABLE_NOT_YET_VERIFIED`; unknown identity remains `UNKNOWN`.
+
+This contract does not authorize automatic provider switching, fallback, credential changes, learned-routing promotion, specialist routing, AWF topology changes, or execution. P2.1's [Provider Execution Profile](../project/PRIORITY_2_PROVIDER_EXECUTION_PROFILE.md) remains the narrower trusted execution requirement gate. A capability profile describes what may be observable; it never becomes a runtime grant.
+
+Validate it with:
+
+```text
+python scripts/validate_provider_model_capability_contract.py
+```

--- a/machine/developer-portal/catalog.v1.json
+++ b/machine/developer-portal/catalog.v1.json
@@ -77,6 +77,27 @@
       "authority_role": "GUIDANCE_OVER_HOST_CAPABILITY_CONTRACT"
     },
     {
+      "id": "uai-provider-model-capability-contract",
+      "title": "UAI Provider/Model Capability Contract",
+      "kind": "machine_contract",
+      "path": "machine/providers/provider-model-capability-contract.v1.json",
+      "authority_role": "PROVIDER_MODEL_CAPABILITY_EVIDENCE_WITHOUT_AUTHORITY"
+    },
+    {
+      "id": "uai-provider-model-capability-schema",
+      "title": "UAI Provider/Model Capability Contract schema",
+      "kind": "machine_schema",
+      "path": "machine/schemas/provider-model-capability-contract.v1.schema.json",
+      "authority_role": "EVIDENCE_SCHEMA"
+    },
+    {
+      "id": "uai-provider-model-capability-guide",
+      "title": "UAI Provider/Model Capability Contract guide",
+      "kind": "human_guide",
+      "path": "docs/setup/PROVIDER_MODEL_CAPABILITY_CONTRACT.md",
+      "authority_role": "GUIDANCE_OVER_PROVIDER_MODEL_CAPABILITY_CONTRACT"
+    },
+    {
       "id": "specialist-registry",
       "title": "Specialist registry",
       "kind": "machine_contract",

--- a/machine/providers/provider-model-capability-contract.v1.json
+++ b/machine/providers/provider-model-capability-contract.v1.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "./machine/schemas/provider-model-capability-contract.v1.schema.json",
+  "schema_version": "orchestra.provider-model-capability-contract.v1",
+  "contract_id": "orchestra-provider-model-capability",
+  "contract_revision": 1,
+  "contract_role": "canonical_uai_provider_model_capability_contract",
+  "authority": {
+    "capability_grants_execution_authority": false,
+    "capability_grants_routing_authority": false,
+    "capability_grants_specialist_selection_authority": false,
+    "capability_grants_workflow_topology_authority": false,
+    "capability_grants_provider_selection_authority": false,
+    "capability_grants_model_selection_authority": false,
+    "automatic_provider_switching": false,
+    "automatic_provider_fallback": false,
+    "learned_routing_promotion": false,
+    "execution_authorized": false
+  },
+  "capability_definitions": [
+    {"capability_id": "TOOL_CALLING", "category": "INTERACTION", "value_kind": "BOOLEAN"},
+    {"capability_id": "STRUCTURED_OUTPUT", "category": "OUTPUT", "value_kind": "BOOLEAN"},
+    {"capability_id": "CONTEXT_LIMITS", "category": "CONTEXT", "value_kind": "INTEGER_OR_RANGE"},
+    {"capability_id": "VISION_MULTIMODAL_INPUT", "category": "INPUT", "value_kind": "BOOLEAN"},
+    {"capability_id": "CODE_TERMINAL_EXPOSURE", "category": "EXECUTION", "value_kind": "ENUM_SET"},
+    {"capability_id": "SUB_AGENT_SUPPORT", "category": "ORCHESTRATION", "value_kind": "BOOLEAN"},
+    {"capability_id": "CONCURRENCY_EXPOSURE", "category": "ORCHESTRATION", "value_kind": "ENUM_SET"},
+    {"capability_id": "MCP_TOOL_COMPATIBILITY", "category": "TRANSPORT", "value_kind": "ENUM_SET"},
+    {"capability_id": "MODEL_SELECTION_CONTROLS", "category": "SELECTION", "value_kind": "ENUM_SET"},
+    {"capability_id": "REASONING_RUNTIME_MODES", "category": "RUNTIME", "value_kind": "ENUM_SET"},
+    {"capability_id": "PERMISSION_SEMANTICS", "category": "PERMISSION", "value_kind": "DESCRIPTIVE"},
+    {"capability_id": "PROVIDER_POLICY_RESTRICTIONS", "category": "POLICY", "value_kind": "DESCRIPTIVE"}
+  ],
+  "provider_model_profiles": [],
+  "evidence_policy": {
+    "positive_disposition_requires_current_evidence": true,
+    "unknown_identity_disposition": "UNKNOWN",
+    "static_declaration_disposition": "AVAILABLE_NOT_YET_VERIFIED",
+    "provider_switching_authorized": false,
+    "learned_routing_promotion_authorized": false
+  }
+}

--- a/machine/schemas/provider-model-capability-contract.v1.schema.json
+++ b/machine/schemas/provider-model-capability-contract.v1.schema.json
@@ -1,0 +1,240 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Baelfyre/Orchestra/blob/main/machine/schemas/provider-model-capability-contract.v1.schema.json",
+  "title": "Orchestra Provider Model Capability Contract v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schema_version",
+    "contract_id",
+    "contract_revision",
+    "contract_role",
+    "authority",
+    "capability_definitions",
+    "provider_model_profiles",
+    "evidence_policy"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "./machine/schemas/provider-model-capability-contract.v1.schema.json"
+    },
+    "schema_version": {
+      "const": "orchestra.provider-model-capability-contract.v1"
+    },
+    "contract_id": {
+      "const": "orchestra-provider-model-capability"
+    },
+    "contract_revision": {
+      "const": 1
+    },
+    "contract_role": {
+      "const": "canonical_uai_provider_model_capability_contract"
+    },
+    "authority": {
+      "$ref": "#/$defs/nonAuthorizingAuthority"
+    },
+    "capability_definitions": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["capability_id", "category", "value_kind"],
+        "properties": {
+          "capability_id": {
+            "enum": [
+              "TOOL_CALLING",
+              "STRUCTURED_OUTPUT",
+              "CONTEXT_LIMITS",
+              "VISION_MULTIMODAL_INPUT",
+              "CODE_TERMINAL_EXPOSURE",
+              "SUB_AGENT_SUPPORT",
+              "CONCURRENCY_EXPOSURE",
+              "MCP_TOOL_COMPATIBILITY",
+              "MODEL_SELECTION_CONTROLS",
+              "REASONING_RUNTIME_MODES",
+              "PERMISSION_SEMANTICS",
+              "PROVIDER_POLICY_RESTRICTIONS"
+            ]
+          },
+          "category": {
+            "enum": [
+              "INTERACTION",
+              "OUTPUT",
+              "CONTEXT",
+              "INPUT",
+              "EXECUTION",
+              "ORCHESTRATION",
+              "TRANSPORT",
+              "SELECTION",
+              "RUNTIME",
+              "PERMISSION",
+              "POLICY"
+            ]
+          },
+          "value_kind": {
+            "enum": ["BOOLEAN", "INTEGER_OR_RANGE", "ENUM_SET", "DESCRIPTIVE"]
+          }
+        }
+      }
+    },
+    "provider_model_profiles": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/providerModelProfile"
+      }
+    },
+    "evidence_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "positive_disposition_requires_current_evidence",
+        "unknown_identity_disposition",
+        "static_declaration_disposition",
+        "provider_switching_authorized",
+        "learned_routing_promotion_authorized"
+      ],
+      "properties": {
+        "positive_disposition_requires_current_evidence": {
+          "const": true
+        },
+        "unknown_identity_disposition": {
+          "const": "UNKNOWN"
+        },
+        "static_declaration_disposition": {
+          "const": "AVAILABLE_NOT_YET_VERIFIED"
+        },
+        "provider_switching_authorized": {
+          "const": false
+        },
+        "learned_routing_promotion_authorized": {
+          "const": false
+        }
+      }
+    }
+  },
+  "$defs": {
+    "nonAuthorizingAuthority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "capability_grants_execution_authority",
+        "capability_grants_routing_authority",
+        "capability_grants_specialist_selection_authority",
+        "capability_grants_workflow_topology_authority",
+        "capability_grants_provider_selection_authority",
+        "capability_grants_model_selection_authority",
+        "automatic_provider_switching",
+        "automatic_provider_fallback",
+        "learned_routing_promotion",
+        "execution_authorized"
+      ],
+      "properties": {
+        "capability_grants_execution_authority": {"const": false},
+        "capability_grants_routing_authority": {"const": false},
+        "capability_grants_specialist_selection_authority": {"const": false},
+        "capability_grants_workflow_topology_authority": {"const": false},
+        "capability_grants_provider_selection_authority": {"const": false},
+        "capability_grants_model_selection_authority": {"const": false},
+        "automatic_provider_switching": {"const": false},
+        "automatic_provider_fallback": {"const": false},
+        "learned_routing_promotion": {"const": false},
+        "execution_authorized": {"const": false}
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_repository",
+        "source_path",
+        "source_commit",
+        "source_type",
+        "observation_id",
+        "observed_at",
+        "freshness"
+      ],
+      "properties": {
+        "source_repository": {"type": "string", "minLength": 1},
+        "source_path": {"type": "string", "minLength": 1},
+        "source_commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "source_type": {"type": "string", "minLength": 1},
+        "observation_id": {"type": "string", "minLength": 1},
+        "observed_at": {"type": "string", "minLength": 1},
+        "freshness": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "max_age_hours", "invalidation_triggers"],
+          "properties": {
+            "status": {"enum": ["CURRENT_AT_OBSERVATION", "STALE", "UNKNOWN"]},
+            "max_age_hours": {"type": "integer", "minimum": 1},
+            "invalidation_triggers": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {"type": "string", "minLength": 1}
+            }
+          }
+        }
+      }
+    },
+    "providerModelProfile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "profile_id",
+        "host_id",
+        "provider_source_id",
+        "provider_id",
+        "model_id",
+        "evidence",
+        "authority",
+        "capabilities"
+      ],
+      "properties": {
+        "profile_id": {
+          "type": "string",
+          "pattern": "^provider-model-capability\\.[0-9a-f]{24}$"
+        },
+        "host_id": {"type": "string", "minLength": 1},
+        "provider_source_id": {"type": "string", "minLength": 1},
+        "provider_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9_.:-]*$"},
+        "model_id": {"type": "string", "minLength": 1, "pattern": "^[^\\r\\n\\u0000]+$"},
+        "evidence": {"$ref": "#/$defs/evidence"},
+        "authority": {"$ref": "#/$defs/nonAuthorizingAuthority"},
+        "capabilities": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["capability_id", "disposition", "evidence_refs"],
+            "properties": {
+              "capability_id": {"type": "string", "minLength": 1},
+              "disposition": {
+                "enum": [
+                  "SUPPORTED_VERIFIED",
+                  "SUPPORTED_WITH_LIMITS",
+                  "AVAILABLE_NOT_YET_VERIFIED",
+                  "UNKNOWN",
+                  "BLOCKED_BY_POLICY",
+                  "VERIFIED_UNSUPPORTED_LOCALLY",
+                  "UNSUPPORTED"
+                ]
+              },
+              "evidence_refs": {
+                "type": "array",
+                "minItems": 1,
+                "uniqueItems": true,
+                "items": {"type": "string", "minLength": 1}
+              },
+              "observed_value": {}
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/validate_provider_model_capability_contract.py
+++ b/scripts/validate_provider_model_capability_contract.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Validate the canonical UAI provider/model capability evidence contract."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+CONTRACT_PATH = Path("machine/providers/provider-model-capability-contract.v1.json")
+SCHEMA_PATH = Path("machine/schemas/provider-model-capability-contract.v1.schema.json")
+CAPABILITY_DEFINITIONS = {
+    "TOOL_CALLING": ("INTERACTION", "BOOLEAN"),
+    "STRUCTURED_OUTPUT": ("OUTPUT", "BOOLEAN"),
+    "CONTEXT_LIMITS": ("CONTEXT", "INTEGER_OR_RANGE"),
+    "VISION_MULTIMODAL_INPUT": ("INPUT", "BOOLEAN"),
+    "CODE_TERMINAL_EXPOSURE": ("EXECUTION", "ENUM_SET"),
+    "SUB_AGENT_SUPPORT": ("ORCHESTRATION", "BOOLEAN"),
+    "CONCURRENCY_EXPOSURE": ("ORCHESTRATION", "ENUM_SET"),
+    "MCP_TOOL_COMPATIBILITY": ("TRANSPORT", "ENUM_SET"),
+    "MODEL_SELECTION_CONTROLS": ("SELECTION", "ENUM_SET"),
+    "REASONING_RUNTIME_MODES": ("RUNTIME", "ENUM_SET"),
+    "PERMISSION_SEMANTICS": ("PERMISSION", "DESCRIPTIVE"),
+    "PROVIDER_POLICY_RESTRICTIONS": ("POLICY", "DESCRIPTIVE"),
+}
+DISPOSITIONS = {
+    "SUPPORTED_VERIFIED",
+    "SUPPORTED_WITH_LIMITS",
+    "AVAILABLE_NOT_YET_VERIFIED",
+    "UNKNOWN",
+    "BLOCKED_BY_POLICY",
+    "VERIFIED_UNSUPPORTED_LOCALLY",
+    "UNSUPPORTED",
+}
+AUTHORITY_FIELDS = {
+    "capability_grants_execution_authority",
+    "capability_grants_routing_authority",
+    "capability_grants_specialist_selection_authority",
+    "capability_grants_workflow_topology_authority",
+    "capability_grants_provider_selection_authority",
+    "capability_grants_model_selection_authority",
+    "automatic_provider_switching",
+    "automatic_provider_fallback",
+    "learned_routing_promotion",
+    "execution_authorized",
+}
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+PROFILE_ID_PATTERN = re.compile(r"^provider-model-capability\.[0-9a-f]{24}$")
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _require_object(value: Any, label: str, errors: list[str]) -> bool:
+    if not isinstance(value, dict):
+        errors.append(f"MALFORMED:{label}:must_be_object")
+        return False
+    return True
+
+
+def _require_non_empty_strings(value: Any, label: str, errors: list[str]) -> None:
+    if not isinstance(value, list) or not value or any(not isinstance(item, str) or not item for item in value):
+        errors.append(f"MALFORMED:{label}:must_be_non_empty_string_list")
+        return
+    if len(value) != len(set(value)):
+        errors.append(f"MALFORMED:{label}:duplicates")
+
+
+def _validate_authority(value: Any, label: str, errors: list[str]) -> None:
+    if not _require_object(value, label, errors):
+        return
+    for field in sorted(AUTHORITY_FIELDS):
+        if value.get(field) is not False:
+            errors.append(f"AUTHORITY_EXPANSION:{label}.{field}")
+    for field in sorted(set(value) - AUTHORITY_FIELDS):
+        errors.append(f"AUTHORITY_EXPANSION:{label}.{field}")
+
+
+def _validate_evidence(value: Any, label: str, errors: list[str]) -> str | None:
+    if not _require_object(value, label, errors):
+        return None
+    for field in ("source_repository", "source_path", "source_type", "observation_id", "observed_at"):
+        if not isinstance(value.get(field), str) or not value[field].strip():
+            errors.append(f"MALFORMED:{label}.{field}")
+    for field in ("source_commit",):
+        if not isinstance(value.get(field), str) or not SHA_PATTERN.fullmatch(value[field]):
+            errors.append(f"MALFORMED:{label}.{field}:sha")
+    freshness = value.get("freshness")
+    if not _require_object(freshness, f"{label}.freshness", errors):
+        return None
+    status = freshness.get("status")
+    if status not in {"CURRENT_AT_OBSERVATION", "STALE", "UNKNOWN"}:
+        errors.append(f"FRESHNESS_INVALID:{label}.freshness.status")
+    if not isinstance(freshness.get("max_age_hours"), int) or freshness["max_age_hours"] < 1:
+        errors.append(f"MALFORMED:{label}.freshness.max_age_hours")
+    _require_non_empty_strings(
+        freshness.get("invalidation_triggers"),
+        f"{label}.freshness.invalidation_triggers",
+        errors,
+    )
+    return status if isinstance(status, str) else None
+
+
+def validate_payload(contract: Any, schema: Any | None = None) -> list[str]:
+    errors: list[str] = []
+    if not _require_object(contract, "contract", errors):
+        return errors
+
+    required = {
+        "$schema",
+        "schema_version",
+        "contract_id",
+        "contract_revision",
+        "contract_role",
+        "authority",
+        "capability_definitions",
+        "provider_model_profiles",
+        "evidence_policy",
+    }
+    for field in sorted(required - set(contract)):
+        errors.append(f"MALFORMED:missing:{field}")
+    expected = {
+        "$schema": "./machine/schemas/provider-model-capability-contract.v1.schema.json",
+        "schema_version": "orchestra.provider-model-capability-contract.v1",
+        "contract_id": "orchestra-provider-model-capability",
+        "contract_revision": 1,
+        "contract_role": "canonical_uai_provider_model_capability_contract",
+    }
+    for field, expected_value in expected.items():
+        if field in contract and contract[field] != expected_value:
+            errors.append(f"MALFORMED:{field}:unexpected_value")
+
+    if schema is not None and not isinstance(schema, dict):
+        errors.append("MALFORMED:schema:must_be_object")
+    else:
+        try:
+            import jsonschema
+
+            validator = jsonschema.Draft202012Validator(schema)
+            for item in validator.iter_errors(contract):
+                location = ".".join(str(part) for part in item.absolute_path) or "$"
+                errors.append(f"SCHEMA_VALIDATION:{location}:{item.message}")
+        except ImportError:
+            pass
+        except Exception as exc:  # pragma: no cover - schema tooling failure is environment-specific
+            errors.append(f"SCHEMA_VALIDATION:validator_error:{exc}")
+
+    _validate_authority(contract.get("authority"), "authority", errors)
+
+    definitions = contract.get("capability_definitions")
+    seen_definitions: set[str] = set()
+    if not isinstance(definitions, list) or not definitions:
+        errors.append("MALFORMED:capability_definitions:must_be_non_empty_list")
+    else:
+        for index, definition in enumerate(definitions):
+            label = f"capability_definitions[{index}]"
+            if not _require_object(definition, label, errors):
+                continue
+            capability_id = definition.get("capability_id")
+            if not isinstance(capability_id, str) or not capability_id:
+                errors.append(f"MALFORMED:{label}.capability_id")
+                continue
+            if capability_id in seen_definitions:
+                errors.append(f"MALFORMED:DUPLICATE_CAPABILITY_DEFINITION:{capability_id}")
+                continue
+            seen_definitions.add(capability_id)
+            expected_definition = CAPABILITY_DEFINITIONS.get(capability_id)
+            if expected_definition is None:
+                errors.append(f"MALFORMED:UNKNOWN_CAPABILITY_DEFINITION:{capability_id}")
+            elif (definition.get("category"), definition.get("value_kind")) != expected_definition:
+                errors.append(f"MALFORMED:CAPABILITY_DEFINITION_DRIFT:{capability_id}")
+    if seen_definitions != set(CAPABILITY_DEFINITIONS):
+        errors.append("MALFORMED:capability_definitions:taxonomy_set_mismatch")
+
+    profiles = contract.get("provider_model_profiles")
+    profile_ids: set[str] = set()
+    if not isinstance(profiles, list):
+        errors.append("MALFORMED:provider_model_profiles:must_be_list")
+    else:
+        for index, profile in enumerate(profiles):
+            label = f"provider_model_profiles[{index}]"
+            if not _require_object(profile, label, errors):
+                continue
+            profile_id = profile.get("profile_id")
+            if not isinstance(profile_id, str) or not PROFILE_ID_PATTERN.fullmatch(profile_id):
+                errors.append(f"MALFORMED:{label}.profile_id")
+            elif profile_id in profile_ids:
+                errors.append(f"MALFORMED:DUPLICATE_PROFILE:{profile_id}")
+            else:
+                profile_ids.add(profile_id)
+            for field in ("host_id", "provider_source_id", "provider_id", "model_id"):
+                if not isinstance(profile.get(field), str) or not profile[field].strip():
+                    errors.append(f"MALFORMED:{label}.{field}")
+            freshness_status = _validate_evidence(profile.get("evidence"), f"{label}.evidence", errors)
+            _validate_authority(profile.get("authority"), f"{label}.authority", errors)
+
+            capabilities = profile.get("capabilities")
+            seen_capabilities: set[str] = set()
+            if not isinstance(capabilities, list) or not capabilities:
+                errors.append(f"MALFORMED:{label}.capabilities:must_be_non_empty_list")
+            else:
+                for capability_index, capability in enumerate(capabilities):
+                    capability_label = f"{label}.capabilities[{capability_index}]"
+                    if not _require_object(capability, capability_label, errors):
+                        continue
+                    capability_id = capability.get("capability_id")
+                    disposition = capability.get("disposition")
+                    if not isinstance(capability_id, str) or not capability_id:
+                        errors.append(f"MALFORMED:{capability_label}.capability_id")
+                    elif capability_id in seen_capabilities:
+                        errors.append(f"CONTRADICTORY_CAPABILITY:{profile_id}:{capability_id}")
+                    else:
+                        seen_capabilities.add(capability_id)
+                        if capability_id not in set(CAPABILITY_DEFINITIONS):
+                            errors.append(f"UNKNOWN_CAPABILITY:{profile_id}:{capability_id}")
+                    if disposition not in DISPOSITIONS:
+                        errors.append(f"MALFORMED:{capability_label}.disposition")
+                    _require_non_empty_strings(
+                        capability.get("evidence_refs"),
+                        f"{capability_label}.evidence_refs",
+                        errors,
+                    )
+                    if disposition in {"SUPPORTED_VERIFIED", "SUPPORTED_WITH_LIMITS"} and freshness_status != "CURRENT_AT_OBSERVATION":
+                        errors.append(f"CONTRADICTORY_EVIDENCE:{profile_id}:{capability_id}:positive_status_with_stale_evidence")
+
+    policy = contract.get("evidence_policy")
+    if _require_object(policy, "evidence_policy", errors):
+        expected_policy = {
+            "positive_disposition_requires_current_evidence": True,
+            "unknown_identity_disposition": "UNKNOWN",
+            "static_declaration_disposition": "AVAILABLE_NOT_YET_VERIFIED",
+            "provider_switching_authorized": False,
+            "learned_routing_promotion_authorized": False,
+        }
+        for field, expected_value in expected_policy.items():
+            if policy.get(field) != expected_value:
+                errors.append(f"AUTHORITY_OR_EVIDENCE_POLICY_DRIFT:evidence_policy.{field}")
+
+    return errors
+
+
+def validate(root: Path) -> list[str]:
+    try:
+        contract = _load_json(root / CONTRACT_PATH)
+    except FileNotFoundError:
+        return [f"MALFORMED:missing:{CONTRACT_PATH.as_posix()}"]
+    except (OSError, json.JSONDecodeError) as exc:
+        return [f"MALFORMED:{CONTRACT_PATH.as_posix()}:{exc}"]
+    try:
+        schema = _load_json(root / SCHEMA_PATH)
+    except FileNotFoundError:
+        return [f"MALFORMED:missing:{SCHEMA_PATH.as_posix()}"] + validate_payload(contract)
+    except (OSError, json.JSONDecodeError) as exc:
+        return [f"MALFORMED:{SCHEMA_PATH.as_posix()}:{exc}"] + validate_payload(contract)
+    return validate_payload(contract, schema)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[1])
+    args = parser.parse_args(argv)
+    errors = validate(args.repo_root.resolve())
+    if errors:
+        for error in errors:
+            print(f"[FAIL] {error}")
+        return 1
+    print("[PASS] UAI provider/model capability contract is schema-valid and authority-bounded.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/runtime/test_provider_model_capability_contract.py
+++ b/tests/runtime/test_provider_model_capability_contract.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+from scripts.validate_provider_model_capability_contract import validate_payload
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT_PATH = ROOT / "machine" / "providers" / "provider-model-capability-contract.v1.json"
+SCHEMA_PATH = ROOT / "machine" / "schemas" / "provider-model-capability-contract.v1.schema.json"
+
+
+def _load(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _canonical() -> tuple[dict[str, object], dict[str, object]]:
+    return deepcopy(_load(CONTRACT_PATH)), _load(SCHEMA_PATH)
+
+
+def _profile(contract: dict[str, object]) -> dict[str, object]:
+    profiles = contract["provider_model_profiles"]
+    assert isinstance(profiles, list)
+    profile = {
+        "profile_id": "provider-model-capability." + "1" * 24,
+        "host_id": "fixture-host",
+        "provider_source_id": "fixture-source",
+        "provider_id": "fixture-provider",
+        "model_id": "fixture-model",
+        "evidence": {
+            "source_repository": "fixture/repository",
+            "source_path": "fixture/evidence.json",
+            "source_commit": "1" * 40,
+            "source_type": "CURRENT_MAINTAINER_OBSERVATION",
+            "observation_id": "fixture-observation",
+            "observed_at": "2026-09-06T00:00:00Z",
+            "freshness": {
+                "status": "CURRENT_AT_OBSERVATION",
+                "max_age_hours": 24,
+                "invalidation_triggers": ["HOST_POLICY_UPDATE"],
+            },
+        },
+        "authority": deepcopy(contract["authority"]),
+        "capabilities": [
+            {
+                "capability_id": "TOOL_CALLING",
+                "disposition": "SUPPORTED_VERIFIED",
+                "evidence_refs": ["fixture-observation#tool-calling"],
+                "observed_value": True,
+            }
+        ],
+    }
+    profiles.append(profile)
+    return profile
+
+
+def test_canonical_contract_is_schema_valid_and_provider_model_neutral() -> None:
+    contract, schema = _canonical()
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(contract)
+    assert validate_payload(contract, schema) == []
+    assert contract["provider_model_profiles"] == []
+    authority = contract["authority"]
+    assert isinstance(authority, dict)
+    assert all(value is False for value in authority.values())
+
+
+def test_profile_positive_capability_requires_current_evidence() -> None:
+    contract, schema = _canonical()
+    profile = _profile(contract)
+    evidence = profile["evidence"]
+    assert isinstance(evidence, dict)
+    freshness = evidence["freshness"]
+    assert isinstance(freshness, dict)
+    freshness["status"] = "STALE"
+    errors = validate_payload(contract, schema)
+    assert any(error.startswith("CONTRADICTORY_EVIDENCE:") for error in errors)
+
+
+def test_duplicate_capability_and_authority_expansion_fail_closed() -> None:
+    contract, schema = _canonical()
+    profile = _profile(contract)
+    capabilities = profile["capabilities"]
+    assert isinstance(capabilities, list)
+    capabilities.append(deepcopy(capabilities[0]))
+    authority = profile["authority"]
+    assert isinstance(authority, dict)
+    authority["capability_grants_provider_selection_authority"] = True
+    errors = validate_payload(contract, schema)
+    assert any(error.startswith("CONTRADICTORY_CAPABILITY:") for error in errors)
+    assert "AUTHORITY_EXPANSION:provider_model_profiles[0].authority.capability_grants_provider_selection_authority" in errors
+
+
+def test_contract_policy_cannot_authorize_provider_switching_or_learning() -> None:
+    contract, schema = _canonical()
+    policy = contract["evidence_policy"]
+    assert isinstance(policy, dict)
+    policy["provider_switching_authorized"] = True
+    policy["learned_routing_promotion_authorized"] = True
+    errors = validate_payload(contract, schema)
+    assert any(error.startswith("SCHEMA_VALIDATION:evidence_policy") for error in errors)
+    assert "AUTHORITY_OR_EVIDENCE_POLICY_DRIFT:evidence_policy.provider_switching_authorized" in errors
+    assert "AUTHORITY_OR_EVIDENCE_POLICY_DRIFT:evidence_policy.learned_routing_promotion_authorized" in errors


### PR DESCRIPTION
## Summary
- add the UAI-3 provider/model-neutral technical capability vocabulary and schema
- validate provenance, freshness, duplicate claims, and non-authorizing boundaries
- keep the canonical provider/model profile set empty because no fresh provider/model observation is admitted
- update machine discovery and setup documentation

## Governance boundaries
- Conductor remains the sole internal specialist router
- AWF remains workflow topology owner
- capability is not authority
- no automatic provider switching or fallback
- no learned-routing promotion, credential changes, release, or deployment

## Validation
- python -B scripts/validate_provider_model_capability_contract.py
- python -B -m pytest -q tests/runtime/test_provider_model_capability_contract.py tests/behavior/test_readme_machine_index.py tests/runtime/test_machine_readme.py
- python -B scripts/validation/validate_architecture_boundaries.py
- git diff --check

Current evidence does not establish a fresh provider/model profile; this PR records that boundary explicitly.