### PR TITLE
docs(aq8): reconstruct closeout delta onto fresh canonical base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 - Adds deterministic, state-bound security, provenance, concurrency, state-machine, and evidence-integrity assurance packs with machine contract/schema parity.
 - Requires controlled interleavings for concurrency proof, aggregate-level analysis for shared invariants, and durable retrievable evidence bound to the exact candidate/tree/workflow.
 - Executes the COV-01 through COV-18 conflict matrix and AQ7 regression anchors while preserving PRAI, Covenant, Steward, Governor, and Arbiter ownership boundaries.
-- Keeps AQ8 source-only: no signed materialization, canonical merge, Padayon reconciliation, provider activation, production action, or AQ9+ authority.
+- Canonicalizes the qualified AQ8 Run N+2 through source PR #879, signed materialization PR #883, and canonical PR #884 at commit `1ef3faf459c9c64ed3ce7b316b44e3d7d793bf82` and tree `f5fa432d154651152061267b23c678d3e389338c`, preserving source/materialized/canonical tree identity.
+- Confirms canonical post-merge Governance, validate/runtime, Required Analysis, cross-platform, and CodeQL validation PASS while leaving AQ9 unauthorized and release, deployment, provider, production, and protected-policy authority unchanged.
 
 ## Unreleased governance policy amendment: AQ8 assurance scope
 

--- a/README.json
+++ b/README.json
@@ -87,7 +87,7 @@
       "authority_note": "Covenant results are evidence-only and non-authorizing. Arbiter remains transition owner; PRAI PASS and specialist PASS do not establish Covenant PASS."
     },
     "adaptive_assurance_aq8_high_risk_packs": {
-      "status": "IMPLEMENTATION_CANDIDATE",
+      "status": "AQ8_COMPLETE_CANONICAL_VERIFIED",
       "purpose": "Evaluates reusable security, provenance, concurrency, state-machine, and evidence-integrity packs as state-bound evidence without creating authority.",
       "machine_sources": [
         "machine/adaptive/aq8-high-risk-assurance-packs.v1.json",
@@ -102,7 +102,16 @@
         "tests/runtime/test_adaptive_assurance_aq8.py",
         "scripts/validation/validate_aq8.py"
       ],
-      "authority_note": "AQ8 results are evidence-only and non-authorizing. Arbiter remains transition owner; the source candidate is not signed-materialized, merged, or reconciled to Padayon."
+      "canonical_source_pr": 879,
+      "qualified_source_head": "c0d30070dfc7655907a87964caffd005078f8896",
+      "signed_materialization_pr": 883,
+      "signed_materialization_commit": "e124efb4fdf9a0e5a69815662c53acb0c1829265",
+      "canonical_pr": 884,
+      "canonical_sha": "1ef3faf459c9c64ed3ce7b316b44e3d7d793bf82",
+      "canonical_tree": "f5fa432d154651152061267b23c678d3e389338c",
+      "canonical_signature": "VERIFIED_VALID",
+      "post_merge_validation": "PASS",
+      "authority_note": "AQ8 results remain evidence-only and non-authorizing after canonicalization. Arbiter remains transition owner; canonical completion does not grant release, deployment, provider, production, protected-policy, or AQ9 authority."
     },
     "runtime_architecture_refoundation": {
       "status": "AR_2_COMPLETE_CANONICAL_VERIFIED",
@@ -2962,7 +2971,7 @@
     "adaptive_assurance_aq1": "AQ1_CANONICAL_VERIFIED_AQ2_AUTHORIZED_IMPLEMENTATION_ONLY",
     "adaptive_assurance_aq2": "AQ2_AUTHORIZED_IMPLEMENTATION_ONLY",
     "adaptive_assurance_aq4": "AQ4_AUTHORIZED_IMPLEMENTATION_ONLY",
-    "adaptive_assurance_aq8": "AQ8_SOURCE_CANDIDATE_IMPLEMENTATION_ONLY"
+    "adaptive_assurance_aq8": "AQ8_COMPLETE_CANONICAL_VERIFIED"
   },
   "ai_review_guidance": {
     "preferred_entrypoint": "README.json",

--- a/docs/architecture/ADAPTIVE_ASSURANCE_AQ8.md
+++ b/docs/architecture/ADAPTIVE_ASSURANCE_AQ8.md
@@ -122,5 +122,24 @@ The suite also runs the AQ-7 regression anchors:
 Seeded controlled fixtures are reported separately from organic observations.
 The implementation does not claim a generalized effectiveness percentage unless
 a clear denominator is available. AQ-8 introduces no network, provider, or
-production side effect and remains a source-candidate phase until independent
-review and separately authorized later gates.
+production side effect. Before independent review and separately authorized
+later gates, AQ-8 remained a source-candidate phase.
+
+## Canonical closeout
+
+AQ-8 completed its governed Run N+2 promotion without authority expansion.
+
+- Qualified source PR: #879 at `c0d30070dfc7655907a87964caffd005078f8896`
+- Qualified source tree: `f5fa432d154651152061267b23c678d3e389338c`
+- Signed materialization PR: #883
+- Signed carrier commit: `e124efb4fdf9a0e5a69815662c53acb0c1829265`
+- Canonical PR: #884
+- Canonical commit: `1ef3faf459c9c64ed3ce7b316b44e3d7d793bf82`
+- Canonical tree: `f5fa432d154651152061267b23c678d3e389338c`
+- Canonical signature: verified / valid
+- Post-merge validation: PASS
+
+The qualified source tree, signed materialization tree, and canonical tree are
+identical. AQ-8 remains evidence-only and non-authorizing. AQ9 is not admitted
+by this closeout. Release, deployment, provider, production, protected-policy,
+and other protected-action authority remain independently governed.


### PR DESCRIPTION
Reconstruction-only PR used to apply the already human-approved AQ8 canonical-closeout lifecycle delta onto a branch created from current canonical main `37207d2d6c43337b9d32a36748cf9e7fedb0c82d`.

Historical evidence source: closed/unmerged PR #885 at head `c3135b28dae698cd7d6f079dda476d758542d69c`.
Human whitelist decision: Padayon `d2e209851065925688344118d0cef26601ae36e0`, preserved by the current AQ8 assurance-scope policy and subsequent human-only whitelist authority rule.

Allowed resulting paths are exactly:
- CHANGELOG.md
- README.json
- docs/architecture/ADAPTIVE_ASSURANCE_AQ8.md

This PR does not target `main`, does not reopen or mutate PR #885, creates no new whitelist, and grants no AQ9, release, deployment, provider, credential, telemetry, production, bypass, or threshold authority. It exists only to obtain a fresh current-main-parented reconstruction commit before independent AQ8 closeout qualification.