### PR TITLE
test(uai): record maturity closeout boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased UAI-10 maturity and closeout
+
+- Records UAI maturity boundaries after cross-host conformance: Copilot remains the only admitted observed host, provider/model profiles remain empty, transport fallback remains non-executing, and projections remain derived-only.
+- Explicitly keeps the focused Copilot Conductor retest promotion-only and excludes provider routing/fallback, learned routing, concurrency widening, AR-3, AR-4, release, deployment, marketplace, credentials, and policy activation.
+
 ## Unreleased UAI-9 cross-host capability conformance
 
 - Adds an evidence-bound comparison matrix for Antigravity, Codex, and GitHub Copilot across discovery, capabilities, transport, specialist ownership, authority, validation, permissions, fallback, provider/model boundaries, and projection parity.

--- a/README.json
+++ b/README.json
@@ -2233,8 +2233,8 @@
       "next_action": "FINAL_EXACT_HEAD_RELEASE_QUALIFICATION"
     },
     "universal_adaptive_integration_uai": {
-      "status": "UAI_9_CROSS_HOST_CAPABILITY_CONFORMANCE_COMPLETE",
-      "purpose": "Versioned host and provider/model capability evidence, deterministic minimal transport selection and non-executing transport fallback planning, shadow-only provider/model eligibility advice, canonical-source-backed portable projection parity, fail-closed negative and unknown capability testing, and evidence-bound cross-host conformance that preserve Conductor specialist routing and AWF workflow topology without authority expansion.",
+      "status": "UAI_10_MATURITY_AND_CLOSEOUT_COMPLETE",
+      "purpose": "Versioned host and provider/model capability evidence, deterministic minimal transport selection and non-executing transport fallback planning, shadow-only provider/model eligibility advice, canonical-source-backed portable projection parity, fail-closed negative and unknown capability testing, evidence-bound cross-host conformance, and maturity closeout that preserve Conductor specialist routing and AWF workflow topology without authority expansion or release implications.",
       "human_sources": [
         "adapters/github-copilot/README.md",
         "adapters/github-copilot/probe-guide.md",
@@ -2243,7 +2243,8 @@
         "docs/setup/PORTABLE_PROJECTION_COMPILER.md",
         "docs/setup/TRANSPORT_FALLBACK_INTEGRATION.md",
         "docs/setup/UAI_NEGATIVE_UNKNOWN_TESTING.md",
-        "docs/setup/UAI_CROSS_HOST_CONFORMANCE.md"
+        "docs/setup/UAI_CROSS_HOST_CONFORMANCE.md",
+        "docs/setup/UAI_MATURITY_CLOSEOUT.md"
       ],
       "machine_sources": [
         "adapters/github-copilot/copilot-instructions.template.md",
@@ -2269,7 +2270,8 @@
         "scripts/compile_portable_projections.py",
         "tests/runtime/test_portable_projection_compiler.py",
         "tests/runtime/test_uai8_negative_unknown_capabilities.py",
-        "tests/runtime/test_uai9_cross_host_capability_conformance.py"
+        "tests/runtime/test_uai9_cross_host_capability_conformance.py",
+        "tests/runtime/test_uai10_maturity_closeout.py"
       ],
       "probed_hosts": [
         "github-copilot"
@@ -2394,11 +2396,13 @@
     "provider_capability_broker": "orchestra_runtime/domain/adaptive/provider_capability.py",
     "negative_unknown_capability_testing": "tests/runtime/test_uai8_negative_unknown_capabilities.py",
     "cross_host_capability_conformance": "tests/runtime/test_uai9_cross_host_capability_conformance.py",
+    "maturity_closeout": "tests/runtime/test_uai10_maturity_closeout.py",
     "integration_strategy_policy": "machine/hosts/integration-strategy-policy.v1.json",
     "integration_strategy_policy_schema": "machine/schemas/integration-strategy-policy.v1.schema.json",
     "transport_fallback_guide": "docs/setup/TRANSPORT_FALLBACK_INTEGRATION.md",
     "negative_unknown_capability_testing_guide": "docs/setup/UAI_NEGATIVE_UNKNOWN_TESTING.md",
     "cross_host_capability_conformance_guide": "docs/setup/UAI_CROSS_HOST_CONFORMANCE.md",
+    "maturity_closeout_guide": "docs/setup/UAI_MATURITY_CLOSEOUT.md",
     "portable_projection_contract": "machine/projections/portable-projection-contract.v1.json",
     "portable_projection_contract_schema": "machine/schemas/portable-projection-contract.v1.schema.json",
     "portable_projection_index_schema": "machine/schemas/portable-projection-index.v1.schema.json",
@@ -2406,6 +2410,7 @@
     "portable_projection_compiler": "scripts/compile_portable_projections.py",
     "negative_unknown_capability_testing": "tests/runtime/test_uai8_negative_unknown_capabilities.py",
     "cross_host_capability_conformance": "tests/runtime/test_uai9_cross_host_capability_conformance.py",
+    "maturity_closeout": "tests/runtime/test_uai10_maturity_closeout.py",
     "prap_certification_contract": "machine/protocol/prap-certification-contract.v1.json",
     "developer_portal_catalog": "machine/developer-portal/catalog.v1.json",
     "murmurs_presentation_policy": "machine/presentation/murmurs-policy.v1.json",
@@ -2725,6 +2730,7 @@
     "portable_projection_compiler": "docs/setup/PORTABLE_PROJECTION_COMPILER.md",
     "negative_unknown_capability_testing": "docs/setup/UAI_NEGATIVE_UNKNOWN_TESTING.md",
     "cross_host_capability_conformance": "docs/setup/UAI_CROSS_HOST_CONFORMANCE.md",
+    "maturity_closeout": "docs/setup/UAI_MATURITY_CLOSEOUT.md",
     "validation": "docs/setup/VALIDATION.md",
     "developer_portal": "docs/developer/README.md",
     "mcp_transport": "docs/developer/MCP_STDIO_TRANSPORT.md",

--- a/docs/README.md
+++ b/docs/README.md
@@ -111,6 +111,7 @@ Cross-repository continuity may be supplied by a user-selected external continui
 - [UAI Transport and Fallback Integration](setup/TRANSPORT_FALLBACK_INTEGRATION.md): deterministic non-executing transport fallback planning without provider switching or routing authority.
 - [UAI Negative and Unknown Capability Testing](setup/UAI_NEGATIVE_UNKNOWN_TESTING.md): fail-closed host, provider/model, transport, fallback, and projection boundary scenarios.
 - [UAI Cross-Host Capability Conformance](setup/UAI_CROSS_HOST_CONFORMANCE.md): evidence-bound comparison of Antigravity, Codex, and GitHub Copilot without fabricated admissions.
+- [UAI Maturity and Closeout](setup/UAI_MATURITY_CLOSEOUT.md): current UAI maturity boundaries, limitations, and deferred authority without release implications.
 - [Adapter SDK and PRAP v1](setup/ADAPTER_SDK_PRAP.md): stable adapter SDK and deterministic compatibility certification.
 - [Developer Portal](developer/README.md): extension and integration discovery surface.
 - [MCP stdio Transport](developer/MCP_STDIO_TRANSPORT.md): first bounded MCP tools transport.

--- a/docs/setup/UAI_MATURITY_CLOSEOUT.md
+++ b/docs/setup/UAI_MATURITY_CLOSEOUT.md
@@ -1,0 +1,32 @@
+# UAI maturity and closeout
+
+UAI-10 closes the current Universal Adaptive Integration sequence after the
+UAI-9 cross-host conformance evidence. It records maturity boundaries and
+current limitations. It is not a release, deployment, marketplace publication,
+credential change, policy activation, or provider-routing promotion.
+
+The executable closeout checks are in
+`tests/runtime/test_uai10_maturity_closeout.py`.
+
+| Boundary | Current canonical disposition |
+| --- | --- |
+| Host capability | GitHub Copilot is the only admitted observed host profile. Its Conductor capability remains `SUPPORTED_WITH_LIMITS`; Ponytail remains `SUPPORTED_VERIFIED`. |
+| Copilot retest | One focused `/conductor` live retest remains required for promotion only. The unavailable Copilot surface does not block UAI-2 through UAI-10. |
+| Provider/model capability | No provider/model profiles are admitted. The broker remains shadow advisory and cannot select, switch, or fall back between providers/models. |
+| Transport | Integration strategy and fallback remain deterministic, non-executing, policy-allowed transport decisions. |
+| Routing and workflow | Conductor remains the sole internal specialist router and AWF remains the workflow-topology owner. `CLEAR_OWNERSHIP` does not bypass Conductor; a direct single-specialist fast route is still distinct from a router bypass. |
+| Projection | Canonical-source-backed projections are current with parity `PASS`; generated projections remain derived-only. |
+| Unobserved hosts | Antigravity and Codex remain unknown/not admitted. No capability or authority is inferred for them. |
+| Deferred work | UAI-3 implementation, automatic provider routing/fallback, learned routing promotion, concurrency widening, AR-3, AR-4, release, deployment, and marketplace work remain outside this closeout. |
+
+The closeout therefore establishes:
+
+- `CONDUCTOR_IS_SOLE_INTERNAL_SPECIALIST_ROUTER`;
+- `CLEAR_OWNERSHIP != CONDUCTOR_BYPASS`;
+- `CLEAR_OWNERSHIP MAY_ENABLE DIRECT_SINGLE_SPECIALIST_FAST_ROUTE`;
+- `FAST_ROUTE != ROUTER_BYPASS`;
+- `HOST != PROVIDER` and `PROVIDER != SPECIALIST`;
+- `CAPABILITY != AUTHORITY`;
+- `TRANSPORT != WORKFLOW` and `UAI_TRANSPORT_SELECTION != AWF_SPECIALIST_ROUTING`;
+- `MODEL_SELECTION != GOVERNANCE`;
+- `AWF = WORKFLOW TOPOLOGY OWNER`.

--- a/machine/developer-portal/catalog.v1.json
+++ b/machine/developer-portal/catalog.v1.json
@@ -133,6 +133,13 @@
       "authority_role": "EVIDENCE_BOUND_CROSS_HOST_COMPARISON_WITHOUT_AUTHORITY"
     },
     {
+      "id": "uai-maturity-closeout-guide",
+      "title": "UAI Maturity and Closeout guide",
+      "kind": "human_guide",
+      "path": "docs/setup/UAI_MATURITY_CLOSEOUT.md",
+      "authority_role": "MATURITY_BOUNDARY_GUIDANCE_WITHOUT_RELEASE_OR_AUTHORITY"
+    },
+    {
       "id": "uai-portable-projection-contract",
       "title": "UAI Portable Projection Contract",
       "kind": "machine_contract",

--- a/tests/runtime/test_uai10_maturity_closeout.py
+++ b/tests/runtime/test_uai10_maturity_closeout.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.compile_portable_projections import compile_projections
+from scripts.validate_host_capability_contract import validate_payload as validate_host_payload
+from scripts.validate_provider_model_capability_contract import validate_payload as validate_provider_payload
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load(relative_path: str) -> dict[str, object]:
+    return json.loads((ROOT / relative_path).read_text(encoding="utf-8"))
+
+
+def test_uai_maturity_is_layered_and_authority_bounded() -> None:
+    host = _load("machine/hosts/capability-contract.v1.json")
+    provider = _load("machine/providers/provider-model-capability-contract.v1.json")
+    integration = _load("machine/hosts/integration-strategy-policy.v1.json")
+    projection = _load("machine/projections/portable-projection-contract.v1.json")
+
+    assert validate_host_payload(host, _load("machine/schemas/host-capability-contract.v1.schema.json")) == []
+    assert validate_provider_payload(provider, _load("machine/schemas/provider-model-capability-contract.v1.schema.json")) == []
+    assert provider["provider_model_profiles"] == []
+    assert integration["authority"] == {
+        "transport_selection_only": True,
+        "specialist_routing_changed": False,
+        "workflow_topology_changed": False,
+        "provider_selection_changed": False,
+        "automatic_fallback": False,
+        "credentials_mutated": False,
+    }
+    assert projection["authority"]["canonical_source_remains_authoritative"] is True
+    assert projection["authority"]["generated_projection_is_derived_only"] is True
+    assert all(value is False for key, value in projection["authority"].items() if key != "canonical_source_remains_authoritative" and key != "generated_projection_is_derived_only")
+
+
+def test_uai_closeout_retains_observed_host_limits_and_retest_boundary() -> None:
+    readme = _load("README.json")
+    uai = readme["capabilities"]["universal_adaptive_integration_uai"]
+
+    assert uai["status"] == "UAI_10_MATURITY_AND_CLOSEOUT_COMPLETE"
+    assert uai["probed_hosts"] == ["github-copilot"]
+    assert uai["copilot_conductor_status"] == "SUPPORTED_WITH_LIMITS"
+    assert uai["copilot_ponytail_status"] == "SUPPORTED_VERIFIED"
+    assert uai["authority_expansion"] is False
+    assert uai["automatic_provider_routing"] is False
+    assert uai["automatic_provider_fallback"] is False
+    assert uai["learned_routing_promotion"] is False
+
+
+def test_uai_closeout_projection_parity_is_current_without_release_claim() -> None:
+    errors, index = compile_projections(ROOT)
+    assert errors == []
+    assert index is not None
+    assert index["parity_status"] == "PASS"
+    assert all(item["parity"] == "PASS" for item in index["projections"])
+    assert _load("README.json")["release_state"]["current_public_release"] == "v1.9.0"


### PR DESCRIPTION
## Summary\n- add UAI-10 maturity and closeout verification\n- preserve Copilot Conductor SUPPORTED_WITH_LIMITS and promotion-only live retest boundary\n- document non-authorizing provider/model, transport, fallback, projection, host, and release boundaries\n\n## Scope\nTests and documentation only. No release, deployment, marketplace publication, credentials, policy activation, provider routing/fallback, learned routing, concurrency widening, AR-3, AR-4, or UAI-3 implementation.\n\n## Validation\n- python -B -m pytest -q tests/runtime/test_uai10_maturity_closeout.py tests/runtime/test_uai9_cross_host_capability_conformance.py tests/runtime/test_uai8_negative_unknown_capabilities.py (21 passed)\n- python -B scripts/validate_host_capability_contract.py\n- python -B scripts/validate_provider_model_capability_contract.py\n- python -B scripts/compile_portable_projections.py\n- python -B scripts/validation/validate_architecture_boundaries.py\n- python -B scripts/validate_machine_contracts.py