### PR TITLE
gov(aq9): canonicalize assurance-scope phase policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased governance policy amendment: AQ9 assurance scope
+
+- Adds the human-authorized exact nine-path AQ9 phase-separation inventory for the historical PRAI, AQ5, and AQ7 scope classifiers.
+- Classifies only the complete AQ9 implementation set as `NOT_APPLICABLE`; AQ9 subsets, mixed scopes, supersets, duplicates, and unknown future AQ paths remain fail-closed `APPLICABLE` or invalid.
+- Records the protected `HUMAN_POLICY` basis from Padayon canonical commit `959369ec84140198c2cb1cf86743a6e368830f71` without creating or modifying any lifecycle whitelist.
+- Preserves historical assurance inventories, validation thresholds, PRAI/Covenant/Overseer/Arbiter boundaries, signed-materialization controls, and independent release/deployment/provider/credential/telemetry/production authority.
+
 ## Unreleased governance assurance realignment: tree-attested promotion
 
 - Extends qualified-tree assurance reuse to PRAI, AQ5, AQ6, and Cosmic Ray on independently verified signed identical-tree promotions while ordinary source candidates retain full assurance.

--- a/README.json
+++ b/README.json
@@ -2916,6 +2916,7 @@
     "covenant_machine_schema": "machine/schemas/covenant.v1.schema.json",
     "covenant_assurance_scope_policy": "docs/governance/COVENANT_ASSURANCE_SCOPE_POLICY.md",
     "aq8_assurance_scope_policy": "docs/governance/AQ8_ASSURANCE_SCOPE_POLICY.md",
+    "aq9_assurance_scope_policy": "docs/governance/AQ9_ASSURANCE_SCOPE_POLICY.md",
     "aq8_canonical_closeout_whitelist_policy": "docs/governance/AQ8_ASSURANCE_SCOPE_POLICY.md",
     "whitelist_human_only_authority": "docs/governance/PROTECTED_GOVERNANCE_ESCALATION_PROTOCOL.md"
   },

