### PR TITLE
feat(uai): add portable projection compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased UAI-5 portable projection compiler
+
+- Adds a canonical-source-backed projection contract and deterministic parity index for the tracked GitHub Copilot repository-instruction and custom-agent surfaces.
+- Fingerprints canonical governance, specialist, routing, host-capability, integration-strategy, Conductor, and Ponytail sources and fails closed on missing invariant markers, stale output, unsupported formats, repository escapes, or `.agents` runtime-copy targets.
+- Does not refresh installed integrations or change Conductor routing, AWF topology, provider/model selection, credentials, automatic fallback, learned routing, release, or deployment.
+
 ## Unreleased UAI-4 integration strategy resolver
 
 - Adds deterministic transport selection across Agent Skills, custom agents, MCP, plugins/extensions, CLI adapters, repository/workspace instructions, instruction-only fallback, and explicit fail-closed unsupported output.

--- a/README.json
+++ b/README.json
@@ -2233,13 +2233,14 @@
       "next_action": "FINAL_EXACT_HEAD_RELEASE_QUALIFICATION"
     },
     "universal_adaptive_integration_uai": {
-      "status": "UAI_4_INTEGRATION_STRATEGY_RESOLVER_COMPLETE_CANONICAL_VERIFIED",
-      "purpose": "Versioned host and provider/model capability evidence plus deterministic minimal transport selection that preserve Conductor specialist routing and AWF workflow topology without authority expansion.",
+      "status": "UAI_5_PORTABLE_PROJECTION_COMPILER_COMPLETE_CANONICAL_VERIFIED",
+      "purpose": "Versioned host and provider/model capability evidence, deterministic minimal transport selection, and canonical-source-backed portable projection parity that preserve Conductor specialist routing and AWF workflow topology without authority expansion.",
       "human_sources": [
         "adapters/github-copilot/README.md",
         "adapters/github-copilot/probe-guide.md",
         "docs/setup/HOST_CAPABILITY_CONTRACT.md",
-        "docs/setup/PROVIDER_MODEL_CAPABILITY_CONTRACT.md"
+        "docs/setup/PROVIDER_MODEL_CAPABILITY_CONTRACT.md",
+        "docs/setup/PORTABLE_PROJECTION_COMPILER.md"
       ],
       "machine_sources": [
         "adapters/github-copilot/copilot-instructions.template.md",
@@ -2255,7 +2256,13 @@
         "machine/hosts/integration-strategy-policy.v1.json",
         "machine/schemas/integration-strategy-policy.v1.schema.json",
         "orchestra_runtime/domain/adaptive/integration_strategy.py",
-        "tests/runtime/test_integration_strategy.py"
+        "tests/runtime/test_integration_strategy.py",
+        "machine/projections/portable-projection-contract.v1.json",
+        "machine/schemas/portable-projection-contract.v1.schema.json",
+        "machine/schemas/portable-projection-index.v1.schema.json",
+        "machine/projections/portable-projection-index.v1.json",
+        "scripts/compile_portable_projections.py",
+        "tests/runtime/test_portable_projection_compiler.py"
       ],
       "probed_hosts": [
         "github-copilot"
@@ -2377,6 +2384,11 @@
     "provider_model_capability_contract_schema": "machine/schemas/provider-model-capability-contract.v1.schema.json",
     "integration_strategy_policy": "machine/hosts/integration-strategy-policy.v1.json",
     "integration_strategy_policy_schema": "machine/schemas/integration-strategy-policy.v1.schema.json",
+    "portable_projection_contract": "machine/projections/portable-projection-contract.v1.json",
+    "portable_projection_contract_schema": "machine/schemas/portable-projection-contract.v1.schema.json",
+    "portable_projection_index_schema": "machine/schemas/portable-projection-index.v1.schema.json",
+    "portable_projection_index": "machine/projections/portable-projection-index.v1.json",
+    "portable_projection_compiler": "scripts/compile_portable_projections.py",
     "prap_certification_contract": "machine/protocol/prap-certification-contract.v1.json",
     "developer_portal_catalog": "machine/developer-portal/catalog.v1.json",
     "murmurs_presentation_policy": "machine/presentation/murmurs-policy.v1.json",
@@ -2577,6 +2589,10 @@
     "provider_model_capability_contract_validator": "scripts/validate_provider_model_capability_contract.py",
     "integration_strategy_policy": "machine/hosts/integration-strategy-policy.v1.json",
     "integration_strategy_policy_schema": "machine/schemas/integration-strategy-policy.v1.schema.json",
+    "portable_projection_contract": "machine/projections/portable-projection-contract.v1.json",
+    "portable_projection_contract_schema": "machine/schemas/portable-projection-contract.v1.schema.json",
+    "portable_projection_index": "machine/projections/portable-projection-index.v1.json",
+    "portable_projection_compiler": "scripts/compile_portable_projections.py",
     "uai_routing_boundaries": "adapters/github-copilot/probe-guide.md",
     "adapter_sdk_reference": "docs/setup/ADAPTER_SDK_PRAP.md",
     "adapter_sdk_stable_import_surface": "orchestra_runtime.protocol.sdk",
@@ -2687,6 +2703,7 @@
     "compatibility": "docs/setup/COMPATIBILITY.md",
     "host_capability_contract": "docs/setup/HOST_CAPABILITY_CONTRACT.md",
     "provider_model_capability_contract": "docs/setup/PROVIDER_MODEL_CAPABILITY_CONTRACT.md",
+    "portable_projection_compiler": "docs/setup/PORTABLE_PROJECTION_COMPILER.md",
     "validation": "docs/setup/VALIDATION.md",
     "developer_portal": "docs/developer/README.md",
     "mcp_transport": "docs/developer/MCP_STDIO_TRANSPORT.md",

--- a/adapters/github-copilot/custom-agent.template.md
+++ b/adapters/github-copilot/custom-agent.template.md
@@ -14,6 +14,8 @@ You are the routing and orchestration layer. You classify execution mode and rou
 
 Native custom-agent availability is only a host transport capability. It does not replace Conductor's internal routing authority. When ownership is clear, Conductor may choose a direct single-specialist fast route, but `CLEAR_OWNERSHIP != CONDUCTOR_BYPASS` and `FAST_ROUTE != ROUTER_BYPASS`.
 
+`CONDUCTOR_IS_SOLE_INTERNAL_SPECIALIST_ROUTER` remains the routing invariant. `UAI_TRANSPORT_SELECTION != AWF_SPECIALIST_ROUTING`; transport selection does not replace Conductor or deterministic AWF workflow topology.
+
 ## Boundaries
 1. Governance sits above Conductor: respect `The Steward` and `The Governor` decisions.
 2. Route domain work exclusively to designated specialists:

--- a/docs/README.md
+++ b/docs/README.md
@@ -107,6 +107,7 @@ Cross-repository continuity may be supplied by a user-selected external continui
 - [Host Updates](setup/HOST_UPDATES.md): governed read-only host update planning.
 - [UAI Host Capability Contract](setup/HOST_CAPABILITY_CONTRACT.md): versioned host capability evidence and transport compatibility without authority expansion.
 - [UAI Provider/Model Capability Contract](setup/PROVIDER_MODEL_CAPABILITY_CONTRACT.md): provider/model-neutral technical capability vocabulary and evidence boundaries without provider selection.
+- [UAI Portable Projection Compiler](setup/PORTABLE_PROJECTION_COMPILER.md): canonical-source-backed host projection parity without installed-integration refresh or authority expansion.
 - [Adapter SDK and PRAP v1](setup/ADAPTER_SDK_PRAP.md): stable adapter SDK and deterministic compatibility certification.
 - [Developer Portal](developer/README.md): extension and integration discovery surface.
 - [MCP stdio Transport](developer/MCP_STDIO_TRANSPORT.md): first bounded MCP tools transport.
@@ -117,6 +118,10 @@ Cross-repository continuity may be supplied by a user-selected external continui
 - `../machine/schemas/host-capability-contract.v1.schema.json`: UAI host capability contract schema.
 - `../machine/providers/provider-model-capability-contract.v1.json`: UAI provider/model capability contract.
 - `../machine/schemas/provider-model-capability-contract.v1.schema.json`: UAI provider/model capability contract schema.
+- `../machine/projections/portable-projection-contract.v1.json`: canonical source and derived projection contract.
+- `../machine/projections/portable-projection-index.v1.json`: generated machine-checkable projection parity index.
+- `../machine/schemas/portable-projection-contract.v1.schema.json`: portable projection contract schema.
+- `../machine/schemas/portable-projection-index.v1.schema.json`: generated parity index schema.
 - `../machine/protocol/prap-certification-contract.v1.json`: PRAP certification contract.
 - `../machine/developer-portal/catalog.v1.json`: machine Developer Portal catalog.
 

--- a/docs/setup/PORTABLE_PROJECTION_COMPILER.md
+++ b/docs/setup/PORTABLE_PROJECTION_COMPILER.md
@@ -1,0 +1,16 @@
+# UAI Portable Projection Compiler
+
+The canonical portable projection contract is [portable-projection-contract.v1.json](../../machine/projections/portable-projection-contract.v1.json). It names the Orchestra governance, routing, specialist, host-capability, and integration-strategy sources that may be represented by a host projection.
+
+The compiler validates those source paths and required routing invariants in the tracked projection surfaces, then writes the deterministic parity index at [portable-projection-index.v1.json](../../machine/projections/portable-projection-index.v1.json). The current projections cover the GitHub Copilot repository-instruction template, repository instruction anchor, and custom-agent template.
+
+Run:
+
+```text
+python scripts/compile_portable_projections.py --write
+python scripts/compile_portable_projections.py --check
+```
+
+The index records normalized SHA-256 fingerprints for canonical sources and projection outputs. Missing markers, missing sources, stale generated output, unsupported formats, repository escapes, and `.agents` runtime-copy targets fail closed.
+
+Projection parity does not create execution, routing, specialist-selection, workflow-topology, provider-selection, governance, installation-refresh, automatic-fallback, or learned-routing authority. Host transport selection remains separate from Conductor routing and deterministic AWF workflow topology.

--- a/machine/developer-portal/catalog.v1.json
+++ b/machine/developer-portal/catalog.v1.json
@@ -112,6 +112,27 @@
       "authority_role": "EVIDENCE_SCHEMA"
     },
     {
+      "id": "uai-portable-projection-contract",
+      "title": "UAI Portable Projection Contract",
+      "kind": "machine_contract",
+      "path": "machine/projections/portable-projection-contract.v1.json",
+      "authority_role": "CANONICAL_SOURCE_AND_DERIVED_PROJECTION_BOUNDARY"
+    },
+    {
+      "id": "uai-portable-projection-index",
+      "title": "UAI Portable Projection Parity Index",
+      "kind": "machine_contract",
+      "path": "machine/projections/portable-projection-index.v1.json",
+      "authority_role": "GENERATED_PARITY_EVIDENCE_ONLY"
+    },
+    {
+      "id": "uai-portable-projection-guide",
+      "title": "UAI Portable Projection Compiler guide",
+      "kind": "human_guide",
+      "path": "docs/setup/PORTABLE_PROJECTION_COMPILER.md",
+      "authority_role": "GUIDANCE_OVER_DERIVED_PROJECTION_COMPILER"
+    },
+    {
       "id": "specialist-registry",
       "title": "Specialist registry",
       "kind": "machine_contract",

--- a/machine/projections/portable-projection-contract.v1.json
+++ b/machine/projections/portable-projection-contract.v1.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "./machine/schemas/portable-projection-contract.v1.schema.json",
+  "schema_version": "orchestra.portable-projection-contract.v1",
+  "contract_id": "orchestra-uai-portable-projection",
+  "contract_revision": 1,
+  "contract_role": "canonical_uai_portable_projection_contract",
+  "authority": {
+    "canonical_source_remains_authoritative": true,
+    "generated_projection_is_derived_only": true,
+    "projection_grants_execution_authority": false,
+    "projection_grants_routing_authority": false,
+    "projection_grants_specialist_selection_authority": false,
+    "projection_grants_workflow_topology_authority": false,
+    "projection_grants_provider_selection_authority": false,
+    "projection_grants_governance_authority": false,
+    "installed_integration_refresh": false,
+    "automatic_provider_routing": false,
+    "automatic_provider_fallback": false,
+    "learned_routing_promotion": false
+  },
+  "required_invariants": [
+    "CONDUCTOR_IS_SOLE_INTERNAL_SPECIALIST_ROUTER",
+    "CLEAR_OWNERSHIP != CONDUCTOR_BYPASS",
+    "CLEAR_OWNERSHIP MAY_ENABLE DIRECT_SINGLE_SPECIALIST_FAST_ROUTE",
+    "FAST_ROUTE != ROUTER_BYPASS",
+    "HOST != PROVIDER",
+    "PROVIDER != SPECIALIST",
+    "HOST_CAPABILITY != EXECUTION_AUTHORITY",
+    "TRANSPORT != WORKFLOW",
+    "UAI_TRANSPORT_SELECTION != AWF_SPECIALIST_ROUTING",
+    "MODEL_SELECTION != GOVERNANCE"
+  ],
+  "canonical_sources": [
+    {
+      "source_id": "governance_policy",
+      "path": "machine/governance/policy.v1.json",
+      "source_role": "GOVERNANCE_POLICY"
+    },
+    {
+      "source_id": "specialist_registry",
+      "path": "machine/specialists/registry.v1.json",
+      "source_role": "SPECIALIST_IDENTITY_AND_OWNERSHIP"
+    },
+    {
+      "source_id": "routing_contract",
+      "path": "machine/routing/routes.v1.json",
+      "source_role": "CONDUCTOR_ROUTING"
+    },
+    {
+      "source_id": "host_capability_contract",
+      "path": "machine/hosts/capability-contract.v1.json",
+      "source_role": "HOST_CAPABILITY_EVIDENCE"
+    },
+    {
+      "source_id": "integration_strategy_policy",
+      "path": "machine/hosts/integration-strategy-policy.v1.json",
+      "source_role": "TRANSPORT_SELECTION_POLICY"
+    },
+    {
+      "source_id": "conductor_skill",
+      "path": "skills/conductor/SKILL.md",
+      "source_role": "CONDUCTOR_BEHAVIOR"
+    },
+    {
+      "source_id": "ponytail_skill",
+      "path": "skills/ponytail/SKILL.md",
+      "source_role": "IMPLEMENTATION_BEHAVIOR"
+    }
+  ],
+  "supported_projection_formats": ["MARKDOWN_TEMPLATE"],
+  "projections": [
+    {
+      "projection_id": "github-copilot-repository-instructions-template",
+      "host_id": "github-copilot",
+      "strategy_id": "REPOSITORY_INSTRUCTIONS",
+      "format": "MARKDOWN_TEMPLATE",
+      "output_path": "adapters/github-copilot/copilot-instructions.template.md",
+      "source_ids": [
+        "governance_policy",
+        "specialist_registry",
+        "routing_contract",
+        "host_capability_contract",
+        "integration_strategy_policy",
+        "conductor_skill",
+        "ponytail_skill"
+      ],
+      "required_markers": [
+        {"marker_id": "conductor-sole-router", "text": "CONDUCTOR_IS_SOLE_INTERNAL_SPECIALIST_ROUTER"},
+        {"marker_id": "clear-ownership-boundary", "text": "CLEAR_OWNERSHIP != CONDUCTOR_BYPASS"},
+        {"marker_id": "fast-route-boundary", "text": "FAST_ROUTE != ROUTER_BYPASS"},
+        {"marker_id": "transport-routing-boundary", "text": "UAI_TRANSPORT_SELECTION != AWF_SPECIALIST_ROUTING"}
+      ]
+    },
+    {
+      "projection_id": "github-copilot-repository-instructions-anchor",
+      "host_id": "github-copilot",
+      "strategy_id": "REPOSITORY_INSTRUCTIONS",
+      "format": "MARKDOWN_TEMPLATE",
+      "output_path": ".github/copilot-instructions.md",
+      "source_ids": [
+        "governance_policy",
+        "specialist_registry",
+        "routing_contract",
+        "host_capability_contract",
+        "integration_strategy_policy",
+        "conductor_skill",
+        "ponytail_skill"
+      ],
+      "required_markers": [
+        {"marker_id": "conductor-sole-router", "text": "CONDUCTOR_IS_SOLE_INTERNAL_SPECIALIST_ROUTER"},
+        {"marker_id": "clear-ownership-boundary", "text": "CLEAR_OWNERSHIP != CONDUCTOR_BYPASS"},
+        {"marker_id": "fast-route-boundary", "text": "FAST_ROUTE != ROUTER_BYPASS"},
+        {"marker_id": "transport-routing-boundary", "text": "UAI_TRANSPORT_SELECTION != AWF_SPECIALIST_ROUTING"}
+      ]
+    },
+    {
+      "projection_id": "github-copilot-custom-agent-template",
+      "host_id": "github-copilot",
+      "strategy_id": "CUSTOM_AGENT",
+      "format": "MARKDOWN_TEMPLATE",
+      "output_path": "adapters/github-copilot/custom-agent.template.md",
+      "source_ids": [
+        "governance_policy",
+        "specialist_registry",
+        "routing_contract",
+        "host_capability_contract",
+        "integration_strategy_policy",
+        "conductor_skill",
+        "ponytail_skill"
+      ],
+      "required_markers": [
+        {"marker_id": "conductor-sole-router", "text": "CONDUCTOR_IS_SOLE_INTERNAL_SPECIALIST_ROUTER"},
+        {"marker_id": "clear-ownership-boundary", "text": "CLEAR_OWNERSHIP != CONDUCTOR_BYPASS"},
+        {"marker_id": "fast-route-boundary", "text": "FAST_ROUTE != ROUTER_BYPASS"},
+        {"marker_id": "transport-routing-boundary", "text": "UAI_TRANSPORT_SELECTION != AWF_SPECIALIST_ROUTING"}
+      ]
+    }
+  ]
+}

--- a/machine/projections/portable-projection-index.v1.json
+++ b/machine/projections/portable-projection-index.v1.json
@@ -1,0 +1,183 @@
+{
+  "$schema": "./machine/schemas/portable-projection-index.v1.schema.json",
+  "schema_version": "orchestra.portable-projection-index.v1",
+  "contract_id": "orchestra-uai-portable-projection",
+  "contract_revision": 1,
+  "generated_from": {
+    "contract_path": "machine/projections/portable-projection-contract.v1.json",
+    "contract_sha256": "2a314b92ce2d7e91a212946be6d30739d79405977c86e1ea44508e3e6b426a42"
+  },
+  "authority": {
+    "canonical_source_remains_authoritative": true,
+    "generated_projection_is_derived_only": true,
+    "projection_grants_execution_authority": false,
+    "projection_grants_routing_authority": false,
+    "projection_grants_specialist_selection_authority": false,
+    "projection_grants_workflow_topology_authority": false,
+    "projection_grants_provider_selection_authority": false,
+    "projection_grants_governance_authority": false,
+    "installed_integration_refresh": false,
+    "automatic_provider_routing": false,
+    "automatic_provider_fallback": false,
+    "learned_routing_promotion": false
+  },
+  "projections": [
+    {
+      "projection_id": "github-copilot-repository-instructions-template",
+      "host_id": "github-copilot",
+      "strategy_id": "REPOSITORY_INSTRUCTIONS",
+      "format": "MARKDOWN_TEMPLATE",
+      "output_path": "adapters/github-copilot/copilot-instructions.template.md",
+      "output_sha256": "4685c2ba37b02331ccbf88910324bb51e688d0406d981e6164ccfc7572878df0",
+      "source_digests": [
+        {
+          "source_id": "governance_policy",
+          "path": "machine/governance/policy.v1.json",
+          "sha256": "9511ba2cd3fa6d77faaaa1855d843e6415fb3776cc234f63da37d13842f78301"
+        },
+        {
+          "source_id": "specialist_registry",
+          "path": "machine/specialists/registry.v1.json",
+          "sha256": "c81ad36b21357217afcbb9b7150539229d32c0733ff6ea013926c1e0acaee0d3"
+        },
+        {
+          "source_id": "routing_contract",
+          "path": "machine/routing/routes.v1.json",
+          "sha256": "640f5a95145520a7e6f360b4512ea2e7a92e2f9e841680ed716bb707f18be782"
+        },
+        {
+          "source_id": "host_capability_contract",
+          "path": "machine/hosts/capability-contract.v1.json",
+          "sha256": "3a295eabfcadae3e6df041d4e407cd10d3e547483228d5b20cf1c8ce0a6a19f0"
+        },
+        {
+          "source_id": "integration_strategy_policy",
+          "path": "machine/hosts/integration-strategy-policy.v1.json",
+          "sha256": "e4d202fbde15a7cb1144ed33321245fc15e561cf233aab911ea97f3deae854fa"
+        },
+        {
+          "source_id": "conductor_skill",
+          "path": "skills/conductor/SKILL.md",
+          "sha256": "a1423c4e70e3f1bf2d010366e348220f83c05c7a9a13513abdb9786d74248fef"
+        },
+        {
+          "source_id": "ponytail_skill",
+          "path": "skills/ponytail/SKILL.md",
+          "sha256": "ed49bdfd0b777ff24a179ed1479f7ec63aeb2e1103de78b565feeb8de0c89a82"
+        }
+      ],
+      "matched_markers": [
+        "conductor-sole-router",
+        "clear-ownership-boundary",
+        "fast-route-boundary",
+        "transport-routing-boundary"
+      ],
+      "parity": "PASS"
+    },
+    {
+      "projection_id": "github-copilot-repository-instructions-anchor",
+      "host_id": "github-copilot",
+      "strategy_id": "REPOSITORY_INSTRUCTIONS",
+      "format": "MARKDOWN_TEMPLATE",
+      "output_path": ".github/copilot-instructions.md",
+      "output_sha256": "cdfc01608176624714f5444261bbb9064af9da39732592187882b26a10d9b8a3",
+      "source_digests": [
+        {
+          "source_id": "governance_policy",
+          "path": "machine/governance/policy.v1.json",
+          "sha256": "9511ba2cd3fa6d77faaaa1855d843e6415fb3776cc234f63da37d13842f78301"
+        },
+        {
+          "source_id": "specialist_registry",
+          "path": "machine/specialists/registry.v1.json",
+          "sha256": "c81ad36b21357217afcbb9b7150539229d32c0733ff6ea013926c1e0acaee0d3"
+        },
+        {
+          "source_id": "routing_contract",
+          "path": "machine/routing/routes.v1.json",
+          "sha256": "640f5a95145520a7e6f360b4512ea2e7a92e2f9e841680ed716bb707f18be782"
+        },
+        {
+          "source_id": "host_capability_contract",
+          "path": "machine/hosts/capability-contract.v1.json",
+          "sha256": "3a295eabfcadae3e6df041d4e407cd10d3e547483228d5b20cf1c8ce0a6a19f0"
+        },
+        {
+          "source_id": "integration_strategy_policy",
+          "path": "machine/hosts/integration-strategy-policy.v1.json",
+          "sha256": "e4d202fbde15a7cb1144ed33321245fc15e561cf233aab911ea97f3deae854fa"
+        },
+        {
+          "source_id": "conductor_skill",
+          "path": "skills/conductor/SKILL.md",
+          "sha256": "a1423c4e70e3f1bf2d010366e348220f83c05c7a9a13513abdb9786d74248fef"
+        },
+        {
+          "source_id": "ponytail_skill",
+          "path": "skills/ponytail/SKILL.md",
+          "sha256": "ed49bdfd0b777ff24a179ed1479f7ec63aeb2e1103de78b565feeb8de0c89a82"
+        }
+      ],
+      "matched_markers": [
+        "conductor-sole-router",
+        "clear-ownership-boundary",
+        "fast-route-boundary",
+        "transport-routing-boundary"
+      ],
+      "parity": "PASS"
+    },
+    {
+      "projection_id": "github-copilot-custom-agent-template",
+      "host_id": "github-copilot",
+      "strategy_id": "CUSTOM_AGENT",
+      "format": "MARKDOWN_TEMPLATE",
+      "output_path": "adapters/github-copilot/custom-agent.template.md",
+      "output_sha256": "067bf8daa66260fa12bdfb19795c642772cefc3ac80e7e05b35f0169d9255aa9",
+      "source_digests": [
+        {
+          "source_id": "governance_policy",
+          "path": "machine/governance/policy.v1.json",
+          "sha256": "9511ba2cd3fa6d77faaaa1855d843e6415fb3776cc234f63da37d13842f78301"
+        },
+        {
+          "source_id": "specialist_registry",
+          "path": "machine/specialists/registry.v1.json",
+          "sha256": "c81ad36b21357217afcbb9b7150539229d32c0733ff6ea013926c1e0acaee0d3"
+        },
+        {
+          "source_id": "routing_contract",
+          "path": "machine/routing/routes.v1.json",
+          "sha256": "640f5a95145520a7e6f360b4512ea2e7a92e2f9e841680ed716bb707f18be782"
+        },
+        {
+          "source_id": "host_capability_contract",
+          "path": "machine/hosts/capability-contract.v1.json",
+          "sha256": "3a295eabfcadae3e6df041d4e407cd10d3e547483228d5b20cf1c8ce0a6a19f0"
+        },
+        {
+          "source_id": "integration_strategy_policy",
+          "path": "machine/hosts/integration-strategy-policy.v1.json",
+          "sha256": "e4d202fbde15a7cb1144ed33321245fc15e561cf233aab911ea97f3deae854fa"
+        },
+        {
+          "source_id": "conductor_skill",
+          "path": "skills/conductor/SKILL.md",
+          "sha256": "a1423c4e70e3f1bf2d010366e348220f83c05c7a9a13513abdb9786d74248fef"
+        },
+        {
+          "source_id": "ponytail_skill",
+          "path": "skills/ponytail/SKILL.md",
+          "sha256": "ed49bdfd0b777ff24a179ed1479f7ec63aeb2e1103de78b565feeb8de0c89a82"
+        }
+      ],
+      "matched_markers": [
+        "conductor-sole-router",
+        "clear-ownership-boundary",
+        "fast-route-boundary",
+        "transport-routing-boundary"
+      ],
+      "parity": "PASS"
+    }
+  ],
+  "parity_status": "PASS"
+}

--- a/machine/schemas/portable-projection-contract.v1.schema.json
+++ b/machine/schemas/portable-projection-contract.v1.schema.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Baelfyre/Orchestra/blob/main/machine/schemas/portable-projection-contract.v1.schema.json",
+  "title": "Orchestra UAI Portable Projection Contract v1",
+  "description": "Canonical source and derived host projection declarations. Projection parity never grants authority.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schema_version",
+    "contract_id",
+    "contract_revision",
+    "contract_role",
+    "authority",
+    "required_invariants",
+    "canonical_sources",
+    "supported_projection_formats",
+    "projections"
+  ],
+  "properties": {
+    "$schema": {"const": "./machine/schemas/portable-projection-contract.v1.schema.json"},
+    "schema_version": {"const": "orchestra.portable-projection-contract.v1"},
+    "contract_id": {"const": "orchestra-uai-portable-projection"},
+    "contract_revision": {"const": 1},
+    "contract_role": {"const": "canonical_uai_portable_projection_contract"},
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "canonical_source_remains_authoritative",
+        "generated_projection_is_derived_only",
+        "projection_grants_execution_authority",
+        "projection_grants_routing_authority",
+        "projection_grants_specialist_selection_authority",
+        "projection_grants_workflow_topology_authority",
+        "projection_grants_provider_selection_authority",
+        "projection_grants_governance_authority",
+        "installed_integration_refresh",
+        "automatic_provider_routing",
+        "automatic_provider_fallback",
+        "learned_routing_promotion"
+      ],
+      "properties": {
+        "canonical_source_remains_authoritative": {"const": true},
+        "generated_projection_is_derived_only": {"const": true},
+        "projection_grants_execution_authority": {"const": false},
+        "projection_grants_routing_authority": {"const": false},
+        "projection_grants_specialist_selection_authority": {"const": false},
+        "projection_grants_workflow_topology_authority": {"const": false},
+        "projection_grants_provider_selection_authority": {"const": false},
+        "projection_grants_governance_authority": {"const": false},
+        "installed_integration_refresh": {"const": false},
+        "automatic_provider_routing": {"const": false},
+        "automatic_provider_fallback": {"const": false},
+        "learned_routing_promotion": {"const": false}
+      }
+    },
+    "required_invariants": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "canonical_sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["source_id", "path", "source_role"],
+        "properties": {
+          "source_id": {"type": "string", "pattern": "^[a-z][a-z0-9_]+$"},
+          "path": {"type": "string", "minLength": 1},
+          "source_role": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "supported_projection_formats": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "projections": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/projection"}
+    }
+  },
+  "$defs": {
+    "marker": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["marker_id", "text"],
+      "properties": {
+        "marker_id": {"type": "string", "pattern": "^[a-z][a-z0-9-]+$"},
+        "text": {"type": "string", "minLength": 1}
+      }
+    },
+    "projection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["projection_id", "host_id", "strategy_id", "format", "output_path", "source_ids", "required_markers"],
+      "properties": {
+        "projection_id": {"type": "string", "pattern": "^[a-z][a-z0-9-]+$"},
+        "host_id": {"type": "string", "pattern": "^[a-z][a-z0-9-]+$"},
+        "strategy_id": {"type": "string", "pattern": "^[A-Z][A-Z0-9_]+$"},
+        "format": {"type": "string", "minLength": 1},
+        "output_path": {"type": "string", "minLength": 1},
+        "source_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "pattern": "^[a-z][a-z0-9_]+$"}
+        },
+        "required_markers": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/marker"}
+        }
+      }
+    }
+  }
+}

