### PR TITLE
governance(aq8): canonicalize exact closeout whitelist policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased governance policy amendment: AQ8 canonical closeout whitelist
+
+- Adds the human-authorized exact three-path AQ8 canonical-closeout whitelist for `CHANGELOG.md`, `README.json`, and `docs/architecture/ADAPTIVE_ASSURANCE_AQ8.md`.
+- Emits an explicit PRAI whitelist notice when that exact lifecycle-only projection is classified `NOT_APPLICABLE` to historical PRAI/AQ5/AQ7 implementation inventories.
+- Keeps AQ8-identifiable subsets, supersets, mixed/unknown scopes, runtime or machine-contract changes, and all other partial AQ8 changes fail-closed `APPLICABLE`; historical assurance inventories and thresholds remain unchanged.
+- Changes no runtime/plugin-engine behavior, PRAI/Covenant disposition semantics, Arbiter authority, release/deployment authority, provider configuration, credentials, telemetry, or production behavior.
+
 ## Unreleased ADAPT-QA AQ-8 high-risk assurance packs
 
 - Adds deterministic, state-bound security, provenance, concurrency, state-machine, and evidence-integrity assurance packs with machine contract/schema parity.

--- a/README.json
+++ b/README.json
@@ -2906,7 +2906,8 @@
     "covenant_machine_contract": "machine/governance/covenant.v1.json",
     "covenant_machine_schema": "machine/schemas/covenant.v1.schema.json",
     "covenant_assurance_scope_policy": "docs/governance/COVENANT_ASSURANCE_SCOPE_POLICY.md",
