### PR TITLE
feat(uai): add shadow provider capability broker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased UAI-7 provider capability broker shadow advisory
+
+- Adds a deterministic shadow-only provider/model capability broker that classifies host-exposed options using task requirements, current evidence, and policy restrictions.
+- Returns `ELIGIBLE`, `ELIGIBLE_WITH_LIMITS`, `INELIGIBLE`, `UNKNOWN`, or `POLICY_BLOCKED` without selecting or switching an active provider/model.
+- Keeps provider capability separate from Conductor routing, AWF topology, transport fallback, credentials, learned-routing promotion, release, and deployment.
+
 ## Unreleased UAI-6 transport and fallback integration
 
 - Adds a deterministic, non-executing transport fallback chain layered on the UAI integration strategy resolver.

--- a/README.json
+++ b/README.json
@@ -2233,8 +2233,8 @@
       "next_action": "FINAL_EXACT_HEAD_RELEASE_QUALIFICATION"
     },
     "universal_adaptive_integration_uai": {
-      "status": "UAI_6_TRANSPORT_AND_FALLBACK_INTEGRATION_COMPLETE",
-      "purpose": "Versioned host and provider/model capability evidence, deterministic minimal transport selection and non-executing transport fallback planning, and canonical-source-backed portable projection parity that preserve Conductor specialist routing and AWF workflow topology without authority expansion.",
+      "status": "UAI_7_PROVIDER_CAPABILITY_BROKER_SHADOW_ADVISORY_COMPLETE",
+      "purpose": "Versioned host and provider/model capability evidence, deterministic minimal transport selection and non-executing transport fallback planning, shadow-only provider/model eligibility advice, and canonical-source-backed portable projection parity that preserve Conductor specialist routing and AWF workflow topology without authority expansion.",
       "human_sources": [
         "adapters/github-copilot/README.md",
         "adapters/github-copilot/probe-guide.md",
@@ -2254,6 +2254,8 @@
         "machine/schemas/provider-model-capability-contract.v1.schema.json",
         "scripts/validate_provider_model_capability_contract.py",
         "tests/runtime/test_provider_model_capability_contract.py",
+        "orchestra_runtime/domain/adaptive/provider_capability.py",
+        "tests/runtime/test_provider_capability_broker.py",
         "machine/hosts/integration-strategy-policy.v1.json",
         "machine/schemas/integration-strategy-policy.v1.schema.json",
         "orchestra_runtime/domain/adaptive/integration_strategy.py",
@@ -2276,6 +2278,7 @@
       "automatic_provider_routing": false,
       "automatic_provider_fallback": false,
       "transport_fallback": "DETERMINISTIC_NON_EXECUTING_CHAIN",
+      "provider_capability_broker": "SHADOW_ADVISORY_NON_AUTHORIZING",
       "learned_routing_promotion": false
     }
   },
@@ -2384,6 +2387,7 @@
     "host_capability_contract_schema": "machine/schemas/host-capability-contract.v1.schema.json",
     "provider_model_capability_contract": "machine/providers/provider-model-capability-contract.v1.json",
     "provider_model_capability_contract_schema": "machine/schemas/provider-model-capability-contract.v1.schema.json",
+    "provider_capability_broker": "orchestra_runtime/domain/adaptive/provider_capability.py",
     "integration_strategy_policy": "machine/hosts/integration-strategy-policy.v1.json",
     "integration_strategy_policy_schema": "machine/schemas/integration-strategy-policy.v1.schema.json",
     "transport_fallback_guide": "docs/setup/TRANSPORT_FALLBACK_INTEGRATION.md",
@@ -2590,6 +2594,7 @@
     "provider_model_capability_contract": "machine/providers/provider-model-capability-contract.v1.json",
     "provider_model_capability_contract_schema": "machine/schemas/provider-model-capability-contract.v1.schema.json",
     "provider_model_capability_contract_validator": "scripts/validate_provider_model_capability_contract.py",
+    "provider_capability_broker": "orchestra_runtime/domain/adaptive/provider_capability.py",
     "integration_strategy_policy": "machine/hosts/integration-strategy-policy.v1.json",
     "integration_strategy_policy_schema": "machine/schemas/integration-strategy-policy.v1.schema.json",
     "transport_fallback_guide": "docs/setup/TRANSPORT_FALLBACK_INTEGRATION.md",

