### PR TITLE
feat: define AQ-1 adaptive assurance doctrine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased ADAPT-QA AQ-1 normative doctrine
+
+- Adds the machine-readable AQ-1 assurance contract, strict schema, pure domain validation rules, seven doctrine fixtures, and discoverable architecture documentation.
+- Keeps source-truth labels, explicit completion-state evidence, reconciliation gates, Conductor routing, provider boundaries, AQ-2 through AQ-14, and CUD10 authorization unchanged.
+
 ## v1.10.0 Universal Adaptive Integration and Conductor Routing - published
 
 - Packages the additive post-v1.9.0 UAI-0 through UAI-10 completion, including the canonical host capability contract, strategy/transport boundaries, portable projections, deterministic fallback planning, shadow-only provider capability classification, negative capability tests, cross-host conformance, and maturity closeout.

--- a/README.json
+++ b/README.json
@@ -2600,7 +2600,8 @@
     "portable_adaptive_memory_reference": "docs/architecture/PORTABLE_ADAPTIVE_MEMORY.md",
     "registry_query_optimization_o7_reference": "docs/architecture/REGISTRY_QUERY_OPTIMIZATION_O7.md",
     "historical_status_policy": "Phase documents may retain phase-era status wording. Current exact state comes from live machine contracts, release evidence, and Git identity.",
