### PR TITLE
feat(uai): add transport fallback integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased UAI-6 transport and fallback integration
+
+- Adds a deterministic, non-executing transport fallback chain layered on the UAI integration strategy resolver.
+- Keeps fallback candidates evidence-supported, capability-compatible, policy-allowed, and authority-preserving; no fallback exists when the resolver cannot establish a supported transport.
+- Explicitly prohibits automatic provider fallback and preserves Conductor specialist routing, AWF workflow topology, model selection, credentials, release, and deployment boundaries.
+
 ## Unreleased UAI-5 portable projection compiler
 
 - Adds a canonical-source-backed projection contract and deterministic parity index for the tracked GitHub Copilot repository-instruction and custom-agent surfaces.

--- a/README.json
+++ b/README.json
@@ -2233,14 +2233,15 @@
       "next_action": "FINAL_EXACT_HEAD_RELEASE_QUALIFICATION"
     },
     "universal_adaptive_integration_uai": {
-      "status": "UAI_5_PORTABLE_PROJECTION_COMPILER_COMPLETE_CANONICAL_VERIFIED",
-      "purpose": "Versioned host and provider/model capability evidence, deterministic minimal transport selection, and canonical-source-backed portable projection parity that preserve Conductor specialist routing and AWF workflow topology without authority expansion.",
+      "status": "UAI_6_TRANSPORT_AND_FALLBACK_INTEGRATION_COMPLETE",
+      "purpose": "Versioned host and provider/model capability evidence, deterministic minimal transport selection and non-executing transport fallback planning, and canonical-source-backed portable projection parity that preserve Conductor specialist routing and AWF workflow topology without authority expansion.",
       "human_sources": [
         "adapters/github-copilot/README.md",
         "adapters/github-copilot/probe-guide.md",
         "docs/setup/HOST_CAPABILITY_CONTRACT.md",
         "docs/setup/PROVIDER_MODEL_CAPABILITY_CONTRACT.md",
-        "docs/setup/PORTABLE_PROJECTION_COMPILER.md"
+        "docs/setup/PORTABLE_PROJECTION_COMPILER.md",
+        "docs/setup/TRANSPORT_FALLBACK_INTEGRATION.md"
       ],
       "machine_sources": [
         "adapters/github-copilot/copilot-instructions.template.md",
@@ -2274,6 +2275,7 @@
       "authority_expansion": false,
       "automatic_provider_routing": false,
       "automatic_provider_fallback": false,
+      "transport_fallback": "DETERMINISTIC_NON_EXECUTING_CHAIN",
       "learned_routing_promotion": false
     }
   },
@@ -2384,6 +2386,7 @@
     "provider_model_capability_contract_schema": "machine/schemas/provider-model-capability-contract.v1.schema.json",
     "integration_strategy_policy": "machine/hosts/integration-strategy-policy.v1.json",
     "integration_strategy_policy_schema": "machine/schemas/integration-strategy-policy.v1.schema.json",
+    "transport_fallback_guide": "docs/setup/TRANSPORT_FALLBACK_INTEGRATION.md",
     "portable_projection_contract": "machine/projections/portable-projection-contract.v1.json",
     "portable_projection_contract_schema": "machine/schemas/portable-projection-contract.v1.schema.json",
     "portable_projection_index_schema": "machine/schemas/portable-projection-index.v1.schema.json",
@@ -2589,6 +2592,7 @@
     "provider_model_capability_contract_validator": "scripts/validate_provider_model_capability_contract.py",
     "integration_strategy_policy": "machine/hosts/integration-strategy-policy.v1.json",
     "integration_strategy_policy_schema": "machine/schemas/integration-strategy-policy.v1.schema.json",
+    "transport_fallback_guide": "docs/setup/TRANSPORT_FALLBACK_INTEGRATION.md",
     "portable_projection_contract": "machine/projections/portable-projection-contract.v1.json",
     "portable_projection_contract_schema": "machine/schemas/portable-projection-contract.v1.schema.json",
     "portable_projection_index": "machine/projections/portable-projection-index.v1.json",

