### PR TITLE
docs(readme): add Claude plugin and MCP quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,33 @@ Add this repository as a Marketplace source, install Orchestra, then invoke:
 @Orchestra
 ```
 
+### Claude
+
+#### Claude app / desktop plugin marketplace
+
+1. Open **Customize > Plugins**.
+2. Under **Personal plugins**, select **+ > Add marketplace > Add from a repository**.
+3. Paste:
+
+```text
+https://github.com/Baelfyre/Orchestra
+```
+
+4. Install the **orchestra** plugin.
+
+If your Claude client exposes plugin management under **Settings > Extensions > Plugins**, choose **Add Marketplace** there and use the same repository URL.
+
+#### Claude Code
+
+From a Claude Code session:
+
+```text
+/plugin marketplace add Baelfyre/Orchestra
+/plugin install orchestra@orchestra
+```
+
+If Claude reports that plugin changes require a reload, run `/reload-plugins`.
+
 ### Antigravity
 
 ```sh
@@ -112,9 +139,36 @@ See the [Getting Started reference](docs/reference/getting-started/README.md), [
 
 Orchestra can expose a bounded tool surface to an MCP-compatible client while preserving the same runtime and governance boundaries.
 
+### Codex MCP
+
 ```sh
 python scripts/mcp_server.py --adapter codex
 ```
+
+### Claude Code MCP
+
+Orchestra already registers `claude-code` as a runtime adapter, so the same local stdio server can be launched with the Claude adapter:
+
+```sh
+python scripts/mcp_server.py --adapter claude-code
+```
+
+To register the local server with Claude Code, replace `<path-to-Orchestra>` with your local clone path:
+
+```sh
+claude mcp add --scope user --transport stdio orchestra -- python "<path-to-Orchestra>/scripts/mcp_server.py" --adapter claude-code
+claude mcp get orchestra
+```
+
+Restart Claude Code after registration, then run:
+
+```text
+/mcp
+```
+
+The Claude MCP path is **prepared at the adapter and stdio-transport level**. The repository does not yet record an installed-host Claude MCP end-to-end proof equivalent to the existing Codex validation, so do not classify Claude MCP host execution as verified until that test is completed.
+
+The Claude marketplace plugin also does not currently auto-register Orchestra MCP because the plugin root does not ship a `.mcp.json`; MCP registration is a separate explicit setup step.
 
 MCP is transport, not authority. Discovery or tool access does not grant permission to perform protected actions.
 


### PR DESCRIPTION
## Summary

Add a bounded Claude onboarding section to the root README without touching AQ5-R2.

### Claude plugin quickstart
- document the current Claude app marketplace flow;
- include the repository URL for `Baelfyre/Orchestra`;
- include Claude Code marketplace commands for the existing `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json`.

### Claude MCP status and setup
- document the existing `claude-code` runtime adapter;
- document manual stdio startup with `scripts/mcp_server.py --adapter claude-code`;
- document Claude Code registration through `claude mcp add --transport stdio`;
- explicitly state that Claude installed-host MCP E2E is not yet recorded;
- explicitly state that the plugin does not yet auto-register MCP because no root `.mcp.json` is shipped.

## Scope

README-only documentation change.

Base: canonical Orchestra main `5781ee68a2053a4a88451522419a9d1d21e7e6f4`

This PR is independent of AQ5-R2 PR #851 and does not alter its candidate lineage, runtime, tests, policy, or validation scope.