--- a/docs/README.md
+++ b/docs/README.md
@@ -106,7 +106,7 @@ Cross-repository continuity may be supplied by a user-selected external continui
 - [Compatibility](setup/COMPATIBILITY.md): host compatibility and maturity.
 - [Host Updates](setup/HOST_UPDATES.md): governed read-only host update planning.
 - [UAI Host Capability Contract](setup/HOST_CAPABILITY_CONTRACT.md): versioned host capability evidence and transport compatibility without authority expansion.
-- [UAI Provider/Model Capability Contract](setup/PROVIDER_MODEL_CAPABILITY_CONTRACT.md): provider/model-neutral technical capability vocabulary and evidence boundaries without provider selection.
+- [UAI Provider/Model Capability Contract](setup/PROVIDER_MODEL_CAPABILITY_CONTRACT.md): provider/model-neutral technical capability vocabulary, evidence boundaries, and shadow-only eligibility advice without provider selection.
 - [UAI Portable Projection Compiler](setup/PORTABLE_PROJECTION_COMPILER.md): canonical-source-backed host projection parity without installed-integration refresh or authority expansion.
 - [UAI Transport and Fallback Integration](setup/TRANSPORT_FALLBACK_INTEGRATION.md): deterministic non-executing transport fallback planning without provider switching or routing authority.
 - [Adapter SDK and PRAP v1](setup/ADAPTER_SDK_PRAP.md): stable adapter SDK and deterministic compatibility certification.

--- a/docs/setup/PROVIDER_MODEL_CAPABILITY_CONTRACT.md
+++ b/docs/setup/PROVIDER_MODEL_CAPABILITY_CONTRACT.md
@@ -12,6 +12,8 @@ This contract does not authorize automatic provider switching, fallback, credent
 
 UAI-4 resolves transport separately with the pure `resolve_integration_strategy` domain function. It considers only current supported evidence, required transport capabilities, host/provider policy, authority preservation, context cost, installation complexity, portability, and evidence quality. If no option is eligible it selects `UNSUPPORTED_FAIL_CLOSED`. The result cannot change specialist routing, AWF topology, provider/model selection, credentials, or fallback behavior.
 