--- a/machine/schemas/portable-projection-index.v1.schema.json
+++ b/machine/schemas/portable-projection-index.v1.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Baelfyre/Orchestra/blob/main/machine/schemas/portable-projection-index.v1.schema.json",
+  "title": "Orchestra UAI Portable Projection Index v1",
+  "description": "Deterministic generated parity evidence for canonical-source-backed host projections.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["$schema", "schema_version", "contract_id", "contract_revision", "generated_from", "authority", "projections", "parity_status"],
+  "properties": {
+    "$schema": {"const": "./machine/schemas/portable-projection-index.v1.schema.json"},
+    "schema_version": {"const": "orchestra.portable-projection-index.v1"},
+    "contract_id": {"const": "orchestra-uai-portable-projection"},
+    "contract_revision": {"const": 1},
+    "generated_from": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["contract_path", "contract_sha256"],
+      "properties": {
+        "contract_path": {"const": "machine/projections/portable-projection-contract.v1.json"},
+        "contract_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["canonical_source_remains_authoritative", "generated_projection_is_derived_only", "projection_grants_execution_authority", "projection_grants_routing_authority", "projection_grants_specialist_selection_authority", "projection_grants_workflow_topology_authority", "projection_grants_provider_selection_authority", "projection_grants_governance_authority", "installed_integration_refresh", "automatic_provider_routing", "automatic_provider_fallback", "learned_routing_promotion"],
+      "properties": {
+        "canonical_source_remains_authoritative": {"const": true},
+        "generated_projection_is_derived_only": {"const": true},
+        "projection_grants_execution_authority": {"const": false},
+        "projection_grants_routing_authority": {"const": false},
+        "projection_grants_specialist_selection_authority": {"const": false},
+        "projection_grants_workflow_topology_authority": {"const": false},
+        "projection_grants_provider_selection_authority": {"const": false},
+        "projection_grants_governance_authority": {"const": false},
+        "installed_integration_refresh": {"const": false},
+        "automatic_provider_routing": {"const": false},
+        "automatic_provider_fallback": {"const": false},
+        "learned_routing_promotion": {"const": false}
+      }
+    },
+    "projections": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["projection_id", "host_id", "strategy_id", "format", "output_path", "output_sha256", "source_digests", "matched_markers", "parity"],
+        "properties": {
+          "projection_id": {"type": "string", "pattern": "^[a-z][a-z0-9-]+$"},
+          "host_id": {"type": "string", "pattern": "^[a-z][a-z0-9-]+$"},
+          "strategy_id": {"type": "string", "pattern": "^[A-Z][A-Z0-9_]+$"},
+          "format": {"type": "string", "minLength": 1},
+          "output_path": {"type": "string", "minLength": 1},
+          "output_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+          "source_digests": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["source_id", "path", "sha256"],
+              "properties": {
+                "source_id": {"type": "string", "pattern": "^[a-z][a-z0-9_]+$"},
+                "path": {"type": "string", "minLength": 1},
+                "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+              }
+            }
+          },
+          "matched_markers": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {"type": "string", "minLength": 1}
+          },
+          "parity": {"const": "PASS"}
+        }
+      }
+    },
+    "parity_status": {"const": "PASS"}
+  }
+}