-    "adaptive_agentic_workflow_awf": "docs/architecture/ADAPTIVE_AGENTIC_WORKFLOW_AWF.md"
+    "adaptive_agentic_workflow_awf": "docs/architecture/ADAPTIVE_AGENTIC_WORKFLOW_AWF.md",
+    "adaptive_assurance_aq1_reference": "docs/architecture/ADAPTIVE_ASSURANCE_AQ1.md"
   },
   "hosts_integrations": {
     "host_update_contract": "machine/hosts/update-contract.v1.json",
@@ -2856,7 +2857,8 @@
     "adaptive_agentic_workflow_awf": "AWF_N1_N5_COMPLETE_CANONICAL_VERIFIED",
     "adaptive_agentic_workflow_intake_n1_n3": "IMPLEMENTATION_CANDIDATE",
     "adaptive_agentic_workflow_semantic_robustness_n5": "IMPLEMENTATION_CANDIDATE",
-    "adaptive_agentic_workflow_advanced_adaptation_n6": "COMPLETE_CANONICAL_VERIFIED_NO_PROMOTION"
+    "adaptive_agentic_workflow_advanced_adaptation_n6": "COMPLETE_CANONICAL_VERIFIED_NO_PROMOTION",
+    "adaptive_assurance_aq1": "IMPLEMENTATION_CANDIDATE_AQ2_AND_CUD10_NOT_AUTHORIZED"
   },
   "ai_review_guidance": {
     "preferred_entrypoint": "README.json",

--- a/docs/architecture/ADAPTIVE_ASSURANCE_AQ1.md
+++ b/docs/architecture/ADAPTIVE_ASSURANCE_AQ1.md
@@ -1,0 +1,63 @@
+# ADAPT-QA AQ-1: Normative Assurance Doctrine
+
+Status: contract defined for AQ-1. AQ-2 and later phases are not implemented by this document or its runtime surface.
+
+## Purpose
+
+ADAPT-QA is Orchestra-derived assurance doctrine for selecting an appropriate development and evidence posture. It is not an external normative standard. AQ-1 defines the minimum vocabulary and gates so that a work item cannot silently turn a prototype, inferred behavior, or domain-only implementation into a product-complete claim.
+
+The canonical planning authority is the Padayon record at `projects/orchestra/10-approved/plans/Orchestra_ADAPT_QA_Repository_Assurance_Enhancement_Plan_20260907.md#AQ-1`, read from Padayon canonical main at the AQ-1 admission boundary.
+
+The machine contract is [`aq1-normative-doctrine.v1.json`](../../machine/adaptive/aq1-normative-doctrine.v1.json), validated by [`adaptive-assurance-doctrine.v1.schema.json`](../../machine/schemas/adaptive-assurance-doctrine.v1.schema.json). The pure domain rules are in [`assurance.py`](../../orchestra_runtime/domain/adaptive/assurance.py).
+
+## Development modes
+
+Every bounded work item selects one of these methodology-neutral modes:
+
+- `SPEC_FIRST`: requirement, invariant, implementation, and test are traced before completion is claimed.
+- `DISCOVERY_FIRST`: a prototype may precede documentation, but product completion requires reconciliation.
+- `AS_BUILT`: observed behavior is reconstructed without inventing historical intent.
+- `RECONCILIATION`: conflicting source records are made explicit and resolved under authority.
+- `DEFECT_DRIVEN`: the assurance slice is organized around a reproduced defect and its regression evidence.
+- `MAINTENANCE`: an existing behavior is changed or preserved with evidence proportional to the change.
+
+Transitions among all six declared modes are supported. The plan's illustrative sequence `DISCOVERY_FIRST -> PROTOTYPE -> SYSTEM_TO_DOCS -> RECONCILIATION -> HARDENING -> CANONICAL` describes intermediate work posture, not additional declared mode values.
+
+## Source truth
+
+Every behavioral statement is labeled exactly once as:
+
+- `OBSERVED`: directly established by source, execution, or recorded evidence.
+- `INFERRED`: a reasoned interpretation that has not been made authoritative.
+- `DECIDED`: an authorized resolution or requirement.
+- `UNVERIFIED`: present but not qualified for completion claims.
+
+`INFERRED` evidence cannot become `DECIDED` without an authority reference. `UNVERIFIED` evidence cannot qualify completion.
+
+## Completion states
+
+The explicit completion vocabulary is:
+
+`IDEATED`, `PROTOTYPED`, `DOMAIN_IMPLEMENTED`, `APPLICATION_INTEGRATED`, `API_INTEGRATED`, `UI_INTEGRATED`, `UNIT_VERIFIED`, `CONTRACT_VERIFIED`, `INTEGRATION_VERIFIED`, `RUNTIME_VERIFIED`, `SECURITY_VERIFIED`, `ADVERSARIALLY_VERIFIED`, `CANONICAL_VERIFIED`, and `PRODUCT_COMPLETE`.
+
+These are explicit claims, not an implied ladder. A lower state does not prove any higher state. `CANONICAL_VERIFIED` qualifies source identity and evidence binding only; it does not prove empirical effectiveness. `DOMAIN_IMPLEMENTED` does not prove application integration.
+
+`PRODUCT_COMPLETE` requires explicit evidence. A `DISCOVERY_FIRST` item also requires an explicit reconciliation qualification, and an item containing `DOMAIN_IMPLEMENTED` must contain explicit `APPLICATION_INTEGRATED` evidence before product completion.
+
+## Validation fixtures
+
+The contract defines seven fixtures for the AQ-1 boundary:
+
+1. `SPEC_FIRST` traces requirement -> invariant -> implementation -> test.
+2. `DISCOVERY_FIRST` permits a prototype before documentation.
+3. `DISCOVERY_FIRST` blocks `PRODUCT_COMPLETE` until reconciliation.
+4. `AS_BUILT` reconstruction does not invent historical intent.
+5. Conflicting documentation and code select `RECONCILIATION`.
+6. `INFERRED` cannot become `DECIDED` without authority.
+7. Completion-state escalation without evidence fails closed.
+
+The focused executable coverage is [`test_adaptive_assurance_aq1.py`](../../tests/runtime/test_adaptive_assurance_aq1.py).
+
+## Authority and boundaries
+
+Conductor remains the router, Ponytail owns implementation, Overseer owns validation strategy and evidence review, and Arbiter owns transition disposition. AQ-1 changes no routing authority, provider eligibility, external integration, or governance gate. AQ-2 through AQ-14 remain outside this implementation, and CUD10 remains held and unauthorized by this phase.

--- a/docs/reference/architecture/README.md
+++ b/docs/reference/architecture/README.md
@@ -7,6 +7,7 @@ This section is a curated entry point into the existing architecture records.
 - [Runtime architecture boundaries](../../../machine/governance/runtime-architecture-boundaries.v1.json)
 - [Router-first architecture](../../routing/ROUTER_FIRST_ARCHITECTURE.md)
 - [Adaptive Agentic Workflow](../../architecture/ADAPTIVE_AGENTIC_WORKFLOW_AWF.md)
+- [ADAPT-QA AQ-1 normative doctrine](../../architecture/ADAPTIVE_ASSURANCE_AQ1.md)
 - [UAI host capability contract](../../setup/HOST_CAPABILITY_CONTRACT.md)
 - [UAI cross-host conformance](../../setup/UAI_CROSS_HOST_CONFORMANCE.md)
 - [UAI maturity and closeout](../../setup/UAI_MATURITY_CLOSEOUT.md)

--- a/machine/adaptive/aq1-normative-doctrine.v1.json
+++ b/machine/adaptive/aq1-normative-doctrine.v1.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "../schemas/adaptive-assurance-doctrine.v1.schema.json",
+  "schema_version": "orchestra.adaptive-assurance-doctrine.v1",
+  "phase": "AQ1_NORMATIVE_ADAPT_QA_DOCTRINE",
+  "status": "CONTRACT_DEFINED",
+  "source": {
+    "plan": "Padayon/projects/orchestra/10-approved/plans/Orchestra_ADAPT_QA_Repository_Assurance_Enhancement_Plan_20260907.md#AQ-1",
+    "reference_basis": "Padayon canonical main 64fcefd42bd606fe95116520e97f28292afacafb",
+    "derived_doctrine": true
+  },
+  "authority": {
+    "owner": "conductor",
+    "implementation_owner": "ponytail",
+    "validation_owner": "overseer",
+    "transition_owner": "arbiter",
+    "authority_expansion": false,
+    "routing_authority_change": false,
+    "provider_integration": "NONE",
+    "aq2_or_later_authorized": false,
+    "cud10_authorized": false
+  },
+  "development_modes": [
+    "SPEC_FIRST",
+    "DISCOVERY_FIRST",
+    "AS_BUILT",
+    "RECONCILIATION",
+    "DEFECT_DRIVEN",
+    "MAINTENANCE"
+  ],
+  "mode_transition": {
+    "supported": true,
+    "all_declared_modes_supported": true,
+    "example_sequence": [
+      "DISCOVERY_FIRST",
+      "PROTOTYPE",
+      "SYSTEM_TO_DOCS",
+      "RECONCILIATION",
+      "HARDENING",
+      "CANONICAL"
+    ]
+  },
+  "source_truth_labels": ["OBSERVED", "INFERRED", "DECIDED", "UNVERIFIED"],
+  "completion_states": [
+    "IDEATED",
+    "PROTOTYPED",
+    "DOMAIN_IMPLEMENTED",
+    "APPLICATION_INTEGRATED",
+    "API_INTEGRATED",
+    "UI_INTEGRATED",
+    "UNIT_VERIFIED",
+    "CONTRACT_VERIFIED",
+    "INTEGRATION_VERIFIED",
+    "RUNTIME_VERIFIED",
+    "SECURITY_VERIFIED",
+    "ADVERSARIALLY_VERIFIED",
+    "CANONICAL_VERIFIED",
+    "PRODUCT_COMPLETE"
+  ],
+  "completion_policy": {
+    "lower_state_does_not_imply_higher_state": true,
+    "state_evidence_required": true,
+    "canonical_verified_proves_empirical_effectiveness": false,
+    "canonical_verified_scope": "SOURCE_AND_EVIDENCE_QUALIFICATION_ONLY",
+    "domain_only_implies_application_integration": false,
+    "product_complete_requires_explicit_evidence": true,
+    "discovery_first_product_complete_requires_reconciliation": true,
+    "inferred_requires_authority_for_decided": true
+  },
+  "validation_fixtures": [
+    {
+      "id": "AQ1-F1",
+      "mode": "SPEC_FIRST",
+      "scenario": "A feature follows requirement to invariant to implementation to test.",
+      "required_evidence": ["REQUIREMENT", "INVARIANT", "IMPLEMENTATION", "TEST"],
+      "expected_disposition": "ADVANCE_WITH_EVIDENCE"
+    },
+    {
+      "id": "AQ1-F2",
+      "mode": "DISCOVERY_FIRST",
+      "scenario": "A prototype is allowed before documentation exists.",
+      "required_evidence": ["PROTOTYPE"],
+      "expected_disposition": "ALLOW_PROTOTYPE_ONLY"
+    },
+    {
+      "id": "AQ1-F3",
+      "mode": "DISCOVERY_FIRST",
+      "scenario": "A discovery-first work item cannot become product complete before reconciliation.",
+      "required_evidence": ["RECONCILIATION"],
+      "expected_disposition": "REQUIRE_RECONCILIATION"
+    },
+    {
+      "id": "AQ1-F4",
+      "mode": "AS_BUILT",
+      "scenario": "Reconstruction records observed behavior without inventing historical intent.",
+      "required_evidence": ["OBSERVED_BEHAVIOR", "HISTORICAL_INTENT_AUTHORITY"],
+      "expected_disposition": "AUTHORITY_REQUIRED"
+    },
+    {
+      "id": "AQ1-F5",
+      "mode": "RECONCILIATION",
+      "scenario": "Conflicting documentation and code selects reconciliation.",
+      "required_evidence": ["CONFLICT_RECORD", "RECONCILIATION_DECISION"],
+      "expected_disposition": "RECONCILIATION_REQUIRED"
+    },
+    {
+      "id": "AQ1-F6",
+      "mode": "AS_BUILT",
+      "scenario": "An inferred statement cannot become decided without authority.",
+      "required_evidence": ["INFERRED_STATEMENT", "AUTHORITY_RECORD"],
+      "expected_disposition": "AUTHORITY_REQUIRED"
+    },
+    {
+      "id": "AQ1-F7",
+      "mode": "MAINTENANCE",
+      "scenario": "Completion-state escalation without evidence fails closed.",
+      "required_evidence": ["TARGET_STATE_EVIDENCE"],
+      "expected_disposition": "FAIL_CLOSED_NO_EVIDENCE"
+    }
+  ],
+  "future_boundary": {
+    "aq2": "NOT_IMPLEMENTED",
+    "aq3_to_a14": "NOT_IMPLEMENTED",
+    "cud10": "NOT_AUTHORIZED"
+  },
+  "human_documentation": "docs/architecture/ADAPTIVE_ASSURANCE_AQ1.md"
+}