--- a/docs/governance/AQ9_ASSURANCE_SCOPE_POLICY.md
+++ b/docs/governance/AQ9_ASSURANCE_SCOPE_POLICY.md
@@ -1,0 +1,91 @@
+# AQ9 Assurance Scope Policy
+
+## Purpose
+
+This policy separates the future AQ9 deep-assurance implementation from the historical PRAI, AQ5, and AQ7 exact implementation inventories without weakening those historical gates.
+
+AQ9 is an assurance-depth phase. Its approved purpose is to expand mutation, property, metamorphic, and bounded fuzz coverage over existing deterministic assurance logic. It does not create a second QA engine, runtime authority, provider behavior, deployment behavior, or production behavior.
+
+The policy is grounded in the primary maintainer's explicit `HUMAN_POLICY` decision recorded in Padayon at canonical commit `959369ec84140198c2cb1cf86743a6e368830f71` under decision ID `ORCHESTRA_AQ9_ASSURANCE_SCOPE_CLASSIFIER_HUMAN_POLICY_20260911`.
+
+## Exact future AQ9 implementation inventory
+
+Only the following exact nine-path set may be classified as a complete AQ9 implementation for historical-scope separation:
+
+1. `CHANGELOG.md`
+2. `README.json`
+3. `cosmic-ray.toml`
+4. `docs/architecture/ADAPTIVE_ASSURANCE_AQ9.md`
+5. `machine/adaptive/aq9-deep-assurance.v1.json`
+6. `machine/schemas/aq9-deep-assurance.v1.schema.json`
+7. `scripts/validation/validate_aq9.py`
+8. `tests/behavior/run_tests.py`
+9. `tests/runtime/test_adaptive_assurance_aq9.py`
+
+This inventory deliberately reuses the existing runtime and assurance architecture. AQ9 does not require a new production runtime module. `cosmic-ray.toml` is part of the exact set because mutation evidence is truthful only when AQ9-relevant existing assurance code is an actual mutation target. `tests/behavior/run_tests.py` is included only to register the AQ9 validator in the existing behavior-validation surface.
+
+## AQ9 anchors
+
+The following AQ9-identifying paths are anchors:
+
+- `docs/architecture/ADAPTIVE_ASSURANCE_AQ9.md`
+- `machine/adaptive/aq9-deep-assurance.v1.json`
+- `machine/schemas/aq9-deep-assurance.v1.schema.json`
+- `scripts/validation/validate_aq9.py`
+- `tests/runtime/test_adaptive_assurance_aq9.py`
+
+If any AQ9 anchor appears without the complete nine-path inventory, historical PRAI/AQ5/AQ7 applicability remains fail-closed `APPLICABLE`.
+
+## Deterministic classification
+
+```text
+EXACT_COMPLETE_AQ9_IMPLEMENTATION_SET
+    => NOT_APPLICABLE to historical exact implementation inventories
+
+PARTIAL_AQ9_SET
+    => APPLICABLE
+
+MIXED_AQ9_SET
+    => APPLICABLE
+
+AQ9_SUPERSET_WITH_UNKNOWN_PATH
+    => APPLICABLE
+
+UNREGISTERED_FUTURE_AQ_PHASE_PATH
+    => APPLICABLE
+```
+
+The classifier compares normalized exact repository paths. Duplicate or unsafe paths remain invalid.
+
+## Not a whitelist
+
+This policy is an assurance-phase taxonomy rule, not a lifecycle whitelist.
+
+```text
+AQ9_SCOPE_POLICY != WHITELIST
+AQ9_SCOPE_SEPARATION != ASSURANCE_BYPASS
+AQ9_SCOPE_SEPARATION != AUTHORITY_EXPANSION
+```
+
+The existing human-only whitelist boundary remains unchanged. This policy cannot create, modify, broaden, narrow, reinterpret, remove, or consume a whitelist.
+
+## Preserved controls
+
+The following remain unchanged:
+
+- PRAI protected-policy handling;
+- Covenant and specialist authority boundaries;
+- Overseer validation ownership;
+- Arbiter transition ownership;
+- historical PRAI, AQ5, AQ6, AQ7, and AQ8 implementation inventories;
+- statement and branch coverage thresholds;
+- mutation evidence truthfulness requirements;
+- repository required checks and rulesets;
+- signed-materialization and tree-attested promotion controls;
+- release, deployment, provider, credential, telemetry, and production authority.
+
+AQ10 through AQ14 are not admitted by this policy. Any later phase needing historical-scope separation requires its own evidence and, where protected policy is implicated, its own human decision.
+
+## Sequencing
+
+This policy amendment must itself complete normal governed qualification, signed materialization when required, canonical promotion, and post-merge verification before the fresh AQ9 implementation begins. Historical source candidates may not consume an unmerged version of this policy as authority.

--- a/scripts/validation/classify_adaptive_assurance_scope.py
+++ b/scripts/validation/classify_adaptive_assurance_scope.py
@@ -113,6 +113,30 @@ AQ8_CANONICAL_CLOSEOUT_PATHS = frozenset(
     }
 )
 
