### PR TITLE
feat(adaptive): add AQ5 repository QA compliance gate

### DIFF
--- a/.github/workflows/qa-compliance.yml
+++ b/.github/workflows/qa-compliance.yml
@@ -1,0 +1,137 @@
+name: AQ5 QA Compliance
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+      - codex/orchestra-aq4-assurance-manifests-20260908
+    paths:
+      - .github/workflows/qa-compliance.yml
+      - docs/architecture/ADAPTIVE_ASSURANCE_AQ5.md
+      - machine/adaptive/aq5-qa-compliance.v1.json
+      - machine/schemas/qa-compliance.v1.schema.json
+      - orchestra_runtime/domain/adaptive/qa_compliance.py
+      - scripts/validation/validate_qa_compliance.py
+      - tests/runtime/test_adaptive_assurance_aq5.py
+      - tests/behavior/test_qa_compliance.py
+
+permissions:
+  contents: read
+
+jobs:
+  aq5-runtime:
+    name: AQ5 runtime contract
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install validation dependencies
+        run: |
+          python -m pip install --upgrade pip pytest pytest-cov hypothesis==6.163.0 "jsonschema[format]>=4.21,<5"
+
+      - name: Run AQ5 runtime suite
+        run: >-
+          python -B -m pytest tests/runtime/test_adaptive_assurance_aq5.py
+          --cov=orchestra_runtime.domain.adaptive.qa_compliance
+          --cov-branch
+          --cov-report=term-missing
+          --cov-fail-under=97
+          -q
+
+      - name: Enforce AQ5 branch coverage
+        run: python -B -m coverage report --fail-under=95
+
+  aq5-behavior:
+    name: AQ5 CLI behavior
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Run AQ5 behavior test
+        run: |
+          python -B -m pytest tests/behavior/test_qa_compliance.py -q
+          python -B tests/behavior/test_qa_compliance.py
+
+  aq5-contract:
+    name: AQ5 schema and contract parity
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install schema dependency
+        run: python -m pip install --upgrade pip "jsonschema[format]>=4.21,<5"
+
+      - name: Validate AQ5 machine contracts
+        run: |
+          python -B - <<'PY'
+          import json
+          from pathlib import Path
+          import jsonschema
+          from orchestra_runtime.domain.adaptive.qa_compliance import validate_qa_compliance_contract
+
+          root = Path.cwd()
+          contract = json.loads((root / "machine/adaptive/aq5-qa-compliance.v1.json").read_text(encoding="utf-8"))
+          validate_qa_compliance_contract(contract)
+          schema = json.loads((root / "machine/schemas/qa-compliance.v1.schema.json").read_text(encoding="utf-8"))
+          jsonschema.Draft202012Validator.check_schema(schema)
+          print("AQ5_CONTRACT_PARITY=PASS")
+          PY
+
+  aq5-scope:
+    name: AQ5 exact scope
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Check AQ5 diff scope and whitespace
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_ref="origin/codex/orchestra-aq4-assurance-manifests-20260908"
+          if ! git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+            base_ref="HEAD^"
+          fi
+          git diff --check "$base_ref...HEAD"
+          git diff --name-only "$base_ref...HEAD" | sort > actual-paths.txt
+          cat > expected-paths.txt <<'EOF'
+          .github/workflows/qa-compliance.yml
+          docs/architecture/ADAPTIVE_ASSURANCE_AQ5.md
+          machine/adaptive/aq5-qa-compliance.v1.json
+          machine/schemas/qa-compliance.v1.schema.json
+          orchestra_runtime/domain/adaptive/qa_compliance.py
+          scripts/validation/validate_qa_compliance.py
+          tests/behavior/test_qa_compliance.py
+          tests/runtime/test_adaptive_assurance_aq5.py
+          EOF
+          sed -i 's/^          //' expected-paths.txt
+          sort -o expected-paths.txt expected-paths.txt
+          diff -u expected-paths.txt actual-paths.txt
+          test "$(wc -l < actual-paths.txt)" -eq 8

--- a/.github/workflows/qa-compliance.yml
+++ b/.github/workflows/qa-compliance.yml
@@ -64,6 +64,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install behavior dependencies
+        run: python -m pip install pytest
+
       - name: Run AQ5 behavior test
         run: |
           python -B -m pytest tests/behavior/test_qa_compliance.py -q

--- a/docs/architecture/ADAPTIVE_ASSURANCE_AQ5.md
+++ b/docs/architecture/ADAPTIVE_ASSURANCE_AQ5.md
@@ -1,0 +1,65 @@
+# AQ-5 Repository QA Compliance
+
+AQ-5 is the independent repository-level control for the adaptive assurance
+chain. It answers one bounded question:
+
+```text
+DID_THIS_CHANGE_RECEIVE_ALL_ASSURANCE_REQUIRED_BY_ITS_RISK_PROFILE?
+```
+
+The control consumes an AQ-4 assurance manifest and its source-bound evidence
+receipts. It evaluates claims; it does not rerun tests, grant authority,
+activate providers, promote a phase, or perform repository mutation.
+
+## Inputs and decision
+
+`orchestra_runtime.domain.adaptive.qa_compliance` is a pure deterministic
+domain module. `evaluate_qa_compliance` validates:
+
+- AQ-4 manifest and receipt semantics;
+- current repository, source, candidate, and tree identity;
+- exact changed-path and declared-path equality, with the maximum nine-path
+  scope preserved;
+- declared semantic risks and their required assurance classes;
+- required assurance and protected-gate evidence;
+- completion-state evidence, including HTTP plus runtime evidence for
+  `RUNTIME_VERIFIED`;
+- caller and integration evidence before `PRODUCT_COMPLETE`;
+- executed-test claims and changed-code coverage;
+- nonzero execution results, stale receipts, and policy self-modification.
+
+The returned `QaComplianceDecision` is canonicalized and SHA-256 bound. Its
+authority model is `EVIDENCE_ONLY_NON_AUTHORIZING`; every authority field is
+false. A `PASS` result is evidence for an independent review gate, not a
+transition authorization.
+
+## Required negative fixtures
+
+The runtime suite keeps these fail-closed cases executable:
+
+| Fixture | Required rejection |
+| --- | --- |
+| F1 | security-sensitive change without security evidence |
+| F2 | concurrent change without concurrency evidence |
+| F3 | runtime claim supported only by API/OpenAPI evidence |
+| F4 | product-complete claim without caller and integration evidence |
+| F5 | `PASS` receipt with nonzero exit |
+| F6 | receipt or claim bound to an old candidate SHA |
+| F7 | required test claimed without execution evidence |
+| F8 | executed test does not cover changed code |
+| F9 | changed path omitted from the declaration |
+| F10 | executor modifies a protected assurance policy |
+
+## Execution boundary
+
+The CLI in `scripts/validation/validate_qa_compliance.py` is the only I/O
+adapter. It reads JSON manifest and receipt inputs, invokes the pure evaluator,
+and optionally writes the descriptive decision JSON. The AQ-5 domain module
+does not access the network, providers, filesystem, test runner, Git state, or
+promotion machinery.
+
+The reusable workflow
+`.github/workflows/qa-compliance.yml` runs the focused AQ-5 runtime and
+behavior suites, validates machine-contract and JSON-Schema parity, and checks
+the exact AQ-5 path scope. AQ-1 through AQ-4 implementation paths remain
+outside the AQ-5 change set.

--- a/machine/adaptive/aq5-qa-compliance.v1.json
+++ b/machine/adaptive/aq5-qa-compliance.v1.json
@@ -1,0 +1,175 @@
+{
+  "authority": {
+    "decision_authorizes_execution": false,
+    "decision_authorizes_transition": false,
+    "decision_expands_authority": false,
+    "lifecycle_transition": false,
+    "production_action": false,
+    "provider_activation": false
+  },
+  "authority_model": "EVIDENCE_ONLY_NON_AUTHORIZING",
+  "completion_claim_scopes": {
+    "ADVERSARIALLY_VERIFIED": "ADVERSARIAL",
+    "API_INTEGRATED": "API",
+    "APPLICATION_INTEGRATED": "APPLICATION",
+    "CANONICAL_VERIFIED": "CANONICAL",
+    "CONTRACT_VERIFIED": "CONTRACT",
+    "DOMAIN_IMPLEMENTED": "DOMAIN",
+    "IDEATED": "COMPLETION",
+    "INTEGRATION_VERIFIED": "INTEGRATION",
+    "PRODUCT_COMPLETE": "PRODUCT",
+    "PROTOTYPED": "COMPLETION",
+    "RUNTIME_VERIFIED": "RUNTIME",
+    "SECURITY_VERIFIED": "SECURITY",
+    "UI_INTEGRATED": "UI",
+    "UNIT_VERIFIED": "UNIT"
+  },
+  "constraints": {
+    "aq6_plus_implementation": false,
+    "network_access": false,
+    "promotion_or_transition": false,
+    "provider_access": false,
+    "pure_domain": true,
+    "repository_mutation": false,
+    "test_execution": false
+  },
+  "decision_fields": [
+    "schema_version",
+    "decision_id",
+    "repository",
+    "source_ref",
+    "candidate_sha",
+    "tree_sha",
+    "work_item_ref",
+    "manifest_id",
+    "result",
+    "compliant",
+    "failure_codes",
+    "changed_paths",
+    "declared_paths",
+    "semantic_risks",
+    "required_assurance",
+    "satisfied_assurance",
+    "covered_slot_ids",
+    "missing_slot_ids",
+    "missing_assurance",
+    "evidence_receipt_ids",
+    "gate_ids",
+    "completion_state",
+    "generated_at",
+    "decision_digest"
+  ],
+  "decision_schema_version": "orchestra.qa-compliance-decision.v1",
+  "max_final_pr_paths": 9,
+  "owner": "overseer",
+  "phase": "AQ5_REPOSITORY_QA_COMPLIANCE",
+  "protected_policy_prefixes": [
+    ".github/workflows/governance-check.yml",
+    ".github/workflows/qa-compliance.yml",
+    "machine/governance/",
+    "machine/adaptive/aq5-qa-compliance.v1.json",
+    "machine/schemas/qa-compliance.v1.schema.json",
+    "scripts/validation/validate_governance",
+    "scripts/validation/validate_qa_compliance.py",
+    "orchestra_runtime/domain/adaptive/qa_compliance.py"
+  ],
+  "quality_assurance_map": {
+    "AUTHORITY_TRUST": "AUTHORITY_TRUST_ASSURANCE",
+    "COMPATIBILITY": "COMPATIBILITY_ASSURANCE",
+    "CONCURRENCY": "CONCURRENCY_ASSURANCE",
+    "DATA_OWNERSHIP": "DATA_OWNERSHIP_ASSURANCE",
+    "DESTRUCTIVE_LIFECYCLE": "DESTRUCTIVE_LIFECYCLE_ASSURANCE",
+    "EXTERNAL_DEPENDENCY": "EXTERNAL_PROVIDER_ASSURANCE",
+    "EXTERNAL_INPUT": "EXTERNAL_INPUT_ASSURANCE",
+    "FLEXIBILITY": "FLEXIBILITY_ASSURANCE",
+    "FUNCTIONAL_SUITABILITY": "FUNCTIONAL_ASSURANCE",
+    "HUMAN_AUTHORITY": "HUMAN_AUTHORITY_ASSURANCE",
+    "INTERACTION_CAPABILITY": "INTERACTION_ASSURANCE",
+    "MAINTAINABILITY": "MAINTAINABILITY_ASSURANCE",
+    "MIGRATION": "MIGRATION_ASSURANCE",
+    "OBSERVABILITY": "OBSERVABILITY_ASSURANCE",
+    "PERFORMANCE_EFFICIENCY": "PERFORMANCE_ASSURANCE",
+    "PRIVACY": "PRIVACY_ASSURANCE",
+    "PROVENANCE": "PROVENANCE_ASSURANCE",
+    "RECOVERY_ROLLBACK": "RECOVERY_ROLLBACK_ASSURANCE",
+    "RELIABILITY": "RELIABILITY_ASSURANCE",
+    "RETRY_IDEMPOTENCY": "RETRY_IDEMPOTENCY_ASSURANCE",
+    "SAFETY": "SAFETY_ASSURANCE",
+    "SECURITY": "SECURITY_ASSURANCE",
+    "STATE_TRANSITIONS": "STATE_TRANSITION_ASSURANCE",
+    "TENANT_WORKSPACE_ISOLATION": "TENANT_ISOLATION_ASSURANCE"
+  },
+  "required_completion_layers": {
+    "ADVERSARIALLY_VERIFIED": [
+      "ADVERSARIAL",
+      "MUTATION"
+    ],
+    "API_INTEGRATED": [
+      "INTEGRATION"
+    ],
+    "APPLICATION_INTEGRATED": [
+      "INTEGRATION"
+    ],
+    "CANONICAL_VERIFIED": [
+      "PROVENANCE"
+    ],
+    "CONTRACT_VERIFIED": [
+      "CONTRACT"
+    ],
+    "DOMAIN_IMPLEMENTED": [
+      "DOMAIN"
+    ],
+    "IDEATED": [
+      "COMPLETION_STATE"
+    ],
+    "INTEGRATION_VERIFIED": [
+      "INTEGRATION"
+    ],
+    "PRODUCT_COMPLETE": [
+      "COMPLETION_STATE"
+    ],
+    "PROTOTYPED": [
+      "COMPLETION_STATE"
+    ],
+    "RUNTIME_VERIFIED": [
+      "HTTP",
+      "RUNTIME"
+    ],
+    "SECURITY_VERIFIED": [
+      "SECURITY"
+    ],
+    "UI_INTEGRATED": [
+      "INTEGRATION"
+    ],
+    "UNIT_VERIFIED": [
+      "UNIT"
+    ]
+  },
+  "required_invariants": [
+    "AQ4_MANIFEST_AND_RECEIPTS_MUST_BE_SEMANTICALLY_VALID",
+    "CURRENT_SOURCE_CANDIDATE_TREE_MUST_MATCH_AQ4",
+    "CHANGED_PATHS_MUST_EQUAL_DECLARED_PATHS",
+    "SEMANTIC_RISK_MUST_BE_DECLARED_AND_ASSURED",
+    "SECURITY_NEEDS_SECURITY_EVIDENCE",
+    "CONCURRENCY_NEEDS_CONCURRENCY_EVIDENCE",
+    "RUNTIME_NEEDS_HTTP_AND_RUNTIME_EVIDENCE",
+    "PRODUCT_COMPLETE_NEEDS_CALLER_AND_INTEGRATION_EVIDENCE",
+    "PASS_WITH_NONZERO_EXIT_MUST_FAIL",
+    "UNEXECUTED_TEST_CLAIMS_MUST_FAIL",
+    "POLICY_SELF_MODIFICATION_MUST_FAIL",
+    "AQ5_DECISION_DOES_NOT_AUTHORIZE_TRANSITION"
+  ],
+  "required_negative_fixtures": [
+    "F1_SECURITY_NO_EVIDENCE",
+    "F2_CONCURRENCY_NO_EVIDENCE",
+    "F3_RUNTIME_ONLY_OPENAPI",
+    "F4_PRODUCT_COMPLETE_WITHOUT_CALLER",
+    "F5_PASS_NONZERO_EXIT",
+    "F6_OLD_CANDIDATE_SHA",
+    "F7_UNEXECUTED_TEST_CLAIM",
+    "F8_TEST_DOES_NOT_REACH_CHANGED_CODE",
+    "F9_CHANGED_PATH_OMITTED",
+    "F10_POLICY_SELF_MODIFICATION"
+  ],
+  "schema_version": "orchestra.qa-compliance.v1"
+}