--- a/machine/schemas/adaptive-assurance-doctrine.v1.schema.json
+++ b/machine/schemas/adaptive-assurance-doctrine.v1.schema.json
@@ -1,0 +1,186 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://orchestra.local/schemas/adaptive-assurance-doctrine.v1.schema.json",
+  "title": "Orchestra Adaptive Assurance Doctrine v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schema_version",
+    "phase",
+    "status",
+    "source",
+    "authority",
+    "development_modes",
+    "mode_transition",
+    "source_truth_labels",
+    "completion_states",
+    "completion_policy",
+    "validation_fixtures",
+    "future_boundary",
+    "human_documentation"
+  ],
+  "properties": {
+    "$schema": {"type": "string", "minLength": 1},
+    "schema_version": {"const": "orchestra.adaptive-assurance-doctrine.v1"},
+    "phase": {"const": "AQ1_NORMATIVE_ADAPT_QA_DOCTRINE"},
+    "status": {"const": "CONTRACT_DEFINED"},
+    "source": {"$ref": "#/$defs/source"},
+    "authority": {"$ref": "#/$defs/authority"},
+    "development_modes": {
+      "type": "array",
+      "minItems": 6,
+      "maxItems": 6,
+      "uniqueItems": true,
+      "items": {"enum": ["SPEC_FIRST", "DISCOVERY_FIRST", "AS_BUILT", "RECONCILIATION", "DEFECT_DRIVEN", "MAINTENANCE"]}
+    },
+    "mode_transition": {"$ref": "#/$defs/mode_transition"},
+    "source_truth_labels": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 4,
+      "uniqueItems": true,
+      "items": {"enum": ["OBSERVED", "INFERRED", "DECIDED", "UNVERIFIED"]}
+    },
+    "completion_states": {
+      "type": "array",
+      "minItems": 14,
+      "maxItems": 14,
+      "uniqueItems": true,
+      "items": {"enum": [
+        "IDEATED",
+        "PROTOTYPED",
+        "DOMAIN_IMPLEMENTED",
+        "APPLICATION_INTEGRATED",
+        "API_INTEGRATED",
+        "UI_INTEGRATED",
+        "UNIT_VERIFIED",
+        "CONTRACT_VERIFIED",
+        "INTEGRATION_VERIFIED",
+        "RUNTIME_VERIFIED",
+        "SECURITY_VERIFIED",
+        "ADVERSARIALLY_VERIFIED",
+        "CANONICAL_VERIFIED",
+        "PRODUCT_COMPLETE"
+      ]}
+    },
+    "completion_policy": {"$ref": "#/$defs/completion_policy"},
+    "validation_fixtures": {
+      "type": "array",
+      "minItems": 7,
+      "maxItems": 7,
+      "items": {"$ref": "#/$defs/fixture"}
+    },
+    "future_boundary": {"$ref": "#/$defs/future_boundary"},
+    "human_documentation": {"const": "docs/architecture/ADAPTIVE_ASSURANCE_AQ1.md"}
+  },
+  "$defs": {
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["plan", "reference_basis", "derived_doctrine"],
+      "properties": {
+        "plan": {"type": "string", "minLength": 1},
+        "reference_basis": {"type": "string", "minLength": 1},
+        "derived_doctrine": {"const": true}
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "owner",
+        "implementation_owner",
+        "validation_owner",
+        "transition_owner",
+        "authority_expansion",
+        "routing_authority_change",
+        "provider_integration",
+        "aq2_or_later_authorized",
+        "cud10_authorized"
+      ],
+      "properties": {
+        "owner": {"const": "conductor"},
+        "implementation_owner": {"const": "ponytail"},
+        "validation_owner": {"const": "overseer"},
+        "transition_owner": {"const": "arbiter"},
+        "authority_expansion": {"const": false},
+        "routing_authority_change": {"const": false},
+        "provider_integration": {"const": "NONE"},
+        "aq2_or_later_authorized": {"const": false},
+        "cud10_authorized": {"const": false}
+      }
+    },
+    "mode_transition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["supported", "all_declared_modes_supported", "example_sequence"],
+      "properties": {
+        "supported": {"const": true},
+        "all_declared_modes_supported": {"const": true},
+        "example_sequence": {
+          "const": ["DISCOVERY_FIRST", "PROTOTYPE", "SYSTEM_TO_DOCS", "RECONCILIATION", "HARDENING", "CANONICAL"]
+        }
+      }
+    },
+    "completion_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "lower_state_does_not_imply_higher_state",
+        "state_evidence_required",
+        "canonical_verified_proves_empirical_effectiveness",
+        "canonical_verified_scope",
+        "domain_only_implies_application_integration",
+        "product_complete_requires_explicit_evidence",
+        "discovery_first_product_complete_requires_reconciliation",
+        "inferred_requires_authority_for_decided"
+      ],
+      "properties": {
+        "lower_state_does_not_imply_higher_state": {"const": true},
+        "state_evidence_required": {"const": true},
+        "canonical_verified_proves_empirical_effectiveness": {"const": false},
+        "canonical_verified_scope": {"const": "SOURCE_AND_EVIDENCE_QUALIFICATION_ONLY"},
+        "domain_only_implies_application_integration": {"const": false},
+        "product_complete_requires_explicit_evidence": {"const": true},
+        "discovery_first_product_complete_requires_reconciliation": {"const": true},
+        "inferred_requires_authority_for_decided": {"const": true}
+      }
+    },
+    "fixture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "mode", "scenario", "required_evidence", "expected_disposition"],
+      "properties": {
+        "id": {"type": "string", "pattern": "^AQ1-F[1-7]$"},
+        "mode": {"enum": ["SPEC_FIRST", "DISCOVERY_FIRST", "AS_BUILT", "RECONCILIATION", "DEFECT_DRIVEN", "MAINTENANCE"]},
+        "scenario": {"type": "string", "minLength": 1},
+        "required_evidence": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "expected_disposition": {
+          "enum": [
+            "ADVANCE_WITH_EVIDENCE",
+            "ALLOW_PROTOTYPE_ONLY",
+            "REQUIRE_RECONCILIATION",
+            "RECONCILIATION_REQUIRED",
+            "AUTHORITY_REQUIRED",
+            "FAIL_CLOSED_NO_EVIDENCE"
+          ]
+        }
+      }
+    },
+    "future_boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["aq2", "aq3_to_a14", "cud10"],
+      "properties": {
+        "aq2": {"const": "NOT_IMPLEMENTED"},
+        "aq3_to_a14": {"const": "NOT_IMPLEMENTED"},
+        "cud10": {"const": "NOT_AUTHORIZED"}
+      }
+    }
+  }
+}