--- a/docs/README.md
+++ b/docs/README.md
@@ -108,6 +108,7 @@ Cross-repository continuity may be supplied by a user-selected external continui
 - [UAI Host Capability Contract](setup/HOST_CAPABILITY_CONTRACT.md): versioned host capability evidence and transport compatibility without authority expansion.
 - [UAI Provider/Model Capability Contract](setup/PROVIDER_MODEL_CAPABILITY_CONTRACT.md): provider/model-neutral technical capability vocabulary and evidence boundaries without provider selection.
 - [UAI Portable Projection Compiler](setup/PORTABLE_PROJECTION_COMPILER.md): canonical-source-backed host projection parity without installed-integration refresh or authority expansion.
+- [UAI Transport and Fallback Integration](setup/TRANSPORT_FALLBACK_INTEGRATION.md): deterministic non-executing transport fallback planning without provider switching or routing authority.
 - [Adapter SDK and PRAP v1](setup/ADAPTER_SDK_PRAP.md): stable adapter SDK and deterministic compatibility certification.
 - [Developer Portal](developer/README.md): extension and integration discovery surface.
 - [MCP stdio Transport](developer/MCP_STDIO_TRANSPORT.md): first bounded MCP tools transport.
@@ -122,6 +123,7 @@ Cross-repository continuity may be supplied by a user-selected external continui
 - `../machine/projections/portable-projection-index.v1.json`: generated machine-checkable projection parity index.
 - `../machine/schemas/portable-projection-contract.v1.schema.json`: portable projection contract schema.
 - `../machine/schemas/portable-projection-index.v1.schema.json`: generated parity index schema.
+- `../machine/hosts/integration-strategy-policy.v1.json`: UAI transport selection and non-executing fallback policy.
 - `../machine/protocol/prap-certification-contract.v1.json`: PRAP certification contract.
 - `../machine/developer-portal/catalog.v1.json`: machine Developer Portal catalog.
 

--- a/docs/setup/TRANSPORT_FALLBACK_INTEGRATION.md
+++ b/docs/setup/TRANSPORT_FALLBACK_INTEGRATION.md
@@ -1,0 +1,24 @@
+# UAI transport and fallback integration
+
+The UAI integration strategy resolver can produce a deterministic transport
+fallback chain from current, evidence-backed transport options. The chain is
+read-only planning data. It does not execute a transport, switch providers, or
+change the active model.
+
+The primary strategy and every fallback must:
+
+- be `SUPPORTED_VERIFIED` or `SUPPORTED_WITH_LIMITS`;
+- satisfy the required capabilities;
+- preserve authority;
+- be allowed by host and provider policy;
+- remain transport decisions, separate from Conductor specialist routing and
+  deterministic AWF workflow topology.
+
+If no eligible transport exists, the resolver returns
+`UNSUPPORTED_FAIL_CLOSED`. A fallback transport is not a provider fallback:
+`automatic_provider_fallback` remains `false`.
+
+The policy is defined in
+`machine/hosts/integration-strategy-policy.v1.json`, and the pure domain API is
+`resolve_transport_fallback` in
+`orchestra_runtime/domain/adaptive/integration_strategy.py`.