--- a/scripts/compile_portable_projections.py
+++ b/scripts/compile_portable_projections.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Compile and validate canonical-source-backed portable projection parity."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+CONTRACT_PATH = Path("machine/projections/portable-projection-contract.v1.json")
+CONTRACT_SCHEMA_PATH = Path("machine/schemas/portable-projection-contract.v1.schema.json")
+INDEX_PATH = Path("machine/projections/portable-projection-index.v1.json")
+INDEX_SCHEMA_PATH = Path("machine/schemas/portable-projection-index.v1.schema.json")
+SUPPORTED_FORMATS = {"MARKDOWN_TEMPLATE"}
+SUPPORTED_STRATEGIES = {
+    "AGENT_SKILLS",
+    "CUSTOM_AGENT",
+    "MCP_TRANSPORT",
+    "PLUGIN_OR_EXTENSION",
+    "CLI_ADAPTER",
+    "REPOSITORY_INSTRUCTIONS",
+    "WORKSPACE_INSTRUCTIONS",
+    "INSTRUCTION_ONLY_FALLBACK",
+}
+REQUIRED_INVARIANTS = (
+    "CONDUCTOR_IS_SOLE_INTERNAL_SPECIALIST_ROUTER",
+    "CLEAR_OWNERSHIP != CONDUCTOR_BYPASS",
+    "CLEAR_OWNERSHIP MAY_ENABLE DIRECT_SINGLE_SPECIALIST_FAST_ROUTE",
+    "FAST_ROUTE != ROUTER_BYPASS",
+    "HOST != PROVIDER",
+    "PROVIDER != SPECIALIST",
+    "HOST_CAPABILITY != EXECUTION_AUTHORITY",
+    "TRANSPORT != WORKFLOW",
+    "UAI_TRANSPORT_SELECTION != AWF_SPECIALIST_ROUTING",
+    "MODEL_SELECTION != GOVERNANCE",
+)
+AUTHORITY = {
+    "canonical_source_remains_authoritative": True,
+    "generated_projection_is_derived_only": True,
+    "projection_grants_execution_authority": False,
+    "projection_grants_routing_authority": False,
+    "projection_grants_specialist_selection_authority": False,
+    "projection_grants_workflow_topology_authority": False,
+    "projection_grants_provider_selection_authority": False,
+    "projection_grants_governance_authority": False,
+    "installed_integration_refresh": False,
+    "automatic_provider_routing": False,
+    "automatic_provider_fallback": False,
+    "learned_routing_promotion": False,
+}
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalized_bytes(path: Path) -> bytes:
+    return path.read_text(encoding="utf-8").replace("\r\n", "\n").replace("\r", "\n").encode("utf-8")
+
+
+def _digest(path: Path, *, json_document: bool = False) -> str:
+    if json_document:
+        value = _load_json(path)
+        payload = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False).encode("utf-8")
+    else:
+        payload = _normalized_bytes(path)
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _repo_path(root: Path, relative_path: str, label: str, errors: list[str]) -> Path | None:
+    if not isinstance(relative_path, str) or not relative_path.strip():
+        errors.append(f"MALFORMED:{label}:path")
+        return None
+    candidate = (root / Path(relative_path)).resolve()
+    resolved_root = root.resolve()
+    if candidate != resolved_root and resolved_root not in candidate.parents:
+        errors.append(f"PROTECTED_PATH:{label}:outside_repository")
+        return None
+    if ".agents" in candidate.parts:
+        errors.append(f"PROTECTED_PATH:{label}:runtime_copy")
+        return None
+    if not candidate.is_file():
+        errors.append(f"MISSING:{label}:{relative_path}")
+        return None
+    return candidate
+
+
+def _schema_errors(value: Any, schema: Any, label: str) -> list[str]:
+    try:
+        import jsonschema
+
+        return [
+            f"SCHEMA_VALIDATION:{label}:{'.'.join(str(part) for part in error.absolute_path) or '$'}:{error.message}"
+            for error in jsonschema.Draft202012Validator(schema).iter_errors(value)
+        ]
+    except ImportError:
+        return []
+    except Exception as exc:  # pragma: no cover - schema tooling failure is environment-specific
+        return [f"SCHEMA_VALIDATION:{label}:validator_error:{exc}"]
+
+
+def validate_contract(root: Path) -> tuple[list[str], dict[str, Any] | None]:
+    errors: list[str] = []
+    contract_path = _repo_path(root, CONTRACT_PATH.as_posix(), "contract", errors)
+    schema_path = _repo_path(root, CONTRACT_SCHEMA_PATH.as_posix(), "contract_schema", errors)
+    if contract_path is None:
+        return errors, None
+    try:
+        contract = _load_json(contract_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        return [f"MALFORMED:contract:{exc}"], None
+    schema = None
+    if schema_path is not None:
+        try:
+            schema = _load_json(schema_path)
+        except (OSError, json.JSONDecodeError) as exc:
+            errors.append(f"MALFORMED:contract_schema:{exc}")
+    if schema is not None:
+        errors.extend(_schema_errors(contract, schema, "contract"))
+    if not isinstance(contract, dict):
+        return errors + ["MALFORMED:contract:object_required"], None
+
+    if contract.get("required_invariants") != list(REQUIRED_INVARIANTS):
+        errors.append("CONTRACT_DRIFT:required_invariants")
+    if contract.get("authority") != AUTHORITY:
+        errors.append("AUTHORITY_EXPANSION:contract.authority")
+    if set(contract.get("supported_projection_formats", ())) != SUPPORTED_FORMATS:
+        errors.append("CONTRACT_DRIFT:supported_projection_formats")
+
+    sources = contract.get("canonical_sources")
+    source_map: dict[str, tuple[str, Path]] = {}
+    if not isinstance(sources, list):
+        errors.append("MALFORMED:canonical_sources:list_required")
+    else:
+        for index, source in enumerate(sources):
+            label = f"canonical_sources[{index}]"
+            if not isinstance(source, dict):
+                errors.append(f"MALFORMED:{label}:object_required")
+                continue
+            source_id = source.get("source_id")
+            source_path = source.get("path")
+            if not isinstance(source_id, str) or not source_id:
+                errors.append(f"MALFORMED:{label}.source_id")
+                continue
+            if source_id in source_map:
+                errors.append(f"CONTRACT_DRIFT:DUPLICATE_SOURCE:{source_id}")
+                continue
+            resolved = _repo_path(root, source_path, f"{label}.path", errors)
+            if resolved is not None:
+                source_map[source_id] = (source_path, resolved)
+
+    projections = contract.get("projections")
+    projection_ids: set[str] = set()
+    output_paths: set[str] = set()
+    if not isinstance(projections, list) or not projections:
+        errors.append("MALFORMED:projections:non_empty_list_required")
+    else:
+        for index, projection in enumerate(projections):
+            label = f"projections[{index}]"
+            if not isinstance(projection, dict):
+                errors.append(f"MALFORMED:{label}:object_required")
+                continue
+            projection_id = projection.get("projection_id")
+            output_path = projection.get("output_path")
+            if not isinstance(projection_id, str) or not projection_id:
+                errors.append(f"MALFORMED:{label}.projection_id")
+            elif projection_id in projection_ids:
+                errors.append(f"CONTRACT_DRIFT:DUPLICATE_PROJECTION:{projection_id}")
+            else:
+                projection_ids.add(projection_id)
+            if not isinstance(output_path, str) or not output_path:
+                errors.append(f"MALFORMED:{label}.output_path")
+            elif output_path in output_paths:
+                errors.append(f"CONTRACT_DRIFT:DUPLICATE_OUTPUT:{output_path}")
+            else:
+                output_paths.add(output_path)
+            if projection.get("format") not in SUPPORTED_FORMATS:
+                errors.append(f"UNSUPPORTED_FORMAT:{label}.format")
+            if projection.get("strategy_id") not in SUPPORTED_STRATEGIES:
+                errors.append(f"UNSUPPORTED_STRATEGY:{label}.strategy_id")
+            for source_id in projection.get("source_ids", ()):
+                if source_id not in source_map:
+                    errors.append(f"MISSING_SOURCE_REFERENCE:{label}:{source_id}")
+            markers = projection.get("required_markers")
+            marker_ids: set[str] = set()
+            if not isinstance(markers, list) or not markers:
+                errors.append(f"MALFORMED:{label}.required_markers")
+            else:
+                for marker in markers:
+                    if not isinstance(marker, dict):
+                        errors.append(f"MALFORMED:{label}.marker:object_required")
+                        continue
+                    marker_id = marker.get("marker_id")
+                    text = marker.get("text")
+                    if not isinstance(marker_id, str) or not marker_id or marker_id in marker_ids:
+                        errors.append(f"CONTRACT_DRIFT:{label}.marker_id")
+                    else:
+                        marker_ids.add(marker_id)
+                    if not isinstance(text, str) or not text:
+                        errors.append(f"MALFORMED:{label}.marker_text")
+            output = _repo_path(root, output_path, f"{label}.output_path", errors)
+            if output is not None and isinstance(markers, list):
+                content = output.read_text(encoding="utf-8")
+                for marker in markers:
+                    if isinstance(marker, dict) and isinstance(marker.get("text"), str) and marker["text"] not in content:
+                        errors.append(f"PARITY_MISSING:{projection_id}:{marker.get('marker_id')}")
+
+    return errors, contract
+
+
+def build_index(root: Path, contract: dict[str, Any]) -> dict[str, Any]:
+    source_map = {
+        source["source_id"]: (source["path"], (root / source["path"]).resolve())
+        for source in contract["canonical_sources"]
+    }
+    projections: list[dict[str, Any]] = []
+    for projection in contract["projections"]:
+        output = (root / projection["output_path"]).resolve()
+        source_digests = [
+            {
+                "source_id": source_id,
+                "path": source_map[source_id][0],
+                "sha256": _digest(source_map[source_id][1], json_document=source_map[source_id][0].endswith(".json")),
+            }
+            for source_id in projection["source_ids"]
+        ]
+        projections.append(
+            {
+                "projection_id": projection["projection_id"],
+                "host_id": projection["host_id"],
+                "strategy_id": projection["strategy_id"],
+                "format": projection["format"],
+                "output_path": projection["output_path"],
+                "output_sha256": _digest(output),
+                "source_digests": source_digests,
+                "matched_markers": [marker["marker_id"] for marker in projection["required_markers"]],
+                "parity": "PASS",
+            }
+        )
+    return {
+        "$schema": "./machine/schemas/portable-projection-index.v1.schema.json",
+        "schema_version": "orchestra.portable-projection-index.v1",
+        "contract_id": contract["contract_id"],
+        "contract_revision": contract["contract_revision"],
+        "generated_from": {
+            "contract_path": CONTRACT_PATH.as_posix(),
+            "contract_sha256": _digest(root / CONTRACT_PATH, json_document=True),
+        },
+        "authority": AUTHORITY,
+        "projections": projections,
+        "parity_status": "PASS",
+    }
+
+
+def compile_projections(root: Path) -> tuple[list[str], dict[str, Any] | None]:
+    errors, contract = validate_contract(root)
+    if errors or contract is None:
+        return errors, None
+    return [], build_index(root, contract)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--write", action="store_true", help="write the deterministic generated parity index")
+    mode.add_argument("--check", action="store_true", help="verify the committed parity index matches current sources")
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[1])
+    args = parser.parse_args(argv)
+    root = args.repo_root.resolve()
+    errors, index = compile_projections(root)
+    if errors or index is None:
+        for error in errors:
+            print(f"[FAIL] {error}")
+        return 1
+
+    if args.write:
+        with (root / INDEX_PATH).open("w", encoding="utf-8", newline="\n") as output:
+            output.write(json.dumps(index, indent=2) + "\n")
+        print(f"[PASS] Wrote {INDEX_PATH.as_posix()} with parity=PASS.")
+        return 0
+
+    index_path = root / INDEX_PATH
+    try:
+        current = _load_json(index_path)
+    except FileNotFoundError:
+        print(f"[FAIL] MISSING:{INDEX_PATH.as_posix()}")
+        return 1
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"[FAIL] MALFORMED:{INDEX_PATH.as_posix()}:{exc}")
+        return 1
+    schema_path = root / INDEX_SCHEMA_PATH
+    if schema_path.is_file():
+        errors = _schema_errors(current, _load_json(schema_path), "index")
+        if errors:
+            for error in errors:
+                print(f"[FAIL] {error}")
+            return 1
+    if current != index:
+        print(f"[FAIL] STALE_GENERATED_INDEX:{INDEX_PATH.as_posix()}")
+        return 1
+    print(f"[PASS] {INDEX_PATH.as_posix()} is current and parity=PASS.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/runtime/test_portable_projection_compiler.py
+++ b/tests/runtime/test_portable_projection_compiler.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import shutil
+
+from jsonschema import Draft202012Validator
+
+from scripts.compile_portable_projections import (
+    CONTRACT_PATH,
+    CONTRACT_SCHEMA_PATH,
+    INDEX_SCHEMA_PATH,
+    compile_projections,
+    validate_contract,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+INDEX_PATH = ROOT / "machine" / "projections" / "portable-projection-index.v1.json"
+
+
+def test_canonical_projection_contract_and_generated_index_are_current() -> None:
+    errors, index = compile_projections(ROOT)
+    assert errors == []
+    assert index is not None
+    current = json.loads(INDEX_PATH.read_text(encoding="utf-8"))
+    contract = json.loads((ROOT / CONTRACT_PATH).read_text(encoding="utf-8"))
+    Draft202012Validator(json.loads((ROOT / CONTRACT_SCHEMA_PATH).read_text(encoding="utf-8"))).validate(contract)
+    Draft202012Validator(json.loads((ROOT / INDEX_SCHEMA_PATH).read_text(encoding="utf-8"))).validate(current)
+    assert current == index
+    assert current["parity_status"] == "PASS"
+    assert all(item["parity"] == "PASS" for item in current["projections"])
+
+
+def test_projection_marker_drift_fails_closed(tmp_path: Path) -> None:
+    contract = json.loads((ROOT / CONTRACT_PATH).read_text(encoding="utf-8"))
+    paths = {CONTRACT_PATH, CONTRACT_SCHEMA_PATH}
+    paths.update(
+        source["path"]
+        for source in contract["canonical_sources"]
+    )
+    paths.update(projection["output_path"] for projection in contract["projections"])
+    for relative_path in paths:
+        source_path = ROOT / relative_path
+        target_path = tmp_path / relative_path
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_path, target_path)
+
+    target = tmp_path / contract["projections"][0]["output_path"]
+    content = target.read_text(encoding="utf-8")
+    content = content.replace("CONDUCTOR_IS_SOLE_INTERNAL_SPECIALIST_ROUTER", "CONDUCTOR_ROUTER_MARKER_REMOVED", 1)
+    target.write_text(content, encoding="utf-8")
+    errors, _ = validate_contract(tmp_path)
+    assert "PARITY_MISSING:github-copilot-repository-instructions-template:conductor-sole-router" in errors


### PR DESCRIPTION
## Summary
- add the canonical UAI-5 portable projection contract and schema
- compile normalized source/output fingerprints into a deterministic parity index
- fail closed on missing source paths, invariant markers, unsupported formats, repository escapes, stale generated output, or .agents runtime-copy targets
- cover the tracked GitHub Copilot repository-instruction anchor/template and custom-agent template without refreshing installed integrations

## Authority boundaries
- canonical Orchestra sources remain authoritative; projections are derived only
- Conductor remains the sole internal specialist router and AWF remains workflow-topology owner
- no provider/model selection, automatic fallback, learned-routing promotion, credential/policy change, release, deployment, or installed-integration refresh

## Validation
- compiler write/check: PASS
- focused compiler, portal, host/provider contract, integration-strategy, README, and machine-readme tests: 27 passed
- structure, manifest, stale-reference, machine-contract, IDE-packaging, architecture, and strict governance checks: PASS
- full pytest baseline: 3129 passed, 1 skipped, 2 failures; the UAI-5 catalog-kind failure was fixed and the remaining failure is pre-existing D:/Dev/Repositories/+conductor/tests/behavior/test_artificer_records.py inspect.getsource infrastructure failure