--- a/orchestra_runtime/domain/adaptive/__init__.py
+++ b/orchestra_runtime/domain/adaptive/__init__.py
@@ -5,6 +5,19 @@ from .advanced_adaptation import (
     PromotionCandidateDecision,
     evaluate_advanced_adaptation_admission,
 )
+from .assurance import (
+    AQ1_DOCTRINE_SCHEMA_VERSION,
+    COMPLETION_STATES,
+    DEVELOPMENT_MODES,
+    SOURCE_TRUTH_LABELS,
+    AssuranceEvidence,
+    CompletionAssessment,
+    select_mode_for_evidence,
+    transition_mode,
+    validate_completion_escalation,
+    validate_development_mode,
+    validate_product_complete,
+)
 from .agentic_workflow import STOP_CONDITIONS, select_agentic_workflow
 from .intake import (
     DERIVATION_POLICY_SCHEMA_VERSION,
@@ -61,10 +74,16 @@ from .topology_validator import (
 
 __all__ = [
     "AUTHORITY_RULE",
+    "AQ1_DOCTRINE_SCHEMA_VERSION",
+    "AssuranceEvidence",
+    "COMPLETION_STATES",
+    "CompletionAssessment",
     "DERIVATION_POLICY_SCHEMA_VERSION",
+    "DEVELOPMENT_MODES",
     "ELIGIBLE_DISPOSITIONS",
     "INTEGRATION_STRATEGY_POLICY_VERSION",
     "SELECTION_TRACE_SCHEMA_VERSION",
+    "SOURCE_TRUTH_LABELS",
     "AUTHORITY_DOMAINS",
     "AUTHORITY_DOMAIN_OWNERS",
     "AUTHORITY_VIEW_SCHEMA_VERSION",
@@ -102,6 +121,11 @@ __all__ = [
     "TransportCapabilityEvidence",
     "parse_authority_view",
     "select_agentic_workflow",
+    "select_mode_for_evidence",
+    "transition_mode",
+    "validate_completion_escalation",
+    "validate_development_mode",
+    "validate_product_complete",
     "resolve_integration_strategy",
     "resolve_transport_fallback",
     "broker_provider_capabilities",

--- a/orchestra_runtime/domain/adaptive/assurance.py
+++ b/orchestra_runtime/domain/adaptive/assurance.py
@@ -1,0 +1,204 @@
+"""Pure domain rules for the AQ-1 adaptive assurance doctrine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+AQ1_DOCTRINE_SCHEMA_VERSION = "orchestra.adaptive-assurance-doctrine.v1"
+
+DEVELOPMENT_MODES = (
+    "SPEC_FIRST",
+    "DISCOVERY_FIRST",
+    "AS_BUILT",
+    "RECONCILIATION",
+    "DEFECT_DRIVEN",
+    "MAINTENANCE",
+)
+
+SOURCE_TRUTH_LABELS = ("OBSERVED", "INFERRED", "DECIDED", "UNVERIFIED")
+
+COMPLETION_STATES = (
+    "IDEATED",
+    "PROTOTYPED",
+    "DOMAIN_IMPLEMENTED",
+    "APPLICATION_INTEGRATED",
+    "API_INTEGRATED",
+    "UI_INTEGRATED",
+    "UNIT_VERIFIED",
+    "CONTRACT_VERIFIED",
+    "INTEGRATION_VERIFIED",
+    "RUNTIME_VERIFIED",
+    "SECURITY_VERIFIED",
+    "ADVERSARIALLY_VERIFIED",
+    "CANONICAL_VERIFIED",
+    "PRODUCT_COMPLETE",
+)
+
+
+def _text(value: object, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return value.strip()
+
+
+def _one_of(value: object, choices: tuple[str, ...], field_name: str) -> str:
+    normalized = _text(value, field_name)
+    if normalized not in choices:
+        raise ValueError(f"{field_name} must be one of {choices}")
+    return normalized
+
+
+def _states(values: Iterable[str]) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)):
+        raise TypeError("states must be an iterable of state strings")
+    normalized = tuple(_one_of(value, COMPLETION_STATES, "completion state") for value in values)
+    if len(normalized) != len(set(normalized)):
+        raise ValueError("completion states must not contain duplicates")
+    return normalized
+
+
+@dataclass(frozen=True, slots=True)
+class AssuranceEvidence:
+    evidence_id: str
+    claimed_state: str
+    source_truth: str
+    authority_ref: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "evidence_id", _text(self.evidence_id, "evidence_id"))
+        object.__setattr__(
+            self,
+            "claimed_state",
+            _one_of(self.claimed_state, COMPLETION_STATES, "claimed_state"),
+        )
+        object.__setattr__(
+            self,
+            "source_truth",
+            _one_of(self.source_truth, SOURCE_TRUTH_LABELS, "source_truth"),
+        )
+        if self.authority_ref is not None:
+            object.__setattr__(self, "authority_ref", _text(self.authority_ref, "authority_ref"))
+
+
+@dataclass(frozen=True, slots=True)
+class CompletionAssessment:
+    explicit_states: tuple[str, ...]
+    target_state: str
+    canonical_proves_empirical_effectiveness: bool = False
+    product_complete: bool = False
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "explicit_states", _states(self.explicit_states))
+        object.__setattr__(
+            self,
+            "target_state",
+            _one_of(self.target_state, COMPLETION_STATES, "target_state"),
+        )
+        if self.canonical_proves_empirical_effectiveness:
+            raise ValueError("CANONICAL_VERIFIED cannot prove empirical effectiveness")
+
+
+def validate_development_mode(mode: str) -> str:
+    """Return a declared mode or fail closed on an unknown mode."""
+
+    return _one_of(mode, DEVELOPMENT_MODES, "development mode")
+
+
+def transition_mode(current_mode: str, target_mode: str) -> str:
+    """Support explicit transitions among all declared AQ-1 modes."""
+
+    validate_development_mode(current_mode)
+    return validate_development_mode(target_mode)
+
+
+def select_mode_for_evidence(current_mode: str, *, conflicting_sources: bool = False) -> str:
+    """Select reconciliation when authoritative sources conflict."""
+
+    current = validate_development_mode(current_mode)
+    if not isinstance(conflicting_sources, bool):
+        raise TypeError("conflicting_sources must be a bool")
+    return "RECONCILIATION" if conflicting_sources else current
+
+
+def validate_completion_escalation(
+    current_states: Iterable[str],
+    target_state: str,
+    evidence: Iterable[AssuranceEvidence],
+    *,
+    claim_source_truth: str = "OBSERVED",
+    authority_ref: str | None = None,
+) -> CompletionAssessment:
+    """Validate one explicit state claim without inferring higher states."""
+
+    current = _states(current_states)
+    target = _one_of(target_state, COMPLETION_STATES, "target_state")
+    claim_truth = _one_of(claim_source_truth, SOURCE_TRUTH_LABELS, "claim_source_truth")
+    records = tuple(evidence)
+    if any(not isinstance(record, AssuranceEvidence) for record in records):
+        raise TypeError("evidence must contain AssuranceEvidence values")
+    if target not in current and not records:
+        raise ValueError("completion-state escalation requires evidence")
+    if target == "PRODUCT_COMPLETE" and not records:
+        raise ValueError("PRODUCT_COMPLETE requires explicit evidence")
+    if claim_truth == "UNVERIFIED" or any(record.source_truth == "UNVERIFIED" for record in records):
+        raise ValueError("UNVERIFIED evidence cannot qualify a completion claim")
+    if any(record.claimed_state != target for record in records):
+        raise ValueError("completion evidence must claim the target state")
+    authority = None if authority_ref is None else _text(authority_ref, "authority_ref")
+    has_inferred_support = any(record.source_truth == "INFERRED" for record in records)
+    if claim_truth == "DECIDED" and has_inferred_support and authority is None:
+        raise ValueError("INFERRED evidence cannot become DECIDED without authority")
+    if claim_truth == "INFERRED" and target not in {"IDEATED", "PROTOTYPED"} and authority is None:
+        raise ValueError("inferred completion claims require authority beyond prototype states")
+
+    explicit = tuple(dict.fromkeys((*current, target)))
+    return CompletionAssessment(
+        explicit_states=explicit,
+        target_state=target,
+        product_complete=target == "PRODUCT_COMPLETE",
+    )
+
+
+def validate_product_complete(
+    mode: str,
+    current_states: Iterable[str],
+    evidence: Iterable[AssuranceEvidence],
+    *,
+    claim_source_truth: str = "OBSERVED",
+    authority_ref: str | None = None,
+    reconciled: bool = False,
+) -> CompletionAssessment:
+    """Apply the product-complete gates that AQ-1 makes explicit."""
+
+    selected_mode = validate_development_mode(mode)
+    if not isinstance(reconciled, bool):
+        raise TypeError("reconciled must be a bool")
+    assessment = validate_completion_escalation(
+        current_states,
+        "PRODUCT_COMPLETE",
+        evidence,
+        claim_source_truth=claim_source_truth,
+        authority_ref=authority_ref,
+    )
+    state_set = set(assessment.explicit_states)
+    if selected_mode == "DISCOVERY_FIRST" and not reconciled:
+        raise ValueError("DISCOVERY_FIRST requires RECONCILIATION before PRODUCT_COMPLETE")
+    if "DOMAIN_IMPLEMENTED" in state_set and "APPLICATION_INTEGRATED" not in state_set:
+        raise ValueError("domain-only implementation cannot be represented as product integration")
+    return assessment
+
+
+__all__ = [
+    "AQ1_DOCTRINE_SCHEMA_VERSION",
+    "AssuranceEvidence",
+    "COMPLETION_STATES",
+    "CompletionAssessment",
+    "DEVELOPMENT_MODES",
+    "SOURCE_TRUTH_LABELS",
+    "select_mode_for_evidence",
+    "transition_mode",
+    "validate_completion_escalation",
+    "validate_development_mode",
+    "validate_product_complete",
+]

--- a/tests/runtime/test_adaptive_assurance_aq1.py
+++ b/tests/runtime/test_adaptive_assurance_aq1.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+from itertools import product
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from orchestra_runtime.domain.adaptive import (
+    AQ1_DOCTRINE_SCHEMA_VERSION,
+    COMPLETION_STATES,
+    DEVELOPMENT_MODES,
+    SOURCE_TRUTH_LABELS,
+    AssuranceEvidence,
+    select_mode_for_evidence,
+    transition_mode,
+    validate_completion_escalation,
+    validate_product_complete,
+)
+
+ROOT = Path(__file__).parents[2]
+CONTRACT_PATH = ROOT / "machine" / "adaptive" / "aq1-normative-doctrine.v1.json"
+SCHEMA_PATH = ROOT / "machine" / "schemas" / "adaptive-assurance-doctrine.v1.schema.json"
+
+
+def _json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _evidence(state: str, truth: str = "OBSERVED", authority_ref: str | None = None) -> AssuranceEvidence:
+    return AssuranceEvidence("evidence-1", state, truth, authority_ref)
+
+
+def test_aq1_contract_matches_schema_and_domain_constants() -> None:
+    contract = _json(CONTRACT_PATH)
+    schema = _json(SCHEMA_PATH)
+    Draft202012Validator.check_schema(schema)
+    errors = sorted(Draft202012Validator(schema).iter_errors(contract), key=str)
+    assert errors == []
+    assert contract["schema_version"] == AQ1_DOCTRINE_SCHEMA_VERSION
+    assert contract["development_modes"] == list(DEVELOPMENT_MODES)
+    assert contract["source_truth_labels"] == list(SOURCE_TRUTH_LABELS)
+    assert contract["completion_states"] == list(COMPLETION_STATES)
+    assert contract["authority"]["aq2_or_later_authorized"] is False
+    assert contract["authority"]["cud10_authorized"] is False
+
+
+@pytest.mark.parametrize("current_mode,target_mode", list(product(DEVELOPMENT_MODES, repeat=2)))
+def test_all_declared_mode_transitions_are_supported(current_mode: str, target_mode: str) -> None:
+    assert transition_mode(current_mode, target_mode) == target_mode
+
+
+def test_conflicting_sources_select_reconciliation() -> None:
+    assert select_mode_for_evidence("AS_BUILT", conflicting_sources=True) == "RECONCILIATION"
+    assert select_mode_for_evidence("AS_BUILT", conflicting_sources=False) == "AS_BUILT"
+
+
+def test_discovery_first_allows_prototype_but_requires_reconciliation_for_product_complete() -> None:
+    prototype = validate_completion_escalation(
+        (), "PROTOTYPED", [_evidence("PROTOTYPED")]
+    )
+    assert prototype.product_complete is False
+    with pytest.raises(ValueError, match="RECONCILIATION"):
+        validate_product_complete(
+            "DISCOVERY_FIRST",
+            ("PROTOTYPED",),
+            [_evidence("PRODUCT_COMPLETE")],
+        )
+    complete = validate_product_complete(
+        "DISCOVERY_FIRST",
+        ("PROTOTYPED", "APPLICATION_INTEGRATED"),
+        [_evidence("PRODUCT_COMPLETE")],
+        reconciled=True,
+    )
+    assert complete.product_complete is True
+
+
+def test_as_built_and_inferred_claims_require_authority() -> None:
+    with pytest.raises(ValueError, match="authority"):
+        validate_completion_escalation(
+            ("DOMAIN_IMPLEMENTED",),
+            "CANONICAL_VERIFIED",
+            [_evidence("CANONICAL_VERIFIED", "INFERRED")],
+            claim_source_truth="INFERRED",
+        )
+    with pytest.raises(ValueError, match="DECIDED"):
+        validate_completion_escalation(
+            ("IDEATED",),
+            "PROTOTYPED",
+            [_evidence("PROTOTYPED", "INFERRED")],
+            claim_source_truth="DECIDED",
+        )
+    assessment = validate_completion_escalation(
+        ("DOMAIN_IMPLEMENTED",),
+        "CANONICAL_VERIFIED",
+        [_evidence("CANONICAL_VERIFIED", "INFERRED", "decision-1")],
+        claim_source_truth="INFERRED",
+        authority_ref="decision-1",
+    )
+    assert assessment.canonical_proves_empirical_effectiveness is False
+
+
+def test_domain_only_implementation_is_not_product_integration() -> None:
+    with pytest.raises(ValueError, match="domain-only"):
+        validate_product_complete(
+            "SPEC_FIRST",
+            ("DOMAIN_IMPLEMENTED",),
+            [_evidence("PRODUCT_COMPLETE")],
+        )
+
+
+def test_completion_escalation_without_evidence_fails_closed() -> None:
+    with pytest.raises(ValueError, match="requires evidence"):
+        validate_completion_escalation(("IDEATED",), "PROTOTYPED", [])


### PR DESCRIPTION
## AQ-1 governed implementation

Implements the Padayon-approved AQ-1 normative ADAPT-QA doctrine only.

### Included
- machine-readable doctrine contract and strict JSON Schema
- pure adaptive-domain validation for modes, source truth, explicit completion states, reconciliation, and evidence gates
- seven AQ-1 fixture definitions and focused executable coverage
- architecture documentation and reference-index entry

### Boundaries preserved
- AQ-2 through AQ-14 are not implemented
- CUD10 remains unauthorized and held
- no routing-authority, provider, governance, production, or release changes

### Validation
- `python -B -m pytest tests/runtime/test_adaptive_assurance_aq1.py`: 42 passed
- `python -B -m pytest tests/runtime`: 2682 passed
- `python -B tests/behavior/run_tests.py` with approved base `6b99d22ba8441e03e519d2c26b366ba6e61aaea1`: PASS
- signed materialization behavior check: 7 passed
- TrueSheet reference check: PASS
- CI-equivalent runtime coverage: 2692 passed; 98.05% statements, 95.03% branches; evidence and critical coverage inventory PASS
- `python -B scripts/validation/validate_architecture_boundaries.py`: PASS
- pre-commit guardrail scan: PASS