### PR TITLE
governance: recognize exact Covenant assurance scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased governance policy amendment: Covenant assurance scope
+
+- Adds a human-authorized exact-scope classification for the future fresh Covenant implementation without changing historical AQ5, AQ6, AQ7, or PRAI implementation inventories.
+- Keeps anchored partial, mixed, unknown, and unrecognized Covenant changes fail-closed `APPLICABLE`.
+- Adds governance regression coverage proving the policy amendment itself remains governance-only under the preexisting classifier behavior.
+- Preserves frozen PR #868, keeps AQ8 unauthorized, and requires a fresh Covenant candidate after canonical policy amendment.
+
 # Changelog
 
 ## Unreleased ADAPT-QA AQ-7 runtime and adapter parity

--- a/README.json
+++ b/README.json
@@ -2855,7 +2855,8 @@
     "cloak_ui_fidelity_handoff_guide": "skills/cloak/UI_FIDELITY_HANDOFF_GUIDE.md",
     "ui_execution_fidelity_plan": "docs/project/UI_EXECUTION_FIDELITY_PLAN.md",
     "github_copilot_adapter": "adapters/github-copilot/README.md",
-    "github_copilot_probe_guide": "adapters/github-copilot/probe-guide.md"
+    "github_copilot_probe_guide": "adapters/github-copilot/probe-guide.md",
+    "covenant_assurance_scope_policy": "docs/governance/COVENANT_ASSURANCE_SCOPE_POLICY.md"
   },
   "representation_policy": {
     "markdown": "Human-readable explanation, rationale, examples, and nuanced specialist guidance",

--- a/docs/governance/COVENANT_ASSURANCE_SCOPE_POLICY.md
+++ b/docs/governance/COVENANT_ASSURANCE_SCOPE_POLICY.md
@@ -1,9 +1,9 @@
 # Covenant Assurance Scope Policy
 
-**Contract:** `ORCHESTRA_COVENANT_ASSURANCE_SCOPE_POLICY_V1`  
-**Authority:** explicit human `APPROVE_POLICY_AMENDMENT` decision  
-**Authority record:** Padayon commit `74bf85651e0f7a935b039fb82adbfadd68917b20`  
-**Originating frozen candidate:** Orchestra PR #868 at `745609d541e97e61f28b1d3c6f9295ba0245d914`  
+**Contract:** `ORCHESTRA_COVENANT_ASSURANCE_SCOPE_POLICY_V1`
+**Authority:** explicit human `APPROVE_POLICY_AMENDMENT` decision
+**Authority record:** Padayon commit `74bf85651e0f7a935b039fb82adbfadd68917b20`
+**Originating frozen candidate:** Orchestra PR #868 at `745609d541e97e61f28b1d3c6f9295ba0245d914`
 **Policy-amendment run:** Run N+1
 
 ## Purpose

--- a/docs/governance/COVENANT_ASSURANCE_SCOPE_POLICY.md
+++ b/docs/governance/COVENANT_ASSURANCE_SCOPE_POLICY.md
@@ -1,0 +1,75 @@
+# Covenant Assurance Scope Policy
+
+**Contract:** `ORCHESTRA_COVENANT_ASSURANCE_SCOPE_POLICY_V1`  
+**Authority:** explicit human `APPROVE_POLICY_AMENDMENT` decision  
+**Authority record:** Padayon commit `74bf85651e0f7a935b039fb82adbfadd68917b20`  
+**Originating frozen candidate:** Orchestra PR #868 at `745609d541e97e61f28b1d3c6f9295ba0245d914`  
+**Policy-amendment run:** Run N+1
+
+## Purpose
+
+The historical AQ5, AQ6, and PRAI exact-scope inventories predate The Covenant. They remain authoritative for their original assurance implementations and must not be broadened merely to make a later governance layer fit those historical inventories.
+
+This policy recognizes The Covenant as a separate governance-assurance implementation scope while preserving historical exact inventories unchanged.
+
+## Classification invariant
+
+```text
+COMPLETE_DECLARED_COVENANT_SCOPE
+= NOT_APPLICABLE_TO_HISTORICAL_AQ5_AQ6_PRAI_EXACT_INVENTORIES
+
+PARTIAL_ANCHORED_COVENANT_SCOPE
+= APPLICABLE
+
+MIXED_COVENANT_SCOPE
+= APPLICABLE
+
+UNKNOWN_OR_UNANCHORED_COVENANT_SCOPE
+= APPLICABLE
+```
+
+The exact complete scope is defined mechanically by
+`COVENANT_IMPLEMENTATION_PATHS` in
+`scripts/validation/classify_adaptive_assurance_scope.py`.
+
+Unique Covenant anchors are separately declared by
+`COVENANT_SCOPE_ANCHOR_PATHS`. If any such anchor appears without the complete declared Covenant slice, historical gates remain fail-closed applicable.
+
+## Historical inventory protection
+
+This amendment does not add, remove, or reinterpret any path in:
+
+- `PRAI_IMPLEMENTATION_PATHS`
+- `AQ5_IMPLEMENTATION_PATHS`
+- `AQ6_IMPLEMENTATION_PATHS`
+- `AQ7_IMPLEMENTATION_PATHS`
+
+It does not change coverage thresholds, required checks, PRAI dispositions, protected governance, Prime Directive interpretation, or transition authority.
+
+## Amendment independence
+
+The policy-amendment candidate itself is a governance-only change set:
+
+- `CHANGELOG.md`
+- `docs/governance/COVENANT_ASSURANCE_SCOPE_POLICY.md`
+- `scripts/test_governance_check.py`
+- `scripts/validation/classify_adaptive_assurance_scope.py`
+
+That change set is already classified as governance-only by the pre-amendment canonical classifier. Therefore the new Covenant exact-scope rule is not required to exempt or certify its own policy-amendment candidate.
+
+The amended classifier must not be represented as independently certifying its own amendment. Canonical promotion additionally requires the human policy authority, ordinary repository checks, independent review, signed materialization when required, and post-merge canonical readback.
+
+## Fresh Covenant reconsideration
+
+After this policy amendment becomes canonical:
+
+1. PR #868 remains historical frozen evidence and is not resumed.
+2. A new Covenant implementation candidate is created from the new canonical main.
+3. The new candidate excludes the policy-amendment-only classifier repair.
+4. Scenario and conflict testing runs on that fresh candidate.
+5. PRAI PASS remains evidence only and is not sufficient for Covenant PASS.
+6. AQ8 remains unauthorized until a later explicit admission decision.
+
+## Authority boundary
+
+This policy creates no execution, merge, release, deployment, or transition authority. It only defines assurance applicability classification for the separately governed Covenant implementation scope.

--- a/scripts/test_governance_check.py
+++ b/scripts/test_governance_check.py
@@ -1,3 +1,5 @@
+# @codebase_provenance_JEO
+# @codebase_rights_JEO
 import os
 import subprocess
 import sys
@@ -13,6 +15,8 @@ if str(ROOT) not in sys.path:
 from adapters.codex import validate_codex_export
 from validation.classify_adaptive_assurance_scope import (
     APPLICABLE,
+    COVENANT_IMPLEMENTATION_PATHS,
+    COVENANT_SCOPE_ANCHOR_PATHS,
     NOT_APPLICABLE,
     classify_paths,
 )
@@ -21,6 +25,18 @@ from validation.classify_adaptive_assurance_scope import (
 def assert_equal(name, actual, expected):
     if actual != expected:
         raise AssertionError(f"{name}: expected {expected!r}, got {actual!r}")
+
+
+COVENANT_COMPLETE_PATHS = tuple(
+    sorted((*COVENANT_IMPLEMENTATION_PATHS, "CHANGELOG.md", "README.json"))
+)
+
+COVENANT_POLICY_AMENDMENT_PATHS = (
+    "CHANGELOG.md",
+    "docs/governance/COVENANT_ASSURANCE_SCOPE_POLICY.md",
+    "scripts/test_governance_check.py",
+    "scripts/validation/classify_adaptive_assurance_scope.py",
+)
 
 
 PROTECTED_GOVERNANCE_AMENDMENT_PATHS = (
@@ -95,6 +111,38 @@ def test_unanchored_assurance_workflow_change_remains_applicable():
         classify_paths(("README.json", ".github/workflows/prai.yml"), "prai"),
         APPLICABLE,
     )
+
+
+
+def test_complete_covenant_scope_is_not_applicable_to_historical_gates():
+    for assurance in ("prai", "aq5", "aq7"):
+        result = classify_paths(COVENANT_COMPLETE_PATHS, assurance)
+        assert_equal(f"{assurance} complete Covenant scope", result, NOT_APPLICABLE)
+
+
+def test_partial_covenant_scope_remains_fail_closed_applicable():
+    anchored_partial = ("CHANGELOG.md", "docs/governance/THE_COVENANT.md")
+    assert_equal(
+        "Covenant anchor registered",
+        "docs/governance/THE_COVENANT.md" in COVENANT_SCOPE_ANCHOR_PATHS,
+        True,
+    )
+    for assurance in ("prai", "aq5", "aq7"):
+        result = classify_paths(anchored_partial, assurance)
+        assert_equal(f"{assurance} partial Covenant scope", result, APPLICABLE)
+
+
+def test_mixed_or_unknown_covenant_scope_remains_fail_closed_applicable():
+    mixed = (*COVENANT_COMPLETE_PATHS, "unexpected-covenant-path.txt")
+    for assurance in ("prai", "aq5", "aq7"):
+        result = classify_paths(mixed, assurance)
+        assert_equal(f"{assurance} mixed Covenant scope", result, APPLICABLE)
+
+
+def test_policy_amendment_scope_uses_preexisting_governance_classification():
+    for assurance in ("prai", "aq5", "aq7"):
+        result = classify_paths(COVENANT_POLICY_AMENDMENT_PATHS, assurance)
+        assert_equal(f"{assurance} Covenant policy amendment", result, NOT_APPLICABLE)
 
 
 def test_tracked_repo_files_only():
@@ -514,6 +562,10 @@ def main():
     test_issue_171_validators_are_registered()
     test_adaptive_assurance_scope_classifier_is_registered()
     test_protected_governance_amendment_is_not_applicable_to_assurance_gates()
+    test_complete_covenant_scope_is_not_applicable_to_historical_gates()
+    test_partial_covenant_scope_remains_fail_closed_applicable()
+    test_mixed_or_unknown_covenant_scope_remains_fail_closed_applicable()
+    test_policy_amendment_scope_uses_preexisting_governance_classification()
     test_partial_owned_assurance_changes_remain_applicable()
     test_assurance_documentation_without_governance_context_remains_applicable()
     test_unanchored_assurance_workflow_change_remains_applicable()

--- a/scripts/validation/classify_adaptive_assurance_scope.py
+++ b/scripts/validation/classify_adaptive_assurance_scope.py
@@ -1,6 +1,6 @@
+#!/usr/bin/env python3
 # @codebase_provenance_JEO
 # @codebase_rights_JEO
-#!/usr/bin/env python3
 """Classify whether a change set requires legacy AQ5 or PRAI exact-scope validation."""
 
 from __future__ import annotations

--- a/scripts/validation/classify_adaptive_assurance_scope.py
+++ b/scripts/validation/classify_adaptive_assurance_scope.py
@@ -1,3 +1,5 @@
+# @codebase_provenance_JEO
+# @codebase_rights_JEO
 #!/usr/bin/env python3
 """Classify whether a change set requires legacy AQ5 or PRAI exact-scope validation."""
 
@@ -80,6 +82,40 @@ AQ7_IMPLEMENTATION_PATHS = frozenset(
     }
 )
 
+
+COVENANT_IMPLEMENTATION_PATHS = frozenset(
+    {
+        "AGENTS.md",
+        "docs/architecture/ADAPTIVE_ASSURANCE_PRAI.md",
+        "docs/governance/README.md",
+        "docs/governance/THE_COVENANT.md",
+        "docs/validation/COVENANT_CONFLICT_SCENARIO_MATRIX_20260910.md",
+        "machine/governance/covenant.v1.json",
+        "machine/schemas/covenant.v1.schema.json",
+        "orchestra_runtime/domain/governance/__init__.py",
+        "orchestra_runtime/domain/governance/covenant.py",
+        "skills/the-governor/COVENANT_PROTECTED_OBLIGATION_JUDGMENT_GUIDE.md",
+        "skills/the-governor/SKILL.md",
+        "skills/the-steward/COVENANT_SYSTEM_INTENT_JUDGMENT_GUIDE.md",
+        "skills/the-steward/SKILL.md",
+        "tests/runtime/test_covenant_contract.py",
+        "tests/runtime/test_covenant_governance_reconciliation.py",
+    }
+)
+
+COVENANT_SCOPE_ANCHOR_PATHS = frozenset(
+    {
+        "docs/governance/THE_COVENANT.md",
+        "docs/validation/COVENANT_CONFLICT_SCENARIO_MATRIX_20260910.md",
+        "machine/governance/covenant.v1.json",
+        "machine/schemas/covenant.v1.schema.json",
+        "orchestra_runtime/domain/governance/covenant.py",
+        "skills/the-governor/COVENANT_PROTECTED_OBLIGATION_JUDGMENT_GUIDE.md",
+        "skills/the-steward/COVENANT_SYSTEM_INTENT_JUDGMENT_GUIDE.md",
+        "tests/runtime/test_covenant_contract.py",
+        "tests/runtime/test_covenant_governance_reconciliation.py",
+    }
+)
 
 ADAPTIVE_ASSURANCE_REFERENCE_PATHS = frozenset(
     {
@@ -168,6 +204,15 @@ def classify_paths(paths: Iterable[str], assurance: str) -> str:
     non_neutral = set(normalized) - COMMON_TRIGGER_PATHS
     if not non_neutral:
         return NOT_APPLICABLE
+
+    # The Covenant is a separate, human-authorized governance-assurance scope.
+    # Only its complete declared slice is outside the historical AQ5/AQ6/PRAI
+    # exact inventories. Any anchored partial or mixed Covenant change remains
+    # APPLICABLE so those legacy gates fail closed rather than silently exempt it.
+    if non_neutral == COVENANT_IMPLEMENTATION_PATHS:
+        return NOT_APPLICABLE
+    if non_neutral.intersection(COVENANT_SCOPE_ANCHOR_PATHS):
+        return APPLICABLE
 
     # AQ6 and AQ7 have their own exact-scope gates. Partial or mixed changes
     # remain APPLICABLE so the legacy gates continue to fail closed.


### PR DESCRIPTION
## Human-authorized Run N+1 policy amendment

Authority source: Padayon canonical commit `74bf85651e0f7a935b039fb82adbfadd68917b20`.

### Purpose

Recognize only the complete declared Covenant implementation slice as separate from historical AQ5/AQ6/PRAI exact inventories.

### Invariants

- Historical PRAI inventory unchanged.
- Historical AQ5 inventory unchanged.
- Historical AQ6/AQ7 inventories unchanged.
- Complete declared Covenant slice: `NOT_APPLICABLE` to historical exact inventories.
- Anchored partial Covenant slice: `APPLICABLE`.
- Mixed/unknown Covenant slice: `APPLICABLE`.
- The amendment candidate itself relies on the preexisting governance-only classification, not the new Covenant special case.

### Scope

- `scripts/validation/classify_adaptive_assurance_scope.py`
- `scripts/test_governance_check.py`
- `docs/governance/COVENANT_ASSURANCE_SCOPE_POLICY.md`
- `CHANGELOG.md`

### Boundaries

- Frozen PR #868 remains untouched and unmerged.
- Frozen PR #858 remains untouched.
- AQ8 remains unauthorized.
- No threshold weakening, historical inventory broadening, workflow relaxation, Prime Directive change, release, deployment, production mutation, ruleset bypass, or history rewrite.

This source candidate must proceed through independent review and the signed-materialization lane before canonical promotion.