-    "aq8_assurance_scope_policy": "docs/governance/AQ8_ASSURANCE_SCOPE_POLICY.md"
+    "aq8_assurance_scope_policy": "docs/governance/AQ8_ASSURANCE_SCOPE_POLICY.md",
+    "aq8_canonical_closeout_whitelist_policy": "docs/governance/AQ8_ASSURANCE_SCOPE_POLICY.md"
   },
   "representation_policy": {
     "markdown": "Human-readable explanation, rationale, examples, and nuanced specialist guidance",

--- a/docs/governance/AQ8_ASSURANCE_SCOPE_POLICY.md
+++ b/docs/governance/AQ8_ASSURANCE_SCOPE_POLICY.md
@@ -3,6 +3,7 @@
 **Contract:** `ORCHESTRA_AQ8_ASSURANCE_SCOPE_POLICY_V1`
 **Authority:** explicit human `APPROVE_POLICY_AMENDMENT` decision
 **Authority record:** Padayon commit `707693aebac73d84cf46f92d725f2d0d99b4b712`
+**Closeout-whitelist authority:** Padayon commit `d2e209851065925688344118d0cef26601ae36e0`
 **Escalation:** `ORCHESTRA_AQ8_ASSURANCE_SCOPE_POLICY_ESCALATION_20260910`
 **Originating frozen candidate:** Orchestra PR #875 at `06e4d12fdcb6fc7f5d604a9a36936a3fd1c98a8c` / tree `74b6e315dd7b6493bf7938c96648176b1ead21b1`
 **Policy-amendment run:** Run N+1
@@ -27,6 +28,9 @@ MIXED_AQ8_SCOPE
 
 UNKNOWN_OR_UNANCHORED_AQ8_SCOPE
 = APPLICABLE
+
+EXACT_AQ8_CANONICAL_CLOSEOUT_SCOPE
+= NOT_APPLICABLE_TO_HISTORICAL_PRAI_AQ5_AQ7_EXACT_INVENTORIES
 ```
 
 The exact complete AQ8 implementation slice is defined mechanically by `AQ8_IMPLEMENTATION_PATHS` in `scripts/validation/classify_adaptive_assurance_scope.py`.
@@ -34,6 +38,20 @@ The exact complete AQ8 implementation slice is defined mechanically by `AQ8_IMPL
 Unique AQ8 anchors are separately declared by `AQ8_SCOPE_ANCHOR_PATHS`. If any AQ8 anchor appears without the complete declared AQ8 slice, the historical gates remain fail-closed `APPLICABLE`.
 
 `CHANGELOG.md` and `README.json` remain neutral documentation triggers for exact-scope classification and do not change the semantic identity of the AQ8 implementation slice.
+
+## Canonical-closeout whitelist
+
+A later human governance decision authorizes one lifecycle-only exception after AQ8 implementation has already been promoted and independently verified. The exact whitelist is:
+
+- `CHANGELOG.md`
+- `README.json`
+- `docs/architecture/ADAPTIVE_ASSURANCE_AQ8.md`
+
+Only that exact three-path set is exempt from the historical PRAI, AQ5, and AQ7 implementation inventories. AQ8-identifiable subsets containing the architecture anchor, supersets, mixed scopes, unknown paths, runtime changes, machine-contract changes, test changes, and workflow changes remain fail-closed `APPLICABLE`. A neutral-only metadata subset retains the preexisting common-documentation behavior and is not treated as an AQ8 closeout.
+
+For PRAI, the classifier emits `PRAI_WHITELIST_NOTICE=AQ8_CANONICAL_CLOSEOUT_EXACT_PATHS` plus a GitHub Actions notice when this exact exception is consumed. The notice records why the historical inventory is not applicable; it is not a PRAI approval, runtime waiver, authority grant, or general bypass.
+
+The whitelist changes classification only. It has no effect on Orchestra runtime/plugin-engine logic, AQ8 assurance evaluation, Covenant evaluation, Arbiter ownership, thresholds, release/deployment authority, providers, credentials, telemetry, or production behavior.
 
 ## Complete declared AQ8 slice
 

--- a/scripts/validation/classify_adaptive_assurance_scope.py
+++ b/scripts/validation/classify_adaptive_assurance_scope.py
@@ -108,6 +108,15 @@ AQ8_SCOPE_ANCHOR_PATHS = frozenset(
 )
 
 
+AQ8_CANONICAL_CLOSEOUT_PATHS = frozenset(
+    {
+        "CHANGELOG.md",
+        "README.json",
+        "docs/architecture/ADAPTIVE_ASSURANCE_AQ8.md",
+    }
+)
+
+
 COVENANT_IMPLEMENTATION_PATHS = frozenset(
     {
         "AGENTS.md",
@@ -222,7 +231,14 @@ def classify_paths(paths: Iterable[str], assurance: str) -> str:
         raise ValueError(f"unsupported assurance gate: {assurance}") from exc
 
     normalized = normalize_paths(paths)
+    normalized_set = set(normalized)
     strict_implementation_paths = implementation_paths - WORKFLOW_INTEGRATION_PATHS
+
+    # Human-authorized AQ8 lifecycle closeout whitelist. This exemption is
+    # exact-set only and does not apply to AQ8 runtime, machine-contract,
+    # workflow, test, mixed, superset, or anchor-bearing subset changes.
+    if normalized_set == AQ8_CANONICAL_CLOSEOUT_PATHS:
+        return NOT_APPLICABLE
     if gate != "aq7" and set(normalized).intersection(strict_implementation_paths):
         return APPLICABLE
 
@@ -275,11 +291,28 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
 
 def main(argv: Iterable[str] | None = None) -> int:
     args = parse_args(argv)
+    raw_paths = tuple(sys.stdin)
     try:
-        result = classify_paths(sys.stdin, args.assurance)
+        result = classify_paths(raw_paths, args.assurance)
+        normalized = normalize_paths(raw_paths)
     except ValueError as exc:
         print(f"scope classification failed: {exc}", file=sys.stderr)
         return 2
+    if (
+        args.assurance == "prai"
+        and result == NOT_APPLICABLE
+        and set(normalized) == AQ8_CANONICAL_CLOSEOUT_PATHS
+    ):
+        print(
+            "::notice title=PRAI scope whitelist::"
+            "AQ8 canonical closeout exact-path whitelist applied; "
+            "lifecycle-only projection with no runtime or authority bypass.",
+            file=sys.stderr,
+        )
+        print(
+            "PRAI_WHITELIST_NOTICE=AQ8_CANONICAL_CLOSEOUT_EXACT_PATHS",
+            file=sys.stderr,
+        )
     print(result)
     return 0
 

--- a/tests/behavior/test_protected_aq8_assurance_scope_policy.py
+++ b/tests/behavior/test_protected_aq8_assurance_scope_policy.py
@@ -17,6 +17,7 @@ from validation.classify_adaptive_assurance_scope import (  # noqa: E402
     AQ5_IMPLEMENTATION_PATHS,
     AQ6_IMPLEMENTATION_PATHS,
     AQ7_IMPLEMENTATION_PATHS,
+    AQ8_CANONICAL_CLOSEOUT_PATHS,
     AQ8_IMPLEMENTATION_PATHS,
     AQ8_SCOPE_ANCHOR_PATHS,
     NOT_APPLICABLE,
@@ -29,6 +30,7 @@ HISTORICAL_GATES = ("prai", "aq5", "aq7")
 AQ8_COMPLETE_PATHS = tuple(
     sorted((*AQ8_IMPLEMENTATION_PATHS, "CHANGELOG.md", "README.json"))
 )
+AQ8_CLOSEOUT_PATHS = tuple(sorted(AQ8_CANONICAL_CLOSEOUT_PATHS))
 
 AQ8_POLICY_AMENDMENT_PATHS = (
     ".github/workflows/governance-check.yml",
@@ -51,6 +53,38 @@ def test_complete_aq8_scope_is_not_applicable_to_historical_gates() -> None:
             f"{assurance} complete AQ8 scope",
             classify_paths(AQ8_COMPLETE_PATHS, assurance),
             NOT_APPLICABLE,
+        )
+
+
+def test_exact_aq8_canonical_closeout_whitelist_is_not_applicable() -> None:
+    for assurance in HISTORICAL_GATES:
+        _assert_equal(
+            f"{assurance} exact AQ8 canonical closeout whitelist",
+            classify_paths(AQ8_CLOSEOUT_PATHS, assurance),
+            NOT_APPLICABLE,
+        )
+
+
+def test_anchor_bearing_closeout_subsets_remain_fail_closed() -> None:
+    anchor = "docs/architecture/ADAPTIVE_ASSURANCE_AQ8.md"
+    for removed in ("CHANGELOG.md", "README.json"):
+        subset = tuple(path for path in AQ8_CLOSEOUT_PATHS if path != removed)
+        _assert_equal(f"{removed} removed retains anchor", anchor in subset, True)
+        for assurance in HISTORICAL_GATES:
+            _assert_equal(
+                f"{assurance} AQ8 closeout subset without {removed}",
+                classify_paths(subset, assurance),
+                APPLICABLE,
+            )
+
+
+def test_closeout_whitelist_superset_remains_fail_closed() -> None:
+    superset = (*AQ8_CLOSEOUT_PATHS, "unexpected-aq8-closeout-surface.txt")
+    for assurance in HISTORICAL_GATES:
+        _assert_equal(
+            f"{assurance} AQ8 closeout whitelist superset",
+            classify_paths(superset, assurance),
+            APPLICABLE,
         )
 
 
@@ -122,6 +156,9 @@ def test_historical_implementation_inventories_remain_separate() -> None:
 
 def main() -> None:
     test_complete_aq8_scope_is_not_applicable_to_historical_gates()
+    test_exact_aq8_canonical_closeout_whitelist_is_not_applicable()
+    test_anchor_bearing_closeout_subsets_remain_fail_closed()
+    test_closeout_whitelist_superset_remains_fail_closed()
     test_partial_aq8_scope_remains_fail_closed_applicable()
     test_mixed_aq8_scope_remains_fail_closed_applicable()
     test_unknown_unanchored_scope_remains_fail_closed_applicable()


### PR DESCRIPTION
Canonical promotion of the human-authorized AQ8 canonical-closeout whitelist policy.

Authority: Padayon `d2e209851065925688344118d0cef26601ae36e0`
Source PR: #886 at `f998b92542ffaf43f8d5748fb378fbf419fdf557`
Reviewed source tree: `090dbdeee7a5d787803e195ec16307a3e4497d9c`
Signed materialization PR: #887
Signed carrier: `589db14232531ab37a340a40767c6ce2dfc60414`
Signed carrier tree: `090dbdeee7a5d787803e195ec16307a3e4497d9c`
Canonical parent expected: `1ef3faf459c9c64ed3ce7b316b44e3d7d793bf82`

The exact three-path AQ8 lifecycle-closeout whitelist is classification-only. It grants no runtime/plugin-engine authority, no PRAI/Covenant waiver, no Arbiter authority change, no historical inventory or threshold change, and no release/deploy/provider/credential/telemetry/production authority. AQ9 remains unauthorized. Frozen PR #885 remains closed and will not be resumed.

This signed head must independently pass the full protected validation matrix before merge.