### PR TITLE
test(uai): add cross-host capability conformance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased UAI-9 cross-host capability conformance
+
+- Adds an evidence-bound comparison matrix for Antigravity, Codex, and GitHub Copilot across discovery, capabilities, transport, specialist ownership, authority, validation, permissions, fallback, provider/model boundaries, and projection parity.
+- Keeps only the observed Copilot profile admitted; Antigravity and Codex remain unknown/not admitted, with no fabricated evidence or provider/model selection behavior.
+
 ## Unreleased UAI-8 negative and unknown capability testing
 
 - Adds a focused 15-scenario matrix for known, missing, unknown, contradictory, stale, policy-blocked, partial, and authority-expanding host/provider/transport/projection inputs.

--- a/README.json
+++ b/README.json
@@ -2233,8 +2233,8 @@
       "next_action": "FINAL_EXACT_HEAD_RELEASE_QUALIFICATION"
     },
     "universal_adaptive_integration_uai": {
-      "status": "UAI_8_NEGATIVE_UNKNOWN_CAPABILITY_TESTING_COMPLETE",
-      "purpose": "Versioned host and provider/model capability evidence, deterministic minimal transport selection and non-executing transport fallback planning, shadow-only provider/model eligibility advice, canonical-source-backed portable projection parity, and fail-closed negative and unknown capability testing that preserve Conductor specialist routing and AWF workflow topology without authority expansion.",
+      "status": "UAI_9_CROSS_HOST_CAPABILITY_CONFORMANCE_COMPLETE",
+      "purpose": "Versioned host and provider/model capability evidence, deterministic minimal transport selection and non-executing transport fallback planning, shadow-only provider/model eligibility advice, canonical-source-backed portable projection parity, fail-closed negative and unknown capability testing, and evidence-bound cross-host conformance that preserve Conductor specialist routing and AWF workflow topology without authority expansion.",
       "human_sources": [
         "adapters/github-copilot/README.md",
         "adapters/github-copilot/probe-guide.md",
@@ -2242,7 +2242,8 @@
         "docs/setup/PROVIDER_MODEL_CAPABILITY_CONTRACT.md",
         "docs/setup/PORTABLE_PROJECTION_COMPILER.md",
         "docs/setup/TRANSPORT_FALLBACK_INTEGRATION.md",
-        "docs/setup/UAI_NEGATIVE_UNKNOWN_TESTING.md"
+        "docs/setup/UAI_NEGATIVE_UNKNOWN_TESTING.md",
+        "docs/setup/UAI_CROSS_HOST_CONFORMANCE.md"
       ],
       "machine_sources": [
         "adapters/github-copilot/copilot-instructions.template.md",
@@ -2267,7 +2268,8 @@
         "machine/projections/portable-projection-index.v1.json",
         "scripts/compile_portable_projections.py",
         "tests/runtime/test_portable_projection_compiler.py",
-        "tests/runtime/test_uai8_negative_unknown_capabilities.py"
+        "tests/runtime/test_uai8_negative_unknown_capabilities.py",
+        "tests/runtime/test_uai9_cross_host_capability_conformance.py"
       ],
       "probed_hosts": [
         "github-copilot"
@@ -2391,16 +2393,19 @@
     "provider_model_capability_contract_schema": "machine/schemas/provider-model-capability-contract.v1.schema.json",
     "provider_capability_broker": "orchestra_runtime/domain/adaptive/provider_capability.py",
     "negative_unknown_capability_testing": "tests/runtime/test_uai8_negative_unknown_capabilities.py",
+    "cross_host_capability_conformance": "tests/runtime/test_uai9_cross_host_capability_conformance.py",
     "integration_strategy_policy": "machine/hosts/integration-strategy-policy.v1.json",
     "integration_strategy_policy_schema": "machine/schemas/integration-strategy-policy.v1.schema.json",
     "transport_fallback_guide": "docs/setup/TRANSPORT_FALLBACK_INTEGRATION.md",
     "negative_unknown_capability_testing_guide": "docs/setup/UAI_NEGATIVE_UNKNOWN_TESTING.md",
+    "cross_host_capability_conformance_guide": "docs/setup/UAI_CROSS_HOST_CONFORMANCE.md",
     "portable_projection_contract": "machine/projections/portable-projection-contract.v1.json",
     "portable_projection_contract_schema": "machine/schemas/portable-projection-contract.v1.schema.json",
     "portable_projection_index_schema": "machine/schemas/portable-projection-index.v1.schema.json",
     "portable_projection_index": "machine/projections/portable-projection-index.v1.json",
     "portable_projection_compiler": "scripts/compile_portable_projections.py",
     "negative_unknown_capability_testing": "tests/runtime/test_uai8_negative_unknown_capabilities.py",
+    "cross_host_capability_conformance": "tests/runtime/test_uai9_cross_host_capability_conformance.py",
     "prap_certification_contract": "machine/protocol/prap-certification-contract.v1.json",
     "developer_portal_catalog": "machine/developer-portal/catalog.v1.json",
     "murmurs_presentation_policy": "machine/presentation/murmurs-policy.v1.json",
@@ -2719,6 +2724,7 @@
     "provider_model_capability_contract": "docs/setup/PROVIDER_MODEL_CAPABILITY_CONTRACT.md",
     "portable_projection_compiler": "docs/setup/PORTABLE_PROJECTION_COMPILER.md",
     "negative_unknown_capability_testing": "docs/setup/UAI_NEGATIVE_UNKNOWN_TESTING.md",
+    "cross_host_capability_conformance": "docs/setup/UAI_CROSS_HOST_CONFORMANCE.md",
     "validation": "docs/setup/VALIDATION.md",
     "developer_portal": "docs/developer/README.md",
     "mcp_transport": "docs/developer/MCP_STDIO_TRANSPORT.md",

--- a/docs/README.md
+++ b/docs/README.md
@@ -110,6 +110,7 @@ Cross-repository continuity may be supplied by a user-selected external continui
 - [UAI Portable Projection Compiler](setup/PORTABLE_PROJECTION_COMPILER.md): canonical-source-backed host projection parity without installed-integration refresh or authority expansion.
 - [UAI Transport and Fallback Integration](setup/TRANSPORT_FALLBACK_INTEGRATION.md): deterministic non-executing transport fallback planning without provider switching or routing authority.
 - [UAI Negative and Unknown Capability Testing](setup/UAI_NEGATIVE_UNKNOWN_TESTING.md): fail-closed host, provider/model, transport, fallback, and projection boundary scenarios.
+- [UAI Cross-Host Capability Conformance](setup/UAI_CROSS_HOST_CONFORMANCE.md): evidence-bound comparison of Antigravity, Codex, and GitHub Copilot without fabricated admissions.
 - [Adapter SDK and PRAP v1](setup/ADAPTER_SDK_PRAP.md): stable adapter SDK and deterministic compatibility certification.
 - [Developer Portal](developer/README.md): extension and integration discovery surface.
 - [MCP stdio Transport](developer/MCP_STDIO_TRANSPORT.md): first bounded MCP tools transport.

--- a/docs/setup/UAI_CROSS_HOST_CONFORMANCE.md
+++ b/docs/setup/UAI_CROSS_HOST_CONFORMANCE.md
@@ -1,0 +1,35 @@
+# UAI cross-host capability conformance
+
+UAI-9 compares the three plan-named host identities against the canonical
+evidence boundary: Antigravity, Codex, and GitHub Copilot. The current source
+contains fresh observed evidence for GitHub Copilot only. Antigravity and Codex
+remain explicitly unadmitted and are not represented by synthetic profiles.
+
+The executable conformance checks are in
+`tests/runtime/test_uai9_cross_host_capability_conformance.py`.
+
+| Surface | GitHub Copilot | Antigravity and Codex |
+| --- | --- | --- |
+| Discovery and host identity | Admitted profile with current observation evidence | Unknown/not admitted; no fabricated profile |
+| Capability dispositions | Mixed: Conductor `SUPPORTED_WITH_LIMITS`, Ponytail `SUPPORTED_VERIFIED`, and other observed or unverified dimensions | Unknown |
+| Transport compatibility | Host-neutral strategies; unverified or locally unsupported surfaces remain bounded | Unknown |
+| Specialist ownership | Conductor remains the sole internal specialist router; Ponytail is the observed specialist surface | Unknown, so no ownership is inferred |
+| Authority | All host authority grants and automatic provider flags are `false` | No host-specific authority exists |
+| Validation and projection | Host/provider contracts and portable projection parity validate with `PASS` | No evidence to validate or promote |
+| Permission and policy | Permission and organization/account policy dimensions remain `AVAILABLE_NOT_YET_VERIFIED` | Unknown |
+| Fallback | Only deterministic, non-executing transport fallback policy applies | No fallback is selected without evidence |
+| Provider/model | No provider/model profiles are admitted; shadow broker remains non-authorizing | Unknown |
+
+This phase does not run the unavailable Copilot `/conductor` surface retest and
+does not promote `SUPPORTED_WITH_LIMITS`. It also does not add hosts, providers,
+models, credentials, transport implementations, automatic routing or fallback,
+learned routing, concurrency, AWF topology changes, release, or deployment.
+
+The routing boundaries remain explicit:
+
+- `CONDUCTOR_IS_SOLE_INTERNAL_SPECIALIST_ROUTER`;
+- `CLEAR_OWNERSHIP != CONDUCTOR_BYPASS`;
+- `CLEAR_OWNERSHIP MAY_ENABLE DIRECT_SINGLE_SPECIALIST_FAST_ROUTE`;
+- `FAST_ROUTE != ROUTER_BYPASS`;
+- `UAI_TRANSPORT_SELECTION != AWF_SPECIALIST_ROUTING`;
+- `AWF = WORKFLOW TOPOLOGY OWNER`.

--- a/machine/developer-portal/catalog.v1.json
+++ b/machine/developer-portal/catalog.v1.json
@@ -126,6 +126,13 @@
       "authority_role": "FAIL_CLOSED_EVIDENCE_GUIDANCE_WITHOUT_AUTHORITY"
     },
     {
+      "id": "uai-cross-host-capability-conformance-guide",
+      "title": "UAI Cross-Host Capability Conformance guide",
+      "kind": "human_guide",
+      "path": "docs/setup/UAI_CROSS_HOST_CONFORMANCE.md",
+      "authority_role": "EVIDENCE_BOUND_CROSS_HOST_COMPARISON_WITHOUT_AUTHORITY"
+    },
+    {
       "id": "uai-portable-projection-contract",
       "title": "UAI Portable Projection Contract",
       "kind": "machine_contract",

--- a/tests/runtime/test_uai9_cross_host_capability_conformance.py
+++ b/tests/runtime/test_uai9_cross_host_capability_conformance.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.compile_portable_projections import compile_projections
+from scripts.validate_host_capability_contract import validate_payload as validate_host_payload
+from scripts.validate_provider_model_capability_contract import validate_payload as validate_provider_payload
+
+
+ROOT = Path(__file__).resolve().parents[2]
+HOST_CONTRACT_PATH = ROOT / "machine" / "hosts" / "capability-contract.v1.json"
+HOST_SCHEMA_PATH = ROOT / "machine" / "schemas" / "host-capability-contract.v1.schema.json"
+PROVIDER_CONTRACT_PATH = ROOT / "machine" / "providers" / "provider-model-capability-contract.v1.json"
+PROVIDER_SCHEMA_PATH = ROOT / "machine" / "schemas" / "provider-model-capability-contract.v1.schema.json"
+DECLARED_HOSTS = ("antigravity", "codex", "github-copilot")
+
+
+def _load(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_cross_host_matrix_does_not_fabricate_unobserved_host_evidence() -> None:
+    contract = _load(HOST_CONTRACT_PATH)
+    schema = _load(HOST_SCHEMA_PATH)
+    assert validate_host_payload(contract, schema) == []
+    profiles = {profile["host_id"]: profile for profile in contract["profiles"]}
+
+    assert set(profiles) == {"github-copilot"}
+    assert "antigravity" not in profiles
+    assert "codex" not in profiles
+
+    for host_id in DECLARED_HOSTS:
+        if host_id in profiles:
+            assert profiles[host_id]["evidence"]["freshness"]["status"] == "CURRENT_AT_OBSERVATION"
+        else:
+            assert host_id in {"antigravity", "codex"}
+
+
+def test_copilot_conformance_covers_discovery_capability_ownership_and_permissions() -> None:
+    contract = _load(HOST_CONTRACT_PATH)
+    profile = contract["profiles"][0]
+    capabilities = {item["capability_id"]: item for item in profile["capabilities"]}
+    dimensions = {item["category"] for item in profile["capabilities"]}
+
+    assert dimensions == set(contract["capability_dimensions"])
+    assert capabilities["orchestra_command_recognition_conductor"]["disposition"] == "SUPPORTED_WITH_LIMITS"
+    assert capabilities["orchestra_specialist_recognition_ponytail"]["disposition"] == "SUPPORTED_VERIFIED"
+    assert capabilities["approval_and_permission_controls"]["disposition"] == "AVAILABLE_NOT_YET_VERIFIED"
+    assert capabilities["organization_or_account_policy_restrictions"]["disposition"] == "AVAILABLE_NOT_YET_VERIFIED"
+    assert all(value is False for value in profile["authority"].values())
+
+    transports = {item["strategy_id"]: item for item in profile["transport_compatibility"]}
+    assert transports["INSTRUCTION_ONLY_FALLBACK"]["disposition"] == "AVAILABLE_NOT_YET_VERIFIED"
+    assert transports["UNSUPPORTED_FAIL_CLOSED"]["disposition"] == "SUPPORTED_VERIFIED"
+    assert all(item["host_neutral"] is True for item in contract["transport_strategies"])
+
+
+def test_cross_host_validation_provider_boundary_and_projection_parity_remain_canonical() -> None:
+    provider_contract = _load(PROVIDER_CONTRACT_PATH)
+    assert validate_provider_payload(provider_contract, _load(PROVIDER_SCHEMA_PATH)) == []
+    assert provider_contract["provider_model_profiles"] == []
+    assert provider_contract["broker_policy"]["provider_selection_changed"] is False
+    assert provider_contract["broker_policy"]["automatic_provider_switching"] is False
+    assert provider_contract["broker_policy"]["automatic_provider_fallback"] is False
+
+    errors, index = compile_projections(ROOT)
+    assert errors == []
+    assert index is not None
+    assert index["parity_status"] == "PASS"
+    assert all(projection["parity"] == "PASS" for projection in index["projections"])


### PR DESCRIPTION
## Summary\n- add UAI-9 conformance checks for Antigravity, Codex, and GitHub Copilot\n- keep only the observed Copilot profile admitted and unobserved hosts unknown/not admitted\n- document cross-host discovery, capability, transport, ownership, authority, permission, fallback, provider/model, validation, and projection boundaries\n\n## Scope\nEvidence and documentation only. No fabricated host evidence, provider/model admission, automatic routing or fallback, learned routing, credentials, release, deployment, or UAI-3 implementation.\n\n## Validation\n- focused conformance and adjacent UAI tests: 30 passed\n- python -B scripts/validate_host_capability_contract.py\n- python -B scripts/validate_provider_model_capability_contract.py\n- python -B scripts/compile_portable_projections.py\n- python -B scripts/validation/validate_architecture_boundaries.py\n- python -B scripts/validate_machine_contracts.py