+AQ9_IMPLEMENTATION_PATHS = frozenset(
+    {
+        "CHANGELOG.md",
+        "README.json",
+        "cosmic-ray.toml",
+        "docs/architecture/ADAPTIVE_ASSURANCE_AQ9.md",
+        "machine/adaptive/aq9-deep-assurance.v1.json",
+        "machine/schemas/aq9-deep-assurance.v1.schema.json",
+        "scripts/validation/validate_aq9.py",
+        "tests/behavior/run_tests.py",
+        "tests/runtime/test_adaptive_assurance_aq9.py",
+    }
+)
+
+AQ9_SCOPE_ANCHOR_PATHS = frozenset(
+    {
+        "docs/architecture/ADAPTIVE_ASSURANCE_AQ9.md",
+        "machine/adaptive/aq9-deep-assurance.v1.json",
+        "machine/schemas/aq9-deep-assurance.v1.schema.json",
+        "scripts/validation/validate_aq9.py",
+        "tests/runtime/test_adaptive_assurance_aq9.py",
+    }
+)
+
 COVENANT_IMPLEMENTATION_PATHS = frozenset(
     {
         "AGENTS.md",
@@ -275,6 +299,16 @@ def classify_paths(paths: Iterable[str], assurance: str) -> str:
     # workflow, test, mixed, superset, or anchor-bearing subset changes.
     if normalized_set == AQ8_CANONICAL_CLOSEOUT_PATHS:
         return NOT_APPLICABLE
+
+    # Human-authorized AQ9 phase-separation taxonomy. Only the exact complete
+    # nine-path AQ9 implementation inventory is exempt from historical exact
+    # inventories. Any anchor-bearing subset, mixed scope, or superset remains
+    # fail-closed APPLICABLE. This is not a lifecycle whitelist.
+    if normalized_set == AQ9_IMPLEMENTATION_PATHS:
+        return NOT_APPLICABLE
+    if normalized_set.intersection(AQ9_SCOPE_ANCHOR_PATHS):
+        return APPLICABLE
+
     if gate != "aq7" and normalized_set.intersection(strict_implementation_paths):
         return APPLICABLE
 

--- a/tests/behavior/test_protected_aq8_assurance_scope_policy.py
+++ b/tests/behavior/test_protected_aq8_assurance_scope_policy.py
@@ -20,6 +20,8 @@ from validation.classify_adaptive_assurance_scope import (  # noqa: E402
     AQ8_CANONICAL_CLOSEOUT_PATHS,
     AQ8_IMPLEMENTATION_PATHS,
     AQ8_SCOPE_ANCHOR_PATHS,
+    AQ9_IMPLEMENTATION_PATHS,
+    AQ9_SCOPE_ANCHOR_PATHS,
     NOT_APPLICABLE,
     PRAI_IMPLEMENTATION_PATHS,
     classify_paths,
@@ -73,6 +75,15 @@ UNREGISTERED_AQ9_SAMPLE = (
     "README.json",
     "orchestra_runtime/domain/adaptive/deep_assurance.py",
     "tests/runtime/test_adaptive_assurance_aq9.py",
+)
+
+AQ9_COMPLETE_PATHS = tuple(sorted(AQ9_IMPLEMENTATION_PATHS))
+AQ9_POLICY_AMENDMENT_PATHS = (
+    "CHANGELOG.md",
+    "README.json",
+    "docs/governance/AQ9_ASSURANCE_SCOPE_POLICY.md",
+    "scripts/validation/classify_adaptive_assurance_scope.py",
+    "tests/behavior/test_protected_aq8_assurance_scope_policy.py",
 )
 
 
@@ -209,6 +220,69 @@ def test_unregistered_future_aq_paths_remain_fail_closed() -> None:
         )
 
 
+def test_complete_aq9_scope_is_not_applicable_to_historical_gates() -> None:
+    _assert_equal("AQ9 exact inventory size", len(AQ9_COMPLETE_PATHS), 9)
+    for assurance in HISTORICAL_GATES:
+        _assert_equal(
+            f"{assurance} complete AQ9 scope",
+            classify_paths(AQ9_COMPLETE_PATHS, assurance),
+            NOT_APPLICABLE,
+        )
+
+
+def test_partial_aq9_scope_remains_fail_closed_applicable() -> None:
+    anchor = "docs/architecture/ADAPTIVE_ASSURANCE_AQ9.md"
+    _assert_equal("AQ9 anchor registered", anchor in AQ9_SCOPE_ANCHOR_PATHS, True)
+    partial = tuple(path for path in AQ9_COMPLETE_PATHS if path != "cosmic-ray.toml")
+    for assurance in HISTORICAL_GATES:
+        _assert_equal(
+            f"{assurance} partial AQ9 scope",
+            classify_paths(partial, assurance),
+            APPLICABLE,
+        )
+
+
+def test_mixed_and_superset_aq9_scopes_remain_fail_closed() -> None:
+    mixed = (*AQ9_COMPLETE_PATHS, "orchestra_runtime/domain/adaptive/deep_assurance.py")
+    for assurance in HISTORICAL_GATES:
+        _assert_equal(
+            f"{assurance} AQ9 superset with unknown path",
+            classify_paths(mixed, assurance),
+            APPLICABLE,
+        )
+
+
+def test_aq9_duplicate_paths_fail_closed() -> None:
+    duplicate = (
+        "docs/architecture/ADAPTIVE_ASSURANCE_AQ9.md",
+        "docs/architecture/ADAPTIVE_ASSURANCE_AQ9.md",
+    )
+    for assurance in HISTORICAL_GATES:
+        try:
+            classify_paths(duplicate, assurance)
+        except ValueError:
+            continue
+        raise AssertionError(f"{assurance} duplicate AQ9 paths did not fail closed")
+
+
+def test_aq9_policy_amendment_uses_existing_governance_taxonomy() -> None:
+    for assurance in HISTORICAL_GATES:
+        _assert_equal(
+            f"{assurance} AQ9 policy amendment",
+            classify_paths(AQ9_POLICY_AMENDMENT_PATHS, assurance),
+            NOT_APPLICABLE,
+        )
+
+
+def test_unregistered_future_aq_phase_remains_fail_closed() -> None:
+    future = ("CHANGELOG.md", "README.json", "docs/architecture/ADAPTIVE_ASSURANCE_AQ10.md")
+    for assurance in HISTORICAL_GATES:
+        _assert_equal(
+            f"{assurance} unregistered future AQ phase",
+            classify_paths(future, assurance),
+            APPLICABLE,
+        )
+
 def test_historical_implementation_inventories_remain_separate() -> None:
     unique_aq8_anchors = AQ8_SCOPE_ANCHOR_PATHS
     for name, historical in (
@@ -234,6 +308,12 @@ def main() -> None:
     test_tree_attested_promotion_realigns_through_governance_taxonomy()
     test_unanchored_specialized_assurance_workflows_remain_fail_closed()
     test_unregistered_future_aq_paths_remain_fail_closed()
+    test_complete_aq9_scope_is_not_applicable_to_historical_gates()
+    test_partial_aq9_scope_remains_fail_closed_applicable()
+    test_mixed_and_superset_aq9_scopes_remain_fail_closed()
+    test_aq9_duplicate_paths_fail_closed()
+    test_aq9_policy_amendment_uses_existing_governance_taxonomy()
+    test_unregistered_future_aq_phase_remains_fail_closed()
     test_historical_implementation_inventories_remain_separate()
     print("AQ8 assurance scope policy tests passed.")
 


### PR DESCRIPTION
Canonical promotion of the fully qualified, human-approved, GitHub-signed AQ9 assurance-scope classifier policy amendment.

Human policy authority: Padayon 959369ec84140198c2cb1cf86743a6e368830f71, decision ORCHESTRA_AQ9_ASSURANCE_SCOPE_CLASSIFIER_HUMAN_POLICY_20260911
Source PR: #902
Qualified source head: 5428dbac4c3408f4559ad6df613f4b126c55b66e
Qualified source tree: f1eb569481e9d1736f46d673e50f4bcecce36080
Materialization PR: #903
Signed carrier: 1a5d4ea0b66f1729382632960e7620029bff9227
Signed carrier tree: f1eb569481e9d1736f46d673e50f4bcecce36080
Canonical parent/base: ec39a7f90de7fc021c2071a0c63689cc4ab02a4a

Invariant: QUALIFIED_SOURCE_TREE == SIGNED_MATERIALIZED_TREE.

Final content is exactly five policy paths. It admits only the exact future nine-path AQ9 implementation inventory for historical PRAI/AQ5/AQ7 phase separation. Partial, mixed, superset, duplicate, unknown, and future-phase scopes remain fail closed.

This is assurance taxonomy, not lifecycle whitelist authority. Historical assurance inventories, thresholds, PRAI/Covenant/Overseer/Arbiter boundaries, rulesets, required checks, and signed provenance controls remain unchanged.

Promotion may reuse fully qualified identical-tree assurance only where the signed provenance chain is independently verified. No AQ9 implementation, release, deployment, provider, credential, telemetry, production, whitelist, threshold-lowering, bypass, force-push, rebase, amend, or history-rewrite authority is created.