+UAI-7 adds the pure `broker_provider_capabilities` domain function. It intersects task requirements, host-exposed provider/model options, provider/model capability evidence, and policy flags, returning only shadow advisories: `ELIGIBLE`, `ELIGIBLE_WITH_LIMITS`, `INELIGIBLE`, `UNKNOWN`, or `POLICY_BLOCKED`. It never selects or switches an active provider/model, and it cannot promote learned routing.
+
 Validate it with:
 
 ```text

--- a/machine/developer-portal/catalog.v1.json
+++ b/machine/developer-portal/catalog.v1.json
@@ -78,10 +78,10 @@
     },
     {
       "id": "uai-provider-model-capability-contract",
-      "title": "UAI Provider/Model Capability Contract",
+      "title": "UAI Provider/Model Capability Contract and Shadow Broker",
       "kind": "machine_contract",
       "path": "machine/providers/provider-model-capability-contract.v1.json",
-      "authority_role": "PROVIDER_MODEL_CAPABILITY_EVIDENCE_WITHOUT_AUTHORITY"
+      "authority_role": "PROVIDER_MODEL_CAPABILITY_EVIDENCE_AND_SHADOW_ADVISORY_WITHOUT_AUTHORITY"
     },
     {
       "id": "uai-provider-model-capability-schema",

--- a/machine/providers/provider-model-capability-contract.v1.json
+++ b/machine/providers/provider-model-capability-contract.v1.json
@@ -16,6 +16,16 @@
     "learned_routing_promotion": false,
     "execution_authorized": false
   },
+  "broker_policy": {
+    "mode": "SHADOW_ADVISORY_NON_AUTHORIZING",
+    "output_dispositions": ["ELIGIBLE", "ELIGIBLE_WITH_LIMITS", "INELIGIBLE", "UNKNOWN", "POLICY_BLOCKED"],
+    "provider_selection_changed": false,
+    "automatic_provider_switching": false,
+    "automatic_provider_fallback": false,
+    "learned_routing_promotion": false,
+    "specialist_routing_changed": false,
+    "workflow_topology_changed": false
+  },
   "capability_definitions": [
     {"capability_id": "TOOL_CALLING", "category": "INTERACTION", "value_kind": "BOOLEAN"},
     {"capability_id": "STRUCTURED_OUTPUT", "category": "OUTPUT", "value_kind": "BOOLEAN"},

--- a/machine/schemas/provider-model-capability-contract.v1.schema.json
+++ b/machine/schemas/provider-model-capability-contract.v1.schema.json
@@ -11,6 +11,7 @@
     "contract_revision",
     "contract_role",
     "authority",
+    "broker_policy",
     "capability_definitions",
     "provider_model_profiles",
     "evidence_policy"
@@ -33,6 +34,21 @@
     },
     "authority": {
       "$ref": "#/$defs/nonAuthorizingAuthority"
+    },
+    "broker_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "output_dispositions", "provider_selection_changed", "automatic_provider_switching", "automatic_provider_fallback", "learned_routing_promotion", "specialist_routing_changed", "workflow_topology_changed"],
+      "properties": {
+        "mode": {"const": "SHADOW_ADVISORY_NON_AUTHORIZING"},
+        "output_dispositions": {"const": ["ELIGIBLE", "ELIGIBLE_WITH_LIMITS", "INELIGIBLE", "UNKNOWN", "POLICY_BLOCKED"]},
+        "provider_selection_changed": {"const": false},
+        "automatic_provider_switching": {"const": false},
+        "automatic_provider_fallback": {"const": false},
+        "learned_routing_promotion": {"const": false},
+        "specialist_routing_changed": {"const": false},
+        "workflow_topology_changed": {"const": false}
+      }
     },
     "capability_definitions": {
       "type": "array",

--- a/orchestra_runtime/domain/adaptive/__init__.py
+++ b/orchestra_runtime/domain/adaptive/__init__.py
@@ -24,6 +24,14 @@ from .integration_strategy import (
     resolve_integration_strategy,
     resolve_transport_fallback,
 )
+from .provider_capability import (
+    HostProviderModelOption,
+    ProviderCapabilityAdvisory,
+    ProviderCapabilityBrokerDecision,
+    ProviderCapabilityEvidence,
+    ProviderCapabilityRequirements,
+    broker_provider_capabilities,
+)
 from .selection_trace import (
     AUTHORITY_RULE,
     SELECTION_TRACE_SCHEMA_VERSION,
@@ -76,6 +84,11 @@ __all__ = [
     "IntegrationStrategy",
     "IntegrationStrategyDecision",
     "IntegrationStrategyRequirements",
+    "HostProviderModelOption",
+    "ProviderCapabilityAdvisory",
+    "ProviderCapabilityBrokerDecision",
+    "ProviderCapabilityEvidence",
+    "ProviderCapabilityRequirements",
     "TransportFallbackDecision",
     "PromotionCandidateDecision",
     "TaskProfileDerivation",
@@ -91,4 +104,5 @@ __all__ = [
     "select_agentic_workflow",
     "resolve_integration_strategy",
     "resolve_transport_fallback",
+    "broker_provider_capabilities",
 ]

--- a/orchestra_runtime/domain/adaptive/provider_capability.py
+++ b/orchestra_runtime/domain/adaptive/provider_capability.py
@@ -1,0 +1,241 @@
+"""Shadow-only provider/model capability advice."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+
+PROVIDER_CAPABILITY_BROKER_POLICY_VERSION = "orchestra.provider-capability-broker.v1"
+BROKER_DISPOSITIONS = frozenset({"ELIGIBLE", "ELIGIBLE_WITH_LIMITS", "INELIGIBLE", "UNKNOWN", "POLICY_BLOCKED"})
+CAPABILITY_DISPOSITIONS = frozenset(
+    {
+        "SUPPORTED_VERIFIED",
+        "SUPPORTED_WITH_LIMITS",
+        "AVAILABLE_NOT_YET_VERIFIED",
+        "UNKNOWN",
+        "BLOCKED_BY_POLICY",
+        "VERIFIED_UNSUPPORTED_LOCALLY",
+        "UNSUPPORTED",
+    }
+)
+
+
+def _unique_strings(values: Iterable[str], field: str, *, required: bool = True) -> tuple[str, ...]:
+    normalized = tuple(str(value).strip() for value in values)
+    if (required and not normalized) or any(not value for value in normalized) or len(set(normalized)) != len(normalized):
+        raise ValueError(f"{field} must contain unique non-empty strings")
+    return normalized
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderCapabilityRequirements:
+    required_capabilities: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "required_capabilities", _unique_strings(self.required_capabilities, "required_capabilities", required=False))
+
+
+@dataclass(frozen=True, slots=True)
+class HostProviderModelOption:
+    host_id: str
+    provider_id: str
+    model_id: str
+    policy_allowed: bool = True
+
+    def __post_init__(self) -> None:
+        for field in ("host_id", "provider_id", "model_id"):
+            if not isinstance(getattr(self, field), str) or not getattr(self, field).strip():
+                raise ValueError(f"{field} must be a non-empty string")
+        if type(self.policy_allowed) is not bool:
+            raise ValueError("policy_allowed must be a boolean")
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderCapabilityEvidence:
+    host_id: str
+    provider_id: str
+    model_id: str
+    capability_dispositions: tuple[tuple[str, str], ...]
+    evidence_refs: tuple[str, ...]
+    freshness_status: str = "CURRENT_AT_OBSERVATION"
+    policy_allowed: bool = True
+    limitations: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        for field in ("host_id", "provider_id", "model_id"):
+            if not isinstance(getattr(self, field), str) or not getattr(self, field).strip():
+                raise ValueError(f"{field} must be a non-empty string")
+        if not self.capability_dispositions:
+            raise ValueError("capability_dispositions must not be empty")
+        seen: set[str] = set()
+        for capability_id, disposition in self.capability_dispositions:
+            if not isinstance(capability_id, str) or not capability_id.strip() or capability_id in seen:
+                raise ValueError("capability_dispositions must contain unique non-empty capability IDs")
+            if disposition not in CAPABILITY_DISPOSITIONS:
+                raise ValueError("capability disposition is unsupported")
+            seen.add(capability_id)
+        object.__setattr__(self, "evidence_refs", _unique_strings(self.evidence_refs, "evidence_refs"))
+        object.__setattr__(self, "limitations", _unique_strings(self.limitations, "limitations", required=False))
+        if self.freshness_status not in {"CURRENT_AT_OBSERVATION", "STALE", "UNKNOWN"}:
+            raise ValueError("freshness_status is unsupported")
+        if type(self.policy_allowed) is not bool:
+            raise ValueError("policy_allowed must be a boolean")
+
+    @property
+    def capabilities(self) -> dict[str, str]:
+        return dict(self.capability_dispositions)
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderCapabilityAdvisory:
+    host_id: str
+    provider_id: str
+    model_id: str
+    disposition: str
+    matched_capabilities: tuple[str, ...]
+    missing_capabilities: tuple[str, ...]
+    evidence_refs: tuple[str, ...]
+    reason_codes: tuple[str, ...]
+    limitations: tuple[str, ...] = ()
+    shadow_only: bool = True
+    provider_selection_authority: bool = False
+    automatic_provider_switching: bool = False
+    automatic_provider_fallback: bool = False
+    learned_routing_promotion: bool = False
+    specialist_routing_changed: bool = False
+    workflow_topology_changed: bool = False
+
+    def __post_init__(self) -> None:
+        if self.disposition not in BROKER_DISPOSITIONS:
+            raise ValueError("broker disposition is unsupported")
+        for field in ("matched_capabilities", "missing_capabilities", "reason_codes", "limitations"):
+            object.__setattr__(self, field, _unique_strings(getattr(self, field), field, required=False))
+        object.__setattr__(self, "evidence_refs", _unique_strings(self.evidence_refs, "evidence_refs", required=False))
+        flags = (
+            "shadow_only",
+            "provider_selection_authority",
+            "automatic_provider_switching",
+            "automatic_provider_fallback",
+            "learned_routing_promotion",
+            "specialist_routing_changed",
+            "workflow_topology_changed",
+        )
+        if self.shadow_only is not True or not all(getattr(self, flag) is False for flag in flags[1:]):
+            raise ValueError("provider capability advice cannot create authority")
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderCapabilityBrokerDecision:
+    advisories: tuple[ProviderCapabilityAdvisory, ...]
+    reason_codes: tuple[str, ...]
+    shadow_only: bool = True
+    provider_selection_changed: bool = False
+    automatic_provider_switching: bool = False
+    automatic_provider_fallback: bool = False
+    learned_routing_promotion: bool = False
+    specialist_routing_changed: bool = False
+    workflow_topology_changed: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.shadow_only or any(
+            getattr(self, field) is not False
+            for field in (
+                "provider_selection_changed",
+                "automatic_provider_switching",
+                "automatic_provider_fallback",
+                "learned_routing_promotion",
+                "specialist_routing_changed",
+                "workflow_topology_changed",
+            )
+        ):
+            raise ValueError("provider capability broker cannot create authority")
+        if not all(isinstance(advisory, ProviderCapabilityAdvisory) for advisory in self.advisories):
+            raise TypeError("advisories must contain ProviderCapabilityAdvisory")
+        object.__setattr__(self, "reason_codes", _unique_strings(self.reason_codes, "reason_codes"))
+
+
+def _advisory(
+    option: HostProviderModelOption,
+    requirements: ProviderCapabilityRequirements,
+    evidence: ProviderCapabilityEvidence | None,
+) -> ProviderCapabilityAdvisory:
+    identity = (option.host_id, option.provider_id, option.model_id)
+    if not option.policy_allowed:
+        return ProviderCapabilityAdvisory(*identity, "POLICY_BLOCKED", (), requirements.required_capabilities, (), ("HOST_OPTION_POLICY_BLOCKED",))
+    if evidence is None:
+        return ProviderCapabilityAdvisory(*identity, "UNKNOWN", (), requirements.required_capabilities, (), ("NO_CURRENT_PROVIDER_MODEL_EVIDENCE",))
+    if not evidence.policy_allowed:
+        return ProviderCapabilityAdvisory(*identity, "POLICY_BLOCKED", (), requirements.required_capabilities, evidence.evidence_refs, ("PROVIDER_MODEL_POLICY_BLOCKED",), evidence.limitations)
+    if evidence.freshness_status != "CURRENT_AT_OBSERVATION":
+        return ProviderCapabilityAdvisory(*identity, "UNKNOWN", (), requirements.required_capabilities, evidence.evidence_refs, ("STALE_OR_UNKNOWN_EVIDENCE",), evidence.limitations)
+
+    capabilities = evidence.capabilities
+    missing = tuple(capability for capability in requirements.required_capabilities if capability not in capabilities)
+    required_dispositions = tuple(capabilities.get(capability) for capability in requirements.required_capabilities if capability in capabilities)
+    if any(disposition == "BLOCKED_BY_POLICY" for disposition in required_dispositions):
+        disposition = "POLICY_BLOCKED"
+        reasons = ("REQUIRED_CAPABILITY_POLICY_BLOCKED",)
+    elif missing:
+        disposition = "UNKNOWN"
+        reasons = ("MISSING_CAPABILITY_EVIDENCE",)
+    elif any(disposition in {"UNKNOWN", "AVAILABLE_NOT_YET_VERIFIED"} for disposition in required_dispositions):
+        disposition = "UNKNOWN"
+        reasons = ("REQUIRED_CAPABILITY_NOT_VERIFIED",)
+    elif any(disposition in {"UNSUPPORTED", "VERIFIED_UNSUPPORTED_LOCALLY"} for disposition in required_dispositions):
+        disposition = "INELIGIBLE"
+        reasons = ("REQUIRED_CAPABILITY_UNSUPPORTED",)
+    elif any(disposition == "SUPPORTED_WITH_LIMITS" for disposition in required_dispositions):
+        disposition = "ELIGIBLE_WITH_LIMITS"
+        reasons = ("REQUIRED_CAPABILITIES_SUPPORTED_WITH_LIMITS",)
+    else:
+        disposition = "ELIGIBLE"
+        reasons = ("REQUIRED_CAPABILITIES_SUPPORTED",)
+    matched = tuple(capability for capability in requirements.required_capabilities if capability not in missing and capabilities[capability] in {"SUPPORTED_VERIFIED", "SUPPORTED_WITH_LIMITS"})
+    return ProviderCapabilityAdvisory(*identity, disposition, matched, missing, evidence.evidence_refs, reasons, evidence.limitations)
+
+
+def broker_provider_capabilities(
+    requirements: ProviderCapabilityRequirements,
+    host_options: Iterable[HostProviderModelOption],
+    evidence_profiles: Iterable[ProviderCapabilityEvidence],
+) -> ProviderCapabilityBrokerDecision:
+    """Classify exposed provider/model options without selecting or switching one."""
+    if not isinstance(requirements, ProviderCapabilityRequirements):
+        raise TypeError("requirements must be ProviderCapabilityRequirements")
+    option_map: dict[tuple[str, str, str], HostProviderModelOption] = {}
+    for option in host_options:
+        if not isinstance(option, HostProviderModelOption):
+            raise TypeError("host_options must contain HostProviderModelOption")
+        key = (option.host_id, option.provider_id, option.model_id)
+        if key in option_map:
+            raise ValueError("host_options must contain unique host/provider/model identities")
+        option_map[key] = option
+    evidence_map: dict[tuple[str, str, str], ProviderCapabilityEvidence] = {}
+    for evidence in evidence_profiles:
+        if not isinstance(evidence, ProviderCapabilityEvidence):
+            raise TypeError("evidence_profiles must contain ProviderCapabilityEvidence")
+        key = (evidence.host_id, evidence.provider_id, evidence.model_id)
+        if key in evidence_map:
+            raise ValueError("evidence_profiles must contain unique host/provider/model identities")
+        evidence_map[key] = evidence
+    advisories = tuple(
+        _advisory(option, requirements, evidence_map.get(key))
+        for key, option in sorted(option_map.items())
+    )
+    return ProviderCapabilityBrokerDecision(
+        advisories=advisories,
+        reason_codes=("SHADOW_ADVISORY_ONLY", "PROVIDER_SELECTION_NOT_PERFORMED", "AUTOMATIC_PROVIDER_SWITCHING_PROHIBITED"),
+    )
+
+
+__all__ = [
+    "BROKER_DISPOSITIONS",
+    "CAPABILITY_DISPOSITIONS",
+    "PROVIDER_CAPABILITY_BROKER_POLICY_VERSION",
+    "HostProviderModelOption",
+    "ProviderCapabilityAdvisory",
+    "ProviderCapabilityBrokerDecision",
+    "ProviderCapabilityEvidence",
+    "ProviderCapabilityRequirements",
+    "broker_provider_capabilities",
+]

--- a/scripts/validate_provider_model_capability_contract.py
+++ b/scripts/validate_provider_model_capability_contract.py
@@ -117,6 +117,7 @@ def validate_payload(contract: Any, schema: Any | None = None) -> list[str]:
         "contract_revision",
         "contract_role",
         "authority",
+        "broker_policy",
         "capability_definitions",
         "provider_model_profiles",
         "evidence_policy",
@@ -150,6 +151,22 @@ def validate_payload(contract: Any, schema: Any | None = None) -> list[str]:
             errors.append(f"SCHEMA_VALIDATION:validator_error:{exc}")
 
     _validate_authority(contract.get("authority"), "authority", errors)
+
+    broker_policy = contract.get("broker_policy")
+    if _require_object(broker_policy, "broker_policy", errors):
+        expected_broker_policy = {
+            "mode": "SHADOW_ADVISORY_NON_AUTHORIZING",
+            "output_dispositions": ["ELIGIBLE", "ELIGIBLE_WITH_LIMITS", "INELIGIBLE", "UNKNOWN", "POLICY_BLOCKED"],
+            "provider_selection_changed": False,
+            "automatic_provider_switching": False,
+            "automatic_provider_fallback": False,
+            "learned_routing_promotion": False,
+            "specialist_routing_changed": False,
+            "workflow_topology_changed": False,
+        }
+        for field, expected_value in expected_broker_policy.items():
+            if broker_policy.get(field) != expected_value:
+                errors.append(f"AUTHORITY_OR_BROKER_POLICY_DRIFT:broker_policy.{field}")
 
     definitions = contract.get("capability_definitions")
     seen_definitions: set[str] = set()

--- a/tests/runtime/test_provider_capability_broker.py
+++ b/tests/runtime/test_provider_capability_broker.py
@@ -4,6 +4,8 @@ import pytest
 
 from orchestra_runtime.domain.adaptive.provider_capability import (
     HostProviderModelOption,
+    ProviderCapabilityAdvisory,
+    ProviderCapabilityBrokerDecision,
     ProviderCapabilityEvidence,
     ProviderCapabilityRequirements,
     broker_provider_capabilities,
@@ -67,6 +69,77 @@ def test_duplicate_identities_and_authority_expansion_fail_closed() -> None:
     with pytest.raises(ValueError, match="unique host/provider/model"):
         broker_provider_capabilities(ProviderCapabilityRequirements(), (option("alpha", "model"), option("alpha", "model")), ())
     with pytest.raises(ValueError, match="cannot create authority"):
-        from orchestra_runtime.domain.adaptive.provider_capability import ProviderCapabilityAdvisory
-
         ProviderCapabilityAdvisory("host", "provider", "model", "UNKNOWN", (), (), (), ("reason",), provider_selection_authority=True)
+
+
+def test_broker_classifies_current_evidence_and_policy_states() -> None:
+    requirements = ProviderCapabilityRequirements(("TOOL_CALLING",))
+    decision = broker_provider_capabilities(
+        requirements,
+        (
+            option("eligible", "model"),
+            option("limited", "model"),
+            option("blocked", "model"),
+            option("missing", "model"),
+            option("unknown", "model"),
+            option("unsupported", "model"),
+            option("profile-blocked", "model"),
+        ),
+        (
+            evidence("eligible", "model", capability_dispositions=(("TOOL_CALLING", "SUPPORTED_VERIFIED"),)),
+            evidence("limited", "model", capability_dispositions=(("TOOL_CALLING", "SUPPORTED_WITH_LIMITS"),)),
+            evidence("blocked", "model", capability_dispositions=(("TOOL_CALLING", "BLOCKED_BY_POLICY"),)),
+            evidence("missing", "model", capability_dispositions=(("OTHER", "SUPPORTED_VERIFIED"),)),
+            evidence("unknown", "model", capability_dispositions=(("TOOL_CALLING", "UNKNOWN"),)),
+            evidence("unsupported", "model", capability_dispositions=(("TOOL_CALLING", "VERIFIED_UNSUPPORTED_LOCALLY"),)),
+            evidence("profile-blocked", "model", policy_allowed=False),
+        ),
+    )
+    assert [(item.provider_id, item.disposition) for item in decision.advisories] == [
+        ("blocked", "POLICY_BLOCKED"),
+        ("eligible", "ELIGIBLE"),
+        ("limited", "ELIGIBLE_WITH_LIMITS"),
+        ("missing", "UNKNOWN"),
+        ("profile-blocked", "POLICY_BLOCKED"),
+        ("unknown", "UNKNOWN"),
+        ("unsupported", "INELIGIBLE"),
+    ]
+
+
+def test_contract_objects_reject_invalid_inputs_and_authority() -> None:
+    with pytest.raises(ValueError, match="unique non-empty"):
+        ProviderCapabilityRequirements(("TOOL_CALLING", "TOOL_CALLING"))
+    with pytest.raises(ValueError, match="unique non-empty"):
+        ProviderCapabilityRequirements(("",))
+    with pytest.raises(ValueError, match="host_id"):
+        HostProviderModelOption("", "provider", "model")
+    with pytest.raises(ValueError, match="boolean"):
+        HostProviderModelOption("host", "provider", "model", policy_allowed=1)
+    with pytest.raises(ValueError, match="host_id"):
+        evidence("provider", "model", host_id="")
+    with pytest.raises(ValueError, match="must not be empty"):
+        evidence("provider", "model", capability_dispositions=())
+    with pytest.raises(ValueError, match="unique non-empty capability IDs"):
+        evidence("provider", "model", capability_dispositions=(("", "SUPPORTED_VERIFIED"),))
+    with pytest.raises(ValueError, match="unsupported"):
+        evidence("provider", "model", capability_dispositions=(("TOOL_CALLING", "NOT_A_DISPOSITION"),))
+    with pytest.raises(ValueError, match="freshness"):
+        evidence("provider", "model", freshness_status="NOT_CURRENT")
+    with pytest.raises(ValueError, match="boolean"):
+        evidence("provider", "model", policy_allowed=1)
+    with pytest.raises(ValueError, match="unsupported"):
+        ProviderCapabilityAdvisory("host", "provider", "model", "NOT_A_DISPOSITION", (), (), (), ("reason",))
+    with pytest.raises(ValueError, match="cannot create authority"):
+        ProviderCapabilityBrokerDecision((), ("reason",), provider_selection_changed=True)
+    with pytest.raises(TypeError, match="ProviderCapabilityAdvisory"):
+        ProviderCapabilityBrokerDecision((object(),), ("reason",))
+    with pytest.raises(TypeError, match="requirements"):
+        broker_provider_capabilities(object(), (), ())
+    with pytest.raises(TypeError, match="host_options"):
+        broker_provider_capabilities(ProviderCapabilityRequirements(), (object(),), ())
+    with pytest.raises(TypeError, match="evidence_profiles"):
+        broker_provider_capabilities(ProviderCapabilityRequirements(), (), (object(),))
+    with pytest.raises(ValueError, match="unique host/provider/model"):
+        broker_provider_capabilities(
+            ProviderCapabilityRequirements(), (), (evidence("provider", "model"), evidence("provider", "model"))
+        )

--- a/tests/runtime/test_provider_capability_broker.py
+++ b/tests/runtime/test_provider_capability_broker.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import pytest
+
+from orchestra_runtime.domain.adaptive.provider_capability import (
+    HostProviderModelOption,
+    ProviderCapabilityEvidence,
+    ProviderCapabilityRequirements,
+    broker_provider_capabilities,
+)
+
+
+def evidence(provider: str, model: str, **overrides: object) -> ProviderCapabilityEvidence:
+    values: dict[str, object] = {
+        "host_id": "fixture-host",
+        "provider_id": provider,
+        "model_id": model,
+        "capability_dispositions": (("TOOL_CALLING", "SUPPORTED_VERIFIED"), ("VISION_MULTIMODAL_INPUT", "SUPPORTED_WITH_LIMITS")),
+        "evidence_refs": (f"fixture:{provider}:{model}",),
+    }
+    values.update(overrides)
+    return ProviderCapabilityEvidence(**values)
+
+
+def option(provider: str, model: str, **overrides: object) -> HostProviderModelOption:
+    values: dict[str, object] = {"host_id": "fixture-host", "provider_id": provider, "model_id": model}
+    values.update(overrides)
+    return HostProviderModelOption(**values)
+
+
+def test_broker_returns_all_classifications_without_selection() -> None:
+    decision = broker_provider_capabilities(
+        ProviderCapabilityRequirements(("TOOL_CALLING", "VISION_MULTIMODAL_INPUT")),
+        (option("alpha", "full"), option("beta", "missing"), option("gamma", "unknown"), option("delta", "blocked", policy_allowed=False)),
+        (
+            evidence("alpha", "full"),
+            evidence("beta", "missing", capability_dispositions=(("TOOL_CALLING", "UNSUPPORTED"), ("VISION_MULTIMODAL_INPUT", "SUPPORTED_VERIFIED"))),
+            evidence("gamma", "unknown", freshness_status="UNKNOWN"),
+        ),
+    )
+    assert [(item.provider_id, item.disposition) for item in decision.advisories] == [
+        ("alpha", "ELIGIBLE_WITH_LIMITS"),
+        ("beta", "INELIGIBLE"),
+        ("delta", "POLICY_BLOCKED"),
+        ("gamma", "UNKNOWN"),
+    ]
+    assert decision.shadow_only is True
+    assert decision.provider_selection_changed is False
+    assert decision.automatic_provider_switching is False
+    assert decision.automatic_provider_fallback is False
+    assert decision.learned_routing_promotion is False
+    assert decision.specialist_routing_changed is False
+    assert decision.workflow_topology_changed is False
+
+
+def test_missing_profile_is_unknown_and_stale_evidence_cannot_be_eligible() -> None:
+    decision = broker_provider_capabilities(
+        ProviderCapabilityRequirements(("TOOL_CALLING",)),
+        (option("missing", "model"), option("stale", "model")),
+        (evidence("stale", "model", freshness_status="STALE"),),
+    )
+    assert [item.disposition for item in decision.advisories] == ["UNKNOWN", "UNKNOWN"]
+    assert all(item.evidence_refs == () for item in decision.advisories if item.provider_id == "missing")
+
+
+def test_duplicate_identities_and_authority_expansion_fail_closed() -> None:
+    with pytest.raises(ValueError, match="unique host/provider/model"):
+        broker_provider_capabilities(ProviderCapabilityRequirements(), (option("alpha", "model"), option("alpha", "model")), ())
+    with pytest.raises(ValueError, match="cannot create authority"):
+        from orchestra_runtime.domain.adaptive.provider_capability import ProviderCapabilityAdvisory
+
+        ProviderCapabilityAdvisory("host", "provider", "model", "UNKNOWN", (), (), (), ("reason",), provider_selection_authority=True)

--- a/tests/runtime/test_provider_model_capability_contract.py
+++ b/tests/runtime/test_provider_model_capability_contract.py
@@ -105,3 +105,13 @@ def test_contract_policy_cannot_authorize_provider_switching_or_learning() -> No
     assert any(error.startswith("SCHEMA_VALIDATION:evidence_policy") for error in errors)
     assert "AUTHORITY_OR_EVIDENCE_POLICY_DRIFT:evidence_policy.provider_switching_authorized" in errors
     assert "AUTHORITY_OR_EVIDENCE_POLICY_DRIFT:evidence_policy.learned_routing_promotion_authorized" in errors
+
+
+def test_broker_policy_is_shadow_only() -> None:
+    contract, schema = _canonical()
+    broker_policy = contract["broker_policy"]
+    assert isinstance(broker_policy, dict)
+    broker_policy["automatic_provider_switching"] = True
+    errors = validate_payload(contract, schema)
+    assert any(error.startswith("SCHEMA_VALIDATION:broker_policy") for error in errors)
+    assert "AUTHORITY_OR_BROKER_POLICY_DRIFT:broker_policy.automatic_provider_switching" in errors


### PR DESCRIPTION
## Summary\n- add a deterministic provider/model capability broker as shadow-only advisory output\n- classify eligible, limited, ineligible, unknown, and policy-blocked options from exact host/provider/model evidence\n- enforce no provider selection, switching, fallback, learned promotion, specialist routing, or workflow-topology authority\n- update the canonical provider contract, schema, validator, docs, and projections\n\n## Validation\n- focused UAI-7 and adjacent runtime tests: 23 passed\n- provider and host capability validators\n- runtime architecture boundaries\n- strict governance\n- structure, manifest, stale-reference, machine-contract, and IDE packaging validators\n- staged runtime guardrail\n\nNo provider profiles, credentials, automatic routing/fallback, or learned routing promotion are included.