### PR TITLE
test(uai): cover negative and unknown capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased UAI-8 negative and unknown capability testing
+
+- Adds a focused 15-scenario matrix for known, missing, unknown, contradictory, stale, policy-blocked, partial, and authority-expanding host/provider/transport/projection inputs.
+- Verifies existing fail-closed contracts without adding provider selection, automatic switching or fallback, learned routing, specialist-routing authority, AWF topology changes, credentials, release, or deployment behavior.
+
 ## Unreleased UAI-7 provider capability broker shadow advisory
 
 - Adds a deterministic shadow-only provider/model capability broker that classifies host-exposed options using task requirements, current evidence, and policy restrictions.

--- a/README.json
+++ b/README.json
@@ -2233,15 +2233,16 @@
       "next_action": "FINAL_EXACT_HEAD_RELEASE_QUALIFICATION"
     },
     "universal_adaptive_integration_uai": {
-      "status": "UAI_7_PROVIDER_CAPABILITY_BROKER_SHADOW_ADVISORY_COMPLETE",
-      "purpose": "Versioned host and provider/model capability evidence, deterministic minimal transport selection and non-executing transport fallback planning, shadow-only provider/model eligibility advice, and canonical-source-backed portable projection parity that preserve Conductor specialist routing and AWF workflow topology without authority expansion.",
+      "status": "UAI_8_NEGATIVE_UNKNOWN_CAPABILITY_TESTING_COMPLETE",
+      "purpose": "Versioned host and provider/model capability evidence, deterministic minimal transport selection and non-executing transport fallback planning, shadow-only provider/model eligibility advice, canonical-source-backed portable projection parity, and fail-closed negative and unknown capability testing that preserve Conductor specialist routing and AWF workflow topology without authority expansion.",
       "human_sources": [
         "adapters/github-copilot/README.md",
         "adapters/github-copilot/probe-guide.md",
         "docs/setup/HOST_CAPABILITY_CONTRACT.md",
         "docs/setup/PROVIDER_MODEL_CAPABILITY_CONTRACT.md",
         "docs/setup/PORTABLE_PROJECTION_COMPILER.md",
-        "docs/setup/TRANSPORT_FALLBACK_INTEGRATION.md"
+        "docs/setup/TRANSPORT_FALLBACK_INTEGRATION.md",
+        "docs/setup/UAI_NEGATIVE_UNKNOWN_TESTING.md"
       ],
       "machine_sources": [
         "adapters/github-copilot/copilot-instructions.template.md",
@@ -2265,7 +2266,8 @@
         "machine/schemas/portable-projection-index.v1.schema.json",
         "machine/projections/portable-projection-index.v1.json",
         "scripts/compile_portable_projections.py",
-        "tests/runtime/test_portable_projection_compiler.py"
+        "tests/runtime/test_portable_projection_compiler.py",
+        "tests/runtime/test_uai8_negative_unknown_capabilities.py"
       ],
       "probed_hosts": [
         "github-copilot"
@@ -2388,14 +2390,17 @@
     "provider_model_capability_contract": "machine/providers/provider-model-capability-contract.v1.json",
     "provider_model_capability_contract_schema": "machine/schemas/provider-model-capability-contract.v1.schema.json",
     "provider_capability_broker": "orchestra_runtime/domain/adaptive/provider_capability.py",
+    "negative_unknown_capability_testing": "tests/runtime/test_uai8_negative_unknown_capabilities.py",
     "integration_strategy_policy": "machine/hosts/integration-strategy-policy.v1.json",
     "integration_strategy_policy_schema": "machine/schemas/integration-strategy-policy.v1.schema.json",
     "transport_fallback_guide": "docs/setup/TRANSPORT_FALLBACK_INTEGRATION.md",
+    "negative_unknown_capability_testing_guide": "docs/setup/UAI_NEGATIVE_UNKNOWN_TESTING.md",
     "portable_projection_contract": "machine/projections/portable-projection-contract.v1.json",
     "portable_projection_contract_schema": "machine/schemas/portable-projection-contract.v1.schema.json",
     "portable_projection_index_schema": "machine/schemas/portable-projection-index.v1.schema.json",
     "portable_projection_index": "machine/projections/portable-projection-index.v1.json",
     "portable_projection_compiler": "scripts/compile_portable_projections.py",
+    "negative_unknown_capability_testing": "tests/runtime/test_uai8_negative_unknown_capabilities.py",
     "prap_certification_contract": "machine/protocol/prap-certification-contract.v1.json",
     "developer_portal_catalog": "machine/developer-portal/catalog.v1.json",
     "murmurs_presentation_policy": "machine/presentation/murmurs-policy.v1.json",
@@ -2713,6 +2718,7 @@
     "host_capability_contract": "docs/setup/HOST_CAPABILITY_CONTRACT.md",
     "provider_model_capability_contract": "docs/setup/PROVIDER_MODEL_CAPABILITY_CONTRACT.md",
     "portable_projection_compiler": "docs/setup/PORTABLE_PROJECTION_COMPILER.md",
+    "negative_unknown_capability_testing": "docs/setup/UAI_NEGATIVE_UNKNOWN_TESTING.md",
     "validation": "docs/setup/VALIDATION.md",
     "developer_portal": "docs/developer/README.md",
     "mcp_transport": "docs/developer/MCP_STDIO_TRANSPORT.md",

--- a/docs/README.md
+++ b/docs/README.md
@@ -109,6 +109,7 @@ Cross-repository continuity may be supplied by a user-selected external continui
 - [UAI Provider/Model Capability Contract](setup/PROVIDER_MODEL_CAPABILITY_CONTRACT.md): provider/model-neutral technical capability vocabulary, evidence boundaries, and shadow-only eligibility advice without provider selection.
 - [UAI Portable Projection Compiler](setup/PORTABLE_PROJECTION_COMPILER.md): canonical-source-backed host projection parity without installed-integration refresh or authority expansion.
 - [UAI Transport and Fallback Integration](setup/TRANSPORT_FALLBACK_INTEGRATION.md): deterministic non-executing transport fallback planning without provider switching or routing authority.
+- [UAI Negative and Unknown Capability Testing](setup/UAI_NEGATIVE_UNKNOWN_TESTING.md): fail-closed host, provider/model, transport, fallback, and projection boundary scenarios.
 - [Adapter SDK and PRAP v1](setup/ADAPTER_SDK_PRAP.md): stable adapter SDK and deterministic compatibility certification.
 - [Developer Portal](developer/README.md): extension and integration discovery surface.
 - [MCP stdio Transport](developer/MCP_STDIO_TRANSPORT.md): first bounded MCP tools transport.

--- a/docs/setup/UAI_NEGATIVE_UNKNOWN_TESTING.md
+++ b/docs/setup/UAI_NEGATIVE_UNKNOWN_TESTING.md
@@ -1,0 +1,38 @@
+# UAI negative and unknown capability testing
+
+UAI-8 exercises the fail-closed boundaries already defined by the host
+capability contract, provider/model shadow broker, transport resolver, and
+portable projection compiler. It is evidence work, not a new authority layer.
+
+The executable matrix is
+`tests/runtime/test_uai8_negative_unknown_capabilities.py`:
+
+| Scenario | Expected result |
+| --- | --- |
+| Known host with admitted capability evidence | Current Copilot evidence validates with Conductor `SUPPORTED_WITH_LIMITS` and Ponytail `SUPPORTED_VERIFIED`. |
+| Known host missing an expected surface | Provider/model advice is `UNKNOWN` with `MISSING_CAPABILITY_EVIDENCE`. |
+| Unknown but capability-compatible host | Advice may be `ELIGIBLE`, but remains shadow-only and non-authorizing. |
+| Host identity contradicts observed capability | Host validation emits `COPILOT_STATUS_DRIFT`. |
+| Policy-disabled MCP/plugin/tools | No eligible transport produces `UNSUPPORTED_FAIL_CLOSED`. |
+| Instruction-only host | `INSTRUCTION_ONLY_FALLBACK` is selectable as a bounded transport surface. |
+| Supported host with unsupported provider/model | Provider/model advice is `INELIGIBLE`. |
+| Unknown provider with declared but unverified capability | Advice is `UNKNOWN`. |
+| Stale provider capability | Advice is `UNKNOWN` and records stale/unknown evidence. |
+| Tool access without execution authority | Host and broker authority flags remain false. |
+| Host/provider selection attempts to alter specialist routing | The broker rejects the authority-expanding decision. |
+| Unauthorized automatic provider switching | The broker rejects automatic switching. |
+| Partial installation | Unverified MCP is rejected and instruction-only transport is selected. |
+| Stale generated projection | Projection parity validation fails closed. |
+| Fallback governance preservation | Fallback remains transport-only, non-automatic, and provider-neutral. |
+
+These tests do not admit new hosts, providers, models, credentials, transport
+implementations, automatic fallback, learned routing, or specialist-routing
+authority. In particular:
+
+- `CONDUCTOR_IS_SOLE_INTERNAL_SPECIALIST_ROUTER` remains the routing invariant;
+- `CLEAR_OWNERSHIP` can enable a direct single-specialist fast route, but does
+  not bypass Conductor;
+- `FAST_ROUTE` is not a router bypass;
+- UAI transport selection is not AWF specialist routing;
+- provider capability advice does not select, switch, or promote a provider or
+  model.

--- a/machine/developer-portal/catalog.v1.json
+++ b/machine/developer-portal/catalog.v1.json
@@ -119,6 +119,13 @@
       "authority_role": "NON_EXECUTING_TRANSPORT_FALLBACK_GUIDANCE"
     },
     {
+      "id": "uai-negative-unknown-capability-testing-guide",
+      "title": "UAI Negative and Unknown Capability Testing guide",
+      "kind": "human_guide",
+      "path": "docs/setup/UAI_NEGATIVE_UNKNOWN_TESTING.md",
+      "authority_role": "FAIL_CLOSED_EVIDENCE_GUIDANCE_WITHOUT_AUTHORITY"
+    },
+    {
       "id": "uai-portable-projection-contract",
       "title": "UAI Portable Projection Contract",
       "kind": "machine_contract",

--- a/tests/runtime/test_uai8_negative_unknown_capabilities.py
+++ b/tests/runtime/test_uai8_negative_unknown_capabilities.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+from pathlib import Path
+import shutil
+
+import pytest
+from orchestra_runtime.domain.adaptive.integration_strategy import (
+    IntegrationStrategy,
+    IntegrationStrategyRequirements,
+    TransportCapabilityEvidence,
+    resolve_integration_strategy,
+    resolve_transport_fallback,
+)
+from orchestra_runtime.domain.adaptive.provider_capability import (
+    HostProviderModelOption,
+    ProviderCapabilityAdvisory,
+    ProviderCapabilityBrokerDecision,
+    ProviderCapabilityEvidence,
+    ProviderCapabilityRequirements,
+    broker_provider_capabilities,
+)
+from scripts.compile_portable_projections import (
+    CONTRACT_PATH,
+    CONTRACT_SCHEMA_PATH,
+    validate_contract,
+)
+from scripts.validate_host_capability_contract import validate_payload as validate_host_payload
+
+
+ROOT = Path(__file__).resolve().parents[2]
+HOST_CONTRACT_PATH = ROOT / "machine" / "hosts" / "capability-contract.v1.json"
+HOST_SCHEMA_PATH = ROOT / "machine" / "schemas" / "host-capability-contract.v1.schema.json"
+PROJECTION_CONTRACT_PATH = ROOT / CONTRACT_PATH
+
+
+def _load(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _provider_evidence(
+    host_id: str,
+    provider_id: str,
+    model_id: str,
+    disposition: str = "SUPPORTED_VERIFIED",
+    **overrides: object,
+) -> ProviderCapabilityEvidence:
+    values: dict[str, object] = {
+        "host_id": host_id,
+        "provider_id": provider_id,
+        "model_id": model_id,
+        "capability_dispositions": (("TOOL_CALLING", disposition),),
+        "evidence_refs": (f"uai8:{host_id}:{provider_id}:{model_id}",),
+    }
+    values.update(overrides)
+    return ProviderCapabilityEvidence(**values)
+
+
+def _transport(
+    strategy: IntegrationStrategy,
+    disposition: str = "SUPPORTED_VERIFIED",
+    *,
+    provided: tuple[str, ...] = ("SPECIALIST_ROUTING_INSTRUCTION",),
+    policy_allowed: bool = True,
+    installation_complexity: int = 0,
+) -> TransportCapabilityEvidence:
+    return TransportCapabilityEvidence(
+        strategy_id=strategy,
+        disposition=disposition,
+        provided_capabilities=provided,
+        evidence_refs=(f"uai8:transport:{strategy.value}",),
+        policy_allowed=policy_allowed,
+        installation_complexity=installation_complexity,
+    )
+
+
+def test_known_host_with_admitted_capability_evidence_is_current() -> None:
+    contract = _load(HOST_CONTRACT_PATH)
+    schema = _load(HOST_SCHEMA_PATH)
+    assert validate_host_payload(contract, schema) == []
+    profile = contract["profiles"][0]
+    capabilities = {item["capability_id"]: item["disposition"] for item in profile["capabilities"]}
+    assert capabilities["orchestra_command_recognition_conductor"] == "SUPPORTED_WITH_LIMITS"
+    assert capabilities["orchestra_specialist_recognition_ponytail"] == "SUPPORTED_VERIFIED"
+    assert all(value is False for value in contract["authority"].values())
+
+
+def test_known_host_missing_expected_surface_is_unknown() -> None:
+    decision = broker_provider_capabilities(
+        ProviderCapabilityRequirements(("TOOL_CALLING",)),
+        (HostProviderModelOption("github-copilot", "declared-provider", "declared-model"),),
+        (_provider_evidence("github-copilot", "declared-provider", "declared-model", capability_dispositions=(("OTHER", "SUPPORTED_VERIFIED"),)),),
+    )
+    assert decision.advisories[0].disposition == "UNKNOWN"
+    assert decision.advisories[0].reason_codes == ("MISSING_CAPABILITY_EVIDENCE",)
+
+
+def test_unknown_capability_compatible_host_remains_non_authorizing_advice() -> None:
+    decision = broker_provider_capabilities(
+        ProviderCapabilityRequirements(("TOOL_CALLING",)),
+        (HostProviderModelOption("unknown-host", "provider", "model"),),
+        (_provider_evidence("unknown-host", "provider", "model"),),
+    )
+    advisory = decision.advisories[0]
+    assert advisory.disposition == "ELIGIBLE"
+    assert advisory.shadow_only is True
+    assert advisory.provider_selection_authority is False
+    assert advisory.specialist_routing_changed is False
+    assert decision.provider_selection_changed is False
+
+
+def test_host_identity_claims_contradict_observed_copilot_capability() -> None:
+    contract = deepcopy(_load(HOST_CONTRACT_PATH))
+    schema = _load(HOST_SCHEMA_PATH)
+    profile = contract["profiles"][0]
+    capability = next(item for item in profile["capabilities"] if item["capability_id"] == "orchestra_command_recognition_conductor")
+    capability["disposition"] = "UNSUPPORTED"
+    errors = validate_host_payload(contract, schema)
+    assert "COPILOT_STATUS_DRIFT:orchestra_command_recognition_conductor:UNSUPPORTED:SUPPORTED_WITH_LIMITS" in errors
+
+
+def test_policy_disabled_transport_fails_closed() -> None:
+    decision = resolve_integration_strategy(
+        IntegrationStrategyRequirements(("SPECIALIST_ROUTING_INSTRUCTION",)),
+        (_transport(IntegrationStrategy.MCP_TRANSPORT, policy_allowed=False),),
+    )
+    assert decision.selected_strategy is IntegrationStrategy.UNSUPPORTED_FAIL_CLOSED
+    assert decision.fail_closed is True
+
+
+def test_instruction_only_host_has_a_bounded_fallback_surface() -> None:
+    decision = resolve_integration_strategy(
+        IntegrationStrategyRequirements(("SPECIALIST_ROUTING_INSTRUCTION",)),
+        (_transport(IntegrationStrategy.INSTRUCTION_ONLY_FALLBACK),),
+    )
+    assert decision.selected_strategy is IntegrationStrategy.INSTRUCTION_ONLY_FALLBACK
+    assert decision.transport_selection_only is True
+    assert decision.specialist_routing_changed is False
+
+
+def test_supported_host_with_unsupported_provider_model_is_ineligible() -> None:
+    decision = broker_provider_capabilities(
+        ProviderCapabilityRequirements(("TOOL_CALLING",)),
+        (HostProviderModelOption("github-copilot", "unsupported-provider", "unsupported-model"),),
+        (_provider_evidence("github-copilot", "unsupported-provider", "unsupported-model", "UNSUPPORTED"),),
+    )
+    assert decision.advisories[0].disposition == "INELIGIBLE"
+
+
+def test_unknown_provider_declared_capability_is_not_verified() -> None:
+    decision = broker_provider_capabilities(
+        ProviderCapabilityRequirements(("TOOL_CALLING",)),
+        (HostProviderModelOption("github-copilot", "unknown-provider", "model"),),
+        (_provider_evidence("github-copilot", "unknown-provider", "model", "AVAILABLE_NOT_YET_VERIFIED"),),
+    )
+    assert decision.advisories[0].disposition == "UNKNOWN"
+
+
+def test_stale_provider_capability_is_unknown() -> None:
+    decision = broker_provider_capabilities(
+        ProviderCapabilityRequirements(("TOOL_CALLING",)),
+        (HostProviderModelOption("github-copilot", "stale-provider", "model"),),
+        (_provider_evidence("github-copilot", "stale-provider", "model", freshness_status="STALE"),),
+    )
+    assert decision.advisories[0].disposition == "UNKNOWN"
+    assert decision.advisories[0].reason_codes == ("STALE_OR_UNKNOWN_EVIDENCE",)
+
+
+def test_tool_access_does_not_create_execution_or_routing_authority() -> None:
+    contract = _load(HOST_CONTRACT_PATH)
+    authority = contract["authority"]
+    assert authority["capability_grants_execution_authority"] is False
+    assert authority["capability_grants_routing_authority"] is False
+    advisory = broker_provider_capabilities(
+        ProviderCapabilityRequirements(("TOOL_CALLING",)),
+        (HostProviderModelOption("github-copilot", "provider", "model"),),
+        (_provider_evidence("github-copilot", "provider", "model"),),
+    ).advisories[0]
+    assert advisory.provider_selection_authority is False
+    assert advisory.workflow_topology_changed is False
+
+
+def test_provider_advice_cannot_change_specialist_routing() -> None:
+    with pytest.raises(ValueError, match="cannot create authority"):
+        ProviderCapabilityAdvisory(
+            "host",
+            "provider",
+            "model",
+            "ELIGIBLE",
+            (),
+            (),
+            (),
+            ("reason",),
+            specialist_routing_changed=True,
+        )
+
+
+def test_provider_broker_cannot_switch_provider_automatically() -> None:
+    with pytest.raises(ValueError, match="cannot create authority"):
+        ProviderCapabilityBrokerDecision(
+            (),
+            ("reason",),
+            automatic_provider_switching=True,
+        )
+
+
+def test_partial_installation_uses_instruction_only_transport_fallback() -> None:
+    decision = resolve_integration_strategy(
+        IntegrationStrategyRequirements(("SPECIALIST_ROUTING_INSTRUCTION",)),
+        (
+            _transport(IntegrationStrategy.MCP_TRANSPORT, "AVAILABLE_NOT_YET_VERIFIED"),
+            _transport(IntegrationStrategy.INSTRUCTION_ONLY_FALLBACK, installation_complexity=2),
+        ),
+    )
+    assert decision.selected_strategy is IntegrationStrategy.INSTRUCTION_ONLY_FALLBACK
+    assert any(strategy == "MCP_TRANSPORT" for strategy, _ in decision.rejected_strategies)
+
+
+def test_stale_generated_projection_fails_closed(tmp_path: Path) -> None:
+    contract = _load(PROJECTION_CONTRACT_PATH)
+    paths = {CONTRACT_PATH, CONTRACT_SCHEMA_PATH}
+    paths.update(source["path"] for source in contract["canonical_sources"])
+    paths.update(projection["output_path"] for projection in contract["projections"])
+    for relative_path in paths:
+        source_path = ROOT / relative_path
+        target_path = tmp_path / relative_path
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_path, target_path)
+    target = tmp_path / contract["projections"][0]["output_path"]
+    content = target.read_text(encoding="utf-8")
+    target.write_text(content.replace("CONDUCTOR_IS_SOLE_INTERNAL_SPECIALIST_ROUTER", "CONDUCTOR_ROUTER_MARKER_REMOVED", 1), encoding="utf-8")
+    errors, _ = validate_contract(tmp_path)
+    assert "PARITY_MISSING:github-copilot-repository-instructions-template:conductor-sole-router" in errors
+
+
+def test_transport_fallback_preserves_governance_and_never_selects_a_provider() -> None:
+    decision = resolve_transport_fallback(
+        IntegrationStrategyRequirements(("SPECIALIST_ROUTING_INSTRUCTION",)),
+        (
+            _transport(IntegrationStrategy.MCP_TRANSPORT, installation_complexity=0),
+            _transport(IntegrationStrategy.INSTRUCTION_ONLY_FALLBACK, installation_complexity=1),
+        ),
+    )
+    assert decision.fail_closed is False
+    assert decision.transport_fallback_only is True
+    assert decision.automatic_provider_fallback is False
+    assert decision.primary_decision.provider_selection_changed is False
+    assert decision.primary_decision.specialist_routing_changed is False
+    assert decision.primary_decision.workflow_topology_changed is False
+    assert "FALLBACK_NON_AUTOMATIC" in decision.reason_codes
+    assert "PROVIDER_FALLBACK_PROHIBITED" in decision.reason_codes


### PR DESCRIPTION
## Summary\n- add the UAI-8 15-scenario negative and unknown capability matrix\n- document fail-closed host, provider/model, transport, fallback, and projection boundaries\n- update the UAI capability index, documentation map, portal catalog, and changelog\n\n## Scope\nTest and documentation evidence only. No provider selection, automatic switching or fallback, learned routing, specialist-routing authority, AWF topology change, credentials, release, or deployment behavior.\n\n## Validation\n- python -B scripts/validate_host_capability_contract.py\n- python -B scripts/validate_provider_model_capability_contract.py\n- python -B scripts/compile_portable_projections.py\n- python -B scripts/validation/validate_architecture_boundaries.py\n- python -B scripts/validate_machine_contracts.py\n- python -B -m pytest -q tests/runtime (2634 passed, 10 subtests passed)