### PR TITLE
feat(uai): add integration strategy resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased UAI-4 integration strategy resolver
+
+- Adds deterministic transport selection across Agent Skills, custom agents, MCP, plugins/extensions, CLI adapters, repository/workspace instructions, instruction-only fallback, and explicit fail-closed unsupported output.
+- Selects the smallest eligible transport using required capabilities, evidence disposition, policy allowance, authority preservation, installation complexity, context cost, portability, and evidence quality.
+- Does not change Conductor routing, AWF topology, provider/model selection, credentials, automatic fallback, learned routing, release, or deployment.
+
 ## Unreleased UAI-3 provider/model capability contract
 
 - Adds a provider/model-neutral capability vocabulary for tool calling, structured output, context limits, multimodal input, host-exposed execution, sub-agents, concurrency exposure, MCP compatibility, model selection, reasoning/runtime modes, permission semantics, and provider-policy restrictions.

--- a/README.json
+++ b/README.json
@@ -2233,8 +2233,8 @@
       "next_action": "FINAL_EXACT_HEAD_RELEASE_QUALIFICATION"
     },
     "universal_adaptive_integration_uai": {
-      "status": "UAI_3_PROVIDER_MODEL_CAPABILITY_CONTRACT_COMPLETE_CANONICAL_VERIFIED",
-      "purpose": "Versioned host and provider/model capability evidence with host-neutral transport compatibility that preserve Conductor specialist routing and AWF workflow topology without authority expansion.",
+      "status": "UAI_4_INTEGRATION_STRATEGY_RESOLVER_COMPLETE_CANONICAL_VERIFIED",
+      "purpose": "Versioned host and provider/model capability evidence plus deterministic minimal transport selection that preserve Conductor specialist routing and AWF workflow topology without authority expansion.",
       "human_sources": [
         "adapters/github-copilot/README.md",
         "adapters/github-copilot/probe-guide.md",
@@ -2251,7 +2251,11 @@
         "machine/providers/provider-model-capability-contract.v1.json",
         "machine/schemas/provider-model-capability-contract.v1.schema.json",
         "scripts/validate_provider_model_capability_contract.py",
-        "tests/runtime/test_provider_model_capability_contract.py"
+        "tests/runtime/test_provider_model_capability_contract.py",
+        "machine/hosts/integration-strategy-policy.v1.json",
+        "machine/schemas/integration-strategy-policy.v1.schema.json",
+        "orchestra_runtime/domain/adaptive/integration_strategy.py",
+        "tests/runtime/test_integration_strategy.py"
       ],
       "probed_hosts": [
         "github-copilot"
@@ -2371,6 +2375,8 @@
     "host_capability_contract_schema": "machine/schemas/host-capability-contract.v1.schema.json",
     "provider_model_capability_contract": "machine/providers/provider-model-capability-contract.v1.json",
     "provider_model_capability_contract_schema": "machine/schemas/provider-model-capability-contract.v1.schema.json",
+    "integration_strategy_policy": "machine/hosts/integration-strategy-policy.v1.json",
+    "integration_strategy_policy_schema": "machine/schemas/integration-strategy-policy.v1.schema.json",
     "prap_certification_contract": "machine/protocol/prap-certification-contract.v1.json",
     "developer_portal_catalog": "machine/developer-portal/catalog.v1.json",
     "murmurs_presentation_policy": "machine/presentation/murmurs-policy.v1.json",
@@ -2569,6 +2575,8 @@
     "provider_model_capability_contract": "machine/providers/provider-model-capability-contract.v1.json",
     "provider_model_capability_contract_schema": "machine/schemas/provider-model-capability-contract.v1.schema.json",
     "provider_model_capability_contract_validator": "scripts/validate_provider_model_capability_contract.py",
+    "integration_strategy_policy": "machine/hosts/integration-strategy-policy.v1.json",
+    "integration_strategy_policy_schema": "machine/schemas/integration-strategy-policy.v1.schema.json",
     "uai_routing_boundaries": "adapters/github-copilot/probe-guide.md",
     "adapter_sdk_reference": "docs/setup/ADAPTER_SDK_PRAP.md",
     "adapter_sdk_stable_import_surface": "orchestra_runtime.protocol.sdk",

--- a/docs/setup/PROVIDER_MODEL_CAPABILITY_CONTRACT.md
+++ b/docs/setup/PROVIDER_MODEL_CAPABILITY_CONTRACT.md
@@ -10,6 +10,8 @@ Provider/model profiles, when admitted later, require exact provider/model ident
 
 This contract does not authorize automatic provider switching, fallback, credential changes, learned-routing promotion, specialist routing, AWF topology changes, or execution. P2.1's [Provider Execution Profile](../project/PRIORITY_2_PROVIDER_EXECUTION_PROFILE.md) remains the narrower trusted execution requirement gate. A capability profile describes what may be observable; it never becomes a runtime grant.
 
+UAI-4 resolves transport separately with the pure `resolve_integration_strategy` domain function. It considers only current supported evidence, required transport capabilities, host/provider policy, authority preservation, context cost, installation complexity, portability, and evidence quality. If no option is eligible it selects `UNSUPPORTED_FAIL_CLOSED`. The result cannot change specialist routing, AWF topology, provider/model selection, credentials, or fallback behavior.
+
 Validate it with:
 
 ```text

--- a/machine/developer-portal/catalog.v1.json
+++ b/machine/developer-portal/catalog.v1.json
@@ -98,6 +98,20 @@
       "authority_role": "GUIDANCE_OVER_PROVIDER_MODEL_CAPABILITY_CONTRACT"
     },
     {
+      "id": "uai-integration-strategy-policy",
+      "title": "UAI Integration Strategy Policy",
+      "kind": "machine_contract",
+      "path": "machine/hosts/integration-strategy-policy.v1.json",
+      "authority_role": "TRANSPORT_SELECTION_WITHOUT_ROUTING_AUTHORITY"
+    },
+    {
+      "id": "uai-integration-strategy-policy-schema",
+      "title": "UAI Integration Strategy Policy schema",
+      "kind": "machine_schema",
+      "path": "machine/schemas/integration-strategy-policy.v1.schema.json",
+      "authority_role": "EVIDENCE_SCHEMA"
+    },
+    {
       "id": "specialist-registry",
       "title": "Specialist registry",
       "kind": "machine_contract",

--- a/machine/hosts/integration-strategy-policy.v1.json
+++ b/machine/hosts/integration-strategy-policy.v1.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "./machine/schemas/integration-strategy-policy.v1.schema.json",
+  "schema_version": "orchestra.integration-strategy-policy.v1",
+  "contract_id": "orchestra-uai-integration-strategy-policy",
+  "contract_revision": 1,
+  "contract_role": "canonical_uai_integration_strategy_selection_policy",
+  "authority": {
+    "transport_selection_only": true,
+    "specialist_routing_changed": false,
+    "workflow_topology_changed": false,
+    "provider_selection_changed": false,
+    "automatic_fallback": false,
+    "credentials_mutated": false
+  },
+  "selection_policy": {
+    "eligible_dispositions": ["SUPPORTED_VERIFIED", "SUPPORTED_WITH_LIMITS"],
+    "authority_preserved_required": true,
+    "policy_allowed_required": true,
+    "fail_closed_strategy": "UNSUPPORTED_FAIL_CLOSED",
+    "ranking_order": ["installation_complexity", "context_cost", "portability_desc", "evidence_quality_desc", "declared_order"]
+  },
+  "strategies": [
+    {"strategy_id": "AGENT_SKILLS", "declared_order": 0, "description": "Repository-scoped skills when indexed by the host."},
+    {"strategy_id": "CUSTOM_AGENT", "declared_order": 1, "description": "Host-native custom agent as an optional transport."},
+    {"strategy_id": "MCP_TRANSPORT", "declared_order": 2, "description": "Configured bounded MCP transport."},
+    {"strategy_id": "PLUGIN_OR_EXTENSION", "declared_order": 3, "description": "Installed and verified host plugin or extension."},
+    {"strategy_id": "CLI_ADAPTER", "declared_order": 4, "description": "Installed and verified host CLI adapter."},
+    {"strategy_id": "REPOSITORY_INSTRUCTIONS", "declared_order": 5, "description": "Repository-scoped instructions."},
+    {"strategy_id": "WORKSPACE_INSTRUCTIONS", "declared_order": 6, "description": "Workspace-scoped instructions."},
+    {"strategy_id": "INSTRUCTION_ONLY_FALLBACK", "declared_order": 7, "description": "Bounded instruction-only integration."},
+    {"strategy_id": "UNSUPPORTED_FAIL_CLOSED", "declared_order": 8, "description": "Stop when a required capability is absent or policy-blocked."}
+  ]
+}

--- a/machine/schemas/integration-strategy-policy.v1.schema.json
+++ b/machine/schemas/integration-strategy-policy.v1.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Baelfyre/Orchestra/blob/main/machine/schemas/integration-strategy-policy.v1.schema.json",
+  "title": "Orchestra UAI Integration Strategy Policy v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["$schema", "schema_version", "contract_id", "contract_revision", "contract_role", "authority", "selection_policy", "strategies"],
+  "properties": {
+    "$schema": {"const": "./machine/schemas/integration-strategy-policy.v1.schema.json"},
+    "schema_version": {"const": "orchestra.integration-strategy-policy.v1"},
+    "contract_id": {"const": "orchestra-uai-integration-strategy-policy"},
+    "contract_revision": {"const": 1},
+    "contract_role": {"const": "canonical_uai_integration_strategy_selection_policy"},
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["transport_selection_only", "specialist_routing_changed", "workflow_topology_changed", "provider_selection_changed", "automatic_fallback", "credentials_mutated"],
+      "properties": {
+        "transport_selection_only": {"const": true},
+        "specialist_routing_changed": {"const": false},
+        "workflow_topology_changed": {"const": false},
+        "provider_selection_changed": {"const": false},
+        "automatic_fallback": {"const": false},
+        "credentials_mutated": {"const": false}
+      }
+    },
+    "selection_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["eligible_dispositions", "authority_preserved_required", "policy_allowed_required", "fail_closed_strategy", "ranking_order"],
+      "properties": {
+        "eligible_dispositions": {"const": ["SUPPORTED_VERIFIED", "SUPPORTED_WITH_LIMITS"]},
+        "authority_preserved_required": {"const": true},
+        "policy_allowed_required": {"const": true},
+        "fail_closed_strategy": {"const": "UNSUPPORTED_FAIL_CLOSED"},
+        "ranking_order": {"const": ["installation_complexity", "context_cost", "portability_desc", "evidence_quality_desc", "declared_order"]}
+      }
+    },
+    "strategies": {
+      "type": "array",
+      "minItems": 9,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["strategy_id", "declared_order", "description"],
+        "properties": {
+          "strategy_id": {"enum": ["AGENT_SKILLS", "CUSTOM_AGENT", "MCP_TRANSPORT", "PLUGIN_OR_EXTENSION", "CLI_ADAPTER", "REPOSITORY_INSTRUCTIONS", "WORKSPACE_INSTRUCTIONS", "INSTRUCTION_ONLY_FALLBACK", "UNSUPPORTED_FAIL_CLOSED"]},
+          "declared_order": {"type": "integer", "minimum": 0},
+          "description": {"type": "string", "minLength": 1}
+        }
+      }
+    }
+  }
+}

--- a/orchestra_runtime/domain/adaptive/__init__.py
+++ b/orchestra_runtime/domain/adaptive/__init__.py
@@ -13,6 +13,15 @@ from .intake import (
     derive_task_profile,
     validate_derivation_policy,
 )
+from .integration_strategy import (
+    ELIGIBLE_DISPOSITIONS,
+    INTEGRATION_STRATEGY_POLICY_VERSION,
+    IntegrationStrategy,
+    IntegrationStrategyDecision,
+    IntegrationStrategyRequirements,
+    TransportCapabilityEvidence,
+    resolve_integration_strategy,
+)
 from .selection_trace import (
     AUTHORITY_RULE,
     SELECTION_TRACE_SCHEMA_VERSION,
@@ -43,6 +52,8 @@ from .topology_validator import (
 __all__ = [
     "AUTHORITY_RULE",
     "DERIVATION_POLICY_SCHEMA_VERSION",
+    "ELIGIBLE_DISPOSITIONS",
+    "INTEGRATION_STRATEGY_POLICY_VERSION",
     "SELECTION_TRACE_SCHEMA_VERSION",
     "AUTHORITY_DOMAINS",
     "AUTHORITY_DOMAIN_OWNERS",
@@ -60,6 +71,9 @@ __all__ = [
     "AdvancedAdaptationAdmission",
     "AgenticWorkflowProfile",
     "IntakeSignal",
+    "IntegrationStrategy",
+    "IntegrationStrategyDecision",
+    "IntegrationStrategyRequirements",
     "PromotionCandidateDecision",
     "TaskProfileDerivation",
     "build_selection_trace",
@@ -69,6 +83,8 @@ __all__ = [
     "CriticContract",
     "SpecialistAuthority",
     "TaskProfile",
+    "TransportCapabilityEvidence",
     "parse_authority_view",
     "select_agentic_workflow",
+    "resolve_integration_strategy",
 ]

--- a/orchestra_runtime/domain/adaptive/integration_strategy.py
+++ b/orchestra_runtime/domain/adaptive/integration_strategy.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Iterable
+
+
+INTEGRATION_STRATEGY_POLICY_VERSION = "orchestra.integration-strategy-policy.v1"
+ELIGIBLE_DISPOSITIONS = frozenset({"SUPPORTED_VERIFIED", "SUPPORTED_WITH_LIMITS"})
+
+
+class IntegrationStrategy(str, Enum):
+    AGENT_SKILLS = "AGENT_SKILLS"
+    CUSTOM_AGENT = "CUSTOM_AGENT"
+    MCP_TRANSPORT = "MCP_TRANSPORT"
+    PLUGIN_OR_EXTENSION = "PLUGIN_OR_EXTENSION"
+    CLI_ADAPTER = "CLI_ADAPTER"
+    REPOSITORY_INSTRUCTIONS = "REPOSITORY_INSTRUCTIONS"
+    WORKSPACE_INSTRUCTIONS = "WORKSPACE_INSTRUCTIONS"
+    INSTRUCTION_ONLY_FALLBACK = "INSTRUCTION_ONLY_FALLBACK"
+    UNSUPPORTED_FAIL_CLOSED = "UNSUPPORTED_FAIL_CLOSED"
+
+
+_DECLARED_ORDER = {strategy: index for index, strategy in enumerate(IntegrationStrategy)}
+
+
+def _unique_strings(values: Iterable[str], field: str) -> tuple[str, ...]:
+    normalized = tuple(str(value).strip() for value in values)
+    if any(not value for value in normalized) or len(set(normalized)) != len(normalized):
+        raise ValueError(f"{field} must contain unique non-empty strings")
+    return normalized
+
+
+@dataclass(frozen=True, slots=True)
+class IntegrationStrategyRequirements:
+    required_capabilities: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "required_capabilities", _unique_strings(self.required_capabilities, "required_capabilities"))
+
+
+@dataclass(frozen=True, slots=True)
+class TransportCapabilityEvidence:
+    strategy_id: IntegrationStrategy | str
+    disposition: str
+    provided_capabilities: tuple[str, ...]
+    evidence_refs: tuple[str, ...]
+    portability_score: int = 0
+    context_cost: int = 0
+    installation_complexity: int = 0
+    evidence_quality: int = 0
+    authority_preserved: bool = True
+    policy_allowed: bool = True
+    limitations: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        try:
+            strategy = IntegrationStrategy(self.strategy_id)
+        except ValueError as exc:
+            raise ValueError("strategy_id is unsupported") from exc
+        if strategy is IntegrationStrategy.UNSUPPORTED_FAIL_CLOSED:
+            raise ValueError("fail-closed strategy is an output, not a capability option")
+        object.__setattr__(self, "strategy_id", strategy)
+        if self.disposition not in ELIGIBLE_DISPOSITIONS | {"AVAILABLE_NOT_YET_VERIFIED", "UNKNOWN", "BLOCKED_BY_POLICY", "VERIFIED_UNSUPPORTED_LOCALLY", "UNSUPPORTED"}:
+            raise ValueError("disposition is unsupported")
+        object.__setattr__(self, "provided_capabilities", _unique_strings(self.provided_capabilities, "provided_capabilities"))
+        object.__setattr__(self, "evidence_refs", _unique_strings(self.evidence_refs, "evidence_refs"))
+        object.__setattr__(self, "limitations", _unique_strings(self.limitations, "limitations"))
+        for field in ("portability_score", "context_cost", "installation_complexity", "evidence_quality"):
+            value = getattr(self, field)
+            if type(value) is not int or value < 0:
+                raise ValueError(f"{field} must be a non-negative integer")
+        if type(self.authority_preserved) is not bool or type(self.policy_allowed) is not bool:
+            raise ValueError("authority_preserved and policy_allowed must be booleans")
+
+
+@dataclass(frozen=True, slots=True)
+class IntegrationStrategyDecision:
+    selected_strategy: IntegrationStrategy
+    fail_closed: bool
+    selected_evidence_refs: tuple[str, ...]
+    reason_codes: tuple[str, ...]
+    rejected_strategies: tuple[tuple[str, tuple[str, ...]], ...]
+    policy_version: str = INTEGRATION_STRATEGY_POLICY_VERSION
+    transport_selection_only: bool = True
+    specialist_routing_changed: bool = False
+    workflow_topology_changed: bool = False
+    provider_selection_changed: bool = False
+
+    def __post_init__(self) -> None:
+        if self.policy_version != INTEGRATION_STRATEGY_POLICY_VERSION:
+            raise ValueError("unsupported integration strategy policy")
+        if self.fail_closed != (self.selected_strategy is IntegrationStrategy.UNSUPPORTED_FAIL_CLOSED):
+            raise ValueError("fail_closed does not match selected strategy")
+        if not self.transport_selection_only or self.specialist_routing_changed or self.workflow_topology_changed or self.provider_selection_changed:
+            raise ValueError("integration strategy decisions cannot expand routing or authority")
+
+
+def _rejection(option: TransportCapabilityEvidence, requirements: IntegrationStrategyRequirements) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if option.disposition not in ELIGIBLE_DISPOSITIONS:
+        reasons.append(f"DISPOSITION:{option.disposition}")
+    if not option.authority_preserved:
+        reasons.append("AUTHORITY_NOT_PRESERVED")
+    if not option.policy_allowed:
+        reasons.append("BLOCKED_BY_HOST_OR_PROVIDER_POLICY")
+    missing = tuple(sorted(set(requirements.required_capabilities) - set(option.provided_capabilities)))
+    if missing:
+        reasons.append("MISSING_CAPABILITIES:" + ",".join(missing))
+    return tuple(reasons)
+
+
+def resolve_integration_strategy(
+    requirements: IntegrationStrategyRequirements,
+    options: Iterable[TransportCapabilityEvidence],
+) -> IntegrationStrategyDecision:
+    if not isinstance(requirements, IntegrationStrategyRequirements):
+        raise TypeError("requirements must be IntegrationStrategyRequirements")
+    unique_options: dict[IntegrationStrategy, TransportCapabilityEvidence] = {}
+    rejected: list[tuple[str, tuple[str, ...]]] = []
+    eligible: list[TransportCapabilityEvidence] = []
+    for option in options:
+        if not isinstance(option, TransportCapabilityEvidence):
+            raise TypeError("options must contain TransportCapabilityEvidence")
+        if option.strategy_id in unique_options:
+            raise ValueError("options must contain one record per strategy")
+        unique_options[option.strategy_id] = option
+        reasons = _rejection(option, requirements)
+        if reasons:
+            rejected.append((option.strategy_id.value, reasons))
+        else:
+            eligible.append(option)
+
+    if not eligible:
+        return IntegrationStrategyDecision(
+            selected_strategy=IntegrationStrategy.UNSUPPORTED_FAIL_CLOSED,
+            fail_closed=True,
+            selected_evidence_refs=(),
+            reason_codes=("NO_EVIDENCE_SUPPORTED_TRANSPORT",),
+            rejected_strategies=tuple(rejected),
+        )
+
+    selected = min(
+        eligible,
+        key=lambda option: (
+            option.installation_complexity,
+            option.context_cost,
+            -option.portability_score,
+            -option.evidence_quality,
+            _DECLARED_ORDER[option.strategy_id],
+        ),
+    )
+    reasons = ["MINIMAL_ELIGIBLE_TRANSPORT"]
+    if selected.disposition == "SUPPORTED_WITH_LIMITS":
+        reasons.append("SELECTED_WITH_LIMITS")
+    return IntegrationStrategyDecision(
+        selected_strategy=selected.strategy_id,
+        fail_closed=False,
+        selected_evidence_refs=selected.evidence_refs,
+        reason_codes=tuple(reasons),
+        rejected_strategies=tuple(rejected),
+    )
+
+
+__all__ = [
+    "ELIGIBLE_DISPOSITIONS",
+    "INTEGRATION_STRATEGY_POLICY_VERSION",
+    "IntegrationStrategy",
+    "IntegrationStrategyDecision",
+    "IntegrationStrategyRequirements",
+    "TransportCapabilityEvidence",
+    "resolve_integration_strategy",
+]

--- a/tests/runtime/test_integration_strategy.py
+++ b/tests/runtime/test_integration_strategy.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+from orchestra_runtime.domain.adaptive.integration_strategy import (
+    IntegrationStrategy,
+    IntegrationStrategyRequirements,
+    TransportCapabilityEvidence,
+    resolve_integration_strategy,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def option(strategy: str, **overrides: object) -> TransportCapabilityEvidence:
+    values: dict[str, object] = {
+        "strategy_id": strategy,
+        "disposition": "SUPPORTED_VERIFIED",
+        "provided_capabilities": ("instructions", "tools"),
+        "evidence_refs": (f"fixture:{strategy}",),
+        "portability_score": 5,
+        "context_cost": 5,
+        "installation_complexity": 5,
+        "evidence_quality": 5,
+    }
+    values.update(overrides)
+    return TransportCapabilityEvidence(**values)
+
+
+def test_policy_schema_and_minimality_are_deterministic() -> None:
+    policy_path = ROOT / "machine" / "hosts" / "integration-strategy-policy.v1.json"
+    schema_path = ROOT / "machine" / "schemas" / "integration-strategy-policy.v1.schema.json"
+    policy = json.loads(policy_path.read_text(encoding="utf-8"))
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    Draft202012Validator(schema).validate(policy)
+    decision = resolve_integration_strategy(
+        IntegrationStrategyRequirements(("instructions",)),
+        (
+            option("PLUGIN_OR_EXTENSION", installation_complexity=1),
+            option("REPOSITORY_INSTRUCTIONS", installation_complexity=0, context_cost=1),
+        ),
+    )
+    assert decision.selected_strategy is IntegrationStrategy.REPOSITORY_INSTRUCTIONS
+    assert decision.fail_closed is False
+    assert decision.transport_selection_only is True
+    assert decision.specialist_routing_changed is False
+    assert decision.workflow_topology_changed is False
+    assert decision.provider_selection_changed is False
+
+
+def test_unverified_or_policy_blocked_options_fail_closed() -> None:
+    decision = resolve_integration_strategy(
+        IntegrationStrategyRequirements(("tools",)),
+        (
+            option("MCP_TRANSPORT", disposition="AVAILABLE_NOT_YET_VERIFIED"),
+            option("CUSTOM_AGENT", policy_allowed=False),
+        ),
+    )
+    assert decision.selected_strategy is IntegrationStrategy.UNSUPPORTED_FAIL_CLOSED
+    assert decision.fail_closed is True
+    assert {item[0] for item in decision.rejected_strategies} == {"MCP_TRANSPORT", "CUSTOM_AGENT"}
+
+
+def test_authority_and_capability_gaps_are_rejected() -> None:
+    decision = resolve_integration_strategy(
+        IntegrationStrategyRequirements(("terminal",)),
+        (
+            option("AGENT_SKILLS", provided_capabilities=("instructions",)),
+            option("CLI_ADAPTER", authority_preserved=False, provided_capabilities=("terminal",)),
+        ),
+    )
+    assert decision.fail_closed is True
+    rejected = dict(decision.rejected_strategies)
+    assert "MISSING_CAPABILITIES:terminal" in rejected["AGENT_SKILLS"]
+    assert "AUTHORITY_NOT_PRESERVED" in rejected["CLI_ADAPTER"]
+
+
+def test_limits_are_explicit_and_duplicate_options_fail() -> None:
+    limited = option("WORKSPACE_INSTRUCTIONS", disposition="SUPPORTED_WITH_LIMITS", limitations=("host policy",))
+    decision = resolve_integration_strategy(IntegrationStrategyRequirements(), (limited,))
+    assert decision.selected_strategy is IntegrationStrategy.WORKSPACE_INSTRUCTIONS
+    assert decision.reason_codes == ("MINIMAL_ELIGIBLE_TRANSPORT", "SELECTED_WITH_LIMITS")
+    try:
+        resolve_integration_strategy(IntegrationStrategyRequirements(), (limited, limited))
+    except ValueError as exc:
+        assert "one record per strategy" in str(exc)
+    else:
+        raise AssertionError("duplicate strategy options must fail closed")


### PR DESCRIPTION
## Summary
- add canonical UAI integration strategy policy and schema
- select the smallest evidence-supported transport deterministically
- fail closed for missing, unverified, policy-blocked, or authority-unsafe options
- keep transport selection separate from Conductor routing, AWF topology, provider/model selection, and fallback

## Validation
- python -B -m pytest -q tests/runtime/test_integration_strategy.py tests/runtime/test_provider_model_capability_contract.py tests/behavior/test_readme_machine_index.py tests/runtime/test_machine_readme.py
- python -B scripts/validation/validate_architecture_boundaries.py
- JSON/schema parse
- git diff --check

No provider, credential, routing, workflow-topology, learned-routing, release, or deployment behavior is changed.