### PR TITLE
chore(aq8): reconstruct changelog parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased ADAPT-QA AQ-8 high-risk assurance packs
+
+- Adds deterministic, state-bound security, provenance, concurrency, state-machine, and evidence-integrity assurance packs with machine contract/schema parity.
+- Requires controlled interleavings for concurrency proof, aggregate-level analysis for shared invariants, and durable retrievable evidence bound to the exact candidate/tree/workflow.
+- Executes the COV-01 through COV-18 conflict matrix and AQ7 regression anchors while preserving PRAI, Covenant, Steward, Governor, and Arbiter ownership boundaries.
+- Keeps AQ8 source-only: no signed materialization, canonical merge, Padayon reconciliation, provider activation, production action, or AQ9+ authority.
 ## Unreleased Covenant cross-governance synthesis
 
 - Adds the evidence-only, non-authorizing Covenant runtime contract, machine schema, exact candidate/tree binding, and no-vote reconciliation rules.


### PR DESCRIPTION
Temporary non-canonical reconstruction lane. Merges only the historical AQ8 changelog entry into an isolated branch based on current canonical main, preserving the already-canonical AQ8 policy amendment entry. This PR targets only tmp/aq8-changelog-combined-20260910 and must never target main. No AQ8 transition, release, deploy, provider, credential, telemetry, production, policy, or AQ9 authority is created.