--- a/machine/schemas/qa-compliance.v1.schema.json
+++ b/machine/schemas/qa-compliance.v1.schema.json
@@ -1,0 +1,321 @@
+{
+  "$id": "https://orchestra.local/schemas/qa-compliance.v1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "candidate_sha": {
+      "pattern": "^[0-9a-f]{40}$",
+      "type": "string"
+    },
+    "changed_paths": {
+      "items": {
+        "maxLength": 1024,
+        "minLength": 1,
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
+    },
+    "completion_state": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "enum": [
+            "IDEATED",
+            "PROTOTYPED",
+            "DOMAIN_IMPLEMENTED",
+            "APPLICATION_INTEGRATED",
+            "API_INTEGRATED",
+            "UI_INTEGRATED",
+            "UNIT_VERIFIED",
+            "CONTRACT_VERIFIED",
+            "INTEGRATION_VERIFIED",
+            "RUNTIME_VERIFIED",
+            "SECURITY_VERIFIED",
+            "ADVERSARIALLY_VERIFIED",
+            "CANONICAL_VERIFIED",
+            "PRODUCT_COMPLETE"
+          ]
+        }
+      ]
+    },
+    "compliant": {
+      "type": "boolean"
+    },
+    "covered_slot_ids": {
+      "items": {
+        "maxLength": 1024,
+        "minLength": 1,
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
+    },
+    "decision_digest": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "decision_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "type": "string"
+    },
+    "declared_paths": {
+      "items": {
+        "maxLength": 1024,
+        "minLength": 1,
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
+    },
+    "evidence_receipt_ids": {
+      "items": {
+        "maxLength": 1024,
+        "minLength": 1,
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
+    },
+    "failure_codes": {
+      "items": {
+        "maxLength": 1024,
+        "minLength": 1,
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
+    },
+    "gate_ids": {
+      "items": {
+        "maxLength": 1024,
+        "minLength": 1,
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
+    },
+    "generated_at": {
+      "format": "date-time",
+      "type": "string"
+    },
+    "manifest_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "type": "string"
+    },
+    "missing_assurance": {
+      "items": {
+        "enum": [
+          "DOCUMENTATION_RECONCILIATION",
+          "ARCHITECTURE_BOUNDARY",
+          "FUNCTIONAL_ASSURANCE",
+          "PERFORMANCE_ASSURANCE",
+          "COMPATIBILITY_ASSURANCE",
+          "INTERACTION_ASSURANCE",
+          "RELIABILITY_ASSURANCE",
+          "SECURITY_ASSURANCE",
+          "MAINTAINABILITY_ASSURANCE",
+          "FLEXIBILITY_ASSURANCE",
+          "SAFETY_ASSURANCE",
+          "PROVENANCE_ASSURANCE",
+          "AUTHORITY_TRUST_ASSURANCE",
+          "PRIVACY_ASSURANCE",
+          "TENANT_ISOLATION_ASSURANCE",
+          "DATA_OWNERSHIP_ASSURANCE",
+          "CONCURRENCY_ASSURANCE",
+          "STATE_TRANSITION_ASSURANCE",
+          "RETRY_IDEMPOTENCY_ASSURANCE",
+          "RECOVERY_ROLLBACK_ASSURANCE",
+          "EXTERNAL_INPUT_ASSURANCE",
+          "EXTERNAL_PROVIDER_ASSURANCE",
+          "MIGRATION_ASSURANCE",
+          "DESTRUCTIVE_LIFECYCLE_ASSURANCE",
+          "HUMAN_AUTHORITY_ASSURANCE",
+          "OBSERVABILITY_ASSURANCE",
+          "AUTHENTICATION_ASSURANCE",
+          "AUTHORIZATION_ASSURANCE",
+          "PRIVILEGE_BOUNDARY_ASSURANCE",
+          "MULTI_ACTOR_ASSURANCE",
+          "AGGREGATE_INVARIANT_ASSURANCE",
+          "TRANSACTION_ASSURANCE",
+          "DELETION_ASSURANCE",
+          "PUBLICATION_ASSURANCE",
+          "INVARIANT_PRESERVATION_ASSURANCE",
+          "ADVERSARIAL_ASSURANCE",
+          "INDEPENDENT_QA"
+        ]
+      },
+      "type": "array",
+      "uniqueItems": true
+    },
+    "missing_slot_ids": {
+      "items": {
+        "maxLength": 1024,
+        "minLength": 1,
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
+    },
+    "repository": {
+      "maxLength": 512,
+      "minLength": 1,
+      "type": "string"
+    },
+    "required_assurance": {
+      "items": {
+        "enum": [
+          "DOCUMENTATION_RECONCILIATION",
+          "ARCHITECTURE_BOUNDARY",
+          "FUNCTIONAL_ASSURANCE",
+          "PERFORMANCE_ASSURANCE",
+          "COMPATIBILITY_ASSURANCE",
+          "INTERACTION_ASSURANCE",
+          "RELIABILITY_ASSURANCE",
+          "SECURITY_ASSURANCE",
+          "MAINTAINABILITY_ASSURANCE",
+          "FLEXIBILITY_ASSURANCE",
+          "SAFETY_ASSURANCE",
+          "PROVENANCE_ASSURANCE",
+          "AUTHORITY_TRUST_ASSURANCE",
+          "PRIVACY_ASSURANCE",
+          "TENANT_ISOLATION_ASSURANCE",
+          "DATA_OWNERSHIP_ASSURANCE",
+          "CONCURRENCY_ASSURANCE",
+          "STATE_TRANSITION_ASSURANCE",
+          "RETRY_IDEMPOTENCY_ASSURANCE",
+          "RECOVERY_ROLLBACK_ASSURANCE",
+          "EXTERNAL_INPUT_ASSURANCE",
+          "EXTERNAL_PROVIDER_ASSURANCE",
+          "MIGRATION_ASSURANCE",
+          "DESTRUCTIVE_LIFECYCLE_ASSURANCE",
+          "HUMAN_AUTHORITY_ASSURANCE",
+          "OBSERVABILITY_ASSURANCE",
+          "AUTHENTICATION_ASSURANCE",
+          "AUTHORIZATION_ASSURANCE",
+          "PRIVILEGE_BOUNDARY_ASSURANCE",
+          "MULTI_ACTOR_ASSURANCE",
+          "AGGREGATE_INVARIANT_ASSURANCE",
+          "TRANSACTION_ASSURANCE",
+          "DELETION_ASSURANCE",
+          "PUBLICATION_ASSURANCE",
+          "INVARIANT_PRESERVATION_ASSURANCE",
+          "ADVERSARIAL_ASSURANCE",
+          "INDEPENDENT_QA"
+        ]
+      },
+      "type": "array",
+      "uniqueItems": true
+    },
+    "result": {
+      "enum": [
+        "PASS",
+        "FAIL",
+        "BLOCKED"
+      ]
+    },
+    "satisfied_assurance": {
+      "items": {
+        "enum": [
+          "DOCUMENTATION_RECONCILIATION",
+          "ARCHITECTURE_BOUNDARY",
+          "FUNCTIONAL_ASSURANCE",
+          "PERFORMANCE_ASSURANCE",
+          "COMPATIBILITY_ASSURANCE",
+          "INTERACTION_ASSURANCE",
+          "RELIABILITY_ASSURANCE",
+          "SECURITY_ASSURANCE",
+          "MAINTAINABILITY_ASSURANCE",
+          "FLEXIBILITY_ASSURANCE",
+          "SAFETY_ASSURANCE",
+          "PROVENANCE_ASSURANCE",
+          "AUTHORITY_TRUST_ASSURANCE",
+          "PRIVACY_ASSURANCE",
+          "TENANT_ISOLATION_ASSURANCE",
+          "DATA_OWNERSHIP_ASSURANCE",
+          "CONCURRENCY_ASSURANCE",
+          "STATE_TRANSITION_ASSURANCE",
+          "RETRY_IDEMPOTENCY_ASSURANCE",
+          "RECOVERY_ROLLBACK_ASSURANCE",
+          "EXTERNAL_INPUT_ASSURANCE",
+          "EXTERNAL_PROVIDER_ASSURANCE",
+          "MIGRATION_ASSURANCE",
+          "DESTRUCTIVE_LIFECYCLE_ASSURANCE",
+          "HUMAN_AUTHORITY_ASSURANCE",
+          "OBSERVABILITY_ASSURANCE",
+          "AUTHENTICATION_ASSURANCE",
+          "AUTHORIZATION_ASSURANCE",
+          "PRIVILEGE_BOUNDARY_ASSURANCE",
+          "MULTI_ACTOR_ASSURANCE",
+          "AGGREGATE_INVARIANT_ASSURANCE",
+          "TRANSACTION_ASSURANCE",
+          "DELETION_ASSURANCE",
+          "PUBLICATION_ASSURANCE",
+          "INVARIANT_PRESERVATION_ASSURANCE",
+          "ADVERSARIAL_ASSURANCE",
+          "INDEPENDENT_QA"
+        ]
+      },
+      "type": "array",
+      "uniqueItems": true
+    },
+    "schema_version": {
+      "const": "orchestra.qa-compliance-decision.v1"
+    },
+    "semantic_risks": {
+      "items": {
+        "maxLength": 1024,
+        "minLength": 1,
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
+    },
+    "source_ref": {
+      "maxLength": 512,
+      "minLength": 1,
+      "type": "string"
+    },
+    "tree_sha": {
+      "pattern": "^[0-9a-f]{40}$",
+      "type": "string"
+    },
+    "work_item_ref": {
+      "maxLength": 512,
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "schema_version",
+    "decision_id",
+    "repository",
+    "source_ref",
+    "candidate_sha",
+    "tree_sha",
+    "work_item_ref",
+    "manifest_id",
+    "result",
+    "compliant",
+    "failure_codes",
+    "changed_paths",
+    "declared_paths",
+    "semantic_risks",
+    "required_assurance",
+    "satisfied_assurance",
+    "covered_slot_ids",
+    "missing_slot_ids",
+    "missing_assurance",
+    "evidence_receipt_ids",
+    "gate_ids",
+    "completion_state",
+    "generated_at",
+    "decision_digest"
+  ],
+  "title": "Orchestra AQ5 QA compliance decision",
+  "type": "object"
+}

--- a/orchestra_runtime/domain/adaptive/qa_compliance.py
+++ b/orchestra_runtime/domain/adaptive/qa_compliance.py
@@ -1,0 +1,965 @@
+"""Pure AQ-5 repository QA-compliance evaluation.
+
+AQ-5 consumes AQ-4 manifests and evidence receipts. It checks that declared
+paths, semantic risk, completion claims, protected gates, and executed-test
+coverage agree with source-bound evidence. The result is descriptive and
+never grants authority or performs I/O.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from hashlib import sha256
+import json
+import re
+from typing import Any, Iterable, Mapping
+
+from .assurance import (
+    CLAIM_SCOPE_BY_STATE,
+    COMPLETION_STATES,
+    REQUIRED_EVIDENCE_LAYERS,
+)
+from .assurance_manifest import (
+    ASSURANCE_ORDER,
+    EvidenceReceipt,
+    AssuranceManifest,
+    AssuranceManifestContractError,
+    FAIL_INVALID_EXECUTION_METADATA,
+    FAIL_PASS_NONZERO_EXIT,
+    FAIL_RECEIPT_CANDIDATE_BINDING,
+    FAIL_RECEIPT_TREE_BINDING,
+    FAIL_STALE_EVIDENCE,
+    FAIL_WRONG_SOURCE,
+    MAX_FINAL_PR_PATHS,
+    reconcile_manifest_evidence,
+    validate_assurance_manifest,
+)
+from .risk_profiler import QUALITY_DIMENSIONS, RISK_CHARACTERISTICS, RISK_RULES
+
+
+AQ5_CONTRACT_SCHEMA_VERSION = "orchestra.qa-compliance.v1"
+AQ5_DECISION_SCHEMA_VERSION = "orchestra.qa-compliance-decision.v1"
+AQ5_AUTHORITY_MODEL = "EVIDENCE_ONLY_NON_AUTHORIZING"
+AQ5_PHASE = "AQ5_REPOSITORY_QA_COMPLIANCE"
+
+QA_COMPLIANCE_FIELDS = (
+    "schema_version",
+    "decision_id",
+    "repository",
+    "source_ref",
+    "candidate_sha",
+    "tree_sha",
+    "work_item_ref",
+    "manifest_id",
+    "result",
+    "compliant",
+    "failure_codes",
+    "changed_paths",
+    "declared_paths",
+    "semantic_risks",
+    "required_assurance",
+    "satisfied_assurance",
+    "covered_slot_ids",
+    "missing_slot_ids",
+    "missing_assurance",
+    "evidence_receipt_ids",
+    "gate_ids",
+    "completion_state",
+    "generated_at",
+    "decision_digest",
+)
+
+ALLOWED_DECISION_RESULTS = ("PASS", "FAIL", "BLOCKED")
+REQUIRED_NEGATIVE_FIXTURES = (
+    "F1_SECURITY_NO_EVIDENCE",
+    "F2_CONCURRENCY_NO_EVIDENCE",
+    "F3_RUNTIME_ONLY_OPENAPI",
+    "F4_PRODUCT_COMPLETE_WITHOUT_CALLER",
+    "F5_PASS_NONZERO_EXIT",
+    "F6_OLD_CANDIDATE_SHA",
+    "F7_UNEXECUTED_TEST_CLAIM",
+    "F8_TEST_DOES_NOT_REACH_CHANGED_CODE",
+    "F9_CHANGED_PATH_OMITTED",
+    "F10_POLICY_SELF_MODIFICATION",
+)
+
+FAIL_SECURITY_NO_EVIDENCE = "AQ5-F1_SECURITY_NO_EVIDENCE"
+FAIL_CONCURRENCY_NO_EVIDENCE = "AQ5-F2_CONCURRENCY_NO_EVIDENCE"
+FAIL_RUNTIME_ONLY_OPENAPI = "AQ5-F3_RUNTIME_ONLY_OPENAPI"
+FAIL_PRODUCT_COMPLETE_WITHOUT_CALLER = "AQ5-F4_PRODUCT_COMPLETE_WITHOUT_CALLER"
+FAIL_PASS_NONZERO_EXIT_CLAIM = "AQ5-F5_PASS_NONZERO_EXIT"
+FAIL_OLD_CANDIDATE_SHA = "AQ5-F6_OLD_CANDIDATE_SHA"
+FAIL_UNEXECUTED_TEST_CLAIM = "AQ5-F7_UNEXECUTED_TEST_CLAIM"
+FAIL_TEST_DOES_NOT_REACH_CHANGED_CODE = "AQ5-F8_TEST_DOES_NOT_REACH_CHANGED_CODE"
+FAIL_CHANGED_PATH_OMITTED = "AQ5-F9_CHANGED_PATH_OMITTED"
+FAIL_POLICY_SELF_MODIFICATION = "AQ5-F10_POLICY_SELF_MODIFICATION"
+
+FAIL_AQ4_INVALID = "AQ5_AQ4_INPUT_INVALID"
+FAIL_AQ4_EVIDENCE_INSUFFICIENT = "AQ5_AQ4_EVIDENCE_INSUFFICIENT"
+FAIL_SOURCE_BINDING = "AQ5_SOURCE_BINDING_MISMATCH"
+FAIL_TREE_BINDING = "AQ5_TREE_BINDING_MISMATCH"
+FAIL_SEMANTIC_RISK_UNDECLARED = "AQ5_SEMANTIC_RISK_UNDECLARED"
+FAIL_REQUIRED_ASSURANCE_MISSING = "AQ5_REQUIRED_ASSURANCE_MISSING"
+FAIL_COMPLETION_SCOPE = "AQ5_COMPLETION_SCOPE_INSUFFICIENT"
+FAIL_GATE_EVIDENCE_MISSING = "AQ5_PROTECTED_GATE_EVIDENCE_MISSING"
+FAIL_POLICY_INPUT_INVALID = "AQ5_POLICY_INPUT_INVALID"
+FAIL_TEST_INPUT_INVALID = "AQ5_TEST_INPUT_INVALID"
+FAIL_INVALID_INPUT = "AQ5_INVALID_INPUT"
+FAIL_SCOPE_LIMIT = "AQ5_SCOPE_EXCEEDS_MAX_FINAL_PR_PATHS"
+
+QUALITY_ASSURANCE_MAP = {
+    "FUNCTIONAL_SUITABILITY": "FUNCTIONAL_ASSURANCE",
+    "PERFORMANCE_EFFICIENCY": "PERFORMANCE_ASSURANCE",
+    "COMPATIBILITY": "COMPATIBILITY_ASSURANCE",
+    "INTERACTION_CAPABILITY": "INTERACTION_ASSURANCE",
+    "RELIABILITY": "RELIABILITY_ASSURANCE",
+    "SECURITY": "SECURITY_ASSURANCE",
+    "MAINTAINABILITY": "MAINTAINABILITY_ASSURANCE",
+    "FLEXIBILITY": "FLEXIBILITY_ASSURANCE",
+    "SAFETY": "SAFETY_ASSURANCE",
+    "PROVENANCE": "PROVENANCE_ASSURANCE",
+    "AUTHORITY_TRUST": "AUTHORITY_TRUST_ASSURANCE",
+    "PRIVACY": "PRIVACY_ASSURANCE",
+    "TENANT_WORKSPACE_ISOLATION": "TENANT_ISOLATION_ASSURANCE",
+    "DATA_OWNERSHIP": "DATA_OWNERSHIP_ASSURANCE",
+    "CONCURRENCY": "CONCURRENCY_ASSURANCE",
+    "STATE_TRANSITIONS": "STATE_TRANSITION_ASSURANCE",
+    "RETRY_IDEMPOTENCY": "RETRY_IDEMPOTENCY_ASSURANCE",
+    "RECOVERY_ROLLBACK": "RECOVERY_ROLLBACK_ASSURANCE",
+    "EXTERNAL_INPUT": "EXTERNAL_INPUT_ASSURANCE",
+    "EXTERNAL_DEPENDENCY": "EXTERNAL_PROVIDER_ASSURANCE",
+    "MIGRATION": "MIGRATION_ASSURANCE",
+    "DESTRUCTIVE_LIFECYCLE": "DESTRUCTIVE_LIFECYCLE_ASSURANCE",
+    "HUMAN_AUTHORITY": "HUMAN_AUTHORITY_ASSURANCE",
+    "OBSERVABILITY": "OBSERVABILITY_ASSURANCE",
+}
+
+PROTECTED_POLICY_PREFIXES = (
+    ".github/workflows/governance-check.yml",
+    ".github/workflows/qa-compliance.yml",
+    "machine/governance/",
+    "machine/adaptive/aq5-qa-compliance.v1.json",
+    "machine/schemas/qa-compliance.v1.schema.json",
+    "scripts/validation/validate_governance",
+    "scripts/validation/validate_qa_compliance.py",
+    "orchestra_runtime/domain/adaptive/qa_compliance.py",
+)
+
+REQUIRED_INVARIANTS = (
+    "AQ4_MANIFEST_AND_RECEIPTS_MUST_BE_SEMANTICALLY_VALID",
+    "CURRENT_SOURCE_CANDIDATE_TREE_MUST_MATCH_AQ4",
+    "CHANGED_PATHS_MUST_EQUAL_DECLARED_PATHS",
+    "SEMANTIC_RISK_MUST_BE_DECLARED_AND_ASSURED",
+    "SECURITY_NEEDS_SECURITY_EVIDENCE",
+    "CONCURRENCY_NEEDS_CONCURRENCY_EVIDENCE",
+    "RUNTIME_NEEDS_HTTP_AND_RUNTIME_EVIDENCE",
+    "PRODUCT_COMPLETE_NEEDS_CALLER_AND_INTEGRATION_EVIDENCE",
+    "PASS_WITH_NONZERO_EXIT_MUST_FAIL",
+    "UNEXECUTED_TEST_CLAIMS_MUST_FAIL",
+    "POLICY_SELF_MODIFICATION_MUST_FAIL",
+    "AQ5_DECISION_DOES_NOT_AUTHORIZE_TRANSITION",
+)
+
+AUTHORITY = {
+    "decision_authorizes_execution": False,
+    "decision_expands_authority": False,
+    "decision_authorizes_transition": False,
+    "provider_activation": False,
+    "production_action": False,
+    "lifecycle_transition": False,
+}
+
+
+class QaComplianceContractError(ValueError):
+    """A fail-closed AQ-5 contract violation."""
+
+    def __init__(self, code: str, detail: str = "") -> None:
+        self.code = code
+        self.detail = detail
+        super().__init__(f"{code}: {detail}" if detail else code)
+
+
+def _fail(code: str, detail: str = "") -> None:
+    raise QaComplianceContractError(code, detail)
+
+
+def _text(value: object, field_name: str, maximum: int = 512) -> str:
+    if not isinstance(value, str) or not value.strip() or len(value.strip()) > maximum:
+        _fail(FAIL_INVALID_INPUT, f"{field_name} must be a bounded non-empty string")
+    return value.strip()
+
+
+def _sha(value: object, field_name: str) -> str:
+    value = _text(value, field_name, 64).casefold()
+    if not re.fullmatch(r"[0-9a-f]{40}", value):
+        _fail(FAIL_INVALID_INPUT, f"{field_name} must be a lowercase Git SHA")
+    return value
+
+
+def _timestamp(value: object, field_name: str) -> str:
+    value = _text(value, field_name, 64)
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise QaComplianceContractError(FAIL_INVALID_INPUT, f"invalid {field_name}") from exc
+    if parsed.tzinfo is None:
+        _fail(FAIL_INVALID_INPUT, f"{field_name} must include a timezone")
+    return value
+
+
+def _values(value: object, field_name: str, maximum: int = 256) -> tuple[str, ...]:
+    if isinstance(value, (str, bytes)) or value is None:
+        _fail(FAIL_INVALID_INPUT, f"{field_name} must be an iterable of strings")
+    try:
+        values = tuple(_text(item, field_name, maximum) for item in value)  # type: ignore[union-attr]
+    except TypeError as exc:
+        raise QaComplianceContractError(FAIL_INVALID_INPUT, f"{field_name} is not iterable") from exc
+    if len(values) != len(set(values)):
+        _fail(FAIL_INVALID_INPUT, f"{field_name} must not contain duplicates")
+    return tuple(sorted(values))
+
+
+def _paths(value: object, field_name: str) -> tuple[str, ...]:
+    values = _values(value, field_name, 1024)
+    normalized: list[str] = []
+    for raw in values:
+        path = raw.replace("\\", "/")
+        if path.startswith("/") or re.match(r"^[A-Za-z]:/", path) or path.startswith("./"):
+            _fail(FAIL_INVALID_INPUT, f"{field_name} contains an invalid path")
+        if ".." in path.split("/") or not path:
+            _fail(FAIL_INVALID_INPUT, f"{field_name} contains an invalid path")
+        normalized.append(path)
+    if len(normalized) != len(set(normalized)):
+        _fail(FAIL_INVALID_INPUT, f"{field_name} contains duplicate normalized paths")
+    return tuple(sorted(normalized))
+
+
+def _identifiers(value: object, field_name: str) -> tuple[str, ...]:
+    return _values(value, field_name, 256)
+
+
+def _assurance(values: object, field_name: str) -> tuple[str, ...]:
+    result = _identifiers(values, field_name)
+    unknown = set(result) - set(ASSURANCE_ORDER)
+    if unknown:
+        _fail(FAIL_INVALID_INPUT, f"{field_name} contains unknown assurance")
+    return tuple(item for item in ASSURANCE_ORDER if item in result)
+
+
+def _digest(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _unique(values: Iterable[str]) -> tuple[str, ...]:
+    return tuple(sorted(set(values)))
+
+
+def _decision_payload(
+    *,
+    schema_version: str,
+    decision_id: str,
+    repository: str,
+    source_ref: str,
+    candidate_sha: str,
+    tree_sha: str,
+    work_item_ref: str,
+    manifest_id: str,
+    result: str,
+    failure_codes: tuple[str, ...],
+    changed_paths: tuple[str, ...],
+    declared_paths: tuple[str, ...],
+    semantic_risks: tuple[str, ...],
+    required_assurance: tuple[str, ...],
+    satisfied_assurance: tuple[str, ...],
+    covered_slot_ids: tuple[str, ...],
+    missing_slot_ids: tuple[str, ...],
+    missing_assurance: tuple[str, ...],
+    evidence_receipt_ids: tuple[str, ...],
+    gate_ids: tuple[str, ...],
+    completion_state: str | None,
+    generated_at: str,
+) -> dict[str, Any]:
+    return {
+        "schema_version": schema_version,
+        "decision_id": decision_id,
+        "repository": repository,
+        "source_ref": source_ref,
+        "candidate_sha": candidate_sha,
+        "tree_sha": tree_sha,
+        "work_item_ref": work_item_ref,
+        "manifest_id": manifest_id,
+        "result": result,
+        "compliant": result == "PASS",
+        "failure_codes": list(failure_codes),
+        "changed_paths": list(changed_paths),
+        "declared_paths": list(declared_paths),
+        "semantic_risks": list(semantic_risks),
+        "required_assurance": list(required_assurance),
+        "satisfied_assurance": list(satisfied_assurance),
+        "covered_slot_ids": list(covered_slot_ids),
+        "missing_slot_ids": list(missing_slot_ids),
+        "missing_assurance": list(missing_assurance),
+        "evidence_receipt_ids": list(evidence_receipt_ids),
+        "gate_ids": list(gate_ids),
+        "completion_state": completion_state,
+        "generated_at": generated_at,
+    }
+
+
+@dataclass(frozen=True, slots=True)
+class QaComplianceDecision:
+    schema_version: str
+    decision_id: str
+    repository: str
+    source_ref: str
+    candidate_sha: str
+    tree_sha: str
+    work_item_ref: str
+    manifest_id: str
+    result: str
+    failure_codes: tuple[str, ...]
+    changed_paths: tuple[str, ...]
+    declared_paths: tuple[str, ...]
+    semantic_risks: tuple[str, ...]
+    required_assurance: tuple[str, ...]
+    satisfied_assurance: tuple[str, ...]
+    covered_slot_ids: tuple[str, ...]
+    missing_slot_ids: tuple[str, ...]
+    missing_assurance: tuple[str, ...]
+    evidence_receipt_ids: tuple[str, ...]
+    gate_ids: tuple[str, ...]
+    completion_state: str | None
+    generated_at: str
+    decision_digest: str
+
+    def __post_init__(self) -> None:
+        if self.schema_version != AQ5_DECISION_SCHEMA_VERSION:
+            _fail(FAIL_INVALID_INPUT, "unsupported AQ5 decision schema")
+        for field_name in (
+            "decision_id",
+            "repository",
+            "source_ref",
+            "work_item_ref",
+            "manifest_id",
+        ):
+            object.__setattr__(self, field_name, _text(getattr(self, field_name), field_name))
+        object.__setattr__(self, "candidate_sha", _sha(self.candidate_sha, "candidate_sha"))
+        object.__setattr__(self, "tree_sha", _sha(self.tree_sha, "tree_sha"))
+        object.__setattr__(self, "result", self.result if self.result in ALLOWED_DECISION_RESULTS else "")
+        if not self.result:
+            _fail(FAIL_INVALID_INPUT, "result is not an allowed decision result")
+        object.__setattr__(self, "failure_codes", _unique(_values(self.failure_codes, "failure_codes")))
+        for field_name in ("changed_paths", "declared_paths"):
+            object.__setattr__(self, field_name, _paths(getattr(self, field_name), field_name))
+        object.__setattr__(self, "semantic_risks", _identifiers(self.semantic_risks, "semantic_risks"))
+        for field_name in ("required_assurance", "satisfied_assurance", "missing_assurance"):
+            object.__setattr__(self, field_name, _assurance(getattr(self, field_name), field_name))
+        for field_name in (
+            "covered_slot_ids",
+            "missing_slot_ids",
+            "evidence_receipt_ids",
+            "gate_ids",
+        ):
+            object.__setattr__(self, field_name, _identifiers(getattr(self, field_name), field_name))
+        if self.completion_state is not None:
+            object.__setattr__(self, "completion_state", _text(self.completion_state, "completion_state", 64))
+            if self.completion_state not in COMPLETION_STATES:
+                _fail(FAIL_INVALID_INPUT, "unknown completion_state")
+        object.__setattr__(self, "generated_at", _timestamp(self.generated_at, "generated_at"))
+        object.__setattr__(self, "decision_digest", _sha256(self.decision_digest))
+        if self.decision_digest != _digest(self._payload()):
+            _fail(FAIL_INVALID_INPUT, "decision_digest does not match canonical decision")
+        if self.result == "PASS" and self.failure_codes:
+            _fail(FAIL_INVALID_INPUT, "PASS decisions cannot contain failure_codes")
+
+    def _payload(self) -> dict[str, Any]:
+        return _decision_payload(
+            schema_version=self.schema_version,
+            decision_id=self.decision_id,
+            repository=self.repository,
+            source_ref=self.source_ref,
+            candidate_sha=self.candidate_sha,
+            tree_sha=self.tree_sha,
+            work_item_ref=self.work_item_ref,
+            manifest_id=self.manifest_id,
+            result=self.result,
+            failure_codes=self.failure_codes,
+            changed_paths=self.changed_paths,
+            declared_paths=self.declared_paths,
+            semantic_risks=self.semantic_risks,
+            required_assurance=self.required_assurance,
+            satisfied_assurance=self.satisfied_assurance,
+            covered_slot_ids=self.covered_slot_ids,
+            missing_slot_ids=self.missing_slot_ids,
+            missing_assurance=self.missing_assurance,
+            evidence_receipt_ids=self.evidence_receipt_ids,
+            gate_ids=self.gate_ids,
+            completion_state=self.completion_state,
+            generated_at=self.generated_at,
+        )
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "QaComplianceDecision":
+        if not isinstance(data, Mapping):
+            raise TypeError("AQ5 decision must be a mapping")
+        unknown = set(data) - set(QA_COMPLIANCE_FIELDS)
+        if unknown:
+            _fail(FAIL_INVALID_INPUT, "unsupported decision fields: " + ", ".join(sorted(unknown)))
+        result = data.get("result", "")
+        compliant = data.get("compliant")
+        if type(compliant) is not bool or compliant != (result == "PASS"):
+            _fail(FAIL_INVALID_INPUT, "compliant must match result")
+        return cls(
+            schema_version=data.get("schema_version", ""),
+            decision_id=data.get("decision_id", ""),
+            repository=data.get("repository", ""),
+            source_ref=data.get("source_ref", ""),
+            candidate_sha=data.get("candidate_sha", ""),
+            tree_sha=data.get("tree_sha", ""),
+            work_item_ref=data.get("work_item_ref", ""),
+            manifest_id=data.get("manifest_id", ""),
+            result=result,
+            failure_codes=tuple(data.get("failure_codes", ())),
+            changed_paths=tuple(data.get("changed_paths", ())),
+            declared_paths=tuple(data.get("declared_paths", ())),
+            semantic_risks=tuple(data.get("semantic_risks", ())),
+            required_assurance=tuple(data.get("required_assurance", ())),
+            satisfied_assurance=tuple(data.get("satisfied_assurance", ())),
+            covered_slot_ids=tuple(data.get("covered_slot_ids", ())),
+            missing_slot_ids=tuple(data.get("missing_slot_ids", ())),
+            missing_assurance=tuple(data.get("missing_assurance", ())),
+            evidence_receipt_ids=tuple(data.get("evidence_receipt_ids", ())),
+            gate_ids=tuple(data.get("gate_ids", ())),
+            completion_state=data.get("completion_state"),
+            generated_at=data.get("generated_at", ""),
+            decision_digest=data.get("decision_digest", ""),
+        )
+
+    @property
+    def compliant(self) -> bool:
+        return self.result == "PASS" and not self.failure_codes
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self._payload()
+        payload["decision_digest"] = self.decision_digest
+        return payload
+
+
+def _sha256(value: object) -> str:
+    if not isinstance(value, str) or not re.fullmatch(r"[0-9a-f]{64}", value):
+        _fail(FAIL_INVALID_INPUT, "decision_digest must be a SHA-256 digest")
+    return value
+
+
+def _coerce_manifest(value: AssuranceManifest | Mapping[str, Any]) -> AssuranceManifest:
+    if isinstance(value, AssuranceManifest):
+        return value
+    if isinstance(value, Mapping):
+        return AssuranceManifest.from_mapping(value)
+    raise TypeError("manifest must be an AssuranceManifest or mapping")
+
+
+def _receipt_values(value: object) -> tuple[object, ...]:
+    if isinstance(value, Mapping):
+        if "receipts" in value:
+            value = value["receipts"]
+        else:
+            return (value,)
+    if isinstance(value, (str, bytes)) or value is None:
+        raise TypeError("receipts must be an iterable")
+    return tuple(value)  # type: ignore[arg-type]
+
+
+def _append(failures: list[str], *codes: str) -> None:
+    for code in codes:
+        if code and code not in failures:
+            failures.append(code)
+
+
+def _risk_assurance(label: str) -> str | None:
+    if label in QUALITY_ASSURANCE_MAP:
+        return QUALITY_ASSURANCE_MAP[label]
+    rule = RISK_RULES.get(label)
+    return None if rule is None else rule[0][0]
+
+
+def _is_policy_path(path: str) -> bool:
+    return any(path == prefix or path.startswith(prefix) for prefix in PROTECTED_POLICY_PREFIXES)
+
+
+def _make_decision(
+    manifest: AssuranceManifest,
+    *,
+    result: str,
+    failures: Iterable[str],
+    changed_paths: tuple[str, ...],
+    declared_paths: tuple[str, ...],
+    semantic_risks: tuple[str, ...],
+    satisfied_assurance: tuple[str, ...],
+    covered_slot_ids: tuple[str, ...],
+    missing_slot_ids: tuple[str, ...],
+    missing_assurance: tuple[str, ...],
+    evidence_receipt_ids: tuple[str, ...],
+    gate_ids: tuple[str, ...],
+    completion_state: str | None,
+    generated_at: str,
+) -> QaComplianceDecision:
+    failure_codes = _unique(failures)
+    seed = _decision_payload(
+        schema_version=AQ5_DECISION_SCHEMA_VERSION,
+        decision_id="pending",
+        repository=manifest.repository,
+        source_ref=manifest.source_ref,
+        candidate_sha=manifest.candidate_sha,
+        tree_sha=manifest.tree_sha,
+        work_item_ref=manifest.work_item_ref,
+        manifest_id=manifest.manifest_id,
+        result=result,
+        failure_codes=failure_codes,
+        changed_paths=changed_paths,
+        declared_paths=declared_paths,
+        semantic_risks=semantic_risks,
+        required_assurance=manifest.required_assurance,
+        satisfied_assurance=satisfied_assurance,
+        covered_slot_ids=covered_slot_ids,
+        missing_slot_ids=missing_slot_ids,
+        missing_assurance=missing_assurance,
+        evidence_receipt_ids=evidence_receipt_ids,
+        gate_ids=gate_ids,
+        completion_state=completion_state,
+        generated_at=generated_at,
+    )
+    decision_id = "qa5-" + _digest(seed)[:20]
+    payload = dict(seed)
+    payload["decision_id"] = decision_id
+    digest = _digest(payload)
+    return QaComplianceDecision(
+        schema_version=AQ5_DECISION_SCHEMA_VERSION,
+        decision_id=decision_id,
+        repository=manifest.repository,
+        source_ref=manifest.source_ref,
+        candidate_sha=manifest.candidate_sha,
+        tree_sha=manifest.tree_sha,
+        work_item_ref=manifest.work_item_ref,
+        manifest_id=manifest.manifest_id,
+        result=result,
+        failure_codes=failure_codes,
+        changed_paths=changed_paths,
+        declared_paths=declared_paths,
+        semantic_risks=semantic_risks,
+        required_assurance=manifest.required_assurance,
+        satisfied_assurance=satisfied_assurance,
+        covered_slot_ids=covered_slot_ids,
+        missing_slot_ids=missing_slot_ids,
+        missing_assurance=missing_assurance,
+        evidence_receipt_ids=evidence_receipt_ids,
+        gate_ids=gate_ids,
+        completion_state=completion_state,
+        generated_at=generated_at,
+        decision_digest=digest,
+    )
+
+
+def evaluate_qa_compliance(
+    manifest: AssuranceManifest | Mapping[str, Any],
+    receipts: Iterable[EvidenceReceipt | Mapping[str, Any]] | Mapping[str, Any],
+    *,
+    current_repository: str | None = None,
+    current_source_ref: str | None = None,
+    current_candidate_sha: str | None = None,
+    current_tree_sha: str | None = None,
+    changed_paths: Iterable[str] = (),
+    declared_paths: Iterable[str] = (),
+    semantic_risks: Iterable[str] | None = None,
+    protected_gate_ids: Iterable[str] = (),
+    completion_state: str | None = None,
+    runtime_claimed: bool = False,
+    caller_authority_ref: str | None = None,
+    integration_evidence_ids: Iterable[str] = (),
+    completion_evidence_ids: Iterable[str] = (),
+    executed_test_ids: Iterable[str] = (),
+    test_coverage: Mapping[str, Iterable[str]] | None = None,
+    test_coverage_paths: Mapping[str, Iterable[str]] | None = None,
+    test_claimed: bool = False,
+    policy_modified_paths: Iterable[str] = (),
+    policy_self_modification: bool = False,
+    policy_paths: Iterable[str] = (),
+    current_authority_boundary: Iterable[str] | None = None,
+    evaluated_at: str | None = None,
+    actual_changed_paths: Iterable[str] | None = None,
+    manifest_declared_paths: Iterable[str] | None = None,
+    claimed_risks: Iterable[str] | None = None,
+) -> QaComplianceDecision:
+    """Evaluate AQ-5 claims against a source-bound AQ-4 manifest and receipts."""
+
+    manifest_obj = _coerce_manifest(manifest)
+    failures: list[str] = []
+    repository = (
+        manifest_obj.repository
+        if current_repository is None
+        else _text(current_repository, "current_repository")
+    )
+    source_ref = (
+        manifest_obj.source_ref
+        if current_source_ref is None
+        else _text(current_source_ref, "current_source_ref")
+    )
+    candidate_sha = (
+        manifest_obj.candidate_sha
+        if current_candidate_sha is None
+        else _sha(current_candidate_sha, "current_candidate_sha")
+    )
+    tree_sha = (
+        manifest_obj.tree_sha
+        if current_tree_sha is None
+        else _sha(current_tree_sha, "current_tree_sha")
+    )
+    generated_at = manifest_obj.generated_at if evaluated_at is None else _timestamp(evaluated_at, "evaluated_at")
+
+    if current_source_ref is not None and manifest_obj.source_ref != source_ref:
+        _append(failures, FAIL_SOURCE_BINDING)
+    if current_candidate_sha is not None and manifest_obj.candidate_sha != candidate_sha:
+        _append(failures, FAIL_OLD_CANDIDATE_SHA)
+    if current_tree_sha is not None and manifest_obj.tree_sha != tree_sha:
+        _append(failures, FAIL_TREE_BINDING)
+
+    try:
+        validate_assurance_manifest(
+            manifest_obj,
+            current_repository=repository,
+            current_candidate_sha=candidate_sha,
+            current_tree_sha=tree_sha,
+            current_authority_boundary=current_authority_boundary,
+        )
+    except AssuranceManifestContractError as exc:
+        _append(failures, FAIL_AQ4_INVALID, exc.code)
+    except (TypeError, ValueError):
+        _append(failures, FAIL_AQ4_INVALID)
+
+    try:
+        receipt_values = _receipt_values(receipts)
+    except (TypeError, ValueError):
+        receipt_values = ()
+        _append(failures, FAIL_AQ4_INVALID)
+
+    evidence = None
+    try:
+        evidence = reconcile_manifest_evidence(manifest_obj, receipt_values)
+    except AssuranceManifestContractError as exc:
+        _append(failures, FAIL_AQ4_INVALID, exc.code)
+    except (TypeError, ValueError):
+        _append(failures, FAIL_AQ4_INVALID)
+    if evidence is None:
+        normalized_receipts: tuple[EvidenceReceipt, ...] = ()
+        satisfied_assurance: tuple[str, ...] = ()
+        covered_slot_ids: tuple[str, ...] = ()
+        missing_slot_ids = tuple(slot.slot_id for slot in manifest_obj.required_evidence_slots)
+        missing_assurance = manifest_obj.required_assurance
+        evidence_ids: tuple[str, ...] = ()
+    else:
+        normalized_receipts = evidence.normalized_receipts
+        satisfied_assurance = evidence.satisfied_assurance
+        covered_slot_ids = evidence.covered_slot_ids
+        missing_slot_ids = evidence.missing_slot_ids
+        missing_assurance = evidence.missing_assurance
+        evidence_ids = evidence.evidence_ids
+        _append(failures, *evidence.failure_codes)
+        if FAIL_RECEIPT_CANDIDATE_BINDING in evidence.failure_codes or FAIL_STALE_EVIDENCE in evidence.failure_codes:
+            _append(failures, FAIL_OLD_CANDIDATE_SHA)
+        if FAIL_RECEIPT_TREE_BINDING in evidence.failure_codes:
+            _append(failures, FAIL_TREE_BINDING)
+        if FAIL_WRONG_SOURCE in evidence.failure_codes:
+            _append(failures, FAIL_SOURCE_BINDING)
+        if not evidence.sufficient:
+            _append(failures, FAIL_AQ4_EVIDENCE_INSUFFICIENT)
+
+    raw_changed_paths = changed_paths if actual_changed_paths is None else actual_changed_paths
+    raw_declared_paths = declared_paths if manifest_declared_paths is None else manifest_declared_paths
+    normalized_changed_paths = _paths(raw_changed_paths, "changed_paths")
+    normalized_declared_paths = _paths(raw_declared_paths, "declared_paths")
+    if normalized_changed_paths != normalized_declared_paths:
+        _append(failures, FAIL_CHANGED_PATH_OMITTED)
+    if len(normalized_changed_paths) > MAX_FINAL_PR_PATHS:
+        _append(failures, FAIL_SCOPE_LIMIT)
+
+    risk_values = semantic_risks
+    if risk_values is None:
+        risk_values = tuple(
+            dict.fromkeys((*manifest_obj.quality_dimensions, *manifest_obj.risk_characteristics))
+        )
+    if claimed_risks is not None:
+        risk_values = claimed_risks
+    normalized_risks = _identifiers(risk_values, "semantic_risks")
+    known_semantics = set(QUALITY_DIMENSIONS) | set(RISK_CHARACTERISTICS)
+    declared_semantics = set(manifest_obj.quality_dimensions) | set(manifest_obj.risk_characteristics)
+    for risk in normalized_risks:
+        if risk not in known_semantics or risk not in declared_semantics:
+            _append(failures, FAIL_SEMANTIC_RISK_UNDECLARED)
+            continue
+        assurance = _risk_assurance(risk)
+        if assurance is None or assurance not in set(manifest_obj.required_assurance):
+            _append(failures, FAIL_REQUIRED_ASSURANCE_MISSING)
+        elif assurance not in set(satisfied_assurance):
+            _append(failures, FAIL_REQUIRED_ASSURANCE_MISSING)
+
+    pass_layers = {receipt.evidence_layer for receipt in normalized_receipts if receipt.result == "PASS"}
+    security_semantics = {
+        "SECURITY",
+        "AUTHENTICATION",
+        "AUTHORIZATION",
+        "PRIVILEGE_MUTATION",
+        "MULTI_TENANT",
+    }
+    concurrency_semantics = {"CONCURRENCY", "MULTI_ACTOR", "AGGREGATE_INVARIANT"}
+    if security_semantics.intersection(normalized_risks) and "SECURITY" not in pass_layers:
+        _append(failures, FAIL_SECURITY_NO_EVIDENCE)
+    if concurrency_semantics.intersection(normalized_risks) and "CONCURRENCY" not in pass_layers:
+        _append(failures, FAIL_CONCURRENCY_NO_EVIDENCE)
+    if "PROVENANCE" in normalized_risks and "PROVENANCE" not in pass_layers:
+        _append(failures, FAIL_REQUIRED_ASSURANCE_MISSING)
+
+    requested_gate_values = tuple(protected_gate_ids)
+    requested_gates = _identifiers(
+        requested_gate_values if requested_gate_values else manifest_obj.protected_gates,
+        "protected_gate_ids",
+    )
+    slot_ids = {slot.slot_id.casefold() for slot in manifest_obj.required_evidence_slots}
+    pass_gate_ids = {
+        receipt.gate_id.casefold()
+        for receipt in normalized_receipts
+        if receipt.result == "PASS"
+    }
+    for gate_id in requested_gates:
+        gate_key = gate_id.casefold()
+        if gate_key in slot_ids and gate_key not in pass_gate_ids:
+            _append(failures, FAIL_GATE_EVIDENCE_MISSING)
+        elif gate_key not in slot_ids and requested_gate_values:
+            _append(failures, FAIL_GATE_EVIDENCE_MISSING)
+
+    normalized_completion_state = None
+    normalized_caller_authority_ref = None
+    if caller_authority_ref is not None:
+        normalized_caller_authority_ref = _text(caller_authority_ref, "caller_authority_ref")
+    if type(runtime_claimed) is not bool or type(test_claimed) is not bool:
+        _append(failures, FAIL_INVALID_INPUT)
+    if completion_state is not None:
+        completion_value = _text(completion_state, "completion_state", 64)
+        if completion_value not in COMPLETION_STATES:
+            _append(failures, FAIL_COMPLETION_SCOPE)
+        else:
+            normalized_completion_state = completion_value
+            required_layers = set(REQUIRED_EVIDENCE_LAYERS[normalized_completion_state])
+            if not required_layers.issubset(pass_layers):
+                _append(failures, FAIL_COMPLETION_SCOPE)
+            if normalized_completion_state == "RUNTIME_VERIFIED" and not {
+                "HTTP",
+                "RUNTIME",
+            }.issubset(pass_layers):
+                _append(failures, FAIL_RUNTIME_ONLY_OPENAPI)
+            if normalized_completion_state == "PRODUCT_COMPLETE":
+                integration_ids = _identifiers(
+                    tuple(dict.fromkeys(integration_evidence_ids)),
+                    "integration_evidence_ids",
+                )
+                completion_ids = _identifiers(
+                    tuple(dict.fromkeys(completion_evidence_ids)),
+                    "completion_evidence_ids",
+                )
+                if (
+                    not normalized_caller_authority_ref
+                    or not integration_ids
+                    or not completion_ids
+                    or not set(integration_ids + completion_ids).issubset(set(evidence_ids))
+                    or not {"INTEGRATION", "HTTP", "RUNTIME"}.intersection(pass_layers)
+                ):
+                    _append(failures, FAIL_PRODUCT_COMPLETE_WITHOUT_CALLER)
+            elif normalized_completion_state == "RUNTIME_VERIFIED":
+                if not {"HTTP", "RUNTIME"}.issubset(pass_layers):
+                    _append(failures, FAIL_COMPLETION_SCOPE)
+
+    if runtime_claimed and not {"HTTP", "RUNTIME"}.issubset(pass_layers):
+        _append(failures, FAIL_RUNTIME_ONLY_OPENAPI, FAIL_COMPLETION_SCOPE)
+
+    coverage = test_coverage if test_coverage is not None else test_coverage_paths
+    executed_test_values = tuple(executed_test_ids)
+    if test_claimed or coverage is not None or executed_test_values:
+        executed_ids = _identifiers(executed_test_values, "executed_test_ids")
+        if not isinstance(coverage, Mapping) or not executed_ids:
+            _append(failures, FAIL_UNEXECUTED_TEST_CLAIM)
+        else:
+            covered_paths: set[str] = set()
+            for test_id in executed_ids:
+                if test_id not in coverage:
+                    _append(failures, FAIL_UNEXECUTED_TEST_CLAIM)
+                    continue
+                try:
+                    covered_paths.update(_paths(coverage[test_id], f"test_coverage[{test_id}]"))
+                except (TypeError, ValueError):
+                    _append(failures, FAIL_UNEXECUTED_TEST_CLAIM)
+            if not set(normalized_changed_paths).issubset(covered_paths):
+                _append(failures, FAIL_TEST_DOES_NOT_REACH_CHANGED_CODE)
+
+    for code in (FAIL_PASS_NONZERO_EXIT, FAIL_INVALID_EXECUTION_METADATA):
+        if evidence is not None and code in evidence.failure_codes:
+            _append(
+                failures,
+                FAIL_PASS_NONZERO_EXIT_CLAIM if code == FAIL_PASS_NONZERO_EXIT else FAIL_UNEXECUTED_TEST_CLAIM,
+            )
+
+    normalized_policy_paths = _paths(policy_modified_paths, "policy_modified_paths")
+    policy_path_values = tuple(policy_paths)
+    normalized_policy_prefixes = (
+        _paths(policy_path_values, "policy_paths") if policy_path_values else ()
+    )
+    if type(policy_self_modification) is not bool:
+        _append(failures, FAIL_POLICY_INPUT_INVALID)
+    if policy_self_modification or any(_is_policy_path(path) for path in normalized_policy_paths):
+        _append(failures, FAIL_POLICY_SELF_MODIFICATION)
+    if normalized_policy_prefixes and any(
+        any(path == prefix or path.startswith(prefix) for prefix in normalized_policy_prefixes)
+        for path in normalized_changed_paths
+    ):
+        _append(failures, FAIL_POLICY_SELF_MODIFICATION)
+
+    result = "PASS" if not failures else "FAIL"
+    return _make_decision(
+        manifest_obj,
+        result=result,
+        failures=failures,
+        changed_paths=normalized_changed_paths,
+        declared_paths=normalized_declared_paths,
+        semantic_risks=normalized_risks,
+        satisfied_assurance=satisfied_assurance,
+        covered_slot_ids=covered_slot_ids,
+        missing_slot_ids=missing_slot_ids,
+        missing_assurance=missing_assurance,
+        evidence_receipt_ids=evidence_ids,
+        gate_ids=requested_gates,
+        completion_state=normalized_completion_state,
+        generated_at=generated_at,
+    )
+
+
+def validate_qa_compliance(
+    manifest: AssuranceManifest | Mapping[str, Any],
+    receipts: Iterable[EvidenceReceipt | Mapping[str, Any]] | Mapping[str, Any],
+    **kwargs: Any,
+) -> QaComplianceDecision:
+    """Compatibility name for the pure AQ-5 evaluator."""
+
+    return evaluate_qa_compliance(manifest, receipts, **kwargs)
+
+
+def assert_qa_compliance(
+    decision_or_manifest: QaComplianceDecision | AssuranceManifest | Mapping[str, Any],
+    receipts: Iterable[EvidenceReceipt | Mapping[str, Any]] | Mapping[str, Any] | None = None,
+    **kwargs: Any,
+) -> QaComplianceDecision:
+    """Return a compliant decision or raise a fail-closed contract error."""
+
+    if isinstance(decision_or_manifest, QaComplianceDecision):
+        decision = decision_or_manifest
+    elif receipts is not None:
+        decision = evaluate_qa_compliance(decision_or_manifest, receipts, **kwargs)
+    else:
+        _fail(FAIL_INVALID_INPUT, "assert_qa_compliance needs receipts")
+    if not decision.compliant:
+        _fail(FAIL_INVALID_INPUT, "AQ5 decision is not compliant")
+    return decision
+
+
+def validate_qa_compliance_contract(contract: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Validate the machine AQ-5 contract against runtime constants."""
+
+    if not isinstance(contract, Mapping):
+        raise TypeError("AQ5 machine contract must be a mapping")
+    constraints = {
+        "pure_domain": True,
+        "network_access": False,
+        "provider_access": False,
+        "repository_mutation": False,
+        "test_execution": False,
+        "promotion_or_transition": False,
+        "aq6_plus_implementation": False,
+    }
+    expected = {
+        "schema_version": AQ5_CONTRACT_SCHEMA_VERSION,
+        "phase": AQ5_PHASE,
+        "owner": "overseer",
+        "authority_model": AQ5_AUTHORITY_MODEL,
+        "decision_schema_version": AQ5_DECISION_SCHEMA_VERSION,
+        "decision_fields": list(QA_COMPLIANCE_FIELDS),
+        "required_negative_fixtures": list(REQUIRED_NEGATIVE_FIXTURES),
+        "required_invariants": list(REQUIRED_INVARIANTS),
+        "max_final_pr_paths": MAX_FINAL_PR_PATHS,
+        "quality_assurance_map": dict(QUALITY_ASSURANCE_MAP),
+        "completion_claim_scopes": dict(CLAIM_SCOPE_BY_STATE),
+        "required_completion_layers": {
+            state: list(layers) for state, layers in REQUIRED_EVIDENCE_LAYERS.items()
+        },
+        "protected_policy_prefixes": list(PROTECTED_POLICY_PREFIXES),
+        "authority": dict(AUTHORITY),
+        "constraints": constraints,
+    }
+    unknown = set(contract) - set(expected)
+    if unknown:
+        _fail(FAIL_INVALID_INPUT, "unsupported contract fields: " + ", ".join(sorted(unknown)))
+    for field_name, expected_value in expected.items():
+        if contract.get(field_name) != expected_value:
+            _fail(FAIL_INVALID_INPUT, f"machine contract drift: {field_name}")
+    return contract
+
+
+validate_machine_contract = validate_qa_compliance_contract
+validate_schema_runtime_parity = validate_qa_compliance_contract
+evaluate_repository_qa_compliance = evaluate_qa_compliance
+QAComplianceDecision = QaComplianceDecision
+
+
+__all__ = [
+    "AQ5_CONTRACT_SCHEMA_VERSION",
+    "AQ5_DECISION_SCHEMA_VERSION",
+    "AQ5_AUTHORITY_MODEL",
+    "AQ5_PHASE",
+    "QA_COMPLIANCE_FIELDS",
+    "ALLOWED_DECISION_RESULTS",
+    "REQUIRED_NEGATIVE_FIXTURES",
+    "REQUIRED_INVARIANTS",
+    "QUALITY_ASSURANCE_MAP",
+    "PROTECTED_POLICY_PREFIXES",
+    "AUTHORITY",
+    "QaComplianceContractError",
+    "QaComplianceDecision",
+    "QAComplianceDecision",
+    "evaluate_qa_compliance",
+    "evaluate_repository_qa_compliance",
+    "validate_qa_compliance",
+    "assert_qa_compliance",
+    "validate_qa_compliance_contract",
+    "validate_machine_contract",
+    "validate_schema_runtime_parity",
+    "FAIL_SECURITY_NO_EVIDENCE",
+    "FAIL_CONCURRENCY_NO_EVIDENCE",
+    "FAIL_RUNTIME_ONLY_OPENAPI",
+    "FAIL_PRODUCT_COMPLETE_WITHOUT_CALLER",
+    "FAIL_PASS_NONZERO_EXIT_CLAIM",
+    "FAIL_OLD_CANDIDATE_SHA",
+    "FAIL_UNEXECUTED_TEST_CLAIM",
+    "FAIL_TEST_DOES_NOT_REACH_CHANGED_CODE",
+    "FAIL_CHANGED_PATH_OMITTED",
+    "FAIL_POLICY_SELF_MODIFICATION",
+    "FAIL_AQ4_INVALID",
+    "FAIL_AQ4_EVIDENCE_INSUFFICIENT",
+    "FAIL_SOURCE_BINDING",
+    "FAIL_TREE_BINDING",
+    "FAIL_SEMANTIC_RISK_UNDECLARED",
+    "FAIL_REQUIRED_ASSURANCE_MISSING",
+    "FAIL_COMPLETION_SCOPE",
+    "FAIL_GATE_EVIDENCE_MISSING",
+    "FAIL_POLICY_INPUT_INVALID",
+    "FAIL_TEST_INPUT_INVALID",
+    "FAIL_INVALID_INPUT",
+    "FAIL_SCOPE_LIMIT",
+]

--- a/scripts/validation/validate_qa_compliance.py
+++ b/scripts/validation/validate_qa_compliance.py
@@ -1,0 +1,97 @@
+"""CLI adapter for the pure AQ-5 QA-compliance evaluator."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from orchestra_runtime.domain.adaptive.qa_compliance import evaluate_qa_compliance
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--receipts", required=True, type=Path)
+    parser.add_argument("--repository")
+    parser.add_argument("--source-ref")
+    parser.add_argument("--candidate-sha")
+    parser.add_argument("--tree-sha")
+    parser.add_argument("--changed-path", action="append", default=[])
+    parser.add_argument("--declared-path", action="append", default=[])
+    parser.add_argument("--semantic-risk", action="append")
+    parser.add_argument("--protected-gate-id", action="append", default=[])
+    parser.add_argument("--completion-state")
+    parser.add_argument("--runtime-claimed", action="store_true")
+    parser.add_argument("--caller-authority-ref")
+    parser.add_argument("--integration-evidence-id", action="append", default=[])
+    parser.add_argument("--completion-evidence-id", action="append", default=[])
+    parser.add_argument("--executed-test-id", action="append", default=[])
+    parser.add_argument("--test-coverage-json", type=Path)
+    parser.add_argument("--test-claimed", action="store_true")
+    parser.add_argument("--policy-modified-path", action="append", default=[])
+    parser.add_argument("--policy-path", action="append", default=[])
+    parser.add_argument("--policy-self-modification", action="store_true")
+    parser.add_argument("--current-authority-boundary", action="append")
+    parser.add_argument("--evaluated-at")
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def _load(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        manifest = _load(args.manifest)
+        receipts = _load(args.receipts)
+        coverage = _load(args.test_coverage_json) if args.test_coverage_json else None
+        decision = evaluate_qa_compliance(
+            manifest,
+            receipts,
+            current_repository=args.repository,
+            current_source_ref=args.source_ref,
+            current_candidate_sha=args.candidate_sha,
+            current_tree_sha=args.tree_sha,
+            changed_paths=args.changed_path,
+            declared_paths=args.declared_path,
+            semantic_risks=args.semantic_risk,
+            protected_gate_ids=args.protected_gate_id,
+            completion_state=args.completion_state,
+            runtime_claimed=args.runtime_claimed,
+            caller_authority_ref=args.caller_authority_ref,
+            integration_evidence_ids=args.integration_evidence_id,
+            completion_evidence_ids=args.completion_evidence_id,
+            executed_test_ids=args.executed_test_id,
+            test_coverage=coverage,
+            test_claimed=args.test_claimed,
+            policy_modified_paths=args.policy_modified_path,
+            policy_self_modification=args.policy_self_modification,
+            policy_paths=args.policy_path,
+            current_authority_boundary=args.current_authority_boundary,
+            evaluated_at=args.evaluated_at,
+        )
+        payload = json.dumps(decision.to_dict(), indent=2, sort_keys=True) + "\n"
+        if args.output:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(payload, encoding="utf-8", newline="\n")
+        print(f"QA_COMPLIANCE={decision.result}")
+        if decision.failure_codes:
+            print("QA_COMPLIANCE_FAILURES=" + ",".join(decision.failure_codes))
+        return 0 if decision.compliant else 1
+    except (OSError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        print(f"QA_COMPLIANCE=BLOCKED: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/behavior/test_qa_compliance.py
+++ b/tests/behavior/test_qa_compliance.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Behavior checks for the AQ-5 CLI boundary."""
+
+from __future__ import annotations
+
+import json
+import contextlib
+import importlib.util
+import io
+from pathlib import Path
+import subprocess
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from orchestra_runtime.domain.adaptive import (
+    EvidenceSlot,
+    build_assurance_manifest,
+    build_evidence_receipt,
+    build_routing_receipt,
+    profile_risk,
+)
+
+spec = importlib.util.spec_from_file_location("validate_qa_compliance", ROOT / "scripts" / "validation" / "validate_qa_compliance.py")
+validation = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(validation)
+
+
+SCRIPT = ROOT / "scripts" / "validation" / "validate_qa_compliance.py"
+SOURCE = "orchestra:2fb6a0a8b1d4a207742c9daaa1f5cbf0e87305de"
+CANDIDATE = "a" * 40
+TREE = "b" * 40
+GENERATED = "2026-09-08T14:00:00+08:00"
+OBSERVED = "2026-09-08T14:01:00+08:00"
+
+
+def _sample():
+    profile = profile_risk(
+        development_mode="SPEC_FIRST",
+        material_behavior="AQ5 CLI behavior validation",
+        authority_boundary=("IMPLEMENTATION",),
+        changed_domains=(),
+        changed_paths=(),
+        quality_dimensions=(),
+        risk_characteristics=(),
+        invariants=(),
+        protected_gates=(),
+    )
+    routing = build_routing_receipt(profile, source_identities=(SOURCE,))
+    slot = EvidenceSlot(
+        slot_id="gate-independent-qa",
+        assurance_class="INDEPENDENT_QA",
+        required_layer="CONTRACT",
+        required_scope="CONTRACT",
+        required_validator="overseer",
+        required_source_truth="OBSERVED",
+        required_provenance="AUTHORITATIVE",
+        covered_risks=(),
+        covered_invariants=(),
+        independence_required=True,
+    )
+    manifest = build_assurance_manifest(
+        profile=profile,
+        receipt=routing,
+        manifest_id="manifest-aq5-behavior",
+        repository="Baelfyre/Orchestra",
+        source_ref=SOURCE,
+        candidate_sha=CANDIDATE,
+        tree_sha=TREE,
+        work_item_ref="AQ5",
+        change_class="AQ5_IMPLEMENTATION",
+        completion_target="AQ5_CANDIDATE_READY_FOR_INDEPENDENT_REVIEW",
+        required_evidence_slots=(slot,),
+        selected_specialists=tuple(routing.selected_specialists),
+        required_assurance=tuple(routing.required_assurance),
+        generated_at=GENERATED,
+    )
+    receipt = build_evidence_receipt(
+        manifest,
+        receipt_id="receipt-gate-independent-qa",
+        gate_id=slot.slot_id,
+        gate_type="TEST",
+        command_or_workflow="python -B -m pytest",
+        result="PASS",
+        observed_at=OBSERVED,
+        producer="ponytail",
+        exit_code=0,
+        logical_identity="logical-gate-independent-qa",
+    )
+    return manifest, receipt
+
+
+def _run_cli_checks():
+    manifest, receipt = _sample()
+    original_load = validation._load
+
+    def fake_load(path: Path):
+        return manifest.to_dict() if path.name == "manifest.json" else [receipt.to_dict()]
+
+    validation._load = fake_load
+    common = [
+        "--manifest",
+        "manifest.json",
+        "--receipts",
+        "receipts.json",
+        "--evaluated-at",
+        OBSERVED,
+    ]
+    try:
+        passed_output = io.StringIO()
+        with contextlib.redirect_stdout(passed_output):
+            passed = validation.main(
+                common
+                + [
+                    "--changed-path",
+                    "orchestra_runtime/domain/adaptive/qa_compliance.py",
+                    "--declared-path",
+                    "orchestra_runtime/domain/adaptive/qa_compliance.py",
+                ]
+            )
+        assert passed == 0
+        assert "QA_COMPLIANCE=PASS" in passed_output.getvalue()
+
+        failed_output = io.StringIO()
+        with contextlib.redirect_stdout(failed_output):
+            failed = validation.main(
+                common + ["--changed-path", "orchestra_runtime/domain/adaptive/qa_compliance.py"]
+            )
+        assert failed == 1
+        assert "AQ5-F9_CHANGED_PATH_OMITTED" in failed_output.getvalue()
+    finally:
+        validation._load = original_load
+
+
+def test_cli_pass_and_fail():
+    _run_cli_checks()
+
+
+def main() -> int:
+    test_cli_pass_and_fail()
+    help_result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--help"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert help_result.returncode == 0, help_result.stderr
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/runtime/test_adaptive_assurance_aq5.py
+++ b/tests/runtime/test_adaptive_assurance_aq5.py
@@ -1,0 +1,685 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from orchestra_runtime.domain.adaptive import (
+    EvidenceReceipt,
+    EvidenceSlot,
+    build_assurance_manifest,
+    build_evidence_receipt,
+    build_routing_receipt,
+    profile_risk,
+)
+from orchestra_runtime.domain.adaptive.assurance_manifest import (
+    AssuranceManifestContractError,
+    FAIL_PASS_NONZERO_EXIT,
+)
+from orchestra_runtime.domain.adaptive import qa_compliance as aq5
+from orchestra_runtime.domain.adaptive.qa_compliance import (
+    AQ5_AUTHORITY_MODEL,
+    AQ5_CONTRACT_SCHEMA_VERSION,
+    AQ5_DECISION_SCHEMA_VERSION,
+    FAIL_CHANGED_PATH_OMITTED,
+    FAIL_CONCURRENCY_NO_EVIDENCE,
+    FAIL_GATE_EVIDENCE_MISSING,
+    FAIL_OLD_CANDIDATE_SHA,
+    FAIL_PASS_NONZERO_EXIT_CLAIM,
+    FAIL_POLICY_SELF_MODIFICATION,
+    FAIL_PRODUCT_COMPLETE_WITHOUT_CALLER,
+    FAIL_REQUIRED_ASSURANCE_MISSING,
+    FAIL_RUNTIME_ONLY_OPENAPI,
+    FAIL_SECURITY_NO_EVIDENCE,
+    FAIL_SEMANTIC_RISK_UNDECLARED,
+    FAIL_SOURCE_BINDING,
+    FAIL_TEST_DOES_NOT_REACH_CHANGED_CODE,
+    FAIL_TREE_BINDING,
+    FAIL_UNEXECUTED_TEST_CLAIM,
+    FAIL_AQ4_INVALID,
+    FAIL_COMPLETION_SCOPE,
+    QaComplianceContractError,
+    QaComplianceDecision,
+    assert_qa_compliance,
+    evaluate_qa_compliance,
+    validate_qa_compliance_contract,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT_PATH = ROOT / "machine" / "adaptive" / "aq5-qa-compliance.v1.json"
+SCHEMA_PATH = ROOT / "machine" / "schemas" / "qa-compliance.v1.schema.json"
+SOURCE = "orchestra:2fb6a0a8b1d4a207742c9daaa1f5cbf0e87305de"
+CANDIDATE = "a" * 40
+TREE = "b" * 40
+OTHER_CANDIDATE = "c" * 40
+OTHER_TREE = "d" * 40
+GENERATED = "2026-09-08T14:00:00+08:00"
+OBSERVED = "2026-09-08T14:01:00+08:00"
+
+
+def _profile(
+    *,
+    quality_dimensions: tuple[str, ...] = (),
+    risk_characteristics: tuple[str, ...] = (),
+    invariants: tuple[str, ...] = (),
+    protected_gates: tuple[str, ...] = (),
+):
+    return profile_risk(
+        development_mode="SPEC_FIRST",
+        material_behavior="repository QA compliance evidence evaluation",
+        authority_boundary=("IMPLEMENTATION",),
+        changed_domains=("domain",),
+        changed_paths=("orchestra_runtime/domain/adaptive/qa_compliance.py",),
+        quality_dimensions=quality_dimensions,
+        risk_characteristics=risk_characteristics,
+        invariants=invariants,
+        protected_gates=protected_gates,
+    )
+
+
+def _layer_for(assurance_class: str) -> tuple[str, str]:
+    if assurance_class == "SECURITY_ASSURANCE":
+        return "SECURITY", "SECURITY"
+    if assurance_class == "CONCURRENCY_ASSURANCE":
+        return "CONCURRENCY", "CONCURRENCY"
+    if assurance_class == "PROVENANCE_ASSURANCE":
+        return "PROVENANCE", "CANONICAL"
+    if assurance_class == "INDEPENDENT_QA":
+        return "CONTRACT", "CONTRACT"
+    return "CONTRACT", "CONTRACT"
+
+
+def _slots(
+    required_assurance: tuple[str, ...],
+    *,
+    risks: tuple[str, ...] = (),
+    invariants: tuple[str, ...] = (),
+    layer_overrides: dict[str, str] | None = None,
+    scope_overrides: dict[str, str] | None = None,
+    extra_slots: tuple[EvidenceSlot, ...] = (),
+) -> tuple[EvidenceSlot, ...]:
+    layer_overrides = layer_overrides or {}
+    scope_overrides = scope_overrides or {}
+    slots = [
+        EvidenceSlot(
+            slot_id=f"gate-{index}-{assurance.casefold()}",
+            assurance_class=assurance,
+            required_layer=layer_overrides.get(assurance, _layer_for(assurance)[0]),
+            required_scope=scope_overrides.get(assurance, _layer_for(assurance)[1]),
+            required_validator="overseer",
+            required_source_truth="OBSERVED",
+            required_provenance="AUTHORITATIVE",
+            covered_risks=risks,
+            covered_invariants=invariants,
+            independence_required=assurance == "INDEPENDENT_QA",
+        )
+        for index, assurance in enumerate(required_assurance)
+    ]
+    return tuple(slots) + extra_slots
+
+
+def _manifest(
+    profile=None,
+    *,
+    layer_overrides: dict[str, str] | None = None,
+    scope_overrides: dict[str, str] | None = None,
+    extra_slots: tuple[EvidenceSlot, ...] = (),
+    protected_gates: tuple[str, ...] | None = None,
+):
+    profile = profile or _profile()
+    routing = build_routing_receipt(profile, source_identities=(SOURCE,))
+    protected = tuple(profile.protected_gates) if protected_gates is None else protected_gates
+    return build_assurance_manifest(
+        profile=profile,
+        receipt=routing,
+        manifest_id="manifest-aq5",
+        repository="Baelfyre/Orchestra",
+        source_ref=SOURCE,
+        candidate_sha=CANDIDATE,
+        tree_sha=TREE,
+        work_item_ref="AQ5",
+        change_class="AQ5_IMPLEMENTATION",
+        completion_target="AQ5_CANDIDATE_READY_FOR_INDEPENDENT_REVIEW",
+        required_evidence_slots=_slots(
+            tuple(routing.required_assurance),
+            risks=tuple(profile.risk_characteristics),
+            invariants=tuple(profile.invariants),
+            layer_overrides=layer_overrides,
+            scope_overrides=scope_overrides,
+            extra_slots=extra_slots,
+        ),
+        selected_specialists=tuple(routing.selected_specialists),
+        required_assurance=tuple(routing.required_assurance),
+        generated_at=GENERATED,
+        protected_gates=protected,
+    )
+
+
+def _receipt(manifest, *, gate_id: str, **overrides: object):
+    values: dict[str, object] = {
+        "receipt_id": f"receipt-{gate_id}",
+        "gate_id": gate_id,
+        "gate_type": "TEST",
+        "command_or_workflow": "python -B -m pytest",
+        "result": "PASS",
+        "observed_at": OBSERVED,
+        "producer": "ponytail",
+        "exit_code": 0,
+        "logical_identity": f"logical-{gate_id}",
+    }
+    values.update(overrides)
+    return build_evidence_receipt(manifest, **values)
+
+
+def _receipts(manifest):
+    return tuple(
+        _receipt(manifest, gate_id=slot.slot_id)
+        for slot in manifest.required_evidence_slots
+    )
+
+
+def _decision(manifest, receipts, **kwargs):
+    kwargs.setdefault("changed_paths", ())
+    kwargs.setdefault("declared_paths", ())
+    kwargs.setdefault("evaluated_at", OBSERVED)
+    return evaluate_qa_compliance(manifest, receipts, **kwargs)
+
+
+def test_positive_decision_is_source_bound_and_non_authorizing():
+    manifest = _manifest(_profile(invariants=("FAILED_VALIDATION_MUST_NOT_BECOME_PASS",)))
+    decision = _decision(manifest, _receipts(manifest))
+    assert decision.result == "PASS"
+    assert decision.compliant is True
+    assert decision.failure_codes == ()
+    assert decision.candidate_sha == CANDIDATE
+    assert decision.tree_sha == TREE
+    assert decision.to_dict()["compliant"] is True
+
+
+def test_contract_runtime_parity_is_strict():
+    contract = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+    assert validate_qa_compliance_contract(contract) is contract
+    assert contract["schema_version"] == AQ5_CONTRACT_SCHEMA_VERSION
+    assert contract["authority_model"] == AQ5_AUTHORITY_MODEL
+    assert contract["decision_schema_version"] == AQ5_DECISION_SCHEMA_VERSION
+    with pytest.raises(QaComplianceContractError):
+        validate_qa_compliance_contract({**contract, "authority_model": "AUTHORIZING"})
+    with pytest.raises(QaComplianceContractError):
+        validate_qa_compliance_contract({**contract, "unexpected": True})
+
+
+def test_decision_schema_is_strict_and_accepts_runtime_output():
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.Draft202012Validator.check_schema(schema)
+    manifest = _manifest(_profile())
+    decision = _decision(manifest, _receipts(manifest))
+    jsonschema.Draft202012Validator(schema).validate(decision.to_dict())
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.Draft202012Validator(schema).validate({**decision.to_dict(), "extra": True})
+
+
+def test_security_sensitive_change_without_security_layer_fails():
+    manifest = _manifest(
+        _profile(quality_dimensions=("SECURITY",), risk_characteristics=("AUTHORIZATION",)),
+        layer_overrides={"SECURITY_ASSURANCE": "CONTRACT"},
+    )
+    decision = _decision(manifest, _receipts(manifest))
+    assert decision.result == "FAIL"
+    assert FAIL_SECURITY_NO_EVIDENCE in decision.failure_codes
+
+
+def test_concurrency_change_without_concurrency_layer_fails():
+    manifest = _manifest(
+        _profile(risk_characteristics=("CONCURRENCY",)),
+        layer_overrides={"CONCURRENCY_ASSURANCE": "CONTRACT"},
+    )
+    decision = _decision(manifest, _receipts(manifest))
+    assert decision.result == "FAIL"
+    assert FAIL_CONCURRENCY_NO_EVIDENCE in decision.failure_codes
+
+
+def test_runtime_claim_needs_http_and_runtime_evidence():
+    manifest = _manifest(
+        _profile(quality_dimensions=("FUNCTIONAL_SUITABILITY",)),
+        layer_overrides={"FUNCTIONAL_ASSURANCE": "HTTP", "INDEPENDENT_QA": "HTTP"},
+    )
+    decision = _decision(manifest, _receipts(manifest), completion_state="RUNTIME_VERIFIED")
+    assert decision.result == "FAIL"
+    assert FAIL_RUNTIME_ONLY_OPENAPI in decision.failure_codes
+
+
+def test_product_complete_needs_caller_and_integration_evidence():
+    manifest = _manifest(_profile())
+    decision = _decision(manifest, _receipts(manifest), completion_state="PRODUCT_COMPLETE")
+    assert decision.result == "FAIL"
+    assert FAIL_PRODUCT_COMPLETE_WITHOUT_CALLER in decision.failure_codes
+
+
+def test_pass_with_nonzero_exit_is_rejected_and_preserved():
+    manifest = _manifest(_profile())
+    receipts = list(_receipts(manifest))
+    tampered = receipts[0].to_dict()
+    tampered["exit_code"] = 1
+    tampered["evidence_digest"] = ""
+    decision = _decision(manifest, [tampered])
+    assert decision.result == "FAIL"
+    assert FAIL_PASS_NONZERO_EXIT_CLAIM in decision.failure_codes
+    assert FAIL_PASS_NONZERO_EXIT in decision.failure_codes
+
+
+def test_old_candidate_sha_is_rejected():
+    manifest = _manifest(_profile())
+    decision = _decision(
+        manifest,
+        _receipts(manifest),
+        current_candidate_sha=OTHER_CANDIDATE,
+    )
+    assert decision.result == "FAIL"
+    assert FAIL_OLD_CANDIDATE_SHA in decision.failure_codes
+
+
+def test_required_test_claim_without_execution_fails():
+    manifest = _manifest(_profile())
+    decision = _decision(
+        manifest,
+        _receipts(manifest),
+        changed_paths=("orchestra_runtime/domain/adaptive/qa_compliance.py",),
+        declared_paths=("orchestra_runtime/domain/adaptive/qa_compliance.py",),
+        test_claimed=True,
+    )
+    assert decision.result == "FAIL"
+    assert FAIL_UNEXECUTED_TEST_CLAIM in decision.failure_codes
+
+
+def test_executed_test_that_misses_changed_code_fails():
+    manifest = _manifest(_profile())
+    decision = _decision(
+        manifest,
+        _receipts(manifest),
+        changed_paths=("orchestra_runtime/domain/adaptive/qa_compliance.py",),
+        declared_paths=("orchestra_runtime/domain/adaptive/qa_compliance.py",),
+        executed_test_ids=("aq5-runtime",),
+        test_coverage={"aq5-runtime": ("tests/runtime/test_adaptive_assurance_aq5.py",)},
+    )
+    assert decision.result == "FAIL"
+    assert FAIL_TEST_DOES_NOT_REACH_CHANGED_CODE in decision.failure_codes
+
+
+def test_changed_path_omitted_from_declaration_fails():
+    manifest = _manifest(_profile())
+    decision = _decision(
+        manifest,
+        _receipts(manifest),
+        changed_paths=("orchestra_runtime/domain/adaptive/qa_compliance.py",),
+        declared_paths=(),
+    )
+    assert decision.result == "FAIL"
+    assert FAIL_CHANGED_PATH_OMITTED in decision.failure_codes
+
+
+def test_policy_self_modification_fails_closed():
+    manifest = _manifest(_profile())
+    decision = _decision(
+        manifest,
+        _receipts(manifest),
+        changed_paths=("machine/governance/policy.json",),
+        declared_paths=("machine/governance/policy.json",),
+        policy_self_modification=True,
+    )
+    assert decision.result == "FAIL"
+    assert FAIL_POLICY_SELF_MODIFICATION in decision.failure_codes
+
+
+def test_undeclared_semantic_risk_fails():
+    manifest = _manifest(_profile())
+    decision = _decision(manifest, _receipts(manifest), semantic_risks=("SECURITY",))
+    assert decision.result == "FAIL"
+    assert FAIL_SEMANTIC_RISK_UNDECLARED in decision.failure_codes
+
+
+def test_explicit_protected_slot_needs_a_pass_receipt():
+    profile = _profile()
+    manifest = _manifest(profile)
+    protected_slot = manifest.required_evidence_slots[0].slot_id
+    manifest = _manifest(profile, protected_gates=(protected_slot,))
+    receipts = tuple(
+        receipt for receipt in _receipts(manifest) if receipt.gate_id != protected_slot
+    )
+    decision = _decision(manifest, receipts)
+    assert decision.result == "FAIL"
+    assert FAIL_GATE_EVIDENCE_MISSING in decision.failure_codes
+
+
+def test_receipt_order_does_not_change_canonical_decision():
+    manifest = _manifest(_profile(quality_dimensions=("PROVENANCE",), risk_characteristics=("PROVENANCE",)))
+    receipts = _receipts(manifest)
+    first = _decision(manifest, receipts, semantic_risks=("PROVENANCE",))
+    second = _decision(manifest, tuple(reversed(receipts)), semantic_risks=("PROVENANCE",))
+    assert first.to_dict() == second.to_dict()
+
+
+def test_decision_mapping_rejects_tampering_and_unknown_fields():
+    manifest = _manifest(_profile())
+    decision = _decision(manifest, _receipts(manifest))
+    from orchestra_runtime.domain.adaptive.qa_compliance import QaComplianceDecision
+
+    with pytest.raises(QaComplianceContractError):
+        QaComplianceDecision.from_mapping({**decision.to_dict(), "compliant": False})
+    with pytest.raises(QaComplianceContractError):
+        QaComplianceDecision.from_mapping({**decision.to_dict(), "extra": True})
+
+
+def test_stale_receipt_candidate_is_rejected():
+    manifest = _manifest(_profile())
+    receipt = _receipts(manifest)[0].to_dict()
+    receipt["candidate_sha"] = OTHER_CANDIDATE
+    receipt["evidence_digest"] = ""
+    decision = _decision(manifest, [receipt])
+    assert decision.result == "FAIL"
+    assert "AQ4-N4_RECEIPT_CANDIDATE_MISMATCH" in decision.failure_codes
+    assert FAIL_OLD_CANDIDATE_SHA in decision.failure_codes
+
+
+def test_mapping_inputs_aliases_and_source_tree_guards():
+    manifest = _manifest(_profile())
+    receipts = _receipts(manifest)
+    mapped = _decision(
+        manifest.to_dict(),
+        {"receipts": [receipt.to_dict() for receipt in receipts]},
+        actual_changed_paths=("orchestra_runtime/domain/adaptive/qa_compliance.py",),
+        manifest_declared_paths=("orchestra_runtime/domain/adaptive/qa_compliance.py",),
+        claimed_risks=(),
+    )
+    assert mapped.result == "PASS"
+    single = _decision(manifest, receipts[0].to_dict())
+    assert single.result == "PASS"
+    source_mismatch = _decision(manifest, receipts, current_source_ref="orchestra:other")
+    tree_mismatch = _decision(manifest, receipts, current_tree_sha=OTHER_TREE)
+    assert FAIL_SOURCE_BINDING in source_mismatch.failure_codes
+    assert FAIL_TREE_BINDING in tree_mismatch.failure_codes
+    invalid_boundary = _decision(manifest, receipts, current_authority_boundary=123)
+    assert FAIL_AQ4_INVALID in invalid_boundary.failure_codes
+
+
+def test_evidence_and_input_exceptions_fail_closed(monkeypatch):
+    manifest = _manifest(_profile())
+    no_receipts = _decision(manifest, None)
+    assert FAIL_AQ4_INVALID in no_receipts.failure_codes
+
+    def raise_aq4(*args, **kwargs):
+        raise AssuranceManifestContractError("AQ4_TEST_FAILURE")
+
+    monkeypatch.setattr(aq5, "reconcile_manifest_evidence", raise_aq4)
+    decision = _decision(manifest, _receipts(manifest))
+    assert "AQ4_TEST_FAILURE" in decision.failure_codes
+
+    def raise_type_error(*args, **kwargs):
+        raise TypeError("reconciliation type failure")
+
+    monkeypatch.setattr(aq5, "reconcile_manifest_evidence", raise_type_error)
+    type_failure = _decision(manifest, _receipts(manifest))
+    assert FAIL_AQ4_INVALID in type_failure.failure_codes
+
+    with pytest.raises(TypeError):
+        evaluate_qa_compliance("not-a-manifest", ())
+
+
+@pytest.mark.parametrize(
+    "operation",
+    (
+        lambda: aq5._text("", "field"),
+        lambda: aq5._sha("z" * 40, "sha"),
+        lambda: aq5._sha256("bad"),
+        lambda: aq5._timestamp("not-a-date", "time"),
+        lambda: aq5._timestamp("2026-09-08T14:00:00", "time"),
+        lambda: aq5._values("not-iterable", "values"),
+        lambda: aq5._values(123, "values"),
+        lambda: aq5._values(("duplicate", "duplicate"), "values"),
+        lambda: aq5._paths(("/absolute.py",), "paths"),
+        lambda: aq5._paths(("C:/absolute.py",), "paths"),
+        lambda: aq5._paths(("./relative.py",), "paths"),
+        lambda: aq5._paths(("a/../b.py",), "paths"),
+        lambda: aq5._paths(("a\\b.py", "a/b.py"), "paths"),
+        lambda: aq5._assurance(("UNKNOWN_ASSURANCE",), "assurance"),
+    ),
+)
+def test_normalizers_fail_closed(operation):
+    with pytest.raises(QaComplianceContractError):
+        operation()
+
+
+def test_normalizer_and_mapping_success_edges():
+    assert aq5._text(" value ", "field") == "value"
+    assert aq5._sha(CANDIDATE.upper(), "sha") == CANDIDATE
+    assert aq5._timestamp(OBSERVED, "time") == OBSERVED
+    assert aq5._values(("b", "a"), "values") == ("a", "b")
+    assert aq5._paths(("a\\b.py",), "paths") == ("a/b.py",)
+    assert aq5._assurance(("INDEPENDENT_QA",), "assurance") == ("INDEPENDENT_QA",)
+    assert aq5._risk_assurance("PROVENANCE") == "PROVENANCE_ASSURANCE"
+    assert aq5._risk_assurance("PROVENANCE") == aq5._risk_assurance("PROVENANCE")
+    assert aq5._risk_assurance("NOT_A_RISK") is None
+    assert aq5._is_policy_path("machine/governance/policy.json") is True
+    assert aq5._is_policy_path("docs/notes.md") is False
+
+
+def test_scope_completion_runtime_and_test_claim_variants():
+    manifest = _manifest(_profile())
+    ten_paths = tuple(f"path-{index}.py" for index in range(10))
+    oversized = _decision(
+        manifest,
+        _receipts(manifest),
+        changed_paths=ten_paths,
+        declared_paths=ten_paths,
+    )
+    assert aq5.FAIL_SCOPE_LIMIT in oversized.failure_codes
+
+    invalid_state = _decision(manifest, _receipts(manifest), completion_state="NOT_A_STATE")
+    assert FAIL_COMPLETION_SCOPE in invalid_state.failure_codes
+
+    runtime_manifest = _manifest(
+        _profile(quality_dimensions=("FUNCTIONAL_SUITABILITY",)),
+        layer_overrides={"FUNCTIONAL_ASSURANCE": "HTTP", "INDEPENDENT_QA": "RUNTIME"},
+    )
+    runtime_receipts = _receipts(runtime_manifest)
+    runtime_pass = _decision(
+        runtime_manifest,
+        runtime_receipts,
+        completion_state="RUNTIME_VERIFIED",
+        runtime_claimed=True,
+    )
+    assert runtime_pass.result == "PASS"
+
+    changed = "orchestra_runtime/domain/adaptive/qa_compliance.py"
+    covered = _decision(
+        manifest,
+        _receipts(manifest),
+        changed_paths=(changed,),
+        declared_paths=(changed,),
+        executed_test_ids=("aq5-runtime",),
+        test_coverage={"aq5-runtime": (changed,)},
+        test_claimed=True,
+    )
+    assert covered.result == "PASS"
+    missing_id = _decision(
+        manifest,
+        _receipts(manifest),
+        executed_test_ids=("missing",),
+        test_coverage={"known": ()},
+    )
+    invalid_coverage = _decision(
+        manifest,
+        _receipts(manifest),
+        executed_test_ids=("bad",),
+        test_coverage={"bad": None},
+    )
+    assert FAIL_UNEXECUTED_TEST_CLAIM in missing_id.failure_codes
+    assert FAIL_UNEXECUTED_TEST_CLAIM in invalid_coverage.failure_codes
+    policy_prefix = _decision(
+        manifest,
+        _receipts(manifest),
+        changed_paths=(changed,),
+        declared_paths=(changed,),
+        policy_paths=("orchestra_runtime",),
+    )
+    assert FAIL_POLICY_SELF_MODIFICATION in policy_prefix.failure_codes
+
+    runtime_failure = _decision(manifest, _receipts(manifest), runtime_claimed=True)
+    assert FAIL_RUNTIME_ONLY_OPENAPI in runtime_failure.failure_codes
+    unit_claim = _decision(manifest, _receipts(manifest), completion_state="UNIT_VERIFIED")
+    assert FAIL_COMPLETION_SCOPE in unit_claim.failure_codes
+    invalid_flags = _decision(
+        manifest,
+        _receipts(manifest),
+        runtime_claimed=1,
+        test_claimed=1,
+        policy_self_modification=1,
+    )
+    assert aq5.FAIL_INVALID_INPUT in invalid_flags.failure_codes
+    assert aq5.FAIL_POLICY_INPUT_INVALID in invalid_flags.failure_codes
+
+
+def test_assurance_presence_and_provenance_layer_guards():
+    functional = _manifest(_profile(quality_dimensions=("FUNCTIONAL_SUITABILITY",)))
+    removed = replace(
+        functional,
+        required_assurance=("INDEPENDENT_QA",),
+        manifest_digest="",
+    )
+    not_required = _decision(
+        removed,
+        _receipts(removed),
+        semantic_risks=("FUNCTIONAL_SUITABILITY",),
+    )
+    assert FAIL_REQUIRED_ASSURANCE_MISSING in not_required.failure_codes
+
+    functional_receipt = next(
+        receipt
+        for receipt in _receipts(functional)
+        if receipt.gate_id == "gate-0-functional_assurance"
+    )
+    missing_receipt = _decision(
+        functional,
+        tuple(receipt for receipt in _receipts(functional) if receipt != functional_receipt),
+        semantic_risks=("FUNCTIONAL_SUITABILITY",),
+    )
+    assert FAIL_REQUIRED_ASSURANCE_MISSING in missing_receipt.failure_codes
+
+    provenance = _manifest(
+        _profile(quality_dimensions=("PROVENANCE",), risk_characteristics=("PROVENANCE",)),
+        layer_overrides={"PROVENANCE_ASSURANCE": "CONTRACT"},
+    )
+    provenance_missing = _decision(
+        provenance,
+        _receipts(provenance),
+        semantic_risks=("PROVENANCE",),
+    )
+    assert FAIL_REQUIRED_ASSURANCE_MISSING in provenance_missing.failure_codes
+
+    protected = functional.required_evidence_slots[0].slot_id
+    assert _decision(functional, _receipts(functional), protected_gate_ids=(protected,)).result == "PASS"
+
+
+def test_validate_alias_and_decision_integrity_boundaries():
+    manifest = _manifest(_profile())
+    receipts = _receipts(manifest)
+    from orchestra_runtime.domain.adaptive.qa_compliance import validate_qa_compliance
+
+    assert validate_qa_compliance(manifest, receipts, evaluated_at=OBSERVED).result == "PASS"
+
+
+def test_product_complete_positive_and_protected_unknown_gate():
+    profile = _profile(quality_dimensions=("FUNCTIONAL_SUITABILITY",))
+    completion_slot = EvidenceSlot(
+        slot_id="gate-completion-state",
+        assurance_class="INDEPENDENT_QA",
+        required_layer="COMPLETION_STATE",
+        required_scope="COMPLETION",
+        required_validator="overseer",
+        required_source_truth="OBSERVED",
+        required_provenance="AUTHORITATIVE",
+        covered_risks=(),
+        covered_invariants=(),
+        independence_required=False,
+    )
+    manifest = _manifest(
+        profile,
+        layer_overrides={"FUNCTIONAL_ASSURANCE": "INTEGRATION", "INDEPENDENT_QA": "INTEGRATION"},
+        extra_slots=(completion_slot,),
+    )
+    receipts = _receipts(manifest)
+    product = _decision(
+        manifest,
+        receipts,
+        completion_state="PRODUCT_COMPLETE",
+        caller_authority_ref="human-review-1",
+        integration_evidence_ids=(receipts[0].receipt_id,),
+        completion_evidence_ids=(receipts[-1].receipt_id,),
+    )
+    assert product.result == "PASS"
+    unknown_gate = _decision(manifest, receipts, protected_gate_ids=("unknown-gate",))
+    assert FAIL_GATE_EVIDENCE_MISSING in unknown_gate.failure_codes
+
+
+def test_invalid_receipt_metadata_and_decision_assertions():
+    manifest = _manifest(_profile())
+    raw = _receipts(manifest)[0].to_dict()
+    raw.pop("exit_code")
+    raw["evidence_digest"] = ""
+    invalid = _decision(manifest, [raw])
+    assert FAIL_UNEXECUTED_TEST_CLAIM in invalid.failure_codes
+
+    good = _decision(manifest, _receipts(manifest))
+    assert QaComplianceDecision.from_mapping(good.to_dict()).to_dict() == good.to_dict()
+    assert assert_qa_compliance(good) is good
+    assert assert_qa_compliance(manifest, _receipts(manifest)).result == "PASS"
+    with pytest.raises(QaComplianceContractError):
+        assert_qa_compliance(invalid)
+    with pytest.raises(QaComplianceContractError):
+        assert_qa_compliance(manifest)
+    with pytest.raises(TypeError):
+        QaComplianceDecision.from_mapping([])
+
+
+def test_decision_constructor_rejects_each_integrity_boundary():
+    manifest = _manifest(_profile())
+    good = _decision(manifest, _receipts(manifest)).to_dict()
+
+    with pytest.raises(QaComplianceContractError):
+        QaComplianceDecision.from_mapping({**good, "schema_version": "wrong"})
+    bad_result = {**good, "result": "UNKNOWN", "compliant": False}
+    bad_result["decision_digest"] = aq5._digest(
+        {key: value for key, value in bad_result.items() if key != "decision_digest"}
+    )
+    with pytest.raises(QaComplianceContractError):
+        QaComplianceDecision.from_mapping(bad_result)
+    bad_state = {**good, "completion_state": "UNKNOWN", "compliant": True}
+    bad_state["decision_digest"] = aq5._digest(
+        {key: value for key, value in bad_state.items() if key != "decision_digest"}
+    )
+    with pytest.raises(QaComplianceContractError):
+        QaComplianceDecision.from_mapping(bad_state)
+    with pytest.raises(QaComplianceContractError):
+        QaComplianceDecision.from_mapping({**good, "decision_digest": "0" * 64})
+
+    failed = _decision(
+        manifest,
+        _receipts(manifest),
+        changed_paths=("a.py",),
+        declared_paths=(),
+    ).to_dict()
+    failed["result"] = "PASS"
+    failed["compliant"] = True
+    failed["decision_digest"] = aq5._digest(
+        {key: value for key, value in failed.items() if key != "decision_digest"}
+    )
+    with pytest.raises(QaComplianceContractError):
+        QaComplianceDecision.from_mapping(failed)
+
+
+def test_contract_validator_type_boundary():
+    with pytest.raises(TypeError):
+        validate_qa_compliance_contract([])


### PR DESCRIPTION
## Scope

Adds the bounded AQ5 repository QA compliance evaluator, strict machine contract/schema, CLI adapter, focused runtime and behavior tests, and the AQ5 validation workflow.

- Stacked directly on frozen AQ4 PR #841 at b02e562d35e02441ce0efbc620f43dcb7430c3ed.
- Exact AQ5 inventory: 8 paths.
- AQ4 implementation paths remain unchanged.
- PRAI is future post-AQ5 planning and is not implemented here.

## Boundaries

No merge, signed materialization, Padayon reconciliation, AQ6+ implementation, provider/deployment activity, force push, amend, rebase, or history rewrite.