### PR TITLE
docs(aq8): complete canonical closeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@
 - Adds deterministic, state-bound security, provenance, concurrency, state-machine, and evidence-integrity assurance packs with machine contract/schema parity.
 - Requires controlled interleavings for concurrency proof, aggregate-level analysis for shared invariants, and durable retrievable evidence bound to the exact candidate/tree/workflow.
 - Executes the COV-01 through COV-18 conflict matrix and AQ7 regression anchors while preserving PRAI, Covenant, Steward, Governor, and Arbiter ownership boundaries.
-- Keeps AQ8 source-only: no signed materialization, canonical merge, Padayon reconciliation, provider activation, production action, or AQ9+ authority.
+- Canonicalizes the qualified AQ8 Run N+2 through source PR #879, signed materialization PR #883, and canonical PR #884 at commit `1ef3faf459c9c64ed3ce7b316b44e3d7d793bf82` and tree `f5fa432d154651152061267b23c678d3e389338c`, preserving source/materialized/canonical tree identity.
+- Confirms canonical post-merge Governance, validate/runtime, Required Analysis, cross-platform, and CodeQL validation PASS while leaving AQ9 unauthorized and release, deployment, provider, production, and protected-policy authority unchanged.
 
 ## Unreleased governance policy amendment: AQ8 assurance scope
 

--- a/README.json
+++ b/README.json
@@ -87,7 +87,7 @@
       "authority_note": "Covenant results are evidence-only and non-authorizing. Arbiter remains transition owner; PRAI PASS and specialist PASS do not establish Covenant PASS."
     },
     "adaptive_assurance_aq8_high_risk_packs": {
-      "status": "IMPLEMENTATION_CANDIDATE",
+      "status": "AQ8_COMPLETE_CANONICAL_VERIFIED",
       "purpose": "Evaluates reusable security, provenance, concurrency, state-machine, and evidence-integrity packs as state-bound evidence without creating authority.",
       "machine_sources": [
         "machine/adaptive/aq8-high-risk-assurance-packs.v1.json",
@@ -102,7 +102,16 @@
         "tests/runtime/test_adaptive_assurance_aq8.py",
         "scripts/validation/validate_aq8.py"
       ],
-      "authority_note": "AQ8 results are evidence-only and non-authorizing. Arbiter remains transition owner; the source candidate is not signed-materialized, merged, or reconciled to Padayon."
+      "canonical_source_pr": 879,
+      "qualified_source_head": "c0d30070dfc7655907a87964caffd005078f8896",
+      "signed_materialization_pr": 883,
+      "signed_materialization_commit": "e124efb4fdf9a0e5a69815662c53acb0c1829265",
+      "canonical_pr": 884,
+      "canonical_sha": "1ef3faf459c9c64ed3ce7b316b44e3d7d793bf82",
+      "canonical_tree": "f5fa432d154651152061267b23c678d3e389338c",
+      "canonical_signature": "VERIFIED_VALID",
+      "post_merge_validation": "PASS",
+      "authority_note": "AQ8 results remain evidence-only and non-authorizing after canonicalization. Arbiter remains transition owner; canonical completion does not grant release, deployment, provider, production, protected-policy, or AQ9 authority."
     },
     "runtime_architecture_refoundation": {
       "status": "AR_2_COMPLETE_CANONICAL_VERIFIED",
@@ -2964,7 +2973,7 @@
     "adaptive_assurance_aq1": "AQ1_CANONICAL_VERIFIED_AQ2_AUTHORIZED_IMPLEMENTATION_ONLY",
     "adaptive_assurance_aq2": "AQ2_AUTHORIZED_IMPLEMENTATION_ONLY",
     "adaptive_assurance_aq4": "AQ4_AUTHORIZED_IMPLEMENTATION_ONLY",
-    "adaptive_assurance_aq8": "AQ8_SOURCE_CANDIDATE_IMPLEMENTATION_ONLY"
+    "adaptive_assurance_aq8": "AQ8_COMPLETE_CANONICAL_VERIFIED"
   },
   "ai_review_guidance": {
     "preferred_entrypoint": "README.json",

--- a/docs/architecture/ADAPTIVE_ASSURANCE_AQ8.md
+++ b/docs/architecture/ADAPTIVE_ASSURANCE_AQ8.md
@@ -122,5 +122,24 @@ The suite also runs the AQ-7 regression anchors:
 Seeded controlled fixtures are reported separately from organic observations.
 The implementation does not claim a generalized effectiveness percentage unless
 a clear denominator is available. AQ-8 introduces no network, provider, or
-production side effect and remains a source-candidate phase until independent
-review and separately authorized later gates.
+production side effect. Before independent review and separately authorized
+later gates, AQ-8 remained a source-candidate phase.
+
+## Canonical closeout
+
+AQ-8 completed its governed Run N+2 promotion without authority expansion.
+
+- Qualified source PR: #879 at `c0d30070dfc7655907a87964caffd005078f8896`
+- Qualified source tree: `f5fa432d154651152061267b23c678d3e389338c`
+- Signed materialization PR: #883
+- Signed carrier commit: `e124efb4fdf9a0e5a69815662c53acb0c1829265`
+- Canonical PR: #884
+- Canonical commit: `1ef3faf459c9c64ed3ce7b316b44e3d7d793bf82`
+- Canonical tree: `f5fa432d154651152061267b23c678d3e389338c`
+- Canonical signature: verified / valid
+- Post-merge validation: PASS
+
+The qualified source tree, signed materialization tree, and canonical tree are
+identical. AQ-8 remains evidence-only and non-authorizing. AQ9 is not admitted
+by this closeout. Release, deployment, provider, production, protected-policy,
+and other protected-action authority remain independently governed.


### PR DESCRIPTION
Fresh AQ8 canonical-closeout candidate reconstructed from current canonical main `37207d2d6c43337b9d32a36748cf9e7fedb0c82d` under the already human-approved exact closeout whitelist.

Candidate head: `861538d8e6fc41febff1b2a34cb9c3eb203bba52`
Candidate parent: `37207d2d6c43337b9d32a36748cf9e7fedb0c82d`
Candidate tree: `1f738f7dc1403bda1115a2a1538b70a0206b66a3`

Exact allowed paths:
- `CHANGELOG.md`
- `README.json`
- `docs/architecture/ADAPTIVE_ASSURANCE_AQ8.md`

Authority basis:
- Human-approved AQ8 exact-closeout whitelist already canonicalized in Orchestra governance.
- Human-only whitelist authority remains canonical and unchanged.
- This run consumes the existing whitelist exactly; it does not create, reinterpret, broaden, narrow, or modify it.

Historical PR #885 remains closed and unmerged and was used read-only as evidence. AQ9 remains unauthorized. No release, deployment, provider, credential, telemetry, production, ruleset bypass, threshold lowering, runtime-engine change, or protected-policy amendment is authorized.

Merge is permitted only if PRAI and all current protected exact-head validation gates pass, the exact three-file scope remains unchanged, review threads are clear, canonical base remains unchanged, and signed materialization/canonical promotion requirements are satisfied.