--- a/machine/developer-portal/catalog.v1.json
+++ b/machine/developer-portal/catalog.v1.json
@@ -99,10 +99,10 @@
     },
     {
       "id": "uai-integration-strategy-policy",
-      "title": "UAI Integration Strategy Policy",
+      "title": "UAI Integration Strategy and Transport Fallback Policy",
       "kind": "machine_contract",
       "path": "machine/hosts/integration-strategy-policy.v1.json",
-      "authority_role": "TRANSPORT_SELECTION_WITHOUT_ROUTING_AUTHORITY"
+      "authority_role": "TRANSPORT_SELECTION_AND_NON_EXECUTING_FALLBACK_WITHOUT_ROUTING_AUTHORITY"
     },
     {
       "id": "uai-integration-strategy-policy-schema",
@@ -110,6 +110,13 @@
       "kind": "machine_schema",
       "path": "machine/schemas/integration-strategy-policy.v1.schema.json",
       "authority_role": "EVIDENCE_SCHEMA"
+    },
+    {
+      "id": "uai-transport-fallback-guide",
+      "title": "UAI Transport and Fallback Integration guide",
+      "kind": "human_guide",
+      "path": "docs/setup/TRANSPORT_FALLBACK_INTEGRATION.md",
+      "authority_role": "NON_EXECUTING_TRANSPORT_FALLBACK_GUIDANCE"
     },
     {
       "id": "uai-portable-projection-contract",

--- a/machine/hosts/integration-strategy-policy.v1.json
+++ b/machine/hosts/integration-strategy-policy.v1.json
@@ -12,6 +12,13 @@
     "automatic_fallback": false,
     "credentials_mutated": false
   },
+  "fallback_policy": {
+    "mode": "DETERMINISTIC_TRANSPORT_CHAIN",
+    "fallback_plan_is_non_executing": true,
+    "same_authority_model_required": true,
+    "automatic_provider_fallback": false,
+    "fail_closed_when_no_supported_transport": true
+  },
   "selection_policy": {
     "eligible_dispositions": ["SUPPORTED_VERIFIED", "SUPPORTED_WITH_LIMITS"],
     "authority_preserved_required": true,

--- a/machine/projections/portable-projection-index.v1.json
+++ b/machine/projections/portable-projection-index.v1.json
@@ -53,7 +53,7 @@
         {
           "source_id": "integration_strategy_policy",
           "path": "machine/hosts/integration-strategy-policy.v1.json",
-          "sha256": "e4d202fbde15a7cb1144ed33321245fc15e561cf233aab911ea97f3deae854fa"
+          "sha256": "d64077135cbd3ee9ca49f71be7bb450fed6611a0eb7053156d399799101256d9"
         },
         {
           "source_id": "conductor_skill",
@@ -105,7 +105,7 @@
         {
           "source_id": "integration_strategy_policy",
           "path": "machine/hosts/integration-strategy-policy.v1.json",
-          "sha256": "e4d202fbde15a7cb1144ed33321245fc15e561cf233aab911ea97f3deae854fa"
+          "sha256": "d64077135cbd3ee9ca49f71be7bb450fed6611a0eb7053156d399799101256d9"
         },
         {
           "source_id": "conductor_skill",
@@ -157,7 +157,7 @@
         {
           "source_id": "integration_strategy_policy",
           "path": "machine/hosts/integration-strategy-policy.v1.json",
-          "sha256": "e4d202fbde15a7cb1144ed33321245fc15e561cf233aab911ea97f3deae854fa"
+          "sha256": "d64077135cbd3ee9ca49f71be7bb450fed6611a0eb7053156d399799101256d9"
         },
         {
           "source_id": "conductor_skill",

--- a/machine/schemas/integration-strategy-policy.v1.schema.json
+++ b/machine/schemas/integration-strategy-policy.v1.schema.json
@@ -4,7 +4,7 @@
   "title": "Orchestra UAI Integration Strategy Policy v1",
   "type": "object",
   "additionalProperties": false,
-  "required": ["$schema", "schema_version", "contract_id", "contract_revision", "contract_role", "authority", "selection_policy", "strategies"],
+  "required": ["$schema", "schema_version", "contract_id", "contract_revision", "contract_role", "authority", "fallback_policy", "selection_policy", "strategies"],
   "properties": {
     "$schema": {"const": "./machine/schemas/integration-strategy-policy.v1.schema.json"},
     "schema_version": {"const": "orchestra.integration-strategy-policy.v1"},
@@ -22,6 +22,18 @@
         "provider_selection_changed": {"const": false},
         "automatic_fallback": {"const": false},
         "credentials_mutated": {"const": false}
+      }
+    },
+    "fallback_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "fallback_plan_is_non_executing", "same_authority_model_required", "automatic_provider_fallback", "fail_closed_when_no_supported_transport"],
+      "properties": {
+        "mode": {"const": "DETERMINISTIC_TRANSPORT_CHAIN"},
+        "fallback_plan_is_non_executing": {"const": true},
+        "same_authority_model_required": {"const": true},
+        "automatic_provider_fallback": {"const": false},
+        "fail_closed_when_no_supported_transport": {"const": true}
       }
     },
     "selection_policy": {

--- a/orchestra_runtime/domain/adaptive/__init__.py
+++ b/orchestra_runtime/domain/adaptive/__init__.py
@@ -19,8 +19,10 @@ from .integration_strategy import (
     IntegrationStrategy,
     IntegrationStrategyDecision,
     IntegrationStrategyRequirements,
+    TransportFallbackDecision,
     TransportCapabilityEvidence,
     resolve_integration_strategy,
+    resolve_transport_fallback,
 )
 from .selection_trace import (
     AUTHORITY_RULE,
@@ -74,6 +76,7 @@ __all__ = [
     "IntegrationStrategy",
     "IntegrationStrategyDecision",
     "IntegrationStrategyRequirements",
+    "TransportFallbackDecision",
     "PromotionCandidateDecision",
     "TaskProfileDerivation",
     "build_selection_trace",
@@ -87,4 +90,5 @@ __all__ = [
     "parse_authority_view",
     "select_agentic_workflow",
     "resolve_integration_strategy",
+    "resolve_transport_fallback",
 ]

--- a/orchestra_runtime/domain/adaptive/integration_strategy.py
+++ b/orchestra_runtime/domain/adaptive/integration_strategy.py
@@ -96,6 +96,29 @@ class IntegrationStrategyDecision:
             raise ValueError("integration strategy decisions cannot expand routing or authority")
 
 
+@dataclass(frozen=True, slots=True)
+class TransportFallbackDecision:
+    primary_decision: IntegrationStrategyDecision
+    fallback_strategies: tuple[IntegrationStrategy, ...]
+    fallback_evidence_refs: tuple[tuple[str, tuple[str, ...]], ...]
+    fail_closed: bool
+    reason_codes: tuple[str, ...]
+    transport_fallback_only: bool = True
+    automatic_provider_fallback: bool = False
+
+    def __post_init__(self) -> None:
+        if self.fail_closed != self.primary_decision.fail_closed:
+            raise ValueError("fail_closed must match the primary decision")
+        if not self.transport_fallback_only or self.automatic_provider_fallback:
+            raise ValueError("fallback decisions cannot expand transport or provider authority")
+        if len(set(self.fallback_strategies)) != len(self.fallback_strategies):
+            raise ValueError("fallback_strategies must be unique")
+        if self.primary_decision.selected_strategy in self.fallback_strategies:
+            raise ValueError("primary strategy cannot also be a fallback")
+        if IntegrationStrategy.UNSUPPORTED_FAIL_CLOSED in self.fallback_strategies:
+            raise ValueError("fail-closed output cannot be a fallback strategy")
+
+
 def _rejection(option: TransportCapabilityEvidence, requirements: IntegrationStrategyRequirements) -> tuple[str, ...]:
     reasons: list[str] = []
     if option.disposition not in ELIGIBLE_DISPOSITIONS:
@@ -110,12 +133,10 @@ def _rejection(option: TransportCapabilityEvidence, requirements: IntegrationStr
     return tuple(reasons)
 
 
-def resolve_integration_strategy(
+def _partition_options(
     requirements: IntegrationStrategyRequirements,
     options: Iterable[TransportCapabilityEvidence],
-) -> IntegrationStrategyDecision:
-    if not isinstance(requirements, IntegrationStrategyRequirements):
-        raise TypeError("requirements must be IntegrationStrategyRequirements")
+) -> tuple[list[TransportCapabilityEvidence], list[tuple[str, tuple[str, ...]]]]:
     unique_options: dict[IntegrationStrategy, TransportCapabilityEvidence] = {}
     rejected: list[tuple[str, tuple[str, ...]]] = []
     eligible: list[TransportCapabilityEvidence] = []
@@ -130,6 +151,29 @@ def resolve_integration_strategy(
             rejected.append((option.strategy_id.value, reasons))
         else:
             eligible.append(option)
+    return eligible, rejected
+
+
+def _rank_eligible(options: Iterable[TransportCapabilityEvidence]) -> list[TransportCapabilityEvidence]:
+    return sorted(
+        options,
+        key=lambda option: (
+            option.installation_complexity,
+            option.context_cost,
+            -option.portability_score,
+            -option.evidence_quality,
+            _DECLARED_ORDER[option.strategy_id],
+        ),
+    )
+
+
+def resolve_integration_strategy(
+    requirements: IntegrationStrategyRequirements,
+    options: Iterable[TransportCapabilityEvidence],
+) -> IntegrationStrategyDecision:
+    if not isinstance(requirements, IntegrationStrategyRequirements):
+        raise TypeError("requirements must be IntegrationStrategyRequirements")
+    eligible, rejected = _partition_options(requirements, options)
 
     if not eligible:
         return IntegrationStrategyDecision(
@@ -140,16 +184,7 @@ def resolve_integration_strategy(
             rejected_strategies=tuple(rejected),
         )
 
-    selected = min(
-        eligible,
-        key=lambda option: (
-            option.installation_complexity,
-            option.context_cost,
-            -option.portability_score,
-            -option.evidence_quality,
-            _DECLARED_ORDER[option.strategy_id],
-        ),
-    )
+    selected = _rank_eligible(eligible)[0]
     reasons = ["MINIMAL_ELIGIBLE_TRANSPORT"]
     if selected.disposition == "SUPPORTED_WITH_LIMITS":
         reasons.append("SELECTED_WITH_LIMITS")
@@ -162,12 +197,44 @@ def resolve_integration_strategy(
     )
 
 
+def resolve_transport_fallback(
+    requirements: IntegrationStrategyRequirements,
+    options: Iterable[TransportCapabilityEvidence],
+) -> TransportFallbackDecision:
+    """Build a deterministic transport fallback plan without executing it."""
+    if not isinstance(requirements, IntegrationStrategyRequirements):
+        raise TypeError("requirements must be IntegrationStrategyRequirements")
+    materialized_options = tuple(options)
+    primary = resolve_integration_strategy(requirements, materialized_options)
+    if primary.fail_closed:
+        return TransportFallbackDecision(
+            primary_decision=primary,
+            fallback_strategies=(),
+            fallback_evidence_refs=(),
+            fail_closed=True,
+            reason_codes=("NO_EVIDENCE_SUPPORTED_TRANSPORT", "TRANSPORT_FALLBACK_FAIL_CLOSED"),
+        )
+
+    eligible, _ = _partition_options(requirements, materialized_options)
+    ranked = _rank_eligible(eligible)
+    fallback_options = [option for option in ranked if option.strategy_id is not primary.selected_strategy]
+    return TransportFallbackDecision(
+        primary_decision=primary,
+        fallback_strategies=tuple(option.strategy_id for option in fallback_options),
+        fallback_evidence_refs=tuple((option.strategy_id.value, option.evidence_refs) for option in fallback_options),
+        fail_closed=False,
+        reason_codes=("DETERMINISTIC_TRANSPORT_FALLBACK_CHAIN", "FALLBACK_NON_AUTOMATIC", "PROVIDER_FALLBACK_PROHIBITED"),
+    )
+
+
 __all__ = [
     "ELIGIBLE_DISPOSITIONS",
     "INTEGRATION_STRATEGY_POLICY_VERSION",
     "IntegrationStrategy",
     "IntegrationStrategyDecision",
     "IntegrationStrategyRequirements",
+    "TransportFallbackDecision",
     "TransportCapabilityEvidence",
     "resolve_integration_strategy",
+    "resolve_transport_fallback",
 ]

--- a/tests/runtime/test_integration_strategy.py
+++ b/tests/runtime/test_integration_strategy.py
@@ -10,6 +10,7 @@ from orchestra_runtime.domain.adaptive.integration_strategy import (
     IntegrationStrategyRequirements,
     TransportCapabilityEvidence,
     resolve_integration_strategy,
+    resolve_transport_fallback,
 )
 
 
@@ -90,3 +91,42 @@ def test_limits_are_explicit_and_duplicate_options_fail() -> None:
         assert "one record per strategy" in str(exc)
     else:
         raise AssertionError("duplicate strategy options must fail closed")
+
+
+def test_transport_fallback_is_deterministic_and_non_authorizing() -> None:
+    decision = resolve_transport_fallback(
+        IntegrationStrategyRequirements(("instructions",)),
+        (
+            option("REPOSITORY_INSTRUCTIONS", installation_complexity=0),
+            option("WORKSPACE_INSTRUCTIONS", installation_complexity=1),
+            option("MCP_TRANSPORT", installation_complexity=2),
+        ),
+    )
+    assert decision.primary_decision.selected_strategy is IntegrationStrategy.REPOSITORY_INSTRUCTIONS
+    assert decision.fallback_strategies == (
+        IntegrationStrategy.WORKSPACE_INSTRUCTIONS,
+        IntegrationStrategy.MCP_TRANSPORT,
+    )
+    assert decision.reason_codes == (
+        "DETERMINISTIC_TRANSPORT_FALLBACK_CHAIN",
+        "FALLBACK_NON_AUTOMATIC",
+        "PROVIDER_FALLBACK_PROHIBITED",
+    )
+    assert decision.transport_fallback_only is True
+    assert decision.automatic_provider_fallback is False
+    assert decision.primary_decision.specialist_routing_changed is False
+    assert decision.primary_decision.workflow_topology_changed is False
+    assert decision.primary_decision.provider_selection_changed is False
+
+
+def test_transport_fallback_fails_closed_without_supported_evidence() -> None:
+    decision = resolve_transport_fallback(
+        IntegrationStrategyRequirements(("tools",)),
+        (option("MCP_TRANSPORT", disposition="UNKNOWN"),),
+    )
+    assert decision.fail_closed is True
+    assert decision.fallback_strategies == ()
+    assert decision.reason_codes == (
+        "NO_EVIDENCE_SUPPORTED_TRANSPORT",
+        "TRANSPORT_FALLBACK_FAIL_CLOSED",
+    )


### PR DESCRIPTION
## Summary\n- add a deterministic, non-executing transport fallback chain on the existing UAI strategy resolver\n- keep fallback candidates evidence-supported, capability-compatible, policy-allowed, and authority-preserving\n- document the policy and preserve Conductor/AWF/provider/model boundaries\n\n## Validation\n- UAI focused suite: 24 passed\n- full suite: 3132 passed, 1 skipped, 1 pre-existing unrelated failure in +conductor/tests/behavior/test_artificer_records.py::TestArtificerRecordsValidator::test_quality_gate\n- strict governance, structure, manifest, stale-reference, machine-contract, IDE-packaging, host/provider, architecture, projection parity, and diff checks passed\n\nNo provider routing/fallback, learned routing promotion, Conductor core, AWF topology, credentials, policy activation, release, deployment, or